### PR TITLE
Add pre-commit hook to automate local testing for commits

### DIFF
--- a/.pre-commit.sh
+++ b/.pre-commit.sh
@@ -6,10 +6,14 @@ RED='\033[1;31m'
 GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
+BOLD='\033[1m'
 
-# Check to make sure commit isn't emtpy
+stash=0
+# Check to make sure commit isn't emtpy, exit with status 1 if it is
 if git diff-index --quiet HEAD --; then
-    echo "${RED} Empty commit"
+    echo "${RED}You've tried to commit an empty commit${NC}"
+    echo "\tMake sure to add your changes with 'git add'"
+    exit 1
 else
     # Stash all changes in the working directory so we test only commit files
     if git stash save -u -k -q $STASH_NAME; then
@@ -17,6 +21,8 @@ else
         stash=1
     fi
 fi
+
+echo "${GREEN} Testing commit\n\n"
 
 cargo doc --no-deps &&
 cargo build &&
@@ -27,6 +33,12 @@ cargo test --all --features profiler
 
 # Capture exit code from tests
 status=$?
+
+# Inform user of build failure
+if [ "$status" -ne "0" ]
+then
+    echo "${RED}Build failed:${NC} if you still want to commit use ${BOLD}'--no-verify'${NC}"
+fi
 
 # Revert stash if changes were stashed to restor working directory files
 if [ "$stash" -eq 1 ]

--- a/.pre-commit.sh
+++ b/.pre-commit.sh
@@ -12,12 +12,15 @@ if git stash save -u -k -q $STASH_NAME; then
     stash=1
 fi
 
-cargo doc --no-deps
-cargo build
+cargo doc --no-deps &&
+cargo build &&
 # Build and test without profiler
-cargo test --all
+cargo test --all &&
 # Build and test with profiler
 cargo test --all --features profiler
+
+# Capture exit code from tests
+status=$?
 
 if [ "$stash" -eq 1 ]
 then
@@ -27,3 +30,6 @@ then
         echo "\n\n${RED}Unable to revert stash command${NC}"
     fi
 fi
+
+# Keep exit code from tests, so if they fail, prevent commit
+exit $status

--- a/.pre-commit.sh
+++ b/.pre-commit.sh
@@ -7,9 +7,15 @@ GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-if git stash save -u -k -q $STASH_NAME; then
-    echo "${YELLOW}Stashed changes as:${NC} ${STASH_NAME}\n\n"
-    stash=1
+# Check to make sure commit isn't emtpy
+if git diff-index --quiet HEAD --; then
+    echo "${RED} Empty commit"
+else
+    # Stash all changes in the working directory so we test only commit files
+    if git stash save -u -k -q $STASH_NAME; then
+        echo "${YELLOW}Stashed changes as:${NC} ${STASH_NAME}\n\n"
+        stash=1
+    fi
 fi
 
 cargo doc --no-deps &&
@@ -22,6 +28,7 @@ cargo test --all --features profiler
 # Capture exit code from tests
 status=$?
 
+# Revert stash if changes were stashed to restor working directory files
 if [ "$stash" -eq 1 ]
 then
     if git stash pop -q; then

--- a/.pre-commit.sh
+++ b/.pre-commit.sh
@@ -2,53 +2,62 @@
 # pre-commit.sh
 
 STASH_NAME="pre-commit-$(date +%s)"
+BRANCH_NAME=$(git branch | grep '*' | sed 's/* //')
 RED='\033[1;31m'
 GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 BOLD='\033[1m'
 
-stash=0
-# Check to make sure commit isn't emtpy, exit with status 1 if it is
-if git diff-index --quiet HEAD --; then
-    echo "${RED}You've tried to commit an empty commit${NC}"
-    echo "\tMake sure to add your changes with 'git add'"
-    exit 1
-else
-    # Stash all changes in the working directory so we test only commit files
-    if git stash save -u -k -q $STASH_NAME; then
-        echo "${YELLOW}Stashed changes as:${NC} ${STASH_NAME}\n\n"
-        stash=1
-    fi
-fi
-
-echo "${GREEN} Testing commit\n\n"
-
-cargo doc --no-deps &&
-cargo build &&
-# Build and test without profiler
-cargo test --all &&
-# Build and test with profiler
-cargo test --all --features profiler
-
-# Capture exit code from tests
-status=$?
-
-# Inform user of build failure
-if [ "$status" -ne "0" ]
+# Check if commit is on a rebase, if not proceed as usual
+if [ $BRANCH_NAME != '(no branch)' ]
 then
