### PR TITLE
Fix InputHandler bug

### DIFF
--- a/src/ecs/resources/input.rs
+++ b/src/ecs/resources/input.rs
@@ -51,7 +51,7 @@ impl InputHandler {
                             // second `Pressed` event.
                         }
                         Entry::Vacant(entry) => {
-                            entry.insert(KeyQueryState::Queried);
+                            entry.insert(KeyQueryState::NotQueried);
                         }
                     }
                 }


### PR DESCRIPTION
When a keypress is inserted into the hashmap, it should be marked as `NotQueried`.