### PR TITLE
add [workspace] to top level Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,5 @@ gfx = "0.11"
 
 [dependencies]
 cgmath="0.11"
+
+[workspace]


### PR DESCRIPTION
This signals to cargo that the top level Cargo.toml project should
be treated as a workspace.

The projects added as dependencies are implicit members of the
workspace.

This ends up fixing issue #116 by causing dev-dependencies to be
downloaded into the projects shared target folder.