### PR TITLE
Make examples smarter by knowing where config lives absolutely.

### DIFF
--- a/examples/sphere.rs
+++ b/examples/sphere.rs
@@ -82,7 +82,10 @@ impl State for Example {
 
 fn main() {
     use amethyst::context::Config;
-    let config = Config::from_file("../config/window_example_config.yml").unwrap();
+    let config = Config::from_file(
+        format!("{}/config/window_example_config.yml",
+                env!("CARGO_MANIFEST_DIR"))
+        ).unwrap();
     let mut game = Application::build(Example, config).done();
     game.run();
 }

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -44,7 +44,10 @@ impl State for Example {
 
 fn main() {
     use amethyst::context::Config;
-    let config = Config::from_file("../config/window_example_config.yml").unwrap();
+	let config = Config::from_file(
+        format!("{}/config/window_example_config.yml",
+                env!("CARGO_MANIFEST_DIR"))
+        ).unwrap(); 
     let mut game = Application::build(Example, config).done();
     game.run();
 }


### PR DESCRIPTION
Makes it so users don't have to run examples inside a subfolder to the manifest dir