### PR TITLE
Add gitattributes to prevent line-ending conversion

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.obj binary
+*.custom binary


### PR DESCRIPTION
Our obj/custom loaders currently don't handle non-LF endings correctly, resulting in issues on windows system due to automatic file ending conversion of git.

*.obj/*.custom are now treated as binary blobs (so diffs also shouldn't work anymore)

Fixes #157 