### PR TITLE
[RFC] Slight code cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,7 @@ done the following things first:
 5. All of the following commands completed without errors.
    * `cargo build`
    * `cargo test -p {crate-name} -v`
+   * `cargo run --example {example-name}`
 
 [ml]: ./COPYING
 [st]: ./src/engine/state.rs#L192-L233

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,8 +96,8 @@ done the following things first:
 3. If your pull request adds new methods or functions to the codebase, you have
    written adequate test cases for them.
    * Unit tests are placed at the bottom of the same .rs file in a submodule
-     called `tests` with `// Unit tests` right above it. For an example, see the
-     unit tests in the [timing.rs][ti] file in the `amethyst_engine` sub-crate.
+     called `tests`. For an example, see the unit tests in the [state.rs][st]
+     file in the top-level `amethyst` crate.
    * Integration tests are placed in a separate .rs file in the `tests`
      subdirectory.
 4. You have processed your source code with `cargo fmt`.
@@ -106,7 +106,7 @@ done the following things first:
    * `cargo test -p {crate-name} -v`
 
 [ml]: ./COPYING
-[ti]: ./src/engine/src/timing.rs#L68-L112
+[st]: ./src/engine/state.rs#L192-L233
 
 > If you want to be publicly known as an author, feel free to add your name
 > and/or GitHub username to the AUTHORS.md file in your pull request.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status][s1]][tc] [![Crates.io][s2]][ci] [![MIT License][s3]][ml] [![Join the chat][s4]][gc]
 
 [s1]: https://travis-ci.org/amethyst/amethyst.svg?branch=master
-[s2]: https://img.shields.io/badge/crates.io-0.3.1-orange.svg
+[s2]: https://img.shields.io/crates/v/amethyst.svg
 [s3]: https://img.shields.io/badge/license-MIT-blue.svg
 [s4]: https://badges.gitter.im/amethyst/general.svg
 

