### PR TITLE
[WIP] Add FXAA anti-aliasing pass to amethyst_renderer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,5 +48,9 @@ path = "examples/03_renderable/main.rs"
 name = "pong"
 path = "examples/04_pong/main.rs"
 
+[[example]]
+name = "fxaa"
+path = "examples/05_fxaa/main.rs"
+
 [dependencies]
 cgmath="0.11"

--- a/examples/05_fxaa/main.rs
+++ b/examples/05_fxaa/main.rs
@@ -1,0 +1,105 @@
+//! Displays a multicolored sphere to the user.
+
+extern crate amethyst;
+extern crate cgmath;
+
+use amethyst::engine::{Application, State, Trans};
+use amethyst::context::{ContextConfig, Context};
+use amethyst::config::Element;
+use amethyst::ecs::{World, Entity};
+
+struct Example;
+
+impl State for Example {
+    fn handle_events(&mut self, events: &[Entity], ctx: &mut Context, _: &mut World) -> Trans {
+        use amethyst::context::event::{EngineEvent, Event, VirtualKeyCode};
+        let mut trans = Trans::None;
+        let storage = ctx.broadcaster.read::<EngineEvent>();
+        for e in events {
+            let event = storage.get(*e).unwrap();
+            match event.payload {
+                Event::KeyboardInput(_, _, Some(VirtualKeyCode::Escape)) => trans = Trans::Quit,
+                Event::Closed => trans = Trans::Quit,
+                _ => (),
+            }
+        }
+        trans
+    }
+
+    fn on_start(&mut self, ctx: &mut Context, _: &mut World) {
+        use amethyst::renderer::pass::{Clear, DrawShaded, FXAA, Null};
+        use amethyst::renderer::{Layer, Camera, Light};
+
+        let (w, h) = ctx.renderer.get_dimensions().unwrap();
+        let proj = Camera::perspective(60.0, w as f32 / h as f32, 1.0, 100.0);
+        let eye = [0., 3., 0.];
+        let target = [0., 0., 0.];
+        let up = [0., 0., 1.];
+        let view = Camera::look_at(eye, target, up);
+        let camera = Camera::new(proj, view);
+
+        ctx.renderer.add_scene("main");
+        ctx.renderer.add_camera(camera, "main");
+
+        ctx.asset_manager.create_constant_texture("dark_blue", [0.0, 0.0, 0.01, 1.]);
+        ctx.asset_manager.create_constant_texture("green", [0.0, 1.0, 0.0, 1.]);
+        ctx.asset_manager.gen_sphere("sphere", 32, 32);
+
+        let translation = cgmath::Vector3::new(0.0, 0.0, 0.0);
+        let transform: [[f32; 4]; 4] = cgmath::Matrix4::from_translation(translation).into();
+        let fragment = ctx.asset_manager.get_fragment("sphere", "dark_blue", "green", transform).unwrap();
+
+        ctx.renderer.add_fragment("main", fragment);
+
+        let light = Light {
+            color: [1., 1., 1., 1.],
+            radius: 1.,
+            center: [2., 2., 2.],
+            propagation_constant: 0.,
+            propagation_linear: 0.,
+            propagation_r_square: 1.,
+        };
+
+        ctx.renderer.add_light("main", light);
+
+        let color_buffer = ctx.asset_manager.get_color_buffer((w as u16, h as u16)).unwrap();
+        ctx.renderer.add_target(color_buffer, "filter_texture".into());
+
+        let filter_texture_draw =
+            Layer::new("filter_texture",
+                        vec![
+                            Clear::new([0., 0., 0., 1.]),
+                            DrawShaded::new("main", "main"),
+                        ]);
+
+        let fxaa_filter =
+            Layer::new("main",
+                       vec![
+                            FXAA::new("filter_texture", (w, h)),
+                       ]);
+
+        let null_filter =
+            Layer::new("main",
+                       vec![
+                           Null::new("filter_texture"),
+                       ]);
+
+        let pipeline = vec![filter_texture_draw, fxaa_filter];
+
+        ctx.renderer.set_pipeline(pipeline);
+    }
+
+    fn update(&mut self, ctx: &mut Context, _: &mut World) -> Trans {
+        ctx.renderer.submit();
+        Trans::None
+    }
+}
+
+fn main() {
+    let path = format!("{}/examples/05_fxaa/resources/config.yml",
+                       env!("CARGO_MANIFEST_DIR"));
+    let config = ContextConfig::from_file(path).unwrap();
+    let ctx = Context::new(config);
+    let mut game = Application::build(Example, ctx).done();
+    game.run();
+}

