### PR TITLE
Cargo categories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.1"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "Data-oriented game engine written in Rust"
 keywords = ["game", "engine", "sdk", "amethyst"]
+categories = ["game-engines"]
 
 documentation = "https://www.amethyst.rs/doc/amethyst"
 homepage = "https://www.amethyst.rs/"

--- a/src/renderer/Cargo.toml
+++ b/src/renderer/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.1"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "High-level rendering engine with multiple backends"
 keywords = ["game", "engine", "renderer", "3d", "amethyst"]
+categories = ["rendering"]
 
 documentation = "https://www.amethyst.rs/doc/amethyst/"
 homepage = "https://www.amethyst.rs/"

--- a/src/renderer/Cargo.toml
+++ b/src/renderer/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.1"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "High-level rendering engine with multiple backends"
 keywords = ["game", "engine", "renderer", "3d", "amethyst"]
-categories = ["rendering"]
+categories = ["rendering", "rendering::engine"]
 
 documentation = "https://www.amethyst.rs/doc/amethyst/"
 homepage = "https://www.amethyst.rs/"


### PR DESCRIPTION
Just adds some categories for Cargo to use for listing purposes.

List of categories: https://crates.io/category_slugs
Cargo metadata: http://doc.crates.io/manifest.html#package-metadata