### PR TITLE
[RFC] Refactor event handling to better match mockup

### DIFF
--- a/examples/01_window/main.rs
+++ b/examples/01_window/main.rs
@@ -4,25 +4,22 @@ extern crate amethyst;
 
 use amethyst::engine::{Application, State, Trans};
 use amethyst::context::{Context, ContextConfig};
+use amethyst::context::event::{Event, VirtualKeyCode};
 use amethyst::config::Element;
-use amethyst::ecs::{World, Entity};
+use amethyst::ecs::World;
 
 struct Example;
 
 impl State for Example {
-    fn handle_events(&mut self, events: &[Entity], ctx: &mut Context, _: &mut World) -> Trans {
-        use amethyst::context::event::{EngineEvent, Event, VirtualKeyCode};
-        let mut trans = Trans::None;
-        let storage = ctx.broadcaster.read::<EngineEvent>();
+    fn handle_events(&mut self, events: &[Event], _: &mut Context, _: &mut World) -> Trans {
         for e in events {
-            let event = storage.get(*e).unwrap();
-            match event.payload {
-                Event::KeyboardInput(_, _, Some(VirtualKeyCode::Escape)) => trans = Trans::Quit,
-                Event::Closed => trans = Trans::Quit,
+            match *e {
+                Event::KeyboardInput(_, _, Some(VirtualKeyCode::Escape)) => return Trans::Quit,
+                Event::Closed => return Trans::Quit,
                 _ => (),
             }
         }
-        trans
+        Trans::None
     }
 
     fn on_start(&mut self, ctx: &mut Context, _: &mut World) {

--- a/examples/02_sphere/main.rs
+++ b/examples/02_sphere/main.rs
@@ -5,25 +5,22 @@ extern crate cgmath;
 
 use amethyst::engine::{Application, State, Trans};
 use amethyst::context::{ContextConfig, Context};
+use amethyst::context::event::{Event, VirtualKeyCode};
 use amethyst::config::Element;
-use amethyst::ecs::{World, Entity};
+use amethyst::ecs::World;
 
 struct Example;
 
 impl State for Example {
-    fn handle_events(&mut self, events: &[Entity], ctx: &mut Context, _: &mut World) -> Trans {
-        use amethyst::context::event::{EngineEvent, Event, VirtualKeyCode};
-        let mut trans = Trans::None;
-        let storage = ctx.broadcaster.read::<EngineEvent>();
+    fn handle_events(&mut self, events: &[Event], _: &mut Context, _: &mut World) -> Trans {
         for e in events {
-            let event = storage.get(*e).unwrap();
-            match event.payload {
-                Event::KeyboardInput(_, _, Some(VirtualKeyCode::Escape)) => trans = Trans::Quit,
-                Event::Closed => trans = Trans::Quit,
+            match *e {
+                Event::KeyboardInput(_, _, Some(VirtualKeyCode::Escape)) => return Trans::Quit,
+                Event::Closed => return Trans::Quit,
                 _ => (),
             }
         }
-        trans
+        Trans::None
     }
 
     fn on_start(&mut self, ctx: &mut Context, _: &mut World) {

--- a/examples/03_renderable/main.rs
+++ b/examples/03_renderable/main.rs
@@ -3,6 +3,7 @@ extern crate amethyst;
 use amethyst::engine::{Application, State, Trans};
 use amethyst::processors::rendering::{RenderingProcessor, Renderable, Light, Camera, Projection};
 use amethyst::context::Context;
+use amethyst::context::event::{Event, VirtualKeyCode};
 use amethyst::config::Element;
 use amethyst::ecs::{World, Join};
 
@@ -65,18 +66,18 @@ impl State for Example {
             .build();
     }
 
-    fn update(&mut self, context: &mut Context, world: &mut World) -> Trans {
-        use amethyst::context::event::{EngineEvent, Event, VirtualKeyCode};
-
-        let engine_events = context.broadcaster.read::<EngineEvent>();
-        for engine_event in engine_events.iter() {
-            match engine_event.payload {
+    fn handle_events(&mut self, events: &[Event], _: &mut Context, _: &mut World) -> Trans {
+        for e in events {
+            match *e {
                 Event::KeyboardInput(_, _, Some(VirtualKeyCode::Escape)) => return Trans::Quit,
                 Event::Closed => return Trans::Quit,
                 _ => (),
             }
         }
+        Trans::None
+    }
 
+    fn update(&mut self, context: &mut Context, world: &mut World) -> Trans {
         let angular_velocity = 2.0; // in radians per second
         self.t += context.delta_time.subsec_nanos() as f32 / 1.0e9;
         let phase = self.t * angular_velocity;

--- a/examples/04_pong/main.rs
+++ b/examples/04_pong/main.rs
@@ -3,11 +3,10 @@ extern crate amethyst;
 use amethyst::engine::{Application, State, Trans};
 use amethyst::processors::rendering::{RenderingProcessor, Renderable, Light, Camera, Projection};
 use amethyst::context::Context;
+use amethyst::context::event::{Event, VirtualKeyCode};
 use amethyst::config::Element;
 use amethyst::ecs::{World, Join, VecStorage, Component, Processor, RunArg};
 use std::sync::{Mutex, Arc};
-
-struct Pong;
 
 struct Ball {
     pub position: [f32; 2],
@@ -56,10 +55,6 @@ impl Component for Plank {
     type Storage = VecStorage<Plank>;
 }
 
-struct PongProcessor;
-
-unsafe impl Sync for PongProcessor {  }
-
 // If right_up == true then the right plank will move up,
 // other fields work the same way
 struct InputState {
@@ -93,6 +88,10 @@ impl Score {
         }
     }
 }
+
+struct PongProcessor;
+
+unsafe impl Sync for PongProcessor {  }
 
 // Pong game processor
 impl Processor<Arc<Mutex<Context>>> for PongProcessor {
@@ -271,7 +270,9 @@ impl Processor<Arc<Mutex<Context>>> for PongProcessor {
     }
 }
 
-impl State for Pong {
+struct Game;
+
+impl State for Game {
     fn on_start(&mut self, context: &mut Context, world: &mut World) {
         let (w, h) = context.renderer.get_dimensions().unwrap();
         let aspect = w as f32 / h as f32;
@@ -338,18 +339,18 @@ impl State for Pong {
             .build();
     }
 
-    fn update(&mut self, context: &mut Context, _: &mut World) -> Trans {
-        // Exit if user hits Escape or closes the window
-        use amethyst::context::event::{EngineEvent, Event, VirtualKeyCode};
-        let engine_events = context.broadcaster.read::<EngineEvent>();
-        for engine_event in engine_events.iter() {
-            match engine_event.payload {
+    fn handle_events(&mut self, events: &[Event], _: &mut Context, _: &mut World) -> Trans {
+        for e in events {
+            match *e {
                 Event::KeyboardInput(_, _, Some(VirtualKeyCode::Escape)) => return Trans::Quit,
                 Event::Closed => return Trans::Quit,
                 _ => (),
             }
         }
+        Trans::None
+    }
 
+    fn update(&mut self, _: &mut Context, _: &mut World) -> Trans {
         Trans::None
     }
 }
@@ -361,7 +362,7 @@ fn main() {
     let config = Config::from_file(path).unwrap();
     let mut context = Context::new(config.context_config);
     let rendering_processor = RenderingProcessor::new(config.renderer_config, &mut context);
-    let mut game = Application::build(Pong, context)
+    let mut game = Application::build(Game, context)
                    .with::<RenderingProcessor>(rendering_processor, "rendering_processor", 0)
                    .register::<Renderable>()
                    .register::<Light>()

--- a/examples/04_pong/main.rs
+++ b/examples/04_pong/main.rs
@@ -95,12 +95,12 @@ unsafe impl Sync for PongProcessor {  }
 
 // Pong game processor
 impl Processor<Arc<Mutex<Context>>> for PongProcessor {
-    fn run(&mut self, arg: RunArg, context: Arc<Mutex<Context>>) {
+    fn run(&mut self, arg: RunArg, ctx: Arc<Mutex<Context>>) {
         use amethyst::context::event::{EngineEvent, Event, VirtualKeyCode, ElementState};
         use std::ops::Deref;
 
         // Get all needed component storages and resources
-        let context = context.lock().unwrap();
+        let context = ctx.lock().unwrap();
         let (mut balls,
              mut planks,
              mut renderables,
@@ -273,8 +273,8 @@ impl Processor<Arc<Mutex<Context>>> for PongProcessor {
 struct Game;
 
 impl State for Game {
-    fn on_start(&mut self, context: &mut Context, world: &mut World) {
-        let (w, h) = context.renderer.get_dimensions().unwrap();
+    fn on_start(&mut self, ctx: &mut Context, world: &mut World) {
+        let (w, h) = ctx.renderer.get_dimensions().unwrap();
         let aspect = w as f32 / h as f32;
         let eye = [0., 0., 0.1];
         let target = [0., 0., 0.];
@@ -305,8 +305,8 @@ impl State for Game {
             .build();
 
         // Generate a square mesh
-        context.asset_manager.create_constant_texture("white", [1.0, 1.0, 1.0, 1.]);
-        context.asset_manager.gen_rectangle("square", 1.0, 1.0);
+        ctx.asset_manager.create_constant_texture("white", [1.0, 1.0, 1.0, 1.]);
+        ctx.asset_manager.gen_rectangle("square", 1.0, 1.0);
         let square = Renderable::new("square", "white", "white");
 
         // Create a ball entity

--- a/src/context/src/asset_manager.rs
+++ b/src/context/src/asset_manager.rs
@@ -1,5 +1,4 @@
-//! This module provides an asset manager
-//! which loads and provides access to assets,
+//! This module provides an asset manager which loads and provides access to assets,
 //! such as `Texture`s, `Mesh`es, and `Fragment`s.
 
 extern crate amethyst_renderer;
@@ -22,18 +21,18 @@ use self::cgmath::{Vector3, InnerSpace};
 use std::collections::HashMap;
 use renderer::{Fragment, FragmentImpl};
 
-/// An enum with variants representing concrete
-/// `Factory` types compatible with different backends.
+/// An enum with variants representing concrete `Factory` types compatible with
+/// different backends.
 pub enum FactoryImpl {
     OpenGL { factory: gfx_device_gl::Factory },
     #[cfg(windows)]
     Direct3D {
-        // stub
+        // TODO: Implementation needed.
     },
     Null,
 }
 
-/// A struct which allows loading and accessing assets.
+/// Manages the loading and accessing of game assets.
 pub struct AssetManager {
     factory_impl: FactoryImpl,
     meshes: HashMap<String, Mesh>,
@@ -41,7 +40,7 @@ pub struct AssetManager {
 }
 
 impl AssetManager {
-    /// Create a new `AssetManager` from `FactoryImpl` (used internally).
+    /// Creates a new `AssetManager` from the given `FactoryImpl` (used internally).
     pub fn new(factory_impl: FactoryImpl) -> AssetManager {
         AssetManager {
             factory_impl: factory_impl,
@@ -49,7 +48,8 @@ impl AssetManager {
             textures: HashMap::new(),
         }
     }
-    /// Load a `Mesh` from vertex data.
+
+    /// Loads a `Mesh` from vertex data.
     pub fn load_mesh(&mut self, name: &str, data: &Vec<VertexPosNormal>) {
         match self.factory_impl {
             FactoryImpl::OpenGL { ref mut factory } => {
@@ -68,7 +68,8 @@ impl AssetManager {
             FactoryImpl::Null => (),
         }
     }
-    /// Generate and load a sphere mesh using the number of vertices accross the equator (u)
+
+    /// Generates and loads a sphere mesh using the number of vertices accross the equator (u)
     /// and the number of vertices from pole to pole (v).
     pub fn gen_sphere(&mut self, name: &str, u: usize, v: usize) {
         let data: Vec<VertexPosNormal> = SphereUV::new(u, v)
@@ -84,7 +85,8 @@ impl AssetManager {
             .collect();
         self.load_mesh(name, &data);
     }
-    /// Generate and load a cube mesh.
+
+    /// Generates and loads a cube mesh.
     pub fn gen_cube(&mut self, name: &str) {
         let data: Vec<VertexPosNormal> = Cube::new()
             .vertex(|(x, y, z)| {
@@ -99,7 +101,9 @@ impl AssetManager {
             .collect();
         self.load_mesh(name, &data);
     }
-    /// Generate and load a rectangle mesh in XY plane with given `width` and `height`.
+
+    /// Generates and loads a rectangle mesh in the XY plane with given `width`
+    /// and `height`.
     pub fn gen_rectangle(&mut self, name: &str, width: f32, height: f32) {
         let data = vec![
             VertexPosNormal {
@@ -135,14 +139,16 @@ impl AssetManager {
         ];
         self.load_mesh(name, &data);
     }
-    /// Lookup a `Mesh` by name.
+
+    /// Looks up a `Mesh` asset by name.
     pub fn get_mesh(&mut self, name: &str) -> Option<Mesh> {
         match self.meshes.get(name.into()) {
             Some(mesh) => Some((*mesh).clone()),
             None => None,
         }
     }
-    /// Load a `Texture` from pixel data.
+
+    /// Loads a `Texture` from pixel data.
     pub fn load_texture(&mut self, name: &str, kind: Kind, data: &[&[<<ColorFormat as Formatted>::Surface as SurfaceTyped>::DataType]]) {
         match self.factory_impl {
             FactoryImpl::OpenGL { ref mut factory } => {
@@ -162,21 +168,25 @@ impl AssetManager {
             FactoryImpl::Null => (),
         }
     }
-    /// Create a constant solid color `Texture` from a specified color.
+
+    /// Creates a new `Texture` asset with the specified color.
     pub fn create_constant_texture(&mut self, name: &str, color: [f32; 4]) {
         let texture = amethyst_renderer::Texture::Constant(color);
         let texture_impl = TextureImpl::OpenGL { texture: texture };
         let texture = Texture { texture_impl: texture_impl };
         self.textures.insert(name.into(), texture);
     }
-    /// Lookup a `Texture` by name.
+
+    /// Looks up a `Texture` asset by name.
     pub fn get_texture(&mut self, name: &str) -> Option<Texture> {
         match self.textures.get(name.into()) {
             Some(texture) => Some((*texture).clone()),
             None => None,
         }
     }
-    /// Construct and return a `Fragment` from previously loaded mesh, ka and kd textures and a transform matrix.
+
+    /// Constructs and returns a `Fragment` from previously loaded mesh, *ka*
+    /// and *kd* textures, and a transform matrix.
     pub fn get_fragment(&mut self, mesh: &str, ka: &str, kd: &str, transform: [[f32; 4]; 4]) -> Option<Fragment> {
         let mesh = match self.get_mesh(mesh) {
             Some(mesh) => mesh,
@@ -232,8 +242,8 @@ impl AssetManager {
     }
 }
 
-/// An enum with variants representing concrete
-/// `Mesh` types compatible with different backends.
+/// An enum with variants representing concrete `Mesh` types compatible with
+/// different backends.
 #[derive(Clone)]
 pub enum MeshImpl {
     OpenGL {
@@ -242,32 +252,30 @@ pub enum MeshImpl {
     },
     #[cfg(windows)]
     Direct3D {
-        // stub
+        // TODO: Implementation needed.
     },
     Null,
 }
 
-/// A wraper around `Buffer` and `Slice` required to
-/// hide all platform specific code from the user.
+/// A backend-agnostic wrapper around `Buffer` and `Slice`.
 #[derive(Clone)]
 pub struct Mesh {
     mesh_impl: MeshImpl,
 }
 
-/// An enum with variants representing concrete
-/// `Texture` types compatible with different backends.
+/// An enum with variants representing concrete `Texture` types compatible with
+/// different backends.
 #[derive(Clone)]
 pub enum TextureImpl {
     OpenGL { texture: amethyst_renderer::Texture<gfx_device_gl::Resources>, },
     #[cfg(windows)]
     Direct3D {
-        // stub
+        // TODO: Implementation needed.
     },
     Null,
 }
 
-/// A wraper around `Texture` required to
-/// hide all platform specific code from the user.
+/// A backend-agnostic wrapper around `Texture`.
 #[derive(Clone)]
 pub struct Texture {
     texture_impl: TextureImpl,

--- a/src/context/src/broadcaster.rs
+++ b/src/context/src/broadcaster.rs
@@ -1,7 +1,7 @@
-//! This module contains `Broadcaster` struct
-//! which allows publishing and polling specs
-//! entities. It is primarily used for event
-//! handling.
+//! Contains the `Broadcaster` struct which allows publishing and polling
+//! [specs][sp] entities. It is primarily used for event handling.
+//!
+//! [sp]: https://github.com/slide-rs/specs
 //!
 //! # Example:
 //! ```

--- a/src/context/src/broadcaster.rs
+++ b/src/context/src/broadcaster.rs
@@ -28,9 +28,8 @@
 //!     }
 //!     {
 //!         let storage = broadcaster.read::<UserEvent>();
-//!         for entity in broadcaster.poll() {
-//!             let user_event = storage.get(entity).unwrap();
-//!             println!("{0}", user_event.data);
+//!         for event in storage.iter() {
+//!             println!("{0}", event.data);
 //!         }
 //!     }
 //!     broadcaster.clean();

--- a/src/engine/app.rs
+++ b/src/engine/app.rs
@@ -65,12 +65,12 @@ impl Application {
             self.context.lock().unwrap().broadcaster.publish().with::<EngineEvent>(e);
         }
 
-        let mut e = Vec::new();
         {
-            let ctx = self.context.lock().unwrap();
-            e = ctx.broadcaster.read::<EngineEvent>().iter().map(|x| x.payload.clone()).collect::<Vec<Event>>();
+            let mut ctx = self.context.lock().unwrap();
+            let e = ctx.broadcaster.read::<EngineEvent>().iter()
+                .map(|x| x.payload.clone()).collect::<Vec<Event>>();
+            self.states.handle_events(&e, ctx.deref_mut());
         }
-        self.states.handle_events(&e, self.context.lock().unwrap().deref_mut());
 
         let fixed_step = self.context.lock().unwrap().fixed_step;
         let last_fixed_update = self.context.lock().unwrap().last_fixed_update;

--- a/src/engine/app.rs
+++ b/src/engine/app.rs
@@ -67,8 +67,11 @@ impl Application {
 
         {
             let mut ctx = self.context.lock().unwrap();
-            let e = ctx.broadcaster.read::<EngineEvent>().iter()
-                .map(|x| x.payload.clone()).collect::<Vec<Event>>();
+            let e = ctx.broadcaster
+                .read::<EngineEvent>()
+                .iter()
+                .map(|x| x.payload.clone())
+                .collect::<Vec<Event>>();
             self.states.handle_events(&e, ctx.deref_mut());
         }
 

--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -1,7 +1,8 @@
 //! Utilities for game state management.
 
 use context::Context;
-use ecs::{Entity, Planner, World};
+use context::event::Event;
+use ecs::{Planner, World};
 use std::sync::{Arc, Mutex};
 
 /// Types of state transitions.
@@ -35,7 +36,7 @@ pub trait State {
 
     /// Executed on every frame before updating, for use in reacting to events.
     fn handle_events(&mut self,
-                     _events: &[Entity],
+                     _events: &[Event],
                      _ctx: &mut Context,
                      _world: &mut World)
                      -> Trans {
@@ -50,7 +51,7 @@ pub trait State {
 
     /// Executed on every frame immediately, as fast as the engine will allow.
     fn update(&mut self, _ctx: &mut Context, _world: &mut World) -> Trans {
-        Trans::Pop
+        Trans::None
     }
 }
 
@@ -97,7 +98,7 @@ impl StateMachine {
     }
 
     /// Passes a vector of events to the active state to handle.
-    pub fn handle_events(&mut self, events: &[Entity], ctx: &mut Context) {
+    pub fn handle_events(&mut self, events: &[Event], ctx: &mut Context) {
         if self.running {
             let trans = match self.state_stack.last_mut() {
                 Some(state) => state.handle_events(events, ctx, self.planner.mut_world()),


### PR DESCRIPTION
This pull request should hopefully reduce the verbosity of event handling when implementing the `State` trait. The goal is to eventually make it better resemble the mockup seen in the [API documentation](https://www.amethyst.rs/doc/develop/amethyst/index.html).

This refactor is not perfect, as it reveals some blemishes in our current `Context` design, but it does make it event handling a bit prettier from the user's point of view.

* Apply some changes proposed by @nchashch in pull request #99
  * Remove `Broadcaster.poll()` entirely
  * Update examples and doc comments to match
* Move event collection out of `update()/handle_events()` and into game loop
* Change method signature of all `handle_events()` methods to accept `&[Event]` instead of `&[Entity]`, thereby removing some boilerplate

### Before:
```rust
fn handle_events(&mut self, events: &[Entity], ctx: &mut Context, _: &mut World) -> Trans {
    use amethyst::context::event::{EngineEvent, Event};
    let storage = ctx.broadcaster.read::<EngineEvent>();
    for e in events {
        let event = storage.get(*e).unwrap();
        match event.payload {
            // React to events...
        }
    }
}
```

### After:
```rust
fn handle_events(&mut self, events: &[Event], _: &mut Context, _: &mut World) -> Trans {
    for e in events {
        match *e {
            // React to events...
        }
    }
}
```