--- a/examples/05_fxaa/main.rs
+++ b/examples/05_fxaa/main.rs
@@ -6,26 +6,11 @@ extern crate cgmath;
 use amethyst::engine::{Application, State, Trans};
 use amethyst::context::{ContextConfig, Context};
 use amethyst::config::Element;
-use amethyst::ecs::{World, Entity};
+use amethyst::ecs::{World, Join};
 
 struct Example;
 
 impl State for Example {
-    fn handle_events(&mut self, events: &[Entity], ctx: &mut Context, _: &mut World) -> Trans {
-        use amethyst::context::event::{EngineEvent, Event, VirtualKeyCode};
-        let mut trans = Trans::None;
-        let storage = ctx.broadcaster.read::<EngineEvent>();
-        for e in events {
-            let event = storage.get(*e).unwrap();
-            match event.payload {
-                Event::KeyboardInput(_, _, Some(VirtualKeyCode::Escape)) => trans = Trans::Quit,
-                Event::Closed => trans = Trans::Quit,
-                _ => (),
-            }
-        }
-        trans
-    }
-
     fn on_start(&mut self, ctx: &mut Context, _: &mut World) {
         use amethyst::renderer::pass::{Clear, DrawShaded, FXAA, Null};
         use amethyst::renderer::{Layer, Camera, Light};
@@ -90,7 +75,17 @@ impl State for Example {
     }
 
     fn update(&mut self, ctx: &mut Context, _: &mut World) -> Trans {
-        ctx.renderer.submit();
+        // Exit if user hits Escape or closes the window
+        use amethyst::context::event::{EngineEvent, Event, VirtualKeyCode};
+        let engine_events = ctx.broadcaster.read::<EngineEvent>();
+        for engine_event in engine_events.iter() {
+            match engine_event.payload {
+                Event::KeyboardInput(_, _, Some(VirtualKeyCode::Escape)) => return Trans::Quit,
+                Event::Closed => return Trans::Quit,
+                _ => (),
+            }
+        }
+
         Trans::None
     }
 }

--- a/examples/05_fxaa/resources/config.yml
+++ b/examples/05_fxaa/resources/config.yml
@@ -1,0 +1,11 @@
+---
+display_config:
+    dimensions: null
+    fullscreen: false
+    max_dimensions: null
+    min_dimensions: null
+    multisampling: 1
+    title: "Sphere Example"
+    visibility: true
+    vsync: true
+    backend: OpenGL

--- a/src/context/src/asset_manager.rs
+++ b/src/context/src/asset_manager.rs
@@ -176,6 +176,50 @@ impl AssetManager {
             None => None,
         }
     }
