### PR TITLE
Reorganize examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,6 @@ repository = "https://github.com/amethyst/amethyst"
 readme = "README.md"
 license = "MIT"
 
-[dependencies.amethyst_ecs]
-path = "src/ecs/"
-version = "0.1.1"
-
-[dependencies.amethyst_renderer]
-path = "src/renderer/"
-version = "0.3.1"
-
 [dependencies.amethyst_config]
 path = "src/config/"
 version = "0.1.0"
@@ -28,6 +20,25 @@ version = "0.1.0"
 path = "src/context/"
 version = "0.1.0"
 
-[dependencies]
-# required for examples/sphere.rs example
+[dependencies.amethyst_ecs]
+path = "src/ecs/"
+version = "0.1.1"
+
+[dependencies.amethyst_renderer]
+path = "src/renderer/"
+version = "0.3.1"
+
+[[example]]
+name = "hello_world"
+path = "examples/00_hello_world/main.rs"
+
+[[example]]
+name = "window"
+path = "examples/01_window/main.rs"
+
+[[example]]
+name = "sphere"
+path = "examples/02_sphere/main.rs"
+
+[dev_dependencies]
 cgmath="0.7"

--- a/examples/00_hello_world/main.rs
+++ b/examples/00_hello_world/main.rs
@@ -1,9 +1,9 @@
-//! The most basic Amethyst example.
+//! The simplest Amethyst example.
 
 extern crate amethyst;
 
 use amethyst::engine::{Application, State, Trans};
-use amethyst::context::{Context, Config};
+use amethyst::context::{Config, Context};
 use amethyst::ecs::World;
 
 struct Example;

