### PR TITLE
Updates to book

### DIFF
--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -19,8 +19,11 @@ Rust compiler. Here are the system requirements (they're pretty modest):
 ## Setting Up
 
 > Note: This guide assumes you have nightly Rust and Cargo installed, and also
-> have a working Internet connection. Please take care of these prerequisites
-> first before proceeding.
+> have a working Internet connection. 
+> Please take care of these prerequisites first before proceeding.
+> See [rustup][ru] for an easy way to have two installations of rust.
+
+[ru]: https://rustup.rs
 
 There are two ways to get started working with Amethyst:
 

--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -21,9 +21,9 @@ Rust compiler. Here are the system requirements (they're pretty modest):
 > Note: This guide assumes you have nightly Rust and Cargo installed, and also
 > have a working Internet connection. 
 > Please take care of these prerequisites first before proceeding.
-> See [rustup][ru] for an easy way to have two installations of rust.
+> See [rustup][ru] for handling multiple rust toolchains.
 
-[ru]: https://rustup.rs
+[ru]: https://www.rustup.rs/
 
 There are two ways to get started working with Amethyst:
 

--- a/book/src/getting_started/hello_world.md
+++ b/book/src/getting_started/hello_world.md
@@ -56,7 +56,7 @@ you're using the [nightly release][nr] of Rust. You can use [rustup][ru] to
 install stable and nightly Rust side-by-side. 
 
 [nr]: https://doc.rust-lang.org/book/release-channels.html
-[ru]: https://rustup.rs
+[ru]: https://www.rustup.rs
 
 Congratulations! You have successfully written your first Amethyst application.
 

--- a/book/src/getting_started/hello_world.md
+++ b/book/src/getting_started/hello_world.md
@@ -9,31 +9,28 @@ extern crate amethyst;
 
 use amethyst::engine::{Application, Duration, State, Trans};
 use amethyst::context::{Context, Config};
-use std::rc::Rc;
-use std::cell::RefCell;
+use amethyst::ecs::World;
 
 struct HelloWorld;
 
 impl State for HelloWorld {
-    fn on_start(&mut self) {
+    fn on_start(&mut self, _: &mut Context, _: &mut World) {
         println!("Game started!");
     }
 
-    fn update(&mut self, _delta: Duration) -> Trans {
+    fn update(&mut self, _: &mut Context, _: &mut World) -> Trans {
         println!("Hello from Amethyst!");
         Trans::Quit
     }
 
-    fn on_stop(&mut self) {
+    fn on_stop(&mut self, _: &mut Context, _: &mut World) {
         println!("Game stopped!");
     }
 }
 
 fn main() {
     let config = Config::from_file("../resources/config.yml").unwrap();
-    let context = Context::new(config);
-    let context_ref = Rc::new(RefCell::new(context));
-    let mut game = Application::new(HelloWorld, context_ref);
+    let mut game = Application::build(HelloWorld, config).done();
     game.run();
 }
 ```

--- a/book/src/getting_started/hello_world.md
+++ b/book/src/getting_started/hello_world.md
@@ -8,6 +8,9 @@ copy and paste the following code:
 extern crate amethyst;
 
 use amethyst::engine::{Application, Duration, State, Trans};
+use amethyst::context::{Context, Config};
+use std::rc::Rc;
+use std::cell::RefCell;
 
 struct HelloWorld;
 
@@ -27,13 +30,16 @@ impl State for HelloWorld {
 }
 
 fn main() {
-    let mut game = Application::new(HelloWorld);
+    let config = Config::from_file("../resources/config.yml").unwrap();
+    let context = Context::new(config);
+    let context_ref = Rc::new(RefCell::new(context));
+    let mut game = Application::new(HelloWorld, context_ref);
     game.run();
 }
 ```
 
-Then, compile and run the code with `cargo run`, or `amethyst run` if you
-have the [CLI tool installed][ct].
+Then, compile and run the code inside "**src/**" with `cargo run`,
+or `amethyst run` if you have the [CLI tool installed][ct].
 
 [ct]: ./getting_started/automatic_setup.html
 
@@ -46,11 +52,11 @@ Game stopped!
 ```
 
 If instead you see `error: use of unstable library feature` then make sure
-you're using the [nightly release][nr] of Rust. You can use [multirust][mr] to
+you're using the [nightly release][nr] of Rust. You can use [rustup][ru] to
 install stable and nightly Rust side-by-side. 
 
 [nr]: https://doc.rust-lang.org/book/release-channels.html
-[mr]: https://github.com/brson/multirust
+[ru]: https://rustup.rs
 
 Congratulations! You have successfully written your first Amethyst application.
 

--- a/book/src/getting_started/manual_cargo_setup.md
+++ b/book/src/getting_started/manual_cargo_setup.md
@@ -16,15 +16,27 @@ the following lines to your "Cargo.toml":
 [dependencies]
 amethyst = "*"
 ```
+### From Git via cargo
 
-### From Git
+If you don't want to get Amethyst from Crates.io but directly from the
+Git repository, you can add the following lines to your "Cargo.toml":
 
-If you don't want to get Amethyst from Crates.io, you can clone the entire SDK
-from the Git repository. Once you're done, create a new Cargo project and `cd`
-into it.
+```toml
+[dependencies]
+amethyst = { git = "https://github.com/amethyst/amethyst.git" }
+```
+
+See the [crates guide][crg] for more information on the Cargo manifest file.
+
+[crg]: http://doc.crates.io/specifying-dependencies.html#specifying-dependencies-from-git-repositories
+
+### From Git via clone
+
+Instead of using the above, you can also clone the entire SDK from the 
+Git repository. Once you're done, create a new Cargo project and `cd` into it.
 
 ```
-$ git clone https://github.com/ebkalderon/amethyst.git
+$ git clone https://github.com/amethyst/amethyst.git
 $ cargo new --bin hello_world
 $ cd hello_world
 ```


### PR DESCRIPTION
Some changes to the book. 
Updated the way of getting the git version since the way that was described is unnecessary if the user doesn't want to make changes to amethyst.

Also note:

    amethyst = {git = "https://github.com/amethyst/amethyst.git", branch = "develop" } 

This will make cargo use the develop branch.

Changed method of switching between toolchains to rustup.