+    /// Create and return a color buffer
+    pub fn get_color_buffer(&mut self, (width, height): (u16, u16)) -> Option<ColorBuffer> {
+        match self.factory_impl {
+            FactoryImpl::OpenGL {
+                ref mut factory,
+            } => {
+                let color_buffer = Box::new(amethyst_renderer::target::ColorBuffer::new(factory, (width, height)));
+                let color_buffer_impl = ColorBufferImpl::OpenGL {
+                    color_buffer: color_buffer,
+                };
+                let color_buffer = ColorBuffer {
+                    color_buffer_impl: color_buffer_impl,
+                };
+                Some(color_buffer)
+            },
+            #[cfg(windows)]
+            FactoryImpl::Direct3D => {
+                unimplemented!();
+            },
+            FactoryImpl::Null => None,
+        }
+    }
+    /// Create and return a geometry buffer
+    pub fn get_geometry_buffer(&mut self, (width, height): (u16, u16)) -> Option<GeometryBuffer> {
+        match self.factory_impl {
+            FactoryImpl::OpenGL {
+                ref mut factory,
+            } => {
+                let geometry_buffer = Box::new(amethyst_renderer::target::GeometryBuffer::new(factory, (width, height)));
+                let geometry_buffer_impl = GeometryBufferImpl::OpenGL {
+                    geometry_buffer: geometry_buffer,
+                };
+                let geometry_buffer = GeometryBuffer {
+                    geometry_buffer_impl: geometry_buffer_impl,
+                };
+                Some(geometry_buffer)
+            },
+            #[cfg(windows)]
+            FactoryImpl::Direct3D => {
+                unimplemented!();
+            },
+            FactoryImpl::Null => None,
+        }
+    }
     /// Construct and return a `Fragment` from previously loaded mesh, ka and kd textures and a transform matrix.
     pub fn get_fragment(&mut self, mesh: &str, ka: &str, kd: &str, transform: [[f32; 4]; 4]) -> Option<Fragment> {
         let mesh = match self.get_mesh(mesh) {
@@ -271,4 +315,34 @@ pub enum TextureImpl {
 #[derive(Clone)]
 pub struct Texture {
     texture_impl: TextureImpl,
+}
+
+pub enum ColorBufferImpl {
+    OpenGL {
+        color_buffer: Box<amethyst_renderer::target::ColorBuffer<gfx_device_gl::Resources>>,
+    },
+    #[cfg(windows)]
+    Direct3D {
+        // stub
+    },
+    Null,
+}
+
+pub struct ColorBuffer {
+    pub color_buffer_impl: ColorBufferImpl,
+}
+
+pub enum GeometryBufferImpl {
+    OpenGL {
+        geometry_buffer: Box<amethyst_renderer::target::GeometryBuffer<gfx_device_gl::Resources>>,
+    },
+    #[cfg(windows)]
+    Direct3D {
+        // stub
+    },
+    Null,
+}
+
+pub struct GeometryBuffer {
+    pub geometry_buffer_impl: GeometryBufferImpl,
 }

--- a/src/context/src/video_init.rs
+++ b/src/context/src/video_init.rs
@@ -5,7 +5,7 @@ extern crate gfx_device_gl;
 extern crate gfx;
 
 use self::amethyst_renderer::{Renderer, Frame};
-use self::amethyst_renderer::target::{ColorFormat, DepthFormat, ColorBuffer};
+use self::amethyst_renderer::target::{ColorFormat, DepthFormat};
 use asset_manager::FactoryImpl;
 use video_context::{DisplayConfig, VideoContext};
 
@@ -61,15 +61,16 @@ fn new_gl(display_config: &DisplayConfig) -> (VideoContext, FactoryImpl) {
     renderer.load_all(&mut factory);
 
     let mut frame = Frame::new();
-    frame.targets.insert("main".into(),
-                         Box::new(ColorBuffer {
-                             color: main_color,
-                             output_depth: main_depth,
-                         }));
+    frame.targets.insert(
+        "main".into(),
+        Box::new(amethyst_renderer::target::ColorBuffer::new_screen(main_color, main_depth))
+    );
 
-    let (w, h) = window.get_inner_size().unwrap();
-    frame.targets.insert("gbuffer".into(),
-                         Box::new(amethyst_renderer::target::GeometryBuffer::new(&mut factory, (w as u16, h as u16))));
+    let (w, h) = window.get_inner_size_pixels().unwrap();
+    frame.targets.insert(
+        "gbuffer".into(),
+        Box::new(amethyst_renderer::target::GeometryBuffer::new(&mut factory, (w as u16, h as u16)))
+    );
 
     let video_context = VideoContext::OpenGL {
         window: window,

--- a/src/renderer/src/lib.rs
+++ b/src/renderer/src/lib.rs
@@ -70,6 +70,9 @@ impl<R, C> Renderer<R, C>
         self.add_pass(pass::deferred::DepthPass::new(factory));
         self.add_pass(pass::deferred::BlitLayer::new(factory));
         self.add_pass(pass::deferred::LightingPass::new(factory));
+
+        self.add_pass(pass::filters::FXAA::new(factory));
+        self.add_pass(pass::filters::Null::new(factory));
     }
 
     /// Add a pass to the table of available passes

--- a/src/renderer/src/pass/filters.rs
+++ b/src/renderer/src/pass/filters.rs
@@ -1,0 +1,267 @@
+use gfx;
+use gfx::traits::FactoryExt;
+use gfx::handle::Buffer;
+use gfx::Slice;
+pub use ::target::{ColorFormat, GeometryBuffer};
+
+gfx_defines!(
+    vertex Vertex {
+        pos: [f32; 2] = "a_Pos",
+        tex_coord: [f32; 2] = "a_TexCoord",
+    }
+
+    constant FXAAArg {
+        inverse_texture_size: [f32; 2] = "u_InverseTextureSize",
+    }
+
+    pipeline fxaa {
+        vbuf: gfx::VertexBuffer<Vertex> = (),
+        source: gfx::TextureSampler<[f32; 4]> = "t_Source",
+        out: gfx::RenderTarget<ColorFormat> = "o_Color",
+        inverse_texture_size: gfx::ConstantBuffer<FXAAArg> = "Arg",
+    }
+
+    pipeline null {
+        vbuf: gfx::VertexBuffer<Vertex> = (),
+        source: gfx::TextureSampler<[f32; 4]> = "t_Source",
+        out: gfx::RenderTarget<ColorFormat> = "o_Color",
+    }
+);
+
+pub static FXAA_VERTEX_SRC: &'static [u8] = b"
+    #version 150 core
+
+    in vec2 a_Pos;
+    in vec2 a_TexCoord;
+    out vec2 v_TexCoord;
+
+    void main() {
+        v_TexCoord = a_TexCoord;
+        gl_Position = vec4(a_Pos, 0.0, 1.0);
+    }
+";
+
+pub static FXAA_FRAGMENT_SRC: &'static [u8] = b"
+    #version 150 core
+
+    uniform sampler2D t_Source;
+    layout (std140) uniform Arg {
+        uniform vec2 u_InverseTextureSize;
+    };
+
+    in vec2 v_TexCoord;
+
+    out vec4 o_Color;
+
+    void main() {
+        // o_Color = texture(t_Source, v_TexCoord);
+        float FXAA_SPAN_MAX = 8.0;
+        float FXAA_REDUCE_MIN = 1.0/128.0;
+        float FXAA_REDUCE_MUL = 1.0/8.0;
+
+        vec3 luma = vec3(0.2126, 0.7152, 0.0722);
+        float lumaM = dot(texture(t_Source, v_TexCoord).xyz, luma);
+        float lumaTL = dot(texture(t_Source, v_TexCoord + (vec2(-1.0, -1.0) * u_InverseTextureSize)).xyz, luma);
+        float lumaTR = dot(texture(t_Source, v_TexCoord + (vec2( 1.0, -1.0) * u_InverseTextureSize)).xyz, luma);
+        float lumaBR = dot(texture(t_Source, v_TexCoord + (vec2( 1.0,  1.0) * u_InverseTextureSize)).xyz, luma);
+        float lumaBL = dot(texture(t_Source, v_TexCoord + (vec2(-1.0,  1.0) * u_InverseTextureSize)).xyz, luma);
+
+        vec2 dir;
+        dir.x = -((lumaTL + lumaTR) - (lumaBL + lumaBR));
+        dir.y = ((lumaTL + lumaBL) - (lumaTR + lumaBR));
+
+        float dirReduce = max((lumaTL + lumaTR + lumaBR + lumaBL) * (FXAA_REDUCE_MUL * 0.25), FXAA_REDUCE_MIN);
+        float dirScaleFactor = 1.0/(min(abs(dir.x), abs(dir.y)) + dirReduce);
+        dir = min(vec2(FXAA_SPAN_MAX, FXAA_SPAN_MAX), max(vec2(-FXAA_SPAN_MAX, -FXAA_SPAN_MAX), dir * dirScaleFactor) * u_InverseTextureSize);
+
+        vec3 result1 = (1/2.0) * (
+                       texture(t_Source, v_TexCoord + dir * vec2(1.0/3.0 - 0.5)).xyz +
+                       texture(t_Source, v_TexCoord + dir * vec2(2.0/3.0 - 0.5)).xyz);
+
+        vec3 result2 = result1 * 1.0/2.0 + (1/4.0) * (
+                       texture(t_Source, v_TexCoord + dir * vec2(0.0/3.0 - 0.5)).xyz +
+                       texture(t_Source, v_TexCoord + dir * vec2(3.0/3.0 - 0.5)).xyz);
+
+        float lumaMin = min(lumaM, min(min(lumaTL, lumaTR), min(lumaBR, lumaBL)));
+        float lumaMax = max(lumaM, max(max(lumaTL, lumaTR), max(lumaBR, lumaBL)));
+        float lumaResult2 = dot(luma, result2);
+
+        if(lumaResult2 < lumaMin || lumaResult2 > lumaMax)
+            o_Color = vec4(result1, 1.0);
+        else
+            o_Color = vec4(result2, 1.0);
+    }
+";
+
+fn create_screen_fill_triangle<F, R>(factory: &mut F) -> (Buffer<R, Vertex>, Slice<R>)
+    where F: gfx::Factory<R>,
+          R: gfx::Resources
+{
+    let vertex_data = [
+        Vertex { pos: [-3., -1.], tex_coord: [-1., 0.] },
+        Vertex { pos: [ 1., -1.], tex_coord: [ 1., 0.] },
+        Vertex { pos: [ 1.,  3.], tex_coord: [ 1., 2.] },
+    ];
+
+    let buffer = factory.create_vertex_buffer(&vertex_data);
+    let slice = Slice::new_match_vertex_buffer(&buffer);
+    (buffer, slice)
+}
+
+pub struct FXAA<R: gfx::Resources> {
+    buffer: Buffer<R, Vertex>,
+    slice: Slice<R>,
+    sampler: gfx::handle::Sampler<R>,
+    pso: gfx::pso::PipelineState<R, fxaa::Meta>,
+    inverse_texture_size: Buffer<R, FXAAArg>,
+}
+
+impl<R> FXAA<R>
+    where R: gfx::Resources
+{
+    pub fn new<F>(factory: &mut F) -> FXAA<R>
+        where F: gfx::Factory<R>
+    {
+        let (buffer, slice) = create_screen_fill_triangle(factory);
+
+        let sampler = factory.create_sampler(
+            gfx::tex::SamplerInfo::new(gfx::tex::FilterMethod::Scale,
+                                       gfx::tex::WrapMode::Clamp)
+        );
+
+        let inverse_texture_size = factory.create_constant_buffer(1);
+
+        FXAA {
+            slice: slice,
+            buffer: buffer,
+            sampler: sampler,
+            pso: factory.create_pipeline_simple(
+                FXAA_VERTEX_SRC,
+                FXAA_FRAGMENT_SRC,
+                fxaa::new()
+            ).unwrap(),
+            inverse_texture_size: inverse_texture_size,
+        }
+    }
+}
+
+impl<R> ::Pass<R> for FXAA<R>
+    where R: gfx::Resources,
+{
+    type Arg = ::pass::FXAA;
+    type Target = ::target::ColorBuffer<R>;
+
+    fn apply<C>(&self, arg: &::pass::FXAA, target: &::target::ColorBuffer<R>, scenes: &::Frame<R>, encoder: &mut gfx::Encoder<R, C>)
+        where C: gfx::CommandBuffer<R>
+    {
+        let src = &scenes.targets[&arg.source];
+        let src = src.downcast_ref::<::target::ColorBuffer<R>>().unwrap();
+
+        let layer = src.texture_color.clone();
+        let layer = layer.unwrap();
+
+        encoder.update_constant_buffer(
+            &self.inverse_texture_size,
+            &FXAAArg {
+                inverse_texture_size: arg.inverse_texture_size,
+            },
+        );
+
+        encoder.draw(
+            &self.slice,
+            &self.pso,
+            &fxaa::Data {
+                vbuf: self.buffer.clone(),
+                source: (layer, self.sampler.clone()),
+                out: target.color.clone(),
+                inverse_texture_size: self.inverse_texture_size.clone(),
+            }
+        );
+    }
+}
+
+pub static NULL_VERTEX_SRC: &'static [u8] = b"
+    #version 150 core
+
+    in vec2 a_Pos;
+    in vec2 a_TexCoord;
+    out vec2 v_TexCoord;
+
+    void main() {
+        v_TexCoord = a_TexCoord;
+        gl_Position = vec4(a_Pos, 0.0, 1.0);
+    }
+";
+
+pub static NULL_FRAGMENT_SRC: &'static [u8] = b"
+    #version 150 core
+
+    uniform sampler2D t_Source;
+
+    in vec2 v_TexCoord;
+    out vec4 o_Color;
+
+    void main() {
+        o_Color = texture(t_Source, v_TexCoord);
+    }
+";
+
+pub struct Null<R: gfx::Resources> {
+    buffer: Buffer<R, Vertex>,
+    slice: Slice<R>,
+    sampler: gfx::handle::Sampler<R>,
+    pso: gfx::pso::PipelineState<R, null::Meta>,
+}
+
+impl<R> Null<R>
+    where R: gfx::Resources
+{
+    pub fn new<F>(factory: &mut F) -> Null<R>
+        where F: gfx::Factory<R>
+    {
+        let (buffer, slice) = create_screen_fill_triangle(factory);
+
+        let sampler = factory.create_sampler(
+            gfx::tex::SamplerInfo::new(gfx::tex::FilterMethod::Scale,
+                                       gfx::tex::WrapMode::Clamp)
+        );
+
+        Null {
+            slice: slice,
+            buffer: buffer,
+            sampler: sampler,
+            pso: factory.create_pipeline_simple(
+                NULL_VERTEX_SRC,
+                NULL_FRAGMENT_SRC,
+                null::new()
+            ).unwrap(),
+        }
+    }
+}
+
+impl<R> ::Pass<R> for Null<R>
+    where R: gfx::Resources,
+{
+    type Arg = ::pass::Null;
+    type Target = ::target::ColorBuffer<R>;
+
+    fn apply<C>(&self, arg: &::pass::Null, target: &::target::ColorBuffer<R>, scenes: &::Frame<R>, encoder: &mut gfx::Encoder<R, C>)
+        where C: gfx::CommandBuffer<R>
+    {
+        let src = &scenes.targets[&arg.source];
+        let src = src.downcast_ref::<::target::ColorBuffer<R>>().unwrap();
+
+        let layer = src.texture_color.clone();
+        let layer = layer.unwrap();
+
+        encoder.draw(
+            &self.slice,
+            &self.pso,
+            &null::Data {
+                vbuf: self.buffer.clone(),
+                source: (layer, self.sampler.clone()),
+                out: target.color.clone(),
+            }
+        );
+    }
+}

--- a/src/renderer/src/pass/filters.rs
+++ b/src/renderer/src/pass/filters.rs
@@ -61,10 +61,10 @@ pub static FXAA_FRAGMENT_SRC: &'static [u8] = b"
 
         vec3 luma = vec3(0.2126, 0.7152, 0.0722);
         float lumaM = dot(texture(t_Source, v_TexCoord).xyz, luma);
-        float lumaTL = dot(texture(t_Source, v_TexCoord + (vec2(-1.0, -1.0) * u_InverseTextureSize)).xyz, luma);
-        float lumaTR = dot(texture(t_Source, v_TexCoord + (vec2( 1.0, -1.0) * u_InverseTextureSize)).xyz, luma);
-        float lumaBR = dot(texture(t_Source, v_TexCoord + (vec2( 1.0,  1.0) * u_InverseTextureSize)).xyz, luma);
-        float lumaBL = dot(texture(t_Source, v_TexCoord + (vec2(-1.0,  1.0) * u_InverseTextureSize)).xyz, luma);
+        float lumaTL = dot(textureOffset(t_Source, v_TexCoord, ivec2(-1, -1)).xyz, luma);
+        float lumaTR = dot(textureOffset(t_Source, v_TexCoord, ivec2( 1, -1)).xyz, luma);
+        float lumaBR = dot(textureOffset(t_Source, v_TexCoord, ivec2( 1,  1)).xyz, luma);
+        float lumaBL = dot(textureOffset(t_Source, v_TexCoord, ivec2(-1,  1)).xyz, luma);
 
         vec2 dir;
         dir.x = -((lumaTL + lumaTR) - (lumaBL + lumaBR));

--- a/src/renderer/src/pass/forward.rs
+++ b/src/renderer/src/pass/forward.rs
@@ -201,7 +201,7 @@ impl<R> Pass<R> for Clear
         where C: gfx::CommandBuffer<R>
     {
         encoder.clear(&target.color, arg.color);
-        encoder.clear_depth(&target.output_depth, 1.0);
+        encoder.clear_depth(&target.depth, 1.0);
     }
 }
 
@@ -263,17 +263,19 @@ impl<R> Pass<R> for DrawFlat<R>
             let ka = e.ka.to_view(&self.ka, encoder);
             let kd = e.kd.to_view(&self.kd, encoder);
 
-            encoder.draw(&e.slice,
-                         &self.pso,
-                         &flat::Data {
-                             vbuf: e.buffer.clone(),
-                             vertex_args: self.vertex.clone(),
-                             fragment_args: self.fragment.clone(),
-                             out_ka: target.color.clone(),
-                             out_depth: target.output_depth.clone(),
-                             ka: (ka, self.sampler.clone()),
-                             kd: (kd, self.sampler.clone()),
-                         });
+            encoder.draw(
+                &e.slice,
+                &self.pso,
+                &flat::Data{
+                    vbuf: e.buffer.clone(),
+                    vertex_args: self.vertex.clone(),
+                    fragment_args: self.fragment.clone(),
+                    out_ka: target.color.clone(),
+                    out_depth: target.depth.clone(),
+                    ka: (ka, self.sampler.clone()),
+                    kd: (kd, self.sampler.clone()),
+                }
+            );
         }
     }
 }