--- a/examples/sphere.rs
+++ b/examples/sphere.rs
@@ -11,12 +11,12 @@ use amethyst::ecs::{World, Entity};
 struct Example;
 
 impl State for Example {
-    fn handle_events(&mut self, events: &[Entity], context: &mut Context, _: &mut World) -> Trans {
+    fn handle_events(&mut self, events: &[Entity], ctx: &mut Context, _: &mut World) -> Trans {
         use amethyst::context::event::{EngineEvent, Event, VirtualKeyCode};
         let mut trans = Trans::None;
-        let storage = context.broadcaster.read::<EngineEvent>();
-        for _event in events {
-            let event = storage.get(*_event).unwrap();
+        let storage = ctx.broadcaster.read::<EngineEvent>();
+        for e in events {
+            let event = storage.get(*e).unwrap();
             let event = &event.payload;
             match *event {
                 Event::KeyboardInput(_, _, Some(VirtualKeyCode::Escape)) => trans = Trans::Quit,
@@ -27,11 +27,11 @@ impl State for Example {
         trans
     }
 
-    fn on_start(&mut self, context: &mut Context, _: &mut World) {
+    fn on_start(&mut self, ctx: &mut Context, _: &mut World) {
         use amethyst::renderer::pass::{Clear, DrawShaded};
         use amethyst::renderer::{Layer, Camera, Light};
 
-        let (w, h) = context.renderer.get_dimensions().unwrap();
+        let (w, h) = ctx.renderer.get_dimensions().unwrap();
         let proj = Camera::perspective(60.0, w as f32 / h as f32, 1.0, 100.0);
         let eye = [0., 5., 0.];
         let target = [0., 0., 0.];
@@ -39,18 +39,18 @@ impl State for Example {
         let view = Camera::look_at(eye, target, up);
         let camera = Camera::new(proj, view);
 
-        context.renderer.add_scene("main");
-        context.renderer.add_camera(camera, "main");
+        ctx.renderer.add_scene("main");
+        ctx.renderer.add_camera(camera, "main");
 
-        context.asset_manager.create_constant_texture("dark_blue", [0.0, 0.0, 0.01, 1.]);
-        context.asset_manager.create_constant_texture("green", [0.0, 1.0, 0.0, 1.]);
-        context.asset_manager.gen_sphere("sphere", 32, 32);
+        ctx.asset_manager.create_constant_texture("dark_blue", [0.0, 0.0, 0.01, 1.]);
+        ctx.asset_manager.create_constant_texture("green", [0.0, 1.0, 0.0, 1.]);
+        ctx.asset_manager.gen_sphere("sphere", 32, 32);
 
         let translation = Vector3::new(0.0, 0.0, 0.0);
         let transform: [[f32; 4]; 4] = cgmath::Matrix4::from_translation(translation).into();
-        let fragment = context.asset_manager.get_fragment("sphere", "dark_blue", "green", transform).unwrap();
+        let fragment = ctx.asset_manager.get_fragment("sphere", "dark_blue", "green", transform).unwrap();
 
-        context.renderer.add_fragment("main", fragment);
+        ctx.renderer.add_fragment("main", fragment);
 
         let light = Light {
             color: [1., 1., 1., 1.],
@@ -61,7 +61,7 @@ impl State for Example {
             propagation_r_square: 1.,
         };
 
-        context.renderer.add_light("main", light);
+        ctx.renderer.add_light("main", light);
 
         let layer =
             Layer::new("main",
@@ -71,11 +71,11 @@ impl State for Example {
                         ]);
 
         let pipeline = vec![layer];
-        context.renderer.set_pipeline(pipeline);
+        ctx.renderer.set_pipeline(pipeline);
     }
 
-    fn update(&mut self, context: &mut Context, _: &mut World) -> Trans {
-        context.renderer.submit();
+    fn update(&mut self, ctx: &mut Context, _: &mut World) -> Trans {
+        ctx.renderer.submit();
         Trans::None
     }
 }
@@ -86,7 +86,7 @@ fn main() {
         format!("{}/config/window_example_config.yml",
                 env!("CARGO_MANIFEST_DIR"))
         ).unwrap();
-    let context = Context::new(config);
-    let mut game = Application::build(Example, context).done();
+    let ctx = Context::new(config);
+    let mut game = Application::build(Example, ctx).done();
     game.run();
 }

--- a/examples/sphere.rs
+++ b/examples/sphere.rs
@@ -11,12 +11,12 @@ use amethyst::ecs::{World, Entity};
 struct Example;
 
 impl State for Example {
-    fn handle_events(&mut self, events: Vec<Entity>, context: &mut Context, _: &mut World) -> Trans {
+    fn handle_events(&mut self, events: &[Entity], context: &mut Context, _: &mut World) -> Trans {
         use amethyst::context::event::{EngineEvent, Event, VirtualKeyCode};
         let mut trans = Trans::None;
         let storage = context.broadcaster.read::<EngineEvent>();
         for _event in events {
-            let event = storage.get(_event).unwrap();
+            let event = storage.get(*_event).unwrap();
             let event = &event.payload;
             match *event {
                 Event::KeyboardInput(_, _, Some(VirtualKeyCode::Escape)) => trans = Trans::Quit,

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -8,12 +8,12 @@ use amethyst::ecs::{World, Entity};
 struct Example;
 
 impl State for Example {
-    fn handle_events(&mut self, events: &[Entity], context: &mut Context, _: &mut World) -> Trans {
+    fn handle_events(&mut self, events: &[Entity], ctx: &mut Context, _: &mut World) -> Trans {
         use amethyst::context::event::{EngineEvent, Event, VirtualKeyCode};
         let mut trans = Trans::None;
-        let storage = context.broadcaster.read::<EngineEvent>();
-        for _event in events {
-            let event = storage.get(*_event).unwrap();
+        let storage = ctx.broadcaster.read::<EngineEvent>();
+        for e in events {
+            let event = storage.get(*e).unwrap();
             let event = &event.payload;
             match *event {
                 Event::KeyboardInput(_, _, Some(VirtualKeyCode::Escape)) => trans = Trans::Quit,
@@ -24,7 +24,7 @@ impl State for Example {
         trans
     }
 
-    fn on_start(&mut self, context: &mut Context, _: &mut World) {
+    fn on_start(&mut self, ctx: &mut Context, _: &mut World) {
         use amethyst::renderer::pass::Clear;
         use amethyst::renderer::Layer;
         let clear_layer =
@@ -33,11 +33,11 @@ impl State for Example {
                             Clear::new([0., 0., 0., 1.]),
                         ]);
         let pipeline = vec![clear_layer];
-        context.renderer.set_pipeline(pipeline);
+        ctx.renderer.set_pipeline(pipeline);
     }
 
-    fn update(&mut self, context: &mut Context, _: &mut World) -> Trans {
-        context.renderer.submit();
+    fn update(&mut self, ctx: &mut Context, _: &mut World) -> Trans {
+        ctx.renderer.submit();
         Trans::None
     }
 }
@@ -48,7 +48,7 @@ fn main() {
         format!("{}/config/window_example_config.yml",
                 env!("CARGO_MANIFEST_DIR"))
         ).unwrap(); 
-    let context = Context::new(config);
-    let mut game = Application::build(Example, context).done();
+    let ctx = Context::new(config);
+    let mut game = Application::build(Example, ctx).done();
     game.run();
 }

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -8,12 +8,12 @@ use amethyst::ecs::{World, Entity};
 struct Example;
 
 impl State for Example {
-    fn handle_events(&mut self, events: Vec<Entity>, context: &mut Context, _: &mut World) -> Trans {
+    fn handle_events(&mut self, events: &[Entity], context: &mut Context, _: &mut World) -> Trans {
         use amethyst::context::event::{EngineEvent, Event, VirtualKeyCode};
         let mut trans = Trans::None;
         let storage = context.broadcaster.read::<EngineEvent>();
         for _event in events {
-            let event = storage.get(_event).unwrap();
+            let event = storage.get(*_event).unwrap();
             let event = &event.payload;
             match *event {
                 Event::KeyboardInput(_, _, Some(VirtualKeyCode::Escape)) => trans = Trans::Quit,

--- a/src/ecs/src/lib.rs
+++ b/src/ecs/src/lib.rs
@@ -1,10 +1,11 @@
-extern crate time;
 extern crate specs;
+extern crate time;
 
 mod sim;
 
-pub use specs::{Allocator, AntiStorage, CreateEntities, Entities, Entity, EntityBuilder,
-                Generation, HashMapStorage, JoinIter, MaskedStorage, NullStorage, Planner,
-                RunArg, Storage, SystemInfo, VecStorage, World, InsertResult, Component,
-                Join, System as Processor, UnprotectedStorage, Priority};
+pub use specs::{Allocator, AntiStorage, CreateEntities, Entities, Entity,
+                EntityBuilder, Generation, HashMapStorage, JoinIter,
+                MaskedStorage, NullStorage, Planner, RunArg, Storage,
+                SystemInfo, VecStorage, World, InsertResult, Component, Join,
+                System as Processor, UnprotectedStorage, Priority};
 pub use self::sim::{Simulation, SimBuilder};

--- a/src/ecs/src/sim.rs
+++ b/src/ecs/src/sim.rs
@@ -1,10 +1,9 @@
 //! Computes the next state.
 
-use time::Duration;
+use super::{World, Processor};
 
 use specs::Planner;
-
-use super::{World, Processor};
+use time::Duration;
 
 pub struct Simulation {
     planner: Planner<Duration>,
@@ -24,11 +23,10 @@ impl Simulation {
     }
 
     /// Adds a new processor to the simulation.
-    pub fn add_processor<T: Processor<Duration> + 'static>(&mut self,
-                                                           p: T,
-                                                           name: &str,
-                                                           priority: i32) {
-        self.planner.add_system(p, name, priority);
+    pub fn add_processor<P>(&mut self, pro: P, name: &str, priority: i32)
+        where P: Processor<Duration> + 'static
+    {
+        self.planner.add_system(pro, name, priority);
     }
 
     /// Get a mutable reference to the world.
@@ -60,12 +58,10 @@ impl SimBuilder {
     }
 
     /// Add a given processor to the simulation.
-    pub fn with<T: Processor<Duration> + 'static>(mut self,
-                                                  p: T,
-                                                  name: &str,
-                                                  priority: i32)
-                                                  -> SimBuilder {
-        self.sim.add_processor(p, name, priority);
+    pub fn with<P>(mut self, pro: P, name: &str, priority: i32) -> SimBuilder
+        where P: Processor<Duration> + 'static
+    {
+        self.sim.add_processor(pro, name, priority);
         self
     }
 

--- a/src/engine/app.rs
+++ b/src/engine/app.rs
@@ -17,10 +17,10 @@ pub struct Application {
 
 impl Application {
     /// Creates a new Application with the given initial game state, planner, and context.
-    pub fn new<T>(initial_state: T, planner: Planner<Arc<Mutex<Context>>>, context: Context) -> Application
+    pub fn new<T>(initial_state: T, planner: Planner<Arc<Mutex<Context>>>, ctx: Context) -> Application
         where T: State + 'static
     {
-        let context = Arc::new(Mutex::new(context));
+        let context = Arc::new(Mutex::new(ctx));
         Application {
             states: StateMachine::new(initial_state, planner),
             timer: Stopwatch::new(),
@@ -29,10 +29,10 @@ impl Application {
     }
 
     /// Build a new Application using builder pattern.
-    pub fn build<T>(initial_state: T, context: Context) -> ApplicationBuilder<T>
+    pub fn build<T>(initial_state: T, ctx: Context) -> ApplicationBuilder<T>
         where T: State + 'static
     {
-        ApplicationBuilder::new(initial_state, context)
+        ApplicationBuilder::new(initial_state, ctx)
     }
 
     /// Starts the application and manages the game loop.
@@ -56,20 +56,22 @@ impl Application {
 
     /// Advances the game world by one tick.
     fn advance_frame(&mut self) {
-        // let context = self.context.lock().unwrap().deref_mut();
-        let engine_events = self.context.lock().unwrap().poll_engine_events();
-        for engine_event in engine_events {
-            self.context.lock().unwrap().broadcaster.publish().with::<EngineEvent>(engine_event);
+        let events = self.context.lock().unwrap().poll_engine_events();
+        for e in events {
+            self.context.lock().unwrap().broadcaster.publish().with::<EngineEvent>(e);
         }
-        let events = self.context.lock().unwrap().broadcaster.poll();
-        self.states.handle_events(events, self.context.lock().unwrap().deref_mut());
+
+        let ents = self.context.lock().unwrap().broadcaster.poll();
+        self.states.handle_events(&ents, self.context.lock().unwrap().deref_mut());
+
         let fixed_step = self.context.lock().unwrap().fixed_step.clone();
         let last_fixed_update = self.context.lock().unwrap().last_fixed_update.clone();
+
         if SteadyTime::now() - last_fixed_update > fixed_step {
             self.states.fixed_update(self.context.lock().unwrap().deref_mut());
-            // self.systems.fixed_iterate(self.fixed_step);
             self.context.lock().unwrap().last_fixed_update = last_fixed_update + fixed_step;
         }
+
         self.states.update(self.context.lock().unwrap().deref_mut());
         self.states.run_processors(self.context.clone());
         self.context.lock().unwrap().broadcaster.clean();
@@ -93,23 +95,20 @@ pub struct ApplicationBuilder<T>
 impl<T> ApplicationBuilder<T>
     where T: State + 'static
 {
-    pub fn new(initial_state: T, context: Context) -> ApplicationBuilder<T> {
+    pub fn new(initial_state: T, ctx: Context) -> ApplicationBuilder<T> {
         let world = World::new();
         let planner = Planner::new(world, 1);
         ApplicationBuilder {
             initial_state: initial_state,
-            context: context,
+            context: ctx,
             planner: planner,
         }
     }
 
-    pub fn with<P>(mut self,
-                   sys: P,
-                   name: &str,
-                   priority: Priority) -> ApplicationBuilder<T>
+    pub fn with<P>(mut self, pro: P, name: &str, pri: Priority) -> ApplicationBuilder<T>
         where P: Processor<Arc<Mutex<Context>>> + 'static
     {
-        self.planner.add_system::<P>(sys, name, priority);
+        self.planner.add_system::<P>(pro, name, pri);
         self
     }
 

--- a/src/engine/app.rs
+++ b/src/engine/app.rs
@@ -97,11 +97,10 @@ impl<T> ApplicationBuilder<T>
 {
     pub fn new(initial_state: T, ctx: Context) -> ApplicationBuilder<T> {
         let world = World::new();
-        let planner = Planner::new(world, 1);
         ApplicationBuilder {
             initial_state: initial_state,
             context: ctx,
-            planner: planner,
+            planner: Planner::new(world, 1),
         }
     }
 

--- a/src/engine/app.rs
+++ b/src/engine/app.rs
@@ -61,8 +61,8 @@ impl Application {
             self.context.lock().unwrap().broadcaster.publish().with::<EngineEvent>(e);
         }
 
-        let ents = self.context.lock().unwrap().broadcaster.poll();
-        self.states.handle_events(&ents, self.context.lock().unwrap().deref_mut());
+        let entities = self.context.lock().unwrap().broadcaster.poll();
+        self.states.handle_events(&entities, self.context.lock().unwrap().deref_mut());
 
         let fixed_step = self.context.lock().unwrap().fixed_step.clone();
         let last_fixed_update = self.context.lock().unwrap().last_fixed_update.clone();

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2,7 +2,6 @@
 
 mod app;
 mod state;
-mod tasks;
 
 pub use self::app::{Application, ApplicationBuilder};
 pub use self::state::{State, StateMachine, Trans};

--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -8,7 +8,8 @@ use std::sync::{Arc, Mutex};
 pub enum Trans {
     /// Continue as normal.
     None,
-    /// Remove the active state and resume the next state on the stack or stop if there are none.
+    /// Remove the active state and resume the next state on the stack or stop
+    /// if there are none.
     Pop,
     /// Pause the active state and push a new state onto the stack.
     Push(Box<State>),
@@ -18,37 +19,35 @@ pub enum Trans {
     Quit,
 }
 
-#[allow(unused_variables)]
 /// A trait which defines game states that can be used by the state machine.
 pub trait State {
     /// Executed when the game state begins.
-    fn on_start(&mut self, context: &mut Context, world: &mut World) {}
+    fn on_start(&mut self, _ctx: &mut Context, _world: &mut World) {}
 
     /// Executed when the game state exits.
-    fn on_stop(&mut self, context: &mut Context, world: &mut World) {}
+    fn on_stop(&mut self, _ctx: &mut Context, _world: &mut World) {}
 
     /// Executed when a different game state is pushed onto the stack.
-    fn on_pause(&mut self, context: &mut Context, world: &mut World) {}
+    fn on_pause(&mut self, _ctx: &mut Context, _world: &mut World) {}
 
     /// Executed when the application returns to this game state once again.
-    fn on_resume(&mut self, context: &mut Context, world: &mut World) {}
+    fn on_resume(&mut self, _ctx: &mut Context, _world: &mut World) {}
 
     /// Executed on every frame before updating, for use in reacting to events.
-    fn handle_events(&mut self, _events: Vec<Entity>, context: &mut Context, world: &mut World) -> Trans { Trans::None }
+    fn handle_events(&mut self, _events: &[Entity], _ctx: &mut Context, _world: &mut World) -> Trans { Trans::None }
 
     /// Executed repeatedly at stable, predictable intervals (1/60th of a second
     /// by default).
-    fn fixed_update(&mut self, context: &mut Context, world: &mut World) -> Trans { Trans::None }
+    fn fixed_update(&mut self, _ctx: &mut Context, _world: &mut World) -> Trans { Trans::None }
 
     /// Executed on every frame immediately, as fast as the engine will allow.
-    fn update(&mut self, context: &mut Context, world: &mut World) -> Trans { Trans::Pop }
+    fn update(&mut self, _ctx: &mut Context, _world: &mut World) -> Trans { Trans::Pop }
 }
-#[warn(unused_variables)]
 
 /// A simple stack-based state machine (pushdown automaton).
 pub struct StateMachine {
-    running: bool,
     planner: Planner<Arc<Mutex<Context>>>,
+    running: bool,
     state_stack: Vec<Box<State>>,
 }
 
@@ -57,8 +56,8 @@ impl StateMachine {
         where T: State + 'static
     {
         StateMachine {
-            running: false,
             planner: planner,
+            running: false,
             state_stack: vec![Box::new(initial_state)],
         }
     }
@@ -69,106 +68,109 @@ impl StateMachine {
     }
 
     /// Runs processors if the state machine is running.
-    pub fn run_processors(&mut self, context: Arc<Mutex<Context>>) {
+    pub fn run_processors(&mut self, ctx: Arc<Mutex<Context>>) {
         if self.running {
-            self.planner.dispatch(context);
+            self.planner.dispatch(ctx);
         }
     }
 
     /// Initializes the state machine.
     /// # Panics
     ///	Panics if no states are present in the stack.
-    pub fn start(&mut self, context: &mut Context) {
+    pub fn start(&mut self, ctx: &mut Context) {
         if !self.running {
             let state = self.state_stack.last_mut().unwrap();
-            state.on_start(context, self.planner.mut_world());
+            state.on_start(ctx, self.planner.mut_world());
             self.running = true;
         }
     }
 
     /// Passes a vector of events to the active state to handle.
-    pub fn handle_events(&mut self, events: Vec<Entity>, context: &mut Context) {
+    pub fn handle_events(&mut self, events: &[Entity], ctx: &mut Context) {
         if self.running {
-            let mut trans = Trans::None;
-            if let Some(state) = self.state_stack.last_mut() {
-                trans = state.handle_events(events, context, self.planner.mut_world());
-            }
-            self.transition(trans, context);
+            let trans = match self.state_stack.last_mut() {
+                Some(state) => state.handle_events(events, ctx, self.planner.mut_world()),
+                None => Trans::None,
+            };
+
+            self.transition(trans, ctx);
         }
     }
 
     /// Updates the currently active state at a steady, fixed interval.
-    pub fn fixed_update(&mut self, context: &mut Context) {
+    pub fn fixed_update(&mut self, ctx: &mut Context) {
         if self.running {
-            let mut trans = Trans::None;
-            if let Some(state) = self.state_stack.last_mut() {
-                trans = state.fixed_update(context, self.planner.mut_world());
-            }
-            self.transition(trans, context);
+            let trans = match self.state_stack.last_mut() {
+                Some(state) => state.fixed_update(ctx, self.planner.mut_world()),
+                None => Trans::None,
+            };
+
+            self.transition(trans, ctx);
         }
     }
 
     /// Updates the currently active state immediately.
-    pub fn update(&mut self, context: &mut Context) {
+    pub fn update(&mut self, ctx: &mut Context) {
         if self.running {
-            let mut trans = Trans::None;
-            if let Some(state) = self.state_stack.last_mut() {
-                trans = state.update(context, self.planner.mut_world());
-            }
-            self.transition(trans, context);
+            let trans = match self.state_stack.last_mut() {
+                Some(state) => state.update(ctx, self.planner.mut_world()),
+                None => Trans::None,
+            };
+
+            self.transition(trans, ctx);
         }
     }
 
     /// Performs a state transition, if requested by either update() or
     /// fixed_update().
-    fn transition(&mut self, request: Trans, context: &mut Context) {
+    fn transition(&mut self, request: Trans, ctx: &mut Context) {
         if self.running {
             match request {
                 Trans::None => (),
-                Trans::Pop => self.pop(context),
-                Trans::Push(state) => self.push(state, context),
-                Trans::Switch(state) => self.switch(state, context),
-                Trans::Quit => self.stop(context),
+                Trans::Pop => self.pop(ctx),
+                Trans::Push(state) => self.push(state, ctx),
+                Trans::Switch(state) => self.switch(state, ctx),
+                Trans::Quit => self.stop(ctx),
             }
         }
     }
 
     /// Removes the current state on the stack and inserts a different one.
-    fn switch(&mut self, state: Box<State>, context: &mut Context) {
+    fn switch(&mut self, state: Box<State>, ctx: &mut Context) {
         if self.running {
             if let Some(mut state) = self.state_stack.pop() {
-                state.on_stop(context, self.planner.mut_world());
+                state.on_stop(ctx, self.planner.mut_world());
             }
 
             self.state_stack.push(state);
             let state = self.state_stack.last_mut().unwrap();
-            state.on_start(context, self.planner.mut_world());
+            state.on_start(ctx, self.planner.mut_world());
         }
     }
 
     /// Pauses the active state and pushes a new state onto the state stack.
-    fn push(&mut self, state: Box<State>, context: &mut Context) {
+    fn push(&mut self, state: Box<State>, ctx: &mut Context) {
         if self.running {
             if let Some(state) = self.state_stack.last_mut() {
-                state.on_pause(context, self.planner.mut_world());
+                state.on_pause(ctx, self.planner.mut_world());
             }
 
             self.state_stack.push(state);
             let state = self.state_stack.last_mut().unwrap();
-            state.on_start(context, self.planner.mut_world());
+            state.on_start(ctx, self.planner.mut_world());
         }
     }
 
     /// Stops and removes the active state and un-pauses the next state on the
     /// stack (if any).
-    fn pop(&mut self, context: &mut Context) {
+    fn pop(&mut self, ctx: &mut Context) {
         if self.running {
             if let Some(mut state) = self.state_stack.pop() {
-                state.on_stop(context, self.planner.mut_world());
+                state.on_stop(ctx, self.planner.mut_world());
             }
 
             if let Some(mut state) = self.state_stack.last_mut() {
-                state.on_resume(context, self.planner.mut_world());
+                state.on_resume(ctx, self.planner.mut_world());
             } else {
                 self.running = false;
             }
@@ -176,10 +178,10 @@ impl StateMachine {
     }
 
     /// Shuts the state machine down.
-    fn stop(&mut self, context: &mut Context) {
+    fn stop(&mut self, ctx: &mut Context) {
         if self.running {
             while let Some(mut state) = self.state_stack.pop() {
-                state.on_stop(context, self.planner.mut_world());
+                state.on_stop(ctx, self.planner.mut_world());
             }
 
             self.running = false;
@@ -187,7 +189,6 @@ impl StateMachine {
     }
 }
 
-// Unit tests
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![crate_name = "amethyst"]
 #![crate_type = "lib"]
-#![doc(html_logo_url = "http://tinyurl.com/jtmm43a")]
+#![doc(html_logo_url = "https://tinyurl.com/jtmm43a")]
 
 //! Amethyst is a free and open source game engine written in idiomatic
 //! [Rust][rs] for building video games and interactive multimedia applications.

--- a/src/renderer/README.md
+++ b/src/renderer/README.md
@@ -3,7 +3,7 @@
 [![Build Status][s1]][tc] [![Crates.io][s2]][ci] [![MIT License][s3]][ml] [![Join the chat][s4]][gc]
 
 [s1]: https://api.travis-ci.org/ebkalderon/amethyst.svg
-[s2]: https://img.shields.io/badge/crates.io-0.3.1-orange.svg
+[s2]: https://img.shields.io/crates/v/amethyst_renderer.svg
 [s3]: https://img.shields.io/badge/license-MIT-blue.svg
 [s4]: https://badges.gitter.im/amethyst/amethyst.svg
 


### PR DESCRIPTION
* Use the more idiomatic `&[Entity]` instead of `Vec<Entity>` in function signatures.
* Use `where` clause to shorten function signatures.
* Remove `// Unit tests` comment requirement from `CONTRIBUTING.md` section on testing.
* Add `cargo run --example {example-name}` to `CONTRIBUTING.md` section on testing.
* Update unit test example from `timing.rs` (no longer in the top-level `amethyst` crate) to `state.rs`.
* Remove unused `tasks` module.
* Miscellaneous formatting changes.
* Use HTTPS where possible in API docs.