### PR TITLE
Prepare for release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ adheres to [Semantic Versioning][sv].
 
 ### Added
 * Initial version of `amethyst_ecs` crate (issue [#37])
-* Add Gitter webhooks support
+* Add Gitter webhooks support to Travis (issue [#27])
 
 ### Changed
 * Update `amethyst_renderer` crate slightly (issue [#37])
 * Remove `publish.sh` script since website repo handles docs now (issue [#27])
+* Updated contribution guidelines on submitting code (issue [#37])
 
 ### Fixed
 * Update broken links for website, wiki, chat, and blog (issue [#27])

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 This project is a *work in progress* and is very incomplete; pardon the dust!
 Read a summary of what happened this past week at [*This Week in Amethyst*][tw].
 
-[tw]: https://thisweekinamethyst.wordpress.com/
+[tw]: https://www.amethyst.rs/
 
 ## Vision
 


### PR DESCRIPTION
This is our first step towards operating on the new branching model (see #27 and #37).