### PR TITLE
Removed renderer and engine from Cargo.toml deps.

### DIFF
--- a/book/src/getting_started/manual_cargo_setup.md
+++ b/book/src/getting_started/manual_cargo_setup.md
@@ -47,12 +47,6 @@ as dependencies:
 ```toml
 [dependencies.amethyst]
 path = "../path/to/amethyst/"
-
-[dependencies.amethyst_engine]
-path = "../path/to/amethyst/src/engine/"
-
-[dependencies.amethyst_renderer]
-path = "../path/to/amethyst/src/renderer/"
 ```
 
 ## Resources Folder


### PR DESCRIPTION
Hi there!

I've been keeping my eye on this project for a while and finally found some time to dive in and try running the examples using a local clone of the develop branch and found some build errors. Removing the dependencies amethyst_engine and amethyst_renderer from the Cargo.toml file works for me.

Keep up the good work! :)