-    echo "${RED}Build failed:${NC} if you still want to commit use ${BOLD}'--no-verify'${NC}"
-fi
-
-# Revert stash if changes were stashed to restor working directory files
-if [ "$stash" -eq 1 ]
-then
-    if git stash pop -q; then
-        echo "\n\n${GREEN}Reverted stash command${NC}"
+    stash=0
+    # Check to make sure commit isn't emtpy, exit with status 1 if it is
+    if git diff-index --quiet HEAD --; then
+        echo "${RED}You've tried to commit an empty commit${NC}"
+        echo "\tMake sure to add your changes with 'git add'"
+        exit 1
     else
-        echo "\n\n${RED}Unable to revert stash command${NC}"
+        # Stash all changes in the working directory so we test only commit files
+        if git stash save -u -k -q $STASH_NAME; then
+            echo "${YELLOW}Stashed changes as:${NC} ${STASH_NAME}\n\n"
+            stash=1
+        fi
     fi
-fi
 
-# Keep exit code from tests, so if they fail, prevent commit
-exit $status
+    echo "${GREEN} Testing commit\n\n"
+
+    cargo doc --no-deps &&
+    cargo build &&
+    # Build and test without profiler
+    cargo test --all &&
+    # Build and test with profiler
+    cargo test --all --features profiler
+
+    # Capture exit code from tests
+    status=$?
+
+    # Revert stash if changes were stashed to restor working directory files
+    if [ "$stash" -eq 1 ]
+    then
+        if git stash pop -q; then
+            echo "\n\n${GREEN}Reverted stash command${NC}"
+        else
+            echo "\n\n${RED}Unable to revert stash command${NC}"
+        fi
+    fi
+
+    # Inform user of build failure
+    if [ "$status" -ne "0" ]
+    then
+        echo "${RED}Build failed:${NC} if you still want to commit use ${BOLD}'--no-verify'${NC}"
+    fi
+
+    # Exit with exit code from tests, so if they fail, prevent commit
+    exit $status
+else
+    # Tests were skipped for rebase, inform user and exit zero
+    echo "${YELLOW}Skipping tests on branchless commit${NC}"
+    exit 0
+fi

