### PR TITLE
fix compile error on rust stable

### DIFF
--- a/src/renderer/src/pass/deferred.rs
+++ b/src/renderer/src/pass/deferred.rs
@@ -5,7 +5,7 @@ use gfx::traits::FactoryExt;
 
 use ConstantColorTexture;
 use pass;
-use target::{ColorFormat, GeometryBuffer};
+pub use target::{ColorFormat, GeometryBuffer};
 
 gfx_vertex_struct!(Vertex {
     pos: [i32; 2] = "a_Pos",


### PR DESCRIPTION
I have been unable to compile amethyst 0.4.* on rust stable - this fixes the issue, but I have no idea why. Issue #188 starts with the error I've been having, though the thread seems to quickly move to an unrelated bug. A bisect revealed that this problem was introduced with commit 00cd53b4010b5c5635e7eef01999fe9fa2114cd4. I have not tested this on nightly, though I can't imagine that it breaks anything.