### PR TITLE
Stopwatch fixes

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,4 +13,5 @@
 * Nikita Chashchinskii
 * Oflor
 * Robbie Cooper
+* Scott Corbeil
 * White-Oak

--- a/src/engine/timing.rs
+++ b/src/engine/timing.rs
@@ -8,7 +8,7 @@ pub enum Stopwatch {
     /// Initial state with an elapsed time value of 0 seconds.
     Waiting,
     /// Stopwatch has started counting the elapsed time since this `Instant`.
-    Started(Instant),
+    Started(Duration, Instant),
     /// Stopwatch has been stopped and reports the elapsed time `Duration`.
     Ended(Duration),
 }
@@ -29,14 +29,14 @@ impl Stopwatch {
     pub fn elapsed(&self) -> Duration {
         match self {
             &Stopwatch::Waiting => Duration::new(0, 0),
-            &Stopwatch::Started(start) => start.elapsed(),
+            &Stopwatch::Started(dur, start) => dur + start.elapsed(),
             &Stopwatch::Ended(dur) => dur,
         }
     }
 
     /// Stops, resets, and starts the stopwatch again.
     pub fn restart(&mut self) {
-        *self = Stopwatch::Started(Instant::now());
+        *self = Stopwatch::Started(Duration::new(0, 0), Instant::now());
     }
 
     /// Starts, or resumes, measuring elapsed time. If the stopwatch has been
@@ -45,8 +45,14 @@ impl Stopwatch {
     ///
     /// Note: Starting an already running stopwatch will do nothing.
     pub fn start(&mut self) {
-        if self == &Stopwatch::Waiting {
-            self.restart();
+        match self {
+            &mut Stopwatch::Waiting => {
+                self.restart();
+            }
+            &mut Stopwatch::Ended(dur) => {
+                *self = Stopwatch::Started(dur, Instant::now());
+            }
+            _ => {}
         }
     }
 
@@ -54,8 +60,8 @@ impl Stopwatch {
     ///
     /// Note: Stopping a stopwatch that isn't running will do nothing.
     pub fn stop(&mut self) {
-        if let &mut Stopwatch::Started(start) = self {
-            *self = Stopwatch::Ended(start.elapsed());
+        if let &mut Stopwatch::Started(dur, start) = self {
+            *self = Stopwatch::Ended(dur + start.elapsed());
         }
     }
 
@@ -80,7 +86,14 @@ mod tests {
         thread::sleep(Duration::from_secs(2));
         watch.stop();
 
-        assert_eq!(2, watch.elapsed().as_secs());
+        // check that elapsed time was 2 sec +/- 1%
+        let elapsed = watch.elapsed();
+        let two_sec = Duration::new(2, 0);
+        let lower = two_sec / 100 * 99;
+        let upper = two_sec / 100 * 101;
+        assert!(elapsed < upper && elapsed > lower,
+                "expected about 2 seconds, got {:?}",
+                elapsed);
     }
 
     #[test]
@@ -107,6 +120,34 @@ mod tests {
         thread::sleep(Duration::from_secs(1));
         watch.stop();
 
-        assert_eq!(1, watch.elapsed().as_secs());
+        // check that elapsed time was 1 sec +/- 1%
+        let elapsed = watch.elapsed();
+        let one_sec = Duration::new(1, 0);
+        let lower = one_sec / 100 * 99;
+        let upper = one_sec / 100 * 101;
+        assert!(elapsed < upper && elapsed > lower,
+                "expected about 1 second, got {:?}",
+                elapsed);
+    }
+
+    // test that multiple start-stop cycles are cumulative
+    #[test]
+    fn stop_start() {
+        let mut watch = Stopwatch::new();
+
+        for _ in 0..3 {
+            watch.start();
+            thread::sleep(Duration::from_secs(1));
+            watch.stop();
+        }
+
+        // check that elapsed time was 3 sec +/- 1%
+        let elapsed = watch.elapsed();
+        let three_sec = Duration::new(3, 0);
+        let lower = three_sec / 100 * 99;
+        let upper = three_sec / 100 * 101;
+        assert!(elapsed < upper && elapsed > lower,
+                "expected about 3 seconds, got {:?}",
+                elapsed);
     }
 }

--- a/src/engine/timing.rs
+++ b/src/engine/timing.rs
@@ -7,7 +7,8 @@ use std::time::{Duration, Instant};
 pub enum Stopwatch {
     /// Initial state with an elapsed time value of 0 seconds.
     Waiting,
-    /// Stopwatch has started counting the elapsed time since this `Instant`.
+    /// Stopwatch has started counting the elapsed time since this `Instant`
+    /// and accumuluated time from previous start/stop cycles `Duration`.
     Started(Duration, Instant),
     /// Stopwatch has been stopped and reports the elapsed time `Duration`.
     Ended(Duration),


### PR DESCRIPTION
Added a Duration to the Started variant of the Stopwatch enum to accumulate time from previous start/stop cycles to match behavior with documentation.

Also, adjusted tests to allow for +/- 1% in elapsed time comparison, as they were periodically failing on my machine (Windows 7 64 bit) due to very small differences in expected vs actual elapsed time.