### PR TITLE
Fix naming in ApplicationBuilder::with method

### DIFF
--- a/src/engine/app.rs
+++ b/src/engine/app.rs
@@ -194,10 +194,10 @@ impl<T> ApplicationBuilder<T>
         self
     }
 
-    pub fn with<P>(mut self, pro: P, name: &str, pri: Priority) -> ApplicationBuilder<T>
-        where P: System<()> + 'static
+    pub fn with<S>(mut self, sys: S, name: &str, pri: Priority) -> ApplicationBuilder<T>
+        where S: System<()> + 'static
     {
-        self.planner.add_system::<P>(pro, name, pri);
+        self.planner.add_system::<S>(sys, name, pri);
         self
     }
 


### PR DESCRIPTION
Changes:
- Rename `pro`[cessor] argument to `sys`[tem].
- Rename `P`[rocessor] generic parameter to `S`[ystem].