### PR TITLE
More functionality to InputHandler

### DIFF
--- a/src/context/src/input.rs
+++ b/src/context/src/input.rs
@@ -1,17 +1,17 @@
 //! The input handler for the game engine
 
-use std::collections::HashSet;
+use std::collections::hash_map::{Entry, HashMap};
 use event::{ElementState, EngineEvent, Event, VirtualKeyCode};
 
 pub struct InputHandler {
-    keys_down: HashSet<VirtualKeyCode>,
+    pressed_keys: HashMap<VirtualKeyCode, bool>,
 }
 
 impl InputHandler {
     /// Create a new InputHandler
     pub fn new() -> InputHandler {
         InputHandler {
-            keys_down: HashSet::new(),
+            pressed_keys: HashMap::new(),
         }
     }
 
@@ -19,9 +19,20 @@ impl InputHandler {
     pub fn update(&mut self, events: &[EngineEvent]) {
         for event in events {
             match event.payload {
-                Event::KeyboardInput(ElementState::Pressed, _, Some(key_code)) => { self.keys_down.insert(key_code); }
-                Event::KeyboardInput(ElementState::Released, _, Some(key_code)) => { self.keys_down.remove(&key_code); }
-                Event::Focused(false) => self.keys_down.clear(),
+                Event::KeyboardInput(ElementState::Pressed, _, Some(key_code)) => {
+                    match self.pressed_keys.entry(key_code) {
+                        Entry::Occupied(mut entry) => {
+                            entry.insert(false);
+                        },
+                        Entry::Vacant(entry) => {
+                            entry.insert(true);
+                        }
+                    }
+                },
+                Event::KeyboardInput(ElementState::Released, _, Some(key_code)) => {
+                    self.pressed_keys.remove(&key_code);
+                },
+                Event::Focused(false) => self.pressed_keys.clear(),
                 _ => {}
             }
         }
@@ -29,6 +40,32 @@ impl InputHandler {
 
     /// Check if `key` is currently pressed
     pub fn key_down(&self, key: VirtualKeyCode) -> bool {
-        self.keys_down.contains(&key)
+        self.pressed_keys.contains_key(&key)
+    }
+    
+    /// Check if all `keys` are currently pressed
+    pub fn keys_down(&self, keys: &[VirtualKeyCode]) -> bool {
+        keys.iter().all(|key| self.key_down(*key))
+    }
+    
+    /// Check if `key` is currently pressed and `key_once` or `keys_once` hasn't been
+    /// called since this `key` was first pressed.
+    pub fn key_once(&mut self, key: VirtualKeyCode) -> bool {
+        if !self.pressed_keys.contains_key(&key) {
+            return false;
+        }
+        if let Some(value) = self.pressed_keys.get_mut(&key) { // Should be safe
+            if *value {
+                *value = false;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// Checks if `keys` are all currently pressed and haven't been called with `key_once` or
+    /// `keys_once`
+    pub fn keys_once(&mut self, keys: &[VirtualKeyCode]) -> bool {
+        keys.iter().any(|key| self.key_once(*key)) && self.keys_down(keys)
     }
 }

--- a/src/context/src/input.rs
+++ b/src/context/src/input.rs
@@ -3,8 +3,14 @@
 use std::collections::hash_map::{Entry, HashMap};
 use event::{ElementState, EngineEvent, Event, VirtualKeyCode};
 
+#[derive(PartialEq, Eq)]
+enum KeyQueryState{
+    NotQueried,
+    Queried,
+}
+
 pub struct InputHandler {
-    pressed_keys: HashMap<VirtualKeyCode, bool>,
+    pressed_keys: HashMap<VirtualKeyCode, KeyQueryState>,
 }
 
 impl InputHandler {
@@ -28,7 +34,7 @@ impl InputHandler {
                             // second `Pressed` event.
                         },
                         Entry::Vacant(entry) => {
-                            entry.insert(true);
+                            entry.insert(KeyQueryState::Queried);
                         }
                     }
                 },
@@ -58,8 +64,8 @@ impl InputHandler {
             return false;
         }
         if let Some(value) = self.pressed_keys.get_mut(&key) { // Should be safe
-            if *value {
-                *value = false;
+            if *value == KeyQueryState::NotQueried {
+                *value = KeyQueryState::Queried;
                 return true;
             }
         }

--- a/src/context/src/input.rs
+++ b/src/context/src/input.rs
@@ -22,7 +22,10 @@ impl InputHandler {
                 Event::KeyboardInput(ElementState::Pressed, _, Some(key_code)) => {
                     match self.pressed_keys.entry(key_code) {
                         Entry::Occupied(mut entry) => {
-                            entry.insert(false);
+                            // nop
+                            // Allows more accurate `key_once` calls,
+                            // I.e `key_once(key)` is queried after 
+                            // second `Pressed` event.
                         },
                         Entry::Vacant(entry) => {
                             entry.insert(true);


### PR DESCRIPTION
Changes:
- Changed from HashSet to HashMap, also renamed `keys_down` to
  `pressed_keys`.
- Added fn `keys_down`. Used to query multiple keys.
- Added fn `key_once`. Used to check if a key was pressed once, and once
  only. Note this function does not care about previous calls to
  `key_down`, only other `key_once` calls.
- Added fn `keys_once`. same as `keys_down` but with `key_once` functionality.