--- a/.pre-commit.sh
+++ b/.pre-commit.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+# pre-commit.sh
+
+STASH_NAME="pre-commit-$(date +%s)"
+RED='\033[1;31m'
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+if git stash save -u -k -q $STASH_NAME; then
+    echo "${YELLOW}Stashed changes as:${NC} ${STASH_NAME}\n\n"
+    stash=1
+fi
+
+cargo doc --no-deps
+cargo build
+# Build and test without profiler
+cargo test --all
+# Build and test with profiler
+cargo test --all --features profiler
+
+if [ "$stash" -eq 1 ]
+then
+    if git stash pop -q; then
+        echo "\n\n${GREEN}Reverted stash command${NC}"
+    else
+        echo "\n\n${RED}Unable to revert stash command${NC}"
+    fi
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,9 +141,9 @@ or copy it to your `.git` folder with
 $ cp .pre-commit.sh .git/hooks/pre-commit
 ```
 
-Note: if you use `cp` you won't get upstream changes, but if you use `ln` and
-you checkout a path without the .pre-commit.sh` script in your working
-directory, the hook won't run.
+Note: if you use `cp` you won't get upstream changes to `.pre-commit.sh`, but if
+you use `ln` and you checkout a path without the .pre-commit.sh` script in your
+ working directory, the hook won't run.
 
 This ensures that you can't commit your changes if tests fail.  If you need to
 make a commit without running tests, then simply use

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,28 @@ done the following things first:
    the work by you, as defined in the Apache 2.0 license, shall be dual
    licensed as above, without any additional terms or conditions.
 
+To streamline the process, the `.pre-commit.sh` script will run tests on each
+commit in a sanitary way for you; to have it run automatically on each commit
+simply create a symbolic link with
+
+```bash
+$ ln -s -f ../../.pre-commit.sh .git/hooks/pre-commit
+```
+
+This ensures that you can't commit your changes if tests fail.  If you need to
+make a commit without running tests, then simply pass the `--no-verify` flag.
+We recommend the following aliases:
+
+```bash
+$ git config --global alias.ci "commit"
+$ git config --global alias.cnv "commit --no-verify"
+```
+
+Note: the `pre-commit` hook stashes all of your unstaged changes temporarily to
+ensure that your changes don't depend on code you haven't included in your
+commit.  So if you've lost any work, run `git stash list` and `git stash apply`
+to bring your changes back.
+
 [lm]: LICENSE-MIT
 [la]: LICENSE-APACHE
 [st]: src/engine/state.rs#L224-L265
@@ -143,7 +165,7 @@ developer, it will be merged into the source tree.
 ### Dealing With Upstream Changes
 
 When pulling remote changes to a local branch or machine, we recommend users to
-rebase instead of creating merge commits. 
+rebase instead of creating merge commits.
 
 This is used sometimes when an upstream change cause problems with your pull
 request. The best practice is to do a fast-forward ("ff") rebase.
@@ -182,7 +204,7 @@ $ git checkout <branch-name>
 $ git rebase upstream/<branch-to-sync-with>
 ```
 
-If any errors occur, Git will try to guess what happened. If you can't figure 
+If any errors occur, Git will try to guess what happened. If you can't figure
 out how to solve your problem, a quick Google search can help, or you can hit us
 up on our [Gitter][gi] chat.
 
@@ -194,7 +216,7 @@ To check whether anything major has changed upstream, you can do:
 ```bash
 $ # Fetch latest changes
 $ git fetch upstream
-$ # Do a "non-intruisive" check. 
+$ # Do a "non-intruisive" check.
 $ git merge --ff-only --no-commit upstream
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,13 +135,21 @@ simply create a symbolic link with
 $ ln -s -f ../../.pre-commit.sh .git/hooks/pre-commit
 ```
 
-This ensures that you can't commit your changes if tests fail.  If you need to
-make a commit without running tests, then simply pass the `--no-verify` flag.
-We recommend the following aliases:
+or copy it to your `.git` folder with
 
 ```bash
-$ git config --global alias.ci "commit"
-$ git config --global alias.cnv "commit --no-verify"
+$ cp .pre-commit.sh .git/hooks/pre-commit
+```
+
+Note: if you use `cp` you won't get upstream changes, but if you use `ln` and
+you checkout a path without the .pre-commit.sh` script in your working
+directory, the hook won't run.
+
+This ensures that you can't commit your changes if tests fail.  If you need to
+make a commit without running tests, then simply use
+
+```bash
+$ git commit --no-verify
 ```
 
 Note: the `pre-commit` hook stashes all of your unstaged changes temporarily to


### PR DESCRIPTION
I started using a `pre-commit` hook on my own repositories and it's made my life much easier by automating the process of running tests; because it stashes all of the unstaged changes, it prevents bugs from cropping up because I've forgotten to add some code to a respective commit that my changes depend on.  It also means I don't have to remember every command I need to use for testing, so if I've forgotten to test with a feature flag this script will catch that for me.

I added instructions for setting up the `pre-commit` hook to CONTRIBUTING.md, but I'm not sure I'm totally satisfied with them.

As for the content of the script, I considered adding `cargo fmt` but it would fail because some of the example and source files were longer than 100 lines, and it introduced a whole host of changes to the source code that I wasn't sure how to deal with.

Finally, I'm not exactly an expert with shell scripts, so if there are changes that can make the script better please suggest away!