### PR TITLE
Pass Context to Application::build instead of Config

### DIFF
--- a/book/src/getting_started/hello_world.md
+++ b/book/src/getting_started/hello_world.md
@@ -7,7 +7,7 @@ copy and paste the following code:
 ```rust
 extern crate amethyst;
 
-use amethyst::engine::{Application, Duration, State, Trans};
+use amethyst::engine::{Application, State, Trans};
 use amethyst::context::{Context, Config};
 use amethyst::ecs::World;
 
@@ -29,8 +29,9 @@ impl State for HelloWorld {
 }
 
 fn main() {
-    let config = Config::from_file("../resources/config.yml").unwrap();
-    let mut game = Application::build(HelloWorld, config).done();
+    let config = Config::default();
+    let context = Context::new(config);
+    let mut game = Application::build(HelloWorld, context).done();
     game.run();
 }
 ```

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -25,6 +25,7 @@ impl State for Example {
 
 fn main() {
     let config = Config::default();
-    let mut game = Application::build(Example, config).done();
+    let context = Context::new(config);
+    let mut game = Application::build(Example, context).done();
     game.run();
 }

--- a/examples/sphere.rs
+++ b/examples/sphere.rs
@@ -83,6 +83,7 @@ impl State for Example {
 fn main() {
     use amethyst::context::Config;
     let config = Config::from_file("../config/window_example_config.yml").unwrap();
-    let mut game = Application::build(Example, config).done();
+    let context = Context::new(config);
+    let mut game = Application::build(Example, context).done();
     game.run();
 }

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -45,6 +45,7 @@ impl State for Example {
 fn main() {
     use amethyst::context::Config;
     let config = Config::from_file("../config/window_example_config.yml").unwrap();
-    let mut game = Application::build(Example, config).done();
+    let context = Context::new(config);
+    let mut game = Application::build(Example, context).done();
     game.run();
 }

--- a/src/engine/app.rs
+++ b/src/engine/app.rs
@@ -3,7 +3,7 @@
 use super::state::{State, StateMachine};
 use context::timing::{SteadyTime, Stopwatch};
 use context::event::EngineEvent;
-use context::{Config, Context};
+use context::Context;
 use ecs::{Planner, World, Processor, Priority};
 use std::sync::{Arc, Mutex};
 use std::ops::DerefMut;
@@ -16,11 +16,10 @@ pub struct Application {
 }
 
 impl Application {
-    /// Creates a new Application with the given initial game state, planner, and config.
-    pub fn new<T>(initial_state: T, planner: Planner<Arc<Mutex<Context>>>, config: Config) -> Application
+    /// Creates a new Application with the given initial game state, planner, and context.
+    pub fn new<T>(initial_state: T, planner: Planner<Arc<Mutex<Context>>>, context: Context) -> Application
         where T: State + 'static
     {
-        let context = Context::new(config);
         let context = Arc::new(Mutex::new(context));
         Application {
             states: StateMachine::new(initial_state, planner),
@@ -30,10 +29,10 @@ impl Application {
     }
 
     /// Build a new Application using builder pattern.
-    pub fn build<T>(initial_state: T, config: Config) -> ApplicationBuilder<T>
+    pub fn build<T>(initial_state: T, context: Context) -> ApplicationBuilder<T>
         where T: State + 'static
     {
-        ApplicationBuilder::new(initial_state, config)
+        ApplicationBuilder::new(initial_state, context)
     }
 
     /// Starts the application and manages the game loop.
@@ -87,19 +86,19 @@ pub struct ApplicationBuilder<T>
     where T: State + 'static
 {
     initial_state: T,
-    config: Config,
+    context: Context,
     planner: Planner<Arc<Mutex<Context>>>,
 }
 
 impl<T> ApplicationBuilder<T>
     where T: State + 'static
 {
-    pub fn new(initial_state: T, config: Config) -> ApplicationBuilder<T> {
+    pub fn new(initial_state: T, context: Context) -> ApplicationBuilder<T> {
         let world = World::new();
         let planner = Planner::new(world, 1);
         ApplicationBuilder {
             initial_state: initial_state,
-            config: config,
+            context: context,
             planner: planner,
         }
     }
@@ -115,6 +114,6 @@ impl<T> ApplicationBuilder<T>
     }
 
     pub fn done(self) -> Application {
-        Application::new(self.initial_state, self.planner, self.config)
+        Application::new(self.initial_state, self.planner, self.context)
     }
 }


### PR DESCRIPTION
It allows passing a `&mut Context` to a processor's init function before calling `Application::build`.