### PR TITLE
Make Transform a wrapper instead of using getter/setters

### DIFF
--- a/examples/03_renderable/main.rs
+++ b/examples/03_renderable/main.rs
@@ -90,7 +90,7 @@ impl State for Example {
         // Test Transform mutation
         let mut locals = world.write::<LocalTransform>();
         for local in (&mut locals).iter() {
-            local.set_translation([phase.sin(), 0.0, phase.cos()]);
+            local.translation = [phase.sin(), 0.0, phase.cos()];
         }
 
         let angular_velocity_light = 0.5;

--- a/examples/04_pong/main.rs
+++ b/examples/04_pong/main.rs
@@ -139,7 +139,7 @@ impl Processor<Arc<Mutex<Context>>> for PongProcessor {
                         }
                     }
                     // Set translation[0] of renderable corresponding to this plank
-                    local.set_translation_index(0, left_boundary + plank.dimensions[0]/2.);
+                    local.translation[0] = left_boundary + plank.dimensions[0]/2.0
                 }
                 // If it is a right plank
                 Side::Right => {
@@ -160,13 +160,13 @@ impl Processor<Arc<Mutex<Context>>> for PongProcessor {
                         }
                     }
                     // Set translation[0] of renderable corresponding to this plank
-                    local.set_translation_index(0, right_boundary - plank.dimensions[0]/2.)
+                    local.translation[0] = right_boundary - plank.dimensions[0]/2.0
                 }
             };
             // Set translation[1] of renderable corresponding to this plank
-            local.set_translation_index(1, plank.position);
+            local.translation[1] = plank.position;
             // Set scale for renderable corresponding to this plank
-            local.set_scale([plank.dimensions[0], plank.dimensions[1], 1.0])
+            local.scale = [plank.dimensions[0], plank.dimensions[1], 1.0];
         }
 
         // Process the ball
@@ -224,10 +224,10 @@ impl Processor<Arc<Mutex<Context>>> for PongProcessor {
             }
 
             // Update the renderable corresponding to this ball
-            local.set_translation_index(0, ball.position[0]);
-            local.set_translation_index(1, ball.position[1]);
-            local.set_scale_index(0, ball.size);
-            local.set_scale_index(1, ball.size);
+            local.translation[0] = ball.position[0];
+            local.translation[1] = ball.position[1];
+            local.scale[0] = ball.size;
+            local.scale[1] = ball.size;
         }
     }
 }

--- a/src/processors/transform.rs
+++ b/src/processors/transform.rs
@@ -10,94 +10,45 @@ use context::Context;
 use std::sync::{Mutex, Arc};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::collections::{HashMap, HashSet};
+use std::ops::{Deref, DerefMut};
+
+#[derive(Debug)]
+pub struct InnerTransform {
+    /// Translation/position vector [x, y, z]
+    pub translation: [f32; 3],
+
+    /// Quaternion [w (scalar), x, y, z]
+    pub rotation: [f32; 4],
+
+    /// Scale vector [x, y, z]
+    pub scale: [f32; 3],
+}
 
 /// Local position, rotation, and scale (from parent if it exists).
 #[derive(Debug)]
 pub struct LocalTransform {
-    /// Translation/position vector [x, y, z]
-    translation: [f32; 3],
-
-    /// Quaternion [w (scalar), x, y, z]
-    rotation: [f32; 4],
-
-    /// Scale vector [x, y, z]
-    scale: [f32; 3],
+    /// Wrapper around the transform data for dirty flag setting.
+    wrapped: InnerTransform,
 
     /// Flag for re-computation
     dirty: AtomicBool,
 }
 
