### PR TITLE
No nightly support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,10 @@ issues first, as it's possible that someone else reported the same issue before
 you. Though it helps save time, don't worry! We won't mind if you accidentally
 post a duplicate issue.
 
+Please note that if an issue can only be reproduced on a nightly compiler it will be closed and marked "Will not fix."
+If an issue can only be reproduced on a beta compiler the next action is to determine if this issue will also occur
+in the next release of stable.  If it will, we'll address it, otherwise it will be closed as "Will not fix."
+
 That's all there is to it! Thanks for posting your issue; we'll take it to heart
 and try our best to resolve it.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,10 @@ issues first, as it's possible that someone else reported the same issue before
 you. Though it helps save time, don't worry! We won't mind if you accidentally
 post a duplicate issue.
 
-Please note that if an issue can only be reproduced on a nightly compiler it will be closed and marked "Will not fix."
-If an issue can only be reproduced on a beta compiler the next action is to determine if this issue will also occur
-in the next release of stable.  If it will, we'll address it, otherwise it will be closed as "Will not fix."
+Amethyst does not officially support beta or nightly channels of Rust.
+If an issue can only be reproduced on those channels our resolution strategy will
+be to communicate with the rust project itself to ensure the issue does not reach
+the stable branch.
 
 That's all there is to it! Thanks for posting your issue; we'll take it to heart
 and try our best to resolve it.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The API reference can be found in `target/doc/amethyst/index.html`.
 
 ## Questions / Help
 
-We do not support anything other than the most recent Rust stable release.  Use nightly and beta channels with this project at your own risk.
+We do not support anything other than the most recent Rust stable release. Use nightly and beta channels with this project at your own risk.
 
 Please check out the [FAQ][faq] before asking.
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ The API reference can be found in `target/doc/amethyst/index.html`.
 
 ## Questions / Help
 
+We do not support anything other than the most recent Rust stable release.  Use nightly and beta channels with this project at your own risk.
+
 Please check out the [FAQ][faq] before asking.
 
 If you have an easy question, just ask on [Gitter][gt] and we'll help you and add it to the FAQ.


### PR DESCRIPTION
Add language to indicate we don't officially support nightly or beta branches of Rust.  I'm of the opinion that trying to support nightly or beta is an exercise in futility and a recipe for wasted time.  If others are in agreement with me I'd like to merge this.