### PR TITLE
Render entities which only have Renderable component in `GfxDevice::render_world`

### DIFF
--- a/examples/02_sphere/main.rs
+++ b/examples/02_sphere/main.rs
@@ -24,7 +24,6 @@ impl State for Example {
         use amethyst::renderer::{Layer, Light};
         use amethyst::world_resources::camera::{Projection, Camera};
         use amethyst::world_resources::ScreenDimensions;
-        use amethyst::components::transform::Transform;
         use amethyst::components::rendering::{Texture, Mesh, Renderable};
         let layer =
             Layer::new("main",
@@ -54,7 +53,6 @@ impl State for Example {
         let sphere = asset_manager.create_renderable("sphere", "dark_blue", "green").unwrap();
         world.create_now()
             .with::<Renderable>(sphere)
-            .with::<Transform>(Transform::default())
             .build();
         let light = Light {
             color: [1.0, 1.0, 1.0, 1.0],

--- a/examples/06_assets/main.rs
+++ b/examples/06_assets/main.rs
@@ -45,7 +45,6 @@ impl State for Example {
     fn on_start(&mut self, world: &mut World, asset_manager: &mut AssetManager, pipeline: &mut Pipeline) {
         use amethyst::renderer::pass::{Clear, DrawShaded};
         use amethyst::renderer::{Layer, Light};
-        use amethyst::components::transform::Transform;
         use amethyst::world_resources::camera::{Camera, Projection};
         use amethyst::world_resources::ScreenDimensions;
 
@@ -81,13 +80,11 @@ impl State for Example {
         let renderable = asset_manager.create_renderable("Mesh000", "dark_blue", "green").unwrap();
         world.create_now()
             .with(renderable)
-            .with(Transform::default())
             .build();
 
         let renderable = asset_manager.create_renderable("Mesh001", "dark_blue", "green").unwrap();
         world.create_now()
             .with(renderable)
-            .with(Transform::default())
             .build();
 
         let light = Light {


### PR DESCRIPTION
Now entities with only Renderable component attached to them (not only Renderable, Transform pair) are also rendered.