+impl Deref for LocalTransform {
+    type Target = InnerTransform;
+    fn deref(&self) -> &InnerTransform {
+        &self.wrapped
+    }
+}
+
+impl DerefMut for LocalTransform {
+    fn deref_mut(&mut self) -> &mut InnerTransform {
+        self.flag(true);
+        &mut self.wrapped
+    }
+}
+
 impl LocalTransform {
-    #[inline]
-    pub fn translation(&self) -> [f32; 3] {
-        self.translation
-    }
-    #[inline]
-    pub fn rotation(&self) -> [f32; 4] {
-        self.rotation
-    }
-    #[inline]
-    pub fn scale(&self) -> [f32; 3] {
-        self.scale
-    }
-    #[inline]
-    pub fn set_translation(&mut self, translation: [f32; 3]) {
-        self.translation = translation;
-        self.flag(true);
-    }
-    #[inline]
-    pub fn set_rotation(&mut self, rotation: [f32; 4]) {
-        self.rotation = rotation;
-        self.flag(true);
-    }
-    #[inline]
-    pub fn set_scale(&mut self, scale: [f32; 3]) {
-        self.scale = scale;
-        self.flag(true);
-    }
-
-    /// Set a specific part of the translation/position without modifying the others
-    /// (must be an index less than 3).
-    ///
-    /// Format: [0 = x, 1 = y, 2 = z]
-    ///
-    /// e.g. `transform.set_translation_index(1, 5.0)` sets `y` to `5.0`
-    #[inline]
-    pub fn set_translation_index(&mut self, index: usize, val: f32) {
-        assert!(index < 3,
-                "Attempted to use `set_pos_index` with an index higher than 2");
-        self.translation[index] = val;
-        self.flag(true);
-    }
-
-    /// Set a specific part of the rotation quaternion without modifying the others
-    /// (must be an index less than 4).
-    ///
-    /// Format: [0 = w, 1 = x, 2 = y, 3 = z]
-    ///
-    /// e.g. `transform.set_rot_index(1, 0.0)` sets `x` to `0.0`
-    #[inline]
-    pub fn set_rotation_index(&mut self, index: usize, val: f32) {
-        assert!(index < 4,
-                "Attempted to use `set_rot_index` with an index higher than 3");
-        self.rotation[index] = val;
-        self.flag(true);
-    }
-
-    /// Set a specific part of the scale without modifying the others
-    /// (must be an index less than 3).
-    ///
-    /// Format: [0 = x, 1 = y, 2 = z]
-    ///
-    /// e.g. `transform.set_scale_index(2, 3.0)` sets `z` to `3.0`
-    #[inline]
-    pub fn set_scale_index(&mut self, index: usize, val: f32) {
-        assert!(index < 3,
-                "Attempted to use `set_scale_index` with an index higher than 2");
-        self.scale[index] = val;
-        self.flag(true);
-    }
-
     /// Flags the current transform for re-computation.
     ///
     /// Note: All `set_*` methods will automatically flag the component.
@@ -133,9 +84,11 @@ impl LocalTransform {
 impl Default for LocalTransform {
     fn default() -> Self {
         LocalTransform {
-            translation: [0.0, 0.0, 0.0],
-            rotation: [1.0, 0.0, 0.0, 0.0],
-            scale: [1.0, 1.0, 1.0],
+            wrapped: InnerTransform {
+                translation: [0.0, 0.0, 0.0],
+                rotation: [1.0, 0.0, 0.0, 0.0],
+                scale: [1.0, 1.0, 1.0],
+            },
             dirty: AtomicBool::new(true),
         }
     }
@@ -395,9 +348,9 @@ mod tests {
     #[test]
     fn transform_matrix() {
         let mut transform = LocalTransform::default();
-        transform.set_translation([5.0, 2.0, -0.5]);
-        transform.set_rotation([1.0, 0.0, 0.0, 0.0]);
-        transform.set_scale([2.0, 2.0, 2.0]);
+        transform.translation = [5.0, 2.0, -0.5];
+        transform.rotation = [1.0, 0.0, 0.0, 0.0];
+        transform.scale = [2.0, 2.0, 2.0];
 
         let decomposed = Decomposed {
             rot: Quaternion::from(transform.rotation),


### PR DESCRIPTION
Should just simplify the usage of the transform system.