### PR TITLE
Use fnv hasher for HashMap and HashSet.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -16,3 +16,4 @@
 * Robbie Cooper
 * Scott Corbeil
 * White-Oak
+* Konstantin Zverev

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,6 +8,7 @@
 * Emil Gardström
 * Eyal Kalderon
 * Ilya Bogdanov
+* Konstantin Zverev
 * Lucio Franco
 * Lukas Schmierer
 * msiglreith
@@ -16,4 +17,3 @@
 * Robbie Cooper
 * Scott Corbeil
 * White-Oak
-* Konstantin Zverev

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ glutin = "0.7"
 imagefmt = "4.0"
 specs = "0.7"
 wavefront_obj = "5.0"
+fnv = "1.0.5"
 
 [target.'cfg(windows)'.dependencies]
 gfx_device_dx11 = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ amethyst_config = { path = "src/config/", version = "0.2.1" }
 amethyst_renderer = { path = "src/renderer", version = "0.4.1" }
 cgmath = "0.12"
 dds-rs = "0.4"
+fnv = "1.0"
 num_cpus = "1.2"
 genmesh = "0.4"
 gfx = "0.14"
@@ -36,7 +37,6 @@ glutin = "0.7"
 imagefmt = "4.0"
 specs = "0.7"
 wavefront_obj = "5.0"
-fnv = "1.0.5"
 
 [target.'cfg(windows)'.dependencies]
 gfx_device_dx11 = "0.4"

--- a/src/asset_manager/asset_manager.rs
+++ b/src/asset_manager/asset_manager.rs
@@ -3,10 +3,10 @@
 
 use cgmath::{InnerSpace, Vector3};
 use dds::DDS;
+use fnv::FnvHashMap as HashMap;
 use gfx::texture::{AaMode, Kind};
 use imagefmt::{ColFmt, Image, read_from};
 use std::any::{Any, TypeId};
-use fnv::FnvHashMap;
 use std::{env, fs};
 use std::io::{Cursor, Read};
 use std::ops::{Deref, DerefMut};