@@ -364,18 +366,20 @@ impl<R> Pass<R> for DrawShaded<R>
             let ka = e.ka.to_view(&self.ka, encoder);
             let kd = e.kd.to_view(&self.kd, encoder);
 
-            encoder.draw(&e.slice,
-                         &self.pso,
-                         &shaded::Data {
-                             vbuf: e.buffer.clone(),
-                             fragment_args: self.fragment.clone(),
-                             vertex_args: self.vertex.clone(),
-                             lights: self.lights.clone(),
-                             out_ka: target.color.clone(),
-                             out_depth: target.output_depth.clone(),
-                             ka: (ka, self.sampler.clone()),
-                             kd: (kd, self.sampler.clone()),
-                         });
+            encoder.draw(
+                &e.slice,
+                &self.pso,
+                &shaded::Data{
+                    vbuf: e.buffer.clone(),
+                    fragment_args: self.fragment.clone(),
+                    vertex_args: self.vertex.clone(),
+                    lights: self.lights.clone(),
+                    out_ka: target.color.clone(),
+                    out_depth: target.depth.clone(),
+                    ka: (ka, self.sampler.clone()),
+                    kd: (kd, self.sampler.clone()),
+                }
+            );
         }
     }
 }

--- a/src/renderer/src/pass/mod.rs
+++ b/src/renderer/src/pass/mod.rs
@@ -1,5 +1,6 @@
 pub mod forward;
 pub mod deferred;
