### PR TITLE
[WIP] Update gfx to master branch and use IDs for textures and meshes

### DIFF
--- a/examples/02_sphere/main.rs
+++ b/examples/02_sphere/main.rs
@@ -7,7 +7,8 @@ use amethyst::engine::{Application, State, Trans};
 use amethyst::context::{ContextConfig, Context};
 use amethyst::config::Element;
 use amethyst::ecs::{World, Join};
-use amethyst::context::asset_manager::{Mesh, Texture};
+use amethyst::context::asset_manager::{Mesh};
+use amethyst::renderer::{Texture};
 
 struct Example;
 

--- a/examples/03_renderable/main.rs
+++ b/examples/03_renderable/main.rs
@@ -6,7 +6,8 @@ use amethyst::processors::transform::{TransformProcessor, Child, Init, Transform
 use amethyst::context::Context;
 use amethyst::config::Element;
 use amethyst::ecs::{World, Join};
-use amethyst::context::asset_manager::{Mesh, Texture};
+use amethyst::context::asset_manager::Mesh;
+use amethyst::renderer::Texture;
 
 struct Example {
     t: f32,

--- a/examples/04_pong/main.rs
+++ b/examples/04_pong/main.rs
@@ -7,7 +7,8 @@ use amethyst::context::Context;
 use amethyst::config::Element;
 use amethyst::ecs::{World, Join, VecStorage, Component, Processor, RunArg};
 use std::sync::{Mutex, Arc};
-use amethyst::context::asset_manager::{Mesh, Texture};
+use amethyst::context::asset_manager::Mesh;
+use amethyst::renderer::Texture;
 
 struct Pong;
 

--- a/examples/06_assets/main.rs
+++ b/examples/06_assets/main.rs
@@ -6,8 +6,8 @@ use amethyst::engine::{Application, State, Trans};
 use amethyst::context::{ContextConfig, Context};
 use amethyst::config::Element;
 use amethyst::ecs::{World, Join};
-use amethyst::context::asset_manager::{Assets, AssetLoader, AssetLoaderRaw, DirectoryStore, Mesh, Texture};
-use amethyst::renderer::VertexPosNormal;
+use amethyst::context::asset_manager::{Assets, AssetLoader, AssetLoaderRaw, DirectoryStore, Mesh};
+use amethyst::renderer::{VertexPosNormal, Texture};
 use cgmath::{InnerSpace, Vector3};
 use std::io::BufReader;
 

--- a/src/context/Cargo.toml
+++ b/src/context/Cargo.toml
@@ -24,11 +24,11 @@ path = "../ecs/"
 version = "0.1.0"
 
 [dependencies]
-gfx = "0.11"
-gfx_core = "0.3"
-gfx_device_gl = "0.10"
-gfx_window_glutin = "0.11"
-glutin = "0.5"
+gfx = { git = "https://github.com/gfx-rs/gfx" }
+gfx_core = { git = "https://github.com/gfx-rs/gfx" }
+gfx_device_gl = { git = "https://github.com/gfx-rs/gfx" }
+gfx_window_glutin = { git = "https://github.com/gfx-rs/gfx" }
+glutin = "0.7"
 time = "0.1"
 genmesh="0.4"
 cgmath="0.11"

--- a/src/context/Cargo.toml
+++ b/src/context/Cargo.toml
@@ -24,10 +24,10 @@ path = "../ecs/"
 version = "0.1.0"
 
 [dependencies]
-gfx = { git = "https://github.com/gfx-rs/gfx" }
-gfx_core = { git = "https://github.com/gfx-rs/gfx" }
-gfx_device_gl = { git = "https://github.com/gfx-rs/gfx" }
-gfx_window_glutin = { git = "https://github.com/gfx-rs/gfx" }
+gfx = { git = "https://github.com/gfx-rs/gfx", rev = "4cc8d52"}
+gfx_core = { git = "https://github.com/gfx-rs/gfx", rev = "4cc8d52"}
+gfx_device_gl = { git = "https://github.com/gfx-rs/gfx", rev = "4cc8d52"}
+gfx_window_glutin = { git = "https://github.com/gfx-rs/gfx", rev = "4cc8d52"}
 glutin = "0.7"
 time = "0.1"
 genmesh="0.4"

--- a/src/context/src/lib.rs
+++ b/src/context/src/lib.rs
@@ -38,7 +38,7 @@ pub mod input;
 mod video_init;
 use video_context::{VideoContext, DisplayConfig};
 use renderer::Renderer;
-use asset_manager::{AssetManager, FactoryImpl};
+use asset_manager::{AssetManager};
 use input::InputHandler;
 use broadcaster::Broadcaster;
 use event::EngineEvent;
@@ -72,7 +72,7 @@ impl Context {
         let (video_context, factory_impl) = video_init::create_video_context_and_factory_impl(config.display_config);
         let renderer = Renderer::new(video_context);
         let mut asset_manager = AssetManager::new();
-        asset_manager.add_loader::<FactoryImpl>(factory_impl);
+        asset_manager.add_loader::<video_init::FactoryStream>(factory_impl);
         let mut broadcaster = Broadcaster::new();
         broadcaster.register::<EngineEvent>();
 

--- a/src/context/src/video_context.rs
+++ b/src/context/src/video_context.rs
@@ -33,8 +33,8 @@ pub enum VideoContext {
     OpenGL {
         window: glutin::Window,
         device: gfx_device_gl::Device,
-        renderer: Renderer<gfx_device_gl::Resources, gfx_device_gl::CommandBuffer>,
-        frame: Frame<gfx_device_gl::Resources>,
+        renderer: Renderer<gfx_device_gl::Resources, gfx_device_gl::CommandBuffer, gfx_device_gl::Factory>,
+        frame: Frame,
     },
 
     #[cfg(windows)]

--- a/src/ecs/Cargo.toml
+++ b/src/ecs/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 time = "^0.1"
-specs = "^0.7.0"
+specs = { path = "../../../specs" } #"^0.7.0"
 
 [[example]]
 name = "usage"

--- a/src/ecs/Cargo.toml
+++ b/src/ecs/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 time = "^0.1"
-specs = { path = "../../../specs" } #"^0.7.0"
+specs = { git = "https://github.com/msiglreith/specs", branch = "alloc" } #"^0.7.0"
 
 [[example]]
 name = "usage"

--- a/src/renderer/Cargo.toml
+++ b/src/renderer/Cargo.toml
@@ -13,13 +13,17 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-gfx = "0.11"
-gfx_core = "0.3"
-gfx_device_gl = "0.10"
-gfx_window_glutin = "0.11"
-glutin = "0.5"
+gfx = { git = "https://github.com/gfx-rs/gfx" }
+gfx_core = { git = "https://github.com/gfx-rs/gfx" }
+gfx_device_gl = { git = "https://github.com/gfx-rs/gfx" }
+gfx_window_glutin = { git = "https://github.com/gfx-rs/gfx" }
+glutin = "0.7"
 cgmath="0.11"
 mopa ="0.2"
+
+[dependencies.amethyst_ecs]
+path = "../ecs/"
+version = "0.1.0"
 
 [dev-dependencies]
 genmesh = "0.4"

--- a/src/renderer/Cargo.toml
+++ b/src/renderer/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-gfx = { git = "https://github.com/gfx-rs/gfx" }
-gfx_core = { git = "https://github.com/gfx-rs/gfx" }
-gfx_device_gl = { git = "https://github.com/gfx-rs/gfx" }
-gfx_window_glutin = { git = "https://github.com/gfx-rs/gfx" }
+gfx = { git = "https://github.com/gfx-rs/gfx", rev = "4cc8d52"}
+gfx_core = { git = "https://github.com/gfx-rs/gfx", rev = "4cc8d52"}
+gfx_device_gl = { git = "https://github.com/gfx-rs/gfx", rev = "4cc8d52"}
+gfx_window_glutin = { git = "https://github.com/gfx-rs/gfx", rev = "4cc8d52"}
 glutin = "0.7"
 cgmath="0.11"
 mopa ="0.2"

--- a/src/renderer/src/lib.rs
+++ b/src/renderer/src/lib.rs
@@ -7,19 +7,32 @@
 
 #[macro_use]
 extern crate gfx;
+extern crate gfx_core;
+extern crate gfx_device_gl;
 #[macro_use]
 extern crate mopa;
 
 extern crate glutin;
 extern crate cgmath;
 
+extern crate amethyst_ecs;
+
 /// Contains the included Render Targets
 pub mod target;
 /// Contains the included Passes
 pub mod pass;
 
+use self::amethyst_ecs::{Allocator, Entity};
+
 use std::any::TypeId;
-use std::collections::HashMap;
+use std::collections::{HashMap};
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::Arc;
+use std::cell::RefCell;
+
+use gfx::{buffer, format, handle, mapping, texture, Factory};
+use gfx_core::handle::Producer;
+use gfx_core::memory::Typed;
 
 pub use pass::PassDescription;
 pub use target::Target;
@@ -28,13 +41,247 @@ pub use pass::Pass;
 /// A Renderer manages passes and the execution of the passes
 /// over the targets. It only contains the passes, all other
 /// data is contained in the `Frame`
-pub struct Renderer<R: gfx::Resources, C: gfx::CommandBuffer<R>> {
+pub struct Renderer<R: gfx::Resources, C: gfx::CommandBuffer<R>, F: gfx::Factory<R>> {
     command_buffer: gfx::Encoder<R, C>,
     passes: HashMap<(TypeId, TypeId),
-                    Box<Fn(&Box<PassDescription>,
+                    Box<Fn(&mut ResourceCache<R>,
+                           &Box<PassDescription>,
                            &Target,
-                           &Frame<R>,
+                           &Frame,
                            &mut gfx::Encoder<R, C>)>>,
+    factory_sink: GpuFactorySink<R, F>,
+    resources: ResourceCache<R>,
+}
+
+pub struct ResourceCache<R: gfx::Resources> {
+    srvs: HashMap<Entity, gfx::handle::RawShaderResourceView<R>>,
+    buffers: HashMap<Entity, gfx::handle::RawBuffer<R>>,
+
+    handles: handle::Manager<Resources>,
+}
+
+impl<R: gfx::Resources> ResourceCache<R> {
+    pub fn new() -> ResourceCache<R> {
+        ResourceCache {
+            srvs: HashMap::new(),
+            buffers: HashMap::new(),
+            handles: handle::Manager::new(),
+        }
+    }
+
+    pub fn get_srv(&mut self, id: &gfx::handle::RawShaderResourceView<Resources>) -> gfx::handle::RawShaderResourceView<R> {
+        let id = self.handles.ref_srv(id);
+        self.srvs.get(id).unwrap().clone()
+    }
+
+    pub fn get_slice(&mut self, slice: &gfx::Slice<Resources>) -> gfx::Slice<R> {
+        use gfx::IndexBuffer;
+        let buffer = match slice.buffer {
+            IndexBuffer::Auto => IndexBuffer::Auto,
+            IndexBuffer::Index16(ref buf) => {
+                let id = self.handles.ref_buffer(buf.raw());
+                IndexBuffer::Index16(gfx::handle::Buffer::new(self.buffers.get(id).unwrap().clone()))
+            }
+            IndexBuffer::Index32(ref buf) => {
+                let id = self.handles.ref_buffer(buf.raw());
+                IndexBuffer::Index32(gfx::handle::Buffer::new(self.buffers.get(id).unwrap().clone()))
+            }
+        };
+
+        gfx::Slice {
+            start: slice.start,
+            end: slice.end,
+            base_vertex: slice.base_vertex,
+            instances: slice.instances,
+            buffer: buffer,
+        }
+    }
+
+    pub fn get_buffer(&mut self, id: &gfx::handle::RawBuffer<Resources>) -> gfx::handle::RawBuffer<R> {
+        let id = self.handles.ref_buffer(id);
+        self.buffers.get(id).unwrap().clone()
+    }
+}
+
+pub enum GpuFactoryCmd<R: gfx::Resources> {
+    CmdCreateBuffer(handle::RawBuffer<Resources>),
+    CmdCreateImmutableBuffer(handle::RawBuffer<Resources>, Vec<u8>),
+    CmdCreateTexture(handle::RawShaderResourceView<Resources>, Option<Vec<u8>>),
+
+    CmdAddBuffer(handle::RawBuffer<R>),
+    CmdAddTexture(handle::RawShaderResourceView<R>),
+}
+
+pub struct GpuFactorySink<R: gfx::Resources, F: gfx::Factory<R>> {
+    receiver: Receiver<(Entity, GpuFactoryCmd<R>)>,
+    factory: F,
+    _marker: std::marker::PhantomData<R>,
+}
+
+pub trait ParallelFactory<R: gfx::Resources> {
+    type Factory;
+
+    fn create_buffer_raw(factory: &mut Self::Factory, buffer: &handle::RawBuffer<Resources>) -> Result<GpuFactoryCmd<R>, buffer::CreationError>;
+    fn create_buffer_immutable_raw(factory: &mut Self::Factory, buffer: &handle::RawBuffer<Resources>, data: &[u8])
+                               -> Result<GpuFactoryCmd<R>, buffer::CreationError>;
+
+}
+
+impl ParallelFactory<gfx_device_gl::Resources> for gfx_device_gl::Resources {
+    type Factory = ();
+    fn create_buffer_raw(factory: &mut Self::Factory, buffer: &handle::RawBuffer<Resources>) -> Result<GpuFactoryCmd<gfx_device_gl::Resources>, buffer::CreationError> {
+        Ok(GpuFactoryCmd::CmdCreateBuffer(buffer.clone()))
+    }
+    fn create_buffer_immutable_raw(factory: &mut Self::Factory, buffer: &handle::RawBuffer<Resources>, data: &[u8])
+                               -> Result<GpuFactoryCmd<gfx_device_gl::Resources>, buffer::CreationError>
+    {
+        Ok(GpuFactoryCmd::CmdCreateImmutableBuffer(buffer.clone(), data.to_vec()))
+    }
+}
+
+pub struct GpuFactoryStream<R: gfx::Resources + ParallelFactory<R>> {
+    sender: Sender<(Entity, GpuFactoryCmd<R>)>,
+    allocator: Arc<Allocator>,
+    handles: Arc<RefCell<handle::Manager<Resources>>>,
+    parallel_factory: R::Factory,
+}
+
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum Resources {}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub struct Fence;
+impl gfx_core::Fence for Fence {
+    fn wait(&self) { unimplemented!() }
+}
+
+#[derive(Debug)]
+pub struct MappingGate;
+impl mapping::Gate<Resources> for MappingGate {
+    unsafe fn set<T>(&self, index: usize, val: T) { unimplemented!() }
+    unsafe fn slice<'a, 'b, T>(&'a self, len: usize) -> &'b [T] { unimplemented!() }
+    unsafe fn mut_slice<'a, 'b, T>(&'a self, len: usize) -> &'b mut [T] { unimplemented!() }
+}
+
+impl gfx::Resources for Resources {
+    type Buffer              = Entity;
+    type Shader              = Entity;
+    type Program             = Entity;
+    type PipelineStateObject = Entity;
+    type Texture             = Entity;
+    type RenderTargetView    = Entity;
+    type DepthStencilView    = Entity;
+    type ShaderResourceView  = Entity;
+    type UnorderedAccessView = ();
+    type Sampler             = Entity;
+    type Fence               = Fence;
+    type Mapping             = MappingGate;
+}
+
+impl<R: gfx::Resources + ParallelFactory<R>> Factory<Resources> for GpuFactoryStream<R> {
+    fn get_capabilities(&self) -> &gfx_core::Capabilities {
+        unimplemented!()
+    }
+
+    fn create_buffer_raw(&mut self, info: buffer::Info) -> Result<handle::RawBuffer<Resources>, buffer::CreationError> {
+        let name = self.allocator.allocate_atomic();
+        let buffer = self.handles.borrow_mut().make_buffer(name, info);
+        R::create_buffer_raw(&mut self.parallel_factory, &buffer).map(|cmd| {
+            self.sender.send((name, cmd));
+            buffer
+        })
+    }
+    
+    fn create_buffer_immutable_raw(&mut self, data: &[u8], stride: usize, role: buffer::Role, bind: gfx_core::memory::Bind)
+                               -> Result<handle::RawBuffer<Resources>, buffer::CreationError> {
+        let name = self.allocator.allocate_atomic();
+        let info = buffer::Info {
+            role: role,
+            usage: gfx_core::memory::Usage::Immutable,
+            bind: bind,
+            size: data.len(),
+            stride: stride,
+        };
+        let buffer = self.handles.borrow_mut().make_buffer(name, info);
+        R::create_buffer_immutable_raw(&mut self.parallel_factory, &buffer, data).map(|cmd| {
+            self.sender.send((name, cmd));
+            buffer
+        })
+    }
+
+    fn create_shader(&mut self, _stage: gfx_core::shade::Stage, _code: &[u8])
+                     -> Result<handle::Shader<Resources>, gfx_core::shade::CreateShaderError> {
+        unimplemented!()
+    }
+
+    fn create_program(&mut self, _shader_set: &gfx_core::ShaderSet<Resources>)
+                      -> Result<handle::Program<Resources>, gfx_core::shade::CreateProgramError> {
+        unimplemented!()
+    }
+
+    fn create_pipeline_state_raw(&mut self, _program: &handle::Program<Resources>, _desc: &gfx_core::pso::Descriptor)
+                                 -> Result<handle::RawPipelineState<Resources>, gfx_core::pso::CreationError> {
+        unimplemented!()
+    }
+
+    fn create_texture_raw(&mut self, _desc: texture::Info, _hint: Option<format::ChannelType>, _data_opt: Option<&[&[u8]]>)
+                          -> Result<handle::RawTexture<Resources>, texture::CreationError> {
+        unimplemented!()
+    }
+
+    fn view_buffer_as_shader_resource_raw(&mut self, _hbuf: &handle::RawBuffer<Resources>)
+                                      -> Result<handle::RawShaderResourceView<Resources>, gfx_core::factory::ResourceViewError> {
+        unimplemented!()
+    }
+
+    fn view_buffer_as_unordered_access_raw(&mut self, _hbuf: &handle::RawBuffer<Resources>)
+                                       -> Result<handle::RawUnorderedAccessView<Resources>, gfx_core::factory::ResourceViewError> {
+        unimplemented!()
+    }
+
+    fn view_texture_as_shader_resource_raw(&mut self, _htex: &handle::RawTexture<Resources>, _desc: texture::ResourceDesc)
+                                       -> Result<handle::RawShaderResourceView<Resources>, gfx_core::factory::ResourceViewError> {
+        unimplemented!()
+    }
+
+    fn view_texture_as_unordered_access_raw(&mut self, _htex: &handle::RawTexture<Resources>)
+                                        -> Result<handle::RawUnorderedAccessView<Resources>, gfx_core::factory::ResourceViewError> {
+        unimplemented!()
+    }
+
+    fn view_texture_as_render_target_raw(&mut self, _htex: &handle::RawTexture<Resources>, _desc: texture::RenderDesc)
+                                         -> Result<handle::RawRenderTargetView<Resources>, gfx_core::factory::TargetViewError> {
+        unimplemented!()
+    }
+
+    fn view_texture_as_depth_stencil_raw(&mut self, _htex: &handle::RawTexture<Resources>, _desc: texture::DepthStencilDesc)
+                                         -> Result<handle::RawDepthStencilView<Resources>, gfx_core::factory::TargetViewError> {
+        unimplemented!()
+    }
+
+    fn create_sampler(&mut self, _info: texture::SamplerInfo) -> handle::Sampler<Resources> {
+        unimplemented!()
+    }
+
+    fn map_buffer_raw(&mut self, _buf: &handle::RawBuffer<Resources>, _access: gfx_core::memory::Access)
+                      -> Result<handle::RawMapping<Resources>, mapping::Error> {
+        unimplemented!()
+    }
+
+    fn map_buffer_readable<T: Copy>(&mut self, _buf: &handle::Buffer<Resources, T>)
+                                    -> Result<mapping::Readable<Resources, T>, mapping::Error> {
+        unimplemented!()
+    }
+
+    fn map_buffer_writable<T: Copy>(&mut self, _buf: &handle::Buffer<Resources, T>)
+                                    -> Result<mapping::Writable<Resources, T>, mapping::Error> {
+        unimplemented!()
+    }
+
+    fn map_buffer_rw<T: Copy>(&mut self, _buf: &handle::Buffer<Resources, T>)
+                              -> Result<mapping::RWable<Resources, T>, mapping::Error> {
+        unimplemented!()
+    }
 }
 
 // placeholder
@@ -44,20 +291,77 @@ gfx_vertex_struct!(VertexPosNormal {
     tex_coord: [f32; 2] = "a_TexCoord",
 });
 
-impl<R, C> Renderer<R, C>
-    where R: gfx::Resources,
-          C: gfx::CommandBuffer<R>
+impl<R, C, F> Renderer<R, C, F>
+    where R: gfx::Resources + ParallelFactory<R>,
+          C: gfx::CommandBuffer<R>,
+          F: gfx::Factory<R>,
 {
     /// Create a new Render pipline
-    pub fn new(combuf: C) -> Renderer<R, C> {
-        Renderer {
+    pub fn new(combuf: C, factory: F, parallel_factory: R::Factory) -> (Renderer<R, C, F>, GpuFactoryStream<R>) {
+        let (stream, sink) = Self::build_factory(factory, parallel_factory);
+        let renderer = Renderer {
             command_buffer: combuf.into(),
             passes: HashMap::new(),
+            factory_sink: sink,
+            resources: ResourceCache::new(),
+        };
+        (renderer, stream)
+    }
+
+    pub fn update_resources(&mut self) {
+        let sink = &mut self.factory_sink;
+        loop {
+            if let Ok((id, value)) = sink.receiver.try_recv() {
+                use self::GpuFactoryCmd::*;
+                match value {
+                    CmdCreateBuffer(_) => {
+                        unimplemented!()
+                    }
+                    CmdCreateImmutableBuffer(buffer, data) => {
+                        let info = buffer.get_info();
+                        // TODO(msiglreith): handle error
+                        let buffer = sink.factory.create_buffer_immutable_raw(&data, info.stride, info.role, info.bind).unwrap();
+                        self.resources.buffers.insert(id, buffer);
+                    }
+                    CmdCreateTexture(texture, data_opt) => {
+                        unimplemented!()
+                    }
+
+                    CmdAddBuffer(buffer) => {
+                        self.resources.buffers.insert(id, buffer);
+                    }
+                    CmdAddTexture(texture) => {
+                        self.resources.srvs.insert(id, texture);
+                    }
+                }
+            } else {
+                return;
+            }
         }
     }
 
+    fn build_factory(factory: F, parallel_factory: R::Factory) -> (GpuFactoryStream<R>, GpuFactorySink<R, F>)
+        where F: gfx::Factory<R>
+    {
+        let allocator = Arc::new(Allocator::new());
+        let handles = Arc::new(RefCell::new(handle::Manager::new()));
+        let (tx, rx) = mpsc::channel();
+        let stream = GpuFactoryStream {
+            sender: tx,
+            allocator: allocator.clone(),
+            handles: handles,
+            parallel_factory: parallel_factory,
+        };
+        let sink = GpuFactorySink {
+            receiver: rx,
+            factory: factory,
+            _marker: std::marker::PhantomData,
+        };
+        (stream, sink)
+    }
+
     /// Load all known passes
-    pub fn load_all<F>(&mut self, factory: &mut F)
+    pub fn load_all(&mut self, factory: &mut F)
         where F: gfx::Factory<R>
     {
         self.add_pass(pass::forward::Clear);
@@ -80,23 +384,25 @@ impl<R, C> Renderer<R, C>
     {
         let id = (TypeId::of::<A>(), TypeId::of::<T>());
         self.passes.insert(id,
-                           Box::new(move |a: &Box<PassDescription>, t: &Target, frame: &Frame<R>, encoder: &mut gfx::Encoder<R, C>| {
+                           Box::new(move |r: &mut ResourceCache<R>, a: &Box<PassDescription>, t: &Target, frame: &Frame, encoder: &mut gfx::Encoder<R, C>| {
                                let a = a.downcast_ref::<A>().unwrap();
                                let t = t.downcast_ref::<T>().unwrap();
-                               p.apply(a, t, frame, encoder)
+                               p.apply(r, a, t, frame, encoder)
                            }));
     }
 
     /// Execute all passes
-    pub fn submit<D>(&mut self, frame: &Frame<R>, device: &mut D)
+    pub fn submit<D>(&mut self, frame: &Frame, device: &mut D)
         where D: gfx::Device<Resources = R, CommandBuffer = C>
     {
+        self.update_resources();
+        self.resources.handles.clear();
         for layer in &frame.layers {
             let fb = frame.targets.get(&layer.target).unwrap();
             for desc in &layer.passes {
                 let id = (mopa::Any::get_type_id(&**desc), mopa::Any::get_type_id(&**fb));
                 if let Some(pass) = self.passes.get(&id) {
-                    pass(desc, &**fb, &frame, &mut self.command_buffer);
+                    pass(&mut self.resources, desc, &**fb, &frame, &mut self.command_buffer);
                 } else {
                     panic!("No pass implementation found for target={}, pass={:?}",
                            layer.target,
@@ -121,11 +427,11 @@ impl<R: gfx::Resources> ConstantColorTexture<R> {
     pub fn new<F>(factory: &mut F) -> ConstantColorTexture<R>
         where F: gfx::Factory<R>
     {
-        let kind = gfx::tex::Kind::D2(1, 1, gfx::tex::AaMode::Single);
+        let kind = gfx::texture::Kind::D2(1, 1, gfx::texture::AaMode::Single);
         let text = factory.create_texture::<gfx::format::R8_G8_B8_A8>(kind,
                                                         1,
                                                         gfx::SHADER_RESOURCE,
-                                                        gfx::Usage::Dynamic,
+                                                        gfx::memory::Usage::Dynamic,
                                                         Some(gfx::format::ChannelType::Unorm))
             .unwrap();
         let levels = (0, text.get_info().levels - 1);
@@ -138,14 +444,16 @@ impl<R: gfx::Resources> ConstantColorTexture<R> {
     }
 }
 
+/// A wraper around `Texture` required to
+/// hide all platform specific code from the user.
 #[derive(Clone)]
-pub enum Texture<R: gfx::Resources> {
+pub enum Texture {
     Constant([f32; 4]),
-    Texture(gfx::handle::ShaderResourceView<R, [f32; 4]>),
+    Texture(gfx::handle::ShaderResourceView<Resources, [f32; 4]>),
 }
 
-impl<R: gfx::Resources> Texture<R> {
-    pub fn to_view<C>(&self, texture: &ConstantColorTexture<R>, encoder: &mut gfx::Encoder<R, C>) -> gfx::handle::ShaderResourceView<R, [f32; 4]>
+impl Texture {
+    pub fn to_view<C, R: gfx::Resources>(&self, texture: &ConstantColorTexture<R>, resources: &mut ResourceCache<R>, encoder: &mut gfx::Encoder<R, C>) -> gfx::handle::ShaderResourceView<R, [f32; 4]>
         where C: gfx::CommandBuffer<R>
     {
         match self {
@@ -160,24 +468,24 @@ impl<R: gfx::Resources> Texture<R> {
                     .unwrap();
                 texture.view.clone()
             }
-            &Texture::Texture(ref tex) => tex.clone(),
+            &Texture::Texture(ref tex) => gfx::handle::ShaderResourceView::new(resources.get_srv(tex.raw())),
         }
     }
 }
 
 /// A fragment is the most basic drawable element
-pub struct Fragment<R: gfx::Resources> {
+pub struct Fragment {
     /// The transform matrix to apply to the matrix, this
     /// is sometimes refereed to as the model matrix
     pub transform: [[f32; 4]; 4],
     /// The vertex buffer
-    pub buffer: gfx::handle::Buffer<R, VertexPosNormal>,
+    pub buffer: gfx::handle::Buffer<Resources, VertexPosNormal>,
     /// A slice of the above vertex buffer
-    pub slice: gfx::Slice<R>,
+    pub slice: gfx::Slice<Resources>,
     /// ambient color
-    pub ka: Texture<R>,
+    pub ka: Texture,
     /// diffuse color
-    pub kd: Texture<R>,
+    pub kd: Texture,
 }
 
 /// A basic light
@@ -203,16 +511,16 @@ pub struct Light {
 
 /// A scene is a collection of fragments and
 /// lights that make up the scene.
-pub struct Scene<R: gfx::Resources> {
+pub struct Scene {
     /// A list of fragments
-    pub fragments: Vec<Fragment<R>>,
+    pub fragments: Vec<Fragment>,
     /// A list of lights
     pub lights: Vec<Light>,
 }
 
-impl<R: gfx::Resources> Scene<R> {
+impl Scene {
     /// Create an empty scene
-    pub fn new() -> Scene<R> {
+    pub fn new() -> Scene {
         Scene {
             fragments: vec![],
             lights: vec![],
@@ -281,7 +589,7 @@ impl Layer {
 }
 
 /// The render job submission
-pub struct Frame<R: gfx::Resources> {
+pub struct Frame {
     /// the layers to be processed
     pub layers: Vec<Layer>,
     /// collection of render targets. A target may be
@@ -290,14 +598,14 @@ pub struct Frame<R: gfx::Resources> {
     /// Collection of scenes, having multiple scenes
     /// allows for selection of different fragments
     /// by different passes
-    pub scenes: HashMap<String, Scene<R>>,
+    pub scenes: HashMap<String, Scene>,
     /// Collection of Cameras owned by the scene
     pub cameras: HashMap<String, Camera>,
 }
 
-impl<R: gfx::Resources> Frame<R> {
+impl Frame {
     /// Create an empty Frame
-    pub fn new() -> Frame<R> {
+    pub fn new() -> Frame {
         Frame {
             layers: vec![],
             targets: HashMap::new(),

--- a/src/renderer/src/pass/mod.rs
+++ b/src/renderer/src/pass/mod.rs
@@ -16,7 +16,7 @@ pub trait Pass<R>
 
     /// encode the pass into the encoder using the supplied argument
     /// frame and render target
-    fn apply<C>(&self, arg: &Self::Arg, target: &Self::Target, scene: &::Frame<R>, encoder: &mut gfx::Encoder<R, C>) where C: gfx::CommandBuffer<R>;
+    fn apply<C>(&self, resources: &mut ::ResourceCache<R>, arg: &Self::Arg, target: &Self::Target, scene: &::Frame, encoder: &mut gfx::Encoder<R, C>) where C: gfx::CommandBuffer<R>;
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Gpu resource creation is not possible in multiple threads for some gfx backends like OpenGL. These need to be allocated on the render thread, requiring to refactor the asset manager.
Now we establish a channel between the asset manager and the renderer to send resource creation commands. Depending on the backend the resource creation will be on done on the render thread or on loading the asset.

TODO:
- [x] Upstream `specs` changes to master or fork (`allocate` as pub)
- [x] Use newly publish `gfx` 0.12.2 Edit: Using master branch as 0.12.2 depends `gfx_core 0.4` (not 0.5) 
- [ ] Add documentation
- [ ] Imrove error handling at some points
- [ ] Implement texture loading