@@ -73,16 +73,16 @@ impl<'a, T: Any + Send + Sync> AssetReadStorage<T> for Storage<Asset<T>, RwLockR
 
 /// Internal assets handler which takes care of storing and loading assets.
 pub struct Assets {
-    loaders: FnvHashMap<LoaderTypeId, Box<Any>>,
-    asset_ids: FnvHashMap<String, AssetId>,
+    loaders: HashMap<LoaderTypeId, Box<Any>>,
+    asset_ids: HashMap<String, AssetId>,
     assets: World,
 }
 
 impl Assets {
     fn new() -> Assets {
         Assets {
-            loaders: FnvHashMap::default(),
-            asset_ids: FnvHashMap::default(),
+            loaders: HashMap::default(),
+            asset_ids: HashMap::default(),
             assets: World::new(),
         }
     }
@@ -149,8 +149,8 @@ impl Assets {
 /// Asset manager which handles assets and loaders.
 pub struct AssetManager {
     assets: Assets,
-    asset_type_ids: FnvHashMap<(String, AssetTypeId), SourceTypeId>,
-    closures: FnvHashMap<(AssetTypeId, SourceTypeId),
+    asset_type_ids: HashMap<(String, AssetTypeId), SourceTypeId>,
+    closures: HashMap<(AssetTypeId, SourceTypeId),
                       Box<FnMut(&mut Assets, &str, &[u8]) -> Option<AssetId>>>,
     stores: Vec<Box<AssetStore>>,
 }
@@ -159,9 +159,9 @@ impl AssetManager {
     /// Create a new asset manager
     pub fn new() -> AssetManager {
         let mut asset_manager = AssetManager {
-            asset_type_ids: FnvHashMap::default(),
+            asset_type_ids: HashMap::default(),
             assets: Assets::new(),
-            closures: FnvHashMap::default(),
+            closures: HashMap::default(),
             stores: Vec::new(),
         };
 

--- a/src/asset_manager/asset_manager.rs
+++ b/src/asset_manager/asset_manager.rs
@@ -6,7 +6,7 @@ use dds::DDS;
 use gfx::texture::{AaMode, Kind};
 use imagefmt::{ColFmt, Image, read_from};
 use std::any::{Any, TypeId};
-use std::collections::HashMap;
+use fnv::FnvHashMap;
 use std::{env, fs};
 use std::io::{Cursor, Read};
 use std::ops::{Deref, DerefMut};
@@ -73,16 +73,16 @@ impl<'a, T: Any + Send + Sync> AssetReadStorage<T> for Storage<Asset<T>, RwLockR
 
 /// Internal assets handler which takes care of storing and loading assets.
 pub struct Assets {
-    loaders: HashMap<LoaderTypeId, Box<Any>>,
-    asset_ids: HashMap<String, AssetId>,
+    loaders: FnvHashMap<LoaderTypeId, Box<Any>>,
+    asset_ids: FnvHashMap<String, AssetId>,
     assets: World,
 }
 
 impl Assets {
     fn new() -> Assets {
         Assets {
-            loaders: HashMap::new(),
-            asset_ids: HashMap::new(),
+            loaders: FnvHashMap::default(),
+            asset_ids: FnvHashMap::default(),
             assets: World::new(),
         }
     }
@@ -149,8 +149,8 @@ impl Assets {
 /// Asset manager which handles assets and loaders.
 pub struct AssetManager {
     assets: Assets,
-    asset_type_ids: HashMap<(String, AssetTypeId), SourceTypeId>,
-    closures: HashMap<(AssetTypeId, SourceTypeId),
+    asset_type_ids: FnvHashMap<(String, AssetTypeId), SourceTypeId>,
+    closures: FnvHashMap<(AssetTypeId, SourceTypeId),
                       Box<FnMut(&mut Assets, &str, &[u8]) -> Option<AssetId>>>,
     stores: Vec<Box<AssetStore>>,
 }
@@ -159,9 +159,9 @@ impl AssetManager {
     /// Create a new asset manager
     pub fn new() -> AssetManager {
         let mut asset_manager = AssetManager {
-            asset_type_ids: HashMap::new(),
+            asset_type_ids: FnvHashMap::default(),
             assets: Assets::new(),
-            closures: HashMap::new(),
+            closures: FnvHashMap::default(),
             stores: Vec::new(),
         };
 

--- a/src/ecs/resources/input.rs
+++ b/src/ecs/resources/input.rs
@@ -1,6 +1,7 @@
 //! World resource that handles all user input.
 
-use std::collections::hash_map::{Entry, HashMap, Keys};
+use std::collections::hash_map::{Entry, Keys};
+use fnv::FnvHashMap;
 use std::iter::Iterator;
 
 use engine::{ElementState, WindowEvent, Event, VirtualKeyCode};
@@ -27,13 +28,13 @@ impl<'a> Iterator for PressedKeysIterator<'a> {
 /// Processes user input events.
 #[derive(Default)]
 pub struct InputHandler {
-    pressed_keys: HashMap<VirtualKeyCode, KeyQueryState>,
+    pressed_keys: FnvHashMap<VirtualKeyCode, KeyQueryState>,
 }
 
 impl InputHandler {
     /// Creates a new input handler.
     pub fn new() -> InputHandler {
-        InputHandler { pressed_keys: HashMap::new() }
+        InputHandler { pressed_keys: FnvHashMap::default() }
     }
 
     /// Updates the input handler with new engine events.

--- a/src/ecs/resources/input.rs
+++ b/src/ecs/resources/input.rs
@@ -1,7 +1,8 @@
 //! World resource that handles all user input.
 
+use fnv::FnvHashMap as HashMap;
+
 use std::collections::hash_map::{Entry, Keys};
-use fnv::FnvHashMap;
 use std::iter::Iterator;
 
 use engine::{ElementState, WindowEvent, Event, VirtualKeyCode};
@@ -28,13 +29,13 @@ impl<'a> Iterator for PressedKeysIterator<'a> {
 /// Processes user input events.
 #[derive(Default)]
 pub struct InputHandler {
-    pressed_keys: FnvHashMap<VirtualKeyCode, KeyQueryState>,
+    pressed_keys: HashMap<VirtualKeyCode, KeyQueryState>,
 }
 
 impl InputHandler {
     /// Creates a new input handler.
     pub fn new() -> InputHandler {
-        InputHandler { pressed_keys: FnvHashMap::default() }
+        InputHandler { pressed_keys: HashMap::default() }
     }
 
     /// Updates the input handler with new engine events.

--- a/src/ecs/systems/transform.rs
+++ b/src/ecs/systems/transform.rs
@@ -1,7 +1,7 @@
 //! Scene graph system and types
 
 use cgmath::Matrix4;
-use fnv::{FnvHashMap, FnvHashSet};
+use fnv::{FnvHashMap as HashMap, FnvHashSet as HashSet};
 
 use ecs::{Join, Entity, RunArg, System};
 use ecs::components::{LocalTransform, Transform, Child, Init};
@@ -11,30 +11,30 @@ use ecs::components::{LocalTransform, Transform, Child, Init};
 #[derive(Default)]
 pub struct TransformSystem {
     /// Map of entities to index in sorted vec.
-    indices: FnvHashMap<Entity, usize>,
+    indices: HashMap<Entity, usize>,
     /// Vec of entities with parents before children. Only contains entities
     /// with parents.
     sorted: Vec<(Entity, Entity)>,
     /// New entities in the current update.
     new: Vec<Entity>,
     /// Entities that have been removed in current frame.
-    dead: FnvHashSet<Entity>,
+    dead: HashSet<Entity>,
     /// Child entities that were dirty.
-    dirty: FnvHashSet<Entity>,
+    dirty: HashSet<Entity>,
     /// Prevent circular infinite loops with parents.
-    swapped: FnvHashSet<Entity>,
+    swapped: HashSet<Entity>,
 }
 
 impl TransformSystem {
     /// Creates a new transform processor.
     pub fn new() -> TransformSystem {
         TransformSystem {
-            indices: FnvHashMap::default(),
+            indices: HashMap::default(),
             sorted: Vec::new(),
             new: Vec::new(),
-            dead: FnvHashSet::default(),
-            dirty: FnvHashSet::default(),
-            swapped: FnvHashSet::default(),
+            dead: HashSet::default(),
+            dirty: HashSet::default(),
+            swapped: HashSet::default(),
         }
     }
 }

--- a/src/ecs/systems/transform.rs
+++ b/src/ecs/systems/transform.rs
@@ -1,7 +1,7 @@
 //! Scene graph system and types
 
 use cgmath::Matrix4;
-use std::collections::{HashMap, HashSet};
+use fnv::{FnvHashMap, FnvHashSet};
 
 use ecs::{Join, Entity, RunArg, System};
 use ecs::components::{LocalTransform, Transform, Child, Init};
@@ -11,30 +11,30 @@ use ecs::components::{LocalTransform, Transform, Child, Init};
 #[derive(Default)]
 pub struct TransformSystem {
     /// Map of entities to index in sorted vec.
-    indices: HashMap<Entity, usize>,
+    indices: FnvHashMap<Entity, usize>,
     /// Vec of entities with parents before children. Only contains entities
     /// with parents.
     sorted: Vec<(Entity, Entity)>,
     /// New entities in the current update.
     new: Vec<Entity>,
     /// Entities that have been removed in current frame.
-    dead: HashSet<Entity>,
+    dead: FnvHashSet<Entity>,
     /// Child entities that were dirty.
-    dirty: HashSet<Entity>,
+    dirty: FnvHashSet<Entity>,
     /// Prevent circular infinite loops with parents.
-    swapped: HashSet<Entity>,
+    swapped: FnvHashSet<Entity>,
 }
 
 impl TransformSystem {
     /// Creates a new transform processor.
     pub fn new() -> TransformSystem {
         TransformSystem {
-            indices: HashMap::new(),
+            indices: FnvHashMap::default(),
             sorted: Vec::new(),
             new: Vec::new(),
-            dead: HashSet::new(),
-            dirty: HashSet::new(),
-            swapped: HashSet::new(),
+            dead: FnvHashSet::default(),
+            dirty: FnvHashSet::default(),
+            swapped: FnvHashSet::default(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ extern crate imagefmt;
 extern crate num_cpus;
 extern crate specs;
 extern crate wavefront_obj;
+extern crate fnv;
 
 pub mod asset_manager;
 pub mod ecs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ pub extern crate amethyst_renderer as renderer;
 
 extern crate cgmath;
 extern crate dds;
+extern crate fnv;
 extern crate gfx;
 extern crate gfx_window_glutin;
 extern crate glutin;
@@ -77,7 +78,6 @@ extern crate imagefmt;
 extern crate num_cpus;
 extern crate specs;
 extern crate wavefront_obj;
-extern crate fnv;
 
 pub mod asset_manager;
 pub mod ecs;

--- a/src/renderer/Cargo.toml
+++ b/src/renderer/Cargo.toml
@@ -25,6 +25,7 @@ gfx_window_glutin = "0.14"
 glutin = "0.7"
 mopa = "0.2"
 specs = "0.7"
+fnv = "1.0.5"
 
 [dev-dependencies]
 genmesh = "0.4"

--- a/src/renderer/Cargo.toml
+++ b/src/renderer/Cargo.toml
@@ -19,13 +19,13 @@ travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
 cgmath = "0.12"
+fnv = "1.0"
 gfx = "0.14"
 gfx_device_gl = "0.13"
 gfx_window_glutin = "0.14"
 glutin = "0.7"
 mopa = "0.2"
 specs = "0.7"
-fnv = "1.0.5"
 
 [dev-dependencies]
 genmesh = "0.4"

--- a/src/renderer/src/lib.rs
+++ b/src/renderer/src/lib.rs
@@ -16,9 +16,9 @@ extern crate mopa;
 pub mod pass;
 pub mod target;
 
+use fnv::FnvHashMap as HashMap;
 use specs::{Component, VecStorage};
 use std::any::TypeId;
-use fnv::FnvHashMap;
 
 pub use pass::{Pass, PassDescription};
 pub use target::Target;
@@ -27,7 +27,7 @@ pub use target::Target;
 /// contains the passes, all other data is contained in the `Frame`.
 pub struct Renderer<R: gfx::Resources, C: gfx::CommandBuffer<R>> {
     cmd_buf: gfx::Encoder<R, C>,
-    passes: FnvHashMap<(TypeId, TypeId),
+    passes: HashMap<(TypeId, TypeId),
                     Box<Fn(&Box<PassDescription>,
                            &Target,
                            &Pipeline,
@@ -51,7 +51,7 @@ impl<R, C> Renderer<R, C>
     pub fn new(cmd_buf: C) -> Renderer<R, C> {
         Renderer {
             cmd_buf: cmd_buf.into(),
-            passes: FnvHashMap::default(),
+            passes: HashMap::default(),
         }
     }
 
@@ -389,7 +389,7 @@ pub struct Pipeline {
     pub layers: Vec<Layer>,
     /// collection of render targets. A target may be
     /// a source or a sink for a `Pass`
-    pub targets: FnvHashMap<String, Box<Target>>,
+    pub targets: HashMap<String, Box<Target>>,
 }
 
 impl Pipeline {
@@ -397,7 +397,7 @@ impl Pipeline {
     pub fn new() -> Pipeline {
         Pipeline {
             layers: Vec::new(),
-            targets: FnvHashMap::default(),
+            targets: HashMap::default(),
         }
     }
 }

--- a/src/renderer/src/lib.rs
+++ b/src/renderer/src/lib.rs
@@ -5,6 +5,7 @@
 #![doc(html_logo_url = "http://tinyurl.com/hgsb45k")]
 
 extern crate cgmath;
+extern crate fnv;
 extern crate glutin;
 extern crate specs;
 #[macro_use]
@@ -17,7 +18,7 @@ pub mod target;
 
 use specs::{Component, VecStorage};
 use std::any::TypeId;
-use std::collections::HashMap;
+use fnv::FnvHashMap;
 
 pub use pass::{Pass, PassDescription};
 pub use target::Target;
@@ -26,7 +27,7 @@ pub use target::Target;
 /// contains the passes, all other data is contained in the `Frame`.
 pub struct Renderer<R: gfx::Resources, C: gfx::CommandBuffer<R>> {
     cmd_buf: gfx::Encoder<R, C>,
-    passes: HashMap<(TypeId, TypeId),
+    passes: FnvHashMap<(TypeId, TypeId),
                     Box<Fn(&Box<PassDescription>,
                            &Target,
                            &Pipeline,
@@ -50,7 +51,7 @@ impl<R, C> Renderer<R, C>
     pub fn new(cmd_buf: C) -> Renderer<R, C> {
         Renderer {
             cmd_buf: cmd_buf.into(),
-            passes: HashMap::new(),
+            passes: FnvHashMap::default(),
         }
     }
 
@@ -388,7 +389,7 @@ pub struct Pipeline {
     pub layers: Vec<Layer>,
     /// collection of render targets. A target may be
     /// a source or a sink for a `Pass`
-    pub targets: HashMap<String, Box<Target>>,
+    pub targets: FnvHashMap<String, Box<Target>>,
 }
 
 impl Pipeline {
@@ -396,7 +397,7 @@ impl Pipeline {
     pub fn new() -> Pipeline {
         Pipeline {
             layers: Vec::new(),
-            targets: HashMap::new(),
+            targets: FnvHashMap::default(),
         }
     }
 }


### PR DESCRIPTION
With ecs, keys for hashmaps and sets are usually some kind of id, hence is very small. So fnv hash function will give significant performance in this case. [Here is compassion](http://cglab.ca/~abeinges/blah/hash-rs/). Also default hasher resistant to HashDoS attacks, but we don't need it anyway.