+pub mod filters;
 
 use std;
 use gfx;
@@ -144,6 +145,48 @@ impl BlitLayer {
         Box::new(BlitLayer {
             gbuffer: String::from(gbuffer),
             layer: String::from(layer),
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+/// Perform an FXAA on a texture
+pub struct FXAA {
+    /// the source to perform FXAA on
+    pub source: String,
+    pub inverse_texture_size: [f32; 2],
+}
+
+impl PassDescription for FXAA {}
+
+impl FXAA {
+    /// Create a boxed FXAA
+    pub fn new<A>(source: A, (width, height): (u32, u32)) -> Box<PassDescription>
+        where String: From<A>
+    {
+        Box::new(FXAA {
+            source: String::from(source),
+            inverse_texture_size: [1. / width as f32, 1. / height as f32],
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+/// Blit pixels from source to target
+pub struct Null {
+    /// the source to perform blit from
+    pub source: String,
+}
+
+impl PassDescription for Null {}
+
+impl Null {
+    /// Create a boxed Null
+    pub fn new<A>(source: A) -> Box<PassDescription>
+        where String: From<A>
+    {
+        Box::new(Null {
+            source: String::from(source),
         })
     }
 }

--- a/src/renderer/src/target.rs
+++ b/src/renderer/src/target.rs
@@ -18,7 +18,43 @@ pub struct ColorBuffer<R: gfx::Resources> {
     /// The color render target
     pub color: gfx::handle::RenderTargetView<R, ColorFormat>,
     /// The depth buffer
-    pub output_depth: gfx::handle::DepthStencilView<R, DepthFormat>,
+    pub depth: gfx::handle::DepthStencilView<R, DepthFormat>,
+
+    /// The color as a texture
+    pub texture_color: Option<gfx::handle::ShaderResourceView<R, [f32; 4]>>,
+    /// the depth buffer as a texture
+    pub texture_depth: Option<gfx::handle::ShaderResourceView<R, f32>>,
+}
+
+impl<R: gfx::Resources> ColorBuffer<R> {
+    /// Create a new ColorBuffer with the supplied factory
+    /// the target will be allocated to the supplied width and height
+    pub fn new<F>(factory: &mut F, (width, height): (u16, u16)) -> Self
+        where F: gfx::Factory<R>
+    {
+        let (_, texture_color,  color) = factory.create_render_target(width, height).unwrap();
+        let (_, texture_depth,  depth) = factory.create_depth_stencil(width, height).unwrap();
+
+        ColorBuffer {
+            color: color,
+            depth: depth,
+            texture_color: Some(texture_color),
+            texture_depth: Some(texture_depth),
+        }
+    }
+
+    /// Create a new screen ColorBuffer with the main color and main depth targets,
+    /// everything rendered to this target will be shown on the screen after the window.swap_buffers() call
+    pub fn new_screen(main_color: gfx::handle::RenderTargetView<R, ColorFormat>,
+               main_depth: gfx::handle::DepthStencilView<R, DepthFormat>) -> Self
+    {
+        ColorBuffer {
+            color: main_color,
+            depth: main_depth,
+            texture_color: None,
+            texture_depth: None,
+        }
+    }
 }
 
 impl<R: gfx::Resources> Target for ColorBuffer<R> {}


### PR DESCRIPTION
Changes:
- Add support for render targets (`AssetManager::get_color_buffer` and `AssetManager::get_geometry_buffer` methods are used to create them)
- Add `Null` filter pass and `FXAA` filter pass

Problems:
When rendering with a filter pass (`Null` or `FXAA`) there is color bending, like this:
`FXAA` filter pass:
![sphere_color_bending](https://cloud.githubusercontent.com/assets/1885232/19214727/451ace84-8d9b-11e6-9c3e-2e70b0c93aed.png)

No `FXAA` filter pass:
![sphere](https://cloud.githubusercontent.com/assets/1885232/19214726/4111b10e-8d9b-11e6-91d0-1e59ab6e9a3f.png)
