### PR TITLE
Add a `from_string` method to `Element` of the config crate

### DIFF
--- a/examples/02_sphere/main.rs
+++ b/examples/02_sphere/main.rs
@@ -83,17 +83,9 @@ impl State for Example {
 }
 
 fn main() {
-    let cfg = DisplayConfig::from_string(r#"dimensions: null
-fullscreen: false
-max_dimensions: null
-min_dimensions: null
-multisampling: 1
-title: "Sphere example"
-visibility: true
-vsync: true
-"#)
-        .unwrap();
-
+    let path = format!("{}/examples/02_sphere/resources/config.yml",
+                       env!("CARGO_MANIFEST_DIR"));
+    let cfg = DisplayConfig::from_file(path).unwrap();
     let mut game = Application::build(Example, cfg).done();
     game.run();
 }

--- a/examples/02_sphere/main.rs
+++ b/examples/02_sphere/main.rs
@@ -83,9 +83,17 @@ impl State for Example {
 }
 
 fn main() {
-    let path = format!("{}/examples/02_sphere/resources/config.yml",
-                       env!("CARGO_MANIFEST_DIR"));
-    let cfg = DisplayConfig::from_file(path).unwrap();
+    let cfg = DisplayConfig::from_string(r#"dimensions: null
+fullscreen: false
+max_dimensions: null
+min_dimensions: null
+multisampling: 1
+title: "Sphere example"
+visibility: true
+vsync: true
+"#)
+        .unwrap();
+
     let mut game = Application::build(Example, cfg).done();
     game.run();
 }

--- a/src/config/src/yaml.rs
+++ b/src/config/src/yaml.rs
@@ -182,7 +182,7 @@ pub trait Element: Sized {
         let found_path = found[0].clone();
         next_meta.path = found_path.clone();
 
-        let mut file = File::open(found_path.as_path()).map_err(|e| ConfigError::FileError(found_path.clone(), e));
+        let mut file = File::open(found_path.as_path()).map_err(|e| ConfigError::FileError(found_path.clone(), e))?;
         let mut buffer = String::new();
 
         file.read_to_string(&mut buffer)

--- a/src/config/src/yaml.rs
+++ b/src/config/src/yaml.rs
@@ -117,7 +117,7 @@ pub trait Element: Sized {
     fn from_string<'a>(src: &'a str) -> Result<Self, ConfigError> {
         let mut meta = ConfigMeta::default();
         meta.path = PathBuf::from("");
-        let yaml = try!(YamlLoader::load_from_str(src).map_err(|e| ConfigError::YamlScan(e)));
+        let yaml = YamlLoader::load_from_str(src).map_err(|e| ConfigError::YamlScan(e))?;
 
         let hash = if yaml.len() > 0 {
             yaml[0].clone()
@@ -182,13 +182,13 @@ pub trait Element: Sized {
         let found_path = found[0].clone();
         next_meta.path = found_path.clone();
 
-        let mut file = try!(File::open(found_path.as_path()).map_err(|e| ConfigError::FileError(found_path.clone(), e)));
+        let mut file = File::open(found_path.as_path()).map_err(|e| ConfigError::FileError(found_path.clone(), e));
         let mut buffer = String::new();
 
-        try!(file.read_to_string(&mut buffer)
-            .map_err(|e| ConfigError::FileError(found_path.clone(), e)));
+        file.read_to_string(&mut buffer)
+            .map_err(|e| ConfigError::FileError(found_path.clone(), e))?;
 
-        let yaml = try!(YamlLoader::load_from_str(&buffer).map_err(|e| ConfigError::YamlScan(e)));
+        let yaml = YamlLoader::load_from_str(&buffer).map_err(|e| ConfigError::YamlScan(e))?;
 
         let hash = if yaml.len() > 0 {
             yaml[0].clone()

--- a/src/config/src/yaml.rs
+++ b/src/config/src/yaml.rs
@@ -114,7 +114,7 @@ pub trait Element: Sized {
     }
 
     /// From some string (should be used for top level elements if you want to embed the code)
-    fn from_string<'a>(src: &'a str) -> Result<Self, ConfigError> {
+    fn from_string(src: &str) -> Result<Self, ConfigError> {
         let mut meta = ConfigMeta::default();
         meta.path = PathBuf::from("");
         let yaml = YamlLoader::load_from_str(src).map_err(|e| ConfigError::YamlScan(e))?;

--- a/src/config/src/yaml.rs
+++ b/src/config/src/yaml.rs
@@ -113,7 +113,7 @@ pub trait Element: Sized {
         None
     }
 
-    /// From a file relative to current config
+    /// From some string (should be used for top level elements if you want to embed the code)
     fn from_string<'a>(src: &'a str) -> Result<Self, ConfigError> {
         let mut meta = ConfigMeta::default();
         meta.path = PathBuf::from("");


### PR DESCRIPTION
This way, the code of a config file can be embedded into the source file.

I'm trying to get Android support for this engine and this would be one step which is necessary.