### PR TITLE
Replace time with std::time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "Data-oriented game engine written in Rust"
 keywords = ["game", "engine", "sdk", "amethyst"]
@@ -14,7 +14,7 @@ license = "MIT"
 
 [dependencies.amethyst_engine]
 path = "src/engine/"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies.amethyst_ecs]
 path = "src/ecs/"

--- a/src/engine/Cargo.toml
+++ b/src/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst_engine"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "Core engine library"
 keywords = ["game", "engine", "core", "amethyst"]
@@ -16,4 +16,3 @@ name = "amethyst_engine"
 path = "src/lib.rs"
 
 [dependencies]
-time = "0.1"

--- a/src/engine/src/app.rs
+++ b/src/engine/src/app.rs
@@ -1,13 +1,13 @@
 //! The core engine framework.
 
 use super::state::{State, StateMachine};
-use super::timing::{Duration, SteadyTime, Stopwatch};
+use super::timing::{Duration, Instant, Stopwatch};
 
 /// User-friendly facade for building games. Manages main loop.
 pub struct Application {
     delta_time: Duration,
     fixed_step: Duration,
-    last_fixed_update: SteadyTime,
+    last_fixed_update: Instant,
     states: StateMachine,
     timer: Stopwatch,
 }
@@ -18,9 +18,9 @@ impl Application {
         where T: State
     {
         Application {
-            delta_time: Duration::zero(),
-            fixed_step: Duration::microseconds(16666),
-            last_fixed_update: SteadyTime::now(),
+            delta_time: Duration::new(0, 0),
+            fixed_step: Duration::new(0, 16666666),
+            last_fixed_update: Instant::now(),
             states: StateMachine::new(initial_state),
             timer: Stopwatch::new(),
         }
@@ -49,7 +49,7 @@ impl Application {
     fn advance_frame(&mut self) {
         // self.states.handle_events(&self.event_queue.poll());
 
-        while SteadyTime::now() - self.last_fixed_update > self.fixed_step {
+        while self.last_fixed_update.elapsed() > self.fixed_step {
             self.states.fixed_update(self.fixed_step);
             // self.systems.fixed_iterate(self.fixed_step);
             self.last_fixed_update = self.last_fixed_update + self.fixed_step;

--- a/src/engine/src/lib.rs
+++ b/src/engine/src/lib.rs
@@ -10,4 +10,4 @@ mod timing;
 
 pub use self::app::Application;
 pub use self::state::{State, StateMachine, Trans};
-pub use self::timing::{Duration, SteadyTime, Stopwatch};
+pub use self::timing::{Duration, Instant, Stopwatch};

--- a/src/engine/src/state.rs
+++ b/src/engine/src/state.rs
@@ -202,10 +202,10 @@ mod tests {
         let mut sm = StateMachine::new(State1(7));
         sm.start();
         for _ in 0..8 {
-            sm.update(Duration::seconds(0));
+            sm.update(Duration::new(0, 0));
             assert!(sm.is_running());
         }
-        sm.update(Duration::seconds(0));
+        sm.update(Duration::new(0, 0));
         assert!(!sm.is_running());
     }
 }

--- a/src/engine/src/timing.rs
+++ b/src/engine/src/timing.rs
@@ -57,7 +57,7 @@ impl Stopwatch {
 
     /// Clears the current elapsed time value.
     pub fn reset(&mut self) {
-        *self = Stopwatch::Started(Instant::now());
+        *self = Stopwatch::Waiting;
     }
 }
 

--- a/src/engine/src/timing.rs
+++ b/src/engine/src/timing.rs
@@ -1,19 +1,17 @@
 //! Utilities for working with time.
 
-extern crate time;
-
-pub use self::time::{Duration, SteadyTime};
+pub use std::time::{Duration, Instant};
 
 /// Useful utility for accurately measuring elapsed time.
 pub struct Stopwatch {
-    start_time: SteadyTime,
-    end_time: SteadyTime,
+    start_time: Instant,
+    end_time: Instant,
     running: bool,
 }
 
 impl Stopwatch {
     pub fn new() -> Stopwatch {
-        let initial_time = SteadyTime::now();
+        let initial_time = Instant::now();
 
         Stopwatch {
             start_time: initial_time,
@@ -40,7 +38,7 @@ impl Stopwatch {
     /// Note: Starting an already running stopwatch will do nothing.
     pub fn start(&mut self) {
         if !self.running {
-            if self.elapsed() == Duration::seconds(0) {
+            if self.elapsed() == Duration::new(0, 0) {
                 self.reset()
             }
 
@@ -53,14 +51,14 @@ impl Stopwatch {
     /// Note: Stopping a stopwatch that isn't running will do nothing.
     pub fn stop(&mut self) {
         if self.running {
-            self.end_time = SteadyTime::now();
+            self.end_time = Instant::now();
             self.running = false;
         }
     }
 
     /// Clears the current elapsed time value.
     pub fn reset(&mut self) {
-        self.start_time = SteadyTime::now();
+        self.start_time = Instant::now();
         self.end_time = self.start_time;
     }
 }
@@ -70,17 +68,17 @@ impl Stopwatch {
 mod tests {
     use super::Stopwatch;
     use std::thread;
-    use std::time;
+    use std::time::Duration;
 
     #[test]
     fn elapsed() {
         let mut watch = Stopwatch::new();
 
         watch.start();
-        thread::sleep(time::Duration::from_secs(2));
+        thread::sleep(Duration::from_secs(2));
         watch.stop();
 
-        assert_eq!(2, watch.elapsed().num_seconds());
+        assert_eq!(2, watch.elapsed().as_secs());
     }
 
     #[test]
@@ -88,11 +86,11 @@ mod tests {
         let mut watch = Stopwatch::new();
 
         watch.start();
-        thread::sleep(time::Duration::from_secs(2));
+        thread::sleep(Duration::from_secs(2));
         watch.stop();
         watch.reset();
 
-        assert_eq!(0, watch.elapsed().num_nanoseconds().unwrap());
+        assert_eq!(0, watch.elapsed().subsec_nanos());
     }
 
     #[test]
@@ -100,13 +98,13 @@ mod tests {
         let mut watch = Stopwatch::new();
 
         watch.start();
-        thread::sleep(time::Duration::from_secs(2));
+        thread::sleep(Duration::from_secs(2));
         watch.stop();
 
         watch.restart();
-        thread::sleep(time::Duration::from_secs(1));
+        thread::sleep(Duration::from_secs(1));
         watch.stop();
 
-        assert_eq!(1, watch.elapsed().num_seconds());
+        assert_eq!(1, watch.elapsed().as_secs());
     }
 }


### PR DESCRIPTION
The changes from time to std::time are straightforward. Also included is a 3rd commit reworking Stopwatch to be an enum
```
enum Stopwatch {
    Waiting,
    Started(Instant),
    Ended(Duration),
}
```
A change in stopwatch is that Started(start).elapsed() returns start.elapsed() instead of Duration::new(0, 0)