### PR TITLE
Spawn number of threads = to number of virtual cores (for Planner)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ path = "examples/06_assets/main.rs"
 gfx = "0.12"
 
 [dependencies]
+num_cpus = "1.2"
 specs = "0.7"
 cgmath = "0.11"
 dds-rs = "0.1.0"

--- a/src/engine/app.rs
+++ b/src/engine/app.rs
@@ -1,5 +1,6 @@
 //! The core engine framework.
 extern crate specs;
+extern crate num_cpus;
 
 use super::state::{State, StateMachine};
 use super::timing::Stopwatch;
@@ -180,7 +181,7 @@ impl<T> ApplicationBuilder<T>
         ApplicationBuilder {
             initial_state: initial_state,
             display_config: display_config,
-            planner: Planner::new(world, 1),
+            planner: Planner::new(world, self::num_cpus::get()),
         }
     }
 


### PR DESCRIPTION
Changes:
* Use `num_cpus` crate to get number of virtual cores and pass it to `Planner::new()`.