### PR TITLE
Change axis behaviour from button down to pressed

### DIFF
--- a/src/ecs/resources/input.rs
+++ b/src/ecs/resources/input.rs
@@ -388,8 +388,8 @@ impl InputHandler {
         self.axes
             .get(&id)
             .map(|a| {
-                let pos = self.button_down(a.pos);
-                let neg = self.button_down(a.neg);
+                let pos = self.button_is_pressed(a.pos);
+                let neg = self.button_is_pressed(a.neg);
                 if pos == neg {
                     0.0
                 } else if pos {


### PR DESCRIPTION
The `InputHandler::axis_value` function is not really useful when it only returns the value for one frame.
This PR changes the queried button function from `button_down` to `button_is_pressed`.