--- a/examples/01_window/main.rs
+++ b/examples/01_window/main.rs
@@ -31,7 +31,7 @@ impl State for Example {
         let clear_layer =
             Layer::new("main",
                         vec![
-                            Clear::new([0., 0., 0., 1.]),
+                            Clear::new([0.0, 0.0, 0.0, 1.0]),
                         ]);
         let pipeline = vec![clear_layer];
         ctx.renderer.set_pipeline(pipeline);

--- a/examples/01_window/main.rs
+++ b/examples/01_window/main.rs
@@ -1,7 +1,9 @@
+//! Opens an empty window.
+
 extern crate amethyst;
 
 use amethyst::engine::{Application, State, Trans};
-use amethyst::context::Context;
+use amethyst::context::{Context, Config};
 use amethyst::config::Element;
 use amethyst::ecs::{World, Entity};
 
@@ -14,8 +16,7 @@ impl State for Example {
         let storage = ctx.broadcaster.read::<EngineEvent>();
         for e in events {
             let event = storage.get(*e).unwrap();
-            let event = &event.payload;
-            match *event {
+            match event.payload {
                 Event::KeyboardInput(_, _, Some(VirtualKeyCode::Escape)) => trans = Trans::Quit,
                 Event::Closed => trans = Trans::Quit,
                 _ => (),
@@ -43,11 +44,9 @@ impl State for Example {
 }
 
 fn main() {
-    use amethyst::context::Config;
-	let config = Config::from_file(
-        format!("{}/config/window_example_config.yml",
-                env!("CARGO_MANIFEST_DIR"))
-        ).unwrap(); 
+    let path = format!("{}/examples/01_window/resources/config.yml",
+                        env!("CARGO_MANIFEST_DIR"));
+	let config = Config::from_file(path).unwrap(); 
     let ctx = Context::new(config);
     let mut game = Application::build(Example, ctx).done();
     game.run();

--- a/examples/01_window/resources/config.yml
+++ b/examples/01_window/resources/config.yml
@@ -1,6 +1,7 @@
-display_config: 
+---
+display_config:
     dimensions: null
-    fullscreen: false
+    fullscreen: false 
     max_dimensions: null
     min_dimensions: null
     multisampling: 1

--- a/examples/02_sphere/main.rs
+++ b/examples/02_sphere/main.rs
@@ -1,10 +1,10 @@
+//! Displays a multicolored sphere to the user.
+
 extern crate amethyst;
 extern crate cgmath;
 
-use cgmath::Vector3;
-
 use amethyst::engine::{Application, State, Trans};
-use amethyst::context::Context;
+use amethyst::context::{Config, Context};
 use amethyst::config::Element;
 use amethyst::ecs::{World, Entity};
 
@@ -17,8 +17,7 @@ impl State for Example {
         let storage = ctx.broadcaster.read::<EngineEvent>();
         for e in events {
             let event = storage.get(*e).unwrap();
-            let event = &event.payload;
-            match *event {
+            match event.payload {
                 Event::KeyboardInput(_, _, Some(VirtualKeyCode::Escape)) => trans = Trans::Quit,
                 Event::Closed => trans = Trans::Quit,
                 _ => (),
@@ -30,20 +29,21 @@ impl State for Example {
     fn on_start(&mut self, ctx: &mut Context, _: &mut World) {
         use amethyst::renderer::pass::{Clear, DrawShaded};
         use amethyst::renderer::{Layer, Camera, Light};
+        use cgmath::Vector3;
 
         let (w, h) = ctx.renderer.get_dimensions().unwrap();
         let proj = Camera::perspective(60.0, w as f32 / h as f32, 1.0, 100.0);
-        let eye = [0., 5., 0.];
-        let target = [0., 0., 0.];
-        let up = [0., 0., 1.];
+        let eye = [0.0, 5.0, 0.0];
+        let target = [0.0, 0.0, 0.0];
+        let up = [0.0, 0.0, 1.0];
         let view = Camera::look_at(eye, target, up);
         let camera = Camera::new(proj, view);
 
         ctx.renderer.add_scene("main");
         ctx.renderer.add_camera(camera, "main");
 
-        ctx.asset_manager.create_constant_texture("dark_blue", [0.0, 0.0, 0.01, 1.]);
-        ctx.asset_manager.create_constant_texture("green", [0.0, 1.0, 0.0, 1.]);
+        ctx.asset_manager.create_constant_texture("dark_blue", [0.0, 0.0, 0.01, 1.0]);
+        ctx.asset_manager.create_constant_texture("green", [0.0, 1.0, 0.0, 1.0]);
         ctx.asset_manager.gen_sphere("sphere", 32, 32);
 
         let translation = Vector3::new(0.0, 0.0, 0.0);
@@ -53,12 +53,12 @@ impl State for Example {
         ctx.renderer.add_fragment("main", fragment);
 
         let light = Light {
-            color: [1., 1., 1., 1.],
-            radius: 1.,
-            center: [2., 2., 2.],
-            propagation_constant: 0.,
-            propagation_linear: 0.,
-            propagation_r_square: 1.,
+            color: [1.0, 1.0, 1.0, 1.0],
+            radius: 1.0,
+            center: [2.0, 2.0, 2.0],
+            propagation_constant: 0.0,
+            propagation_linear: 0.0,
+            propagation_r_square: 1.0,
         };
 
         ctx.renderer.add_light("main", light);
@@ -66,7 +66,7 @@ impl State for Example {
         let layer =
             Layer::new("main",
                         vec![
-                            Clear::new([0., 0., 0., 1.]),
+                            Clear::new([0.0, 0.0, 0.0, 1.0]),
                             DrawShaded::new("main", "main"),
                         ]);
 
@@ -81,11 +81,9 @@ impl State for Example {
 }
 
 fn main() {
-    use amethyst::context::Config;
-    let config = Config::from_file(
-        format!("{}/config/window_example_config.yml",
-                env!("CARGO_MANIFEST_DIR"))
-        ).unwrap();
+    let path = format!("{}/examples/02_sphere/resources/config.yml",
+                       env!("CARGO_MANIFEST_DIR"));
+    let config = Config::from_file(path).unwrap();
     let ctx = Context::new(config);
     let mut game = Application::build(Example, ctx).done();
     game.run();

--- a/examples/02_sphere/resources/config.yml
+++ b/examples/02_sphere/resources/config.yml
@@ -1,0 +1,11 @@
+---
+display_config: 
+    dimensions: null
+    fullscreen: false
+    max_dimensions: null
+    min_dimensions: null
+    multisampling: 1
+    title: "Sphere Example"
+    visibility: true
+    vsync: true
+    backend: OpenGL

--- a/examples/config_template.yml
+++ b/examples/config_template.yml
@@ -1,4 +1,4 @@
-
+---
 display: 
     brightness: 1.0
     dimensions: [1024, 768]


### PR DESCRIPTION
Examples are now put in separate folders, with each one containing a `resources/config.yml` much like a real Amethyst project would. That is, all except for the "hello, world" example which is just a lone `main.rs` file. This demonstrates how to use the engine without a `resources` folder. Each example is now sorted by increasing level of complexity, making it straightforward for newcomers to follow. Does everyone agree with this change?