### PR TITLE
Input rebinding phase 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,11 +36,11 @@ gfx_device_gl = "0.13"
 gfx_window_glutin = "0.14"
 glutin = "0.7"
 imagefmt = "4.0"
+smallvec = "0.4"
 specs = "0.9.1"
 rayon = "0.7"
 ticketed_lock = "0.1"
 wavefront_obj = "5.0"
-smallvec = "0.4"
 
 thread_profiler = { version = "0.1", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ specs = "0.9.1"
 rayon = "0.7"
 ticketed_lock = "0.1"
 wavefront_obj = "5.0"
+smallvec = "0.4"
 
 thread_profiler = { version = "0.1", optional = true }
 

--- a/src/ecs/resources/input.rs
+++ b/src/ecs/resources/input.rs
@@ -168,18 +168,18 @@ impl InputHandler {
     }
 
     /// Returns a vector containing pressed down keys.
-    pub fn pressed_keys(&self) -> &[VirtualKeyCode] {
-        &*self.pressed_keys
+    pub fn pressed_keys(&self) -> Iter<VirtualKeyCode> {
+        self.pressed_keys.iter()
     }
 
     /// Returns a vector containing keys pressed on this frame.
-    pub fn down_keys(&self) -> &[VirtualKeyCode] {
-        &*self.down_keys
+    pub fn down_keys(&self) -> Iter<VirtualKeyCode> {
+        self.down_keys.iter()
     }
 
     /// Returns a vector containing keys released on this frame.
-    pub fn released_keys(&self) -> &[VirtualKeyCode] {
-        &*self.released_keys
+    pub fn released_keys(&self) -> Iter<VirtualKeyCode> {
+        self.released_keys.iter()
     }
 
     /// Checks if the given key is being pressed.
@@ -208,18 +208,18 @@ impl InputHandler {
     }
 
     /// Returns a vector containing pressed down mouse buttons.
-    pub fn pressed_mouse_buttons(&self) -> &[MouseButton] {
-        &*self.pressed_mouse_buttons
+    pub fn pressed_mouse_buttons(&self) -> Iter<MouseButton> {
+        self.pressed_mouse_buttons.iter()
     }
 
     /// Returns a vector containing mouse buttons pressed on this frame.
-    pub fn down_mouse_buttons(&self) -> &[MouseButton]  {
-        &*self.down_mouse_buttons
+    pub fn down_mouse_buttons(&self) -> Iter<MouseButton>  {
+        self.down_mouse_buttons.iter()
     }
 
     /// Returns a vector containing mouse buttons released on this frame.
-    pub fn released_mouse_buttons(&self) -> &[MouseButton] {
-        &*self.released_mouse_buttons
+    pub fn released_mouse_buttons(&self) -> Iter<MouseButton> {
+        self.released_mouse_buttons.iter()
     }
 
     /// Checks if the given mouse button is being pressed.

--- a/src/ecs/resources/input.rs
+++ b/src/ecs/resources/input.rs
@@ -32,9 +32,9 @@ impl From<MouseButton> for Button {
 /// Represents an axis made up of digital inputs, like W and S or A and D.
 /// Two of these could be analogous to a DPAD.
 pub struct Axis {
-    /// Positive button, when pressed down the axis value will return 1 if `neg` is not pressed down.
+    /// Positive button, when pressed down axis value will return 1 if `neg` is not pressed down.
     pub pos: Button,
-    /// Negative button, when pressed down the axis value will return -1 if `neg` is not pressed down.
+    /// Negative button, when pressed down axis value will return -1 if `neg` is not pressed down.
     pub neg: Button,
 }
 
@@ -309,7 +309,7 @@ impl InputHandler {
         }
     }
 
-    /// Checks if the all the given buttons are being pressed and at least one was pressed this frame.
+    /// Checks if the all given buttons are being pressed and at least one was pressed this frame.
     pub fn buttons_down(&self, buttons: &[Button]) -> bool {
         buttons.iter().any(|&b| self.button_down(b)) &&
         buttons.iter().all(|&b| self.button_is_pressed(b))
@@ -380,7 +380,7 @@ impl InputHandler {
             .map(|ref buttons| buttons.iter().any(|&b| self.button_released(b)))
     }
 
-    /// Checks if the all the given actions are being pressed and at least one was pressed this frame.
+    /// Checks if the all given actions are being pressed and at least one was pressed this frame.
     ///
     /// If any action in this list is invalid this will return the id of it in Err.
     pub fn actions_down(&self, actions: &[i32]) -> Result<bool, Vec<i32>> {

--- a/src/ecs/resources/input.rs
+++ b/src/ecs/resources/input.rs
@@ -333,9 +333,9 @@ impl InputHandler {
     }
 
     /// Returns the value of an axis by the i32 id, if the id doesn't exist this returns None.
-    pub fn axis_value(&self, id: i32) -> Option<f32> {
+    pub fn axis_value(&self, id: &str) -> Option<f32> {
         self.axes
-            .get(&id)
+            .get(id)
             .map(|a| {
                 let pos = self.button_is_pressed(a.pos);
                 let neg = self.button_is_pressed(a.neg);
@@ -447,7 +447,7 @@ impl InputHandler {
 
     /// Get's a list of all axes
     pub fn get_axes(&self) -> Vec<String> {
-        self.axes.keys().map(|&k| k).collect::<Vec<String>>()
+        self.axes.keys().map(|k| k.clone()).collect::<Vec<String>>()
     }
 
     /// Add a button to an action.
@@ -496,6 +496,6 @@ impl InputHandler {
 
     /// Get's a list of all action bindings
     pub fn get_actions(&self) -> Vec<String> {
-        self.actions.keys().map(|&k| k).collect::<Vec<String>>()
+        self.actions.keys().map(|k| k.clone()).collect::<Vec<String>>()
     }
 }

--- a/src/ecs/resources/input.rs
+++ b/src/ecs/resources/input.rs
@@ -428,6 +428,11 @@ impl InputHandler {
         self.axes.get(&id)
     }
 
+    /// Get's a list of all axes
+    pub fn get_axes(&self) -> Vec<i32> {
+        self.axes.keys().map(|&k| k).collect::<Vec<i32>>()
+    }
+
     /// Add a button to an action.
     ///
     /// This will insert a new binding between this action and the button.

--- a/src/ecs/resources/input.rs
+++ b/src/ecs/resources/input.rs
@@ -436,13 +436,13 @@ impl InputHandler {
     }
 
     /// Removes an axis, this will return the removed axis if successful.
-    pub fn remove_axis(&mut self, id: String) -> Option<Axis> {
-        self.axes.remove(&id)
+    pub fn remove_axis(&mut self, id: &str) -> Option<Axis> {
+        self.axes.remove(id)
     }
 
     /// Returns a reference to an axis.
-    pub fn get_axis(&mut self, id: String) -> Option<&Axis> {
-        self.axes.get(&id)
+    pub fn get_axis(&mut self, id: &str) -> Option<&Axis> {
+        self.axes.get(id)
     }
 
     /// Get's a list of all axes

--- a/src/ecs/resources/input.rs
+++ b/src/ecs/resources/input.rs
@@ -173,17 +173,17 @@ impl InputHandler {
         self.text_this_frame.as_str()
     }
 
-    /// Returns a vector containing pressed down keys.
+    /// Returns an iterator over pressed down keys.
     pub fn pressed_keys(&self) -> KeyCodes {
         self.pressed_keys.iter()
     }
 
-    /// Returns a vector containing keys pressed on this frame.
+    /// Returns an iterator over keys pressed on this frame.
     pub fn down_keys(&self) -> KeyCodes {
         self.down_keys.iter()
     }
 
-    /// Returns a vector containing keys released on this frame.
+    /// Returns an iterator over keys released on this frame.
     pub fn released_keys(&self) -> KeyCodes {
         self.released_keys.iter()
     }
@@ -213,17 +213,17 @@ impl InputHandler {
         keys.iter().all(|key| self.key_is_pressed(*key))
     }
 
-    /// Returns a vector containing pressed down mouse buttons.
+    /// Returns an iterator over containing pressed down mouse buttons.
     pub fn pressed_mouse_buttons(&self) -> MouseButtons {
         self.pressed_mouse_buttons.iter()
     }
 
-    /// Returns a vector containing mouse buttons pressed on this frame.
+    /// Returns an iterator over containing mouse buttons pressed on this frame.
     pub fn down_mouse_buttons(&self) -> MouseButtons  {
         self.down_mouse_buttons.iter()
     }
 
-    /// Returns a vector containing mouse buttons released on this frame.
+    /// Returns an iterator over mouse buttons released on this frame.
     pub fn released_mouse_buttons(&self) -> MouseButtons {
         self.released_mouse_buttons.iter()
     }
@@ -393,14 +393,14 @@ impl InputHandler {
     pub fn action_down<T: AsRef<str>>(&self, action: T) -> Option<bool> {
         self.actions
             .get(action.as_ref())
-            .map(|ref buttons| buttons.iter().any(|&b| self.button_down(b)))
+            .map(|buttons| buttons.iter().any(|&b| self.button_down(b)))
     }
 
     /// Checks if the given action was released on this frame.
     pub fn action_released<T: AsRef<str>>(&self, action: T) -> Option<bool> {
         self.actions
             .get(action.as_ref())
-            .map(|ref buttons| buttons.iter().any(|&b| self.button_released(b)))
+            .map(|buttons| buttons.iter().any(|&b| self.button_released(b)))
     }
 
     /// Checks if the all given actions are being pressed and at least one was pressed this frame.
@@ -437,8 +437,8 @@ impl InputHandler {
     ///
     /// This will insert a new axis if no entry for this id exists.
     /// If one does exist this will replace the axis at that id and return it.
-    pub fn insert_axis(&mut self, id: String, axis: Axis) -> Option<Axis> {
-        self.axes.insert(id, axis)
+    pub fn insert_axis<T: Into<String>>(&mut self, id: T, axis: Axis) -> Option<Axis> {
+        self.axes.insert(id.into(), axis)
     }
 
     /// Removes an axis, this will return the removed axis if successful.
@@ -451,7 +451,7 @@ impl InputHandler {
         self.axes.get(id.as_ref())
     }
 
-    /// Get's a list of all axes
+    /// Gets a list of all axes
     pub fn axes(&self) -> Vec<String> {
         self.axes.keys().map(|k| k.clone()).collect::<Vec<String>>()
     }
@@ -486,9 +486,7 @@ impl InputHandler {
             if let Some(index) = index {
                 action_bindings.swap_remove(index);
             }
-            if action_bindings.len() == 0 {
-                kill_it = true;
-            }
+            kill_it = action_bindings.is_empty();
         }
         if kill_it {
             self.actions.remove(id.as_ref());

--- a/src/ecs/resources/input.rs
+++ b/src/ecs/resources/input.rs
@@ -441,12 +441,12 @@ impl InputHandler {
     }
 
     /// Returns a reference to an axis.
-    pub fn get_axis(&mut self, id: &str) -> Option<&Axis> {
+    pub fn axis(&mut self, id: &str) -> Option<&Axis> {
         self.axes.get(id)
     }
 
     /// Get's a list of all axes
-    pub fn get_axes(&self) -> Vec<String> {
+    pub fn axes(&self) -> Vec<String> {
         self.axes.keys().map(|k| k.clone()).collect::<Vec<String>>()
     }
 
@@ -490,12 +490,12 @@ impl InputHandler {
     }
 
     /// Returns an action's bindings.
-    pub fn get_action_bindings(&self, id: &str) -> Option<&[Button]> {
+    pub fn action_bindings(&self, id: &str) -> Option<&[Button]> {
         self.actions.get(id).map(|a| &**a)
     }
 
     /// Get's a list of all action bindings
-    pub fn get_actions(&self) -> Vec<String> {
+    pub fn actions(&self) -> Vec<String> {
         self.actions.keys().map(|k| k.clone()).collect::<Vec<String>>()
     }
 }

--- a/src/ecs/resources/input.rs
+++ b/src/ecs/resources/input.rs
@@ -255,10 +255,8 @@ impl InputHandler {
     pub fn pressed_buttons(&self) -> SmallVec<[Button; 16]> {
         let mouse_buttons = self.pressed_mouse_buttons
             .iter()
-            .map((|&mb| Button::Mouse(mb)) as fn(&MouseButton) -> Button);
-        let keys = self.pressed_keys
-            .iter()
-            .map((|&k| Button::Key(k)) as fn(&VirtualKeyCode) -> Button);
+            .map((|&mb| Button::Mouse(mb)));
+        let keys = self.pressed_keys.iter().map((|&k| Button::Key(k)));
         mouse_buttons
             .chain(keys)
             .collect::<SmallVec<[Button; 16]>>()
@@ -268,10 +266,8 @@ impl InputHandler {
     pub fn down_buttons(&self) -> SmallVec<[Button; 8]> {
         let mouse_buttons = self.down_mouse_buttons
             .iter()
-            .map((|&mb| Button::Mouse(mb)) as fn(&MouseButton) -> Button);
-        let keys = self.down_keys
-            .iter()
-            .map((|&k| Button::Key(k)) as fn(&VirtualKeyCode) -> Button);
+            .map((|&mb| Button::Mouse(mb)));
+        let keys = self.down_keys.iter().map((|&k| Button::Key(k)));
         mouse_buttons.chain(keys).collect::<SmallVec<[Button; 8]>>()
     }
 
@@ -279,10 +275,8 @@ impl InputHandler {
     pub fn released_buttons(&self) -> SmallVec<[Button; 8]> {
         let mouse_buttons = self.released_mouse_buttons
             .iter()
-            .map((|&mb| Button::Mouse(mb)) as fn(&MouseButton) -> Button);
-        let keys = self.released_keys
-            .iter()
-            .map((|&k| Button::Key(k)) as fn(&VirtualKeyCode) -> Button);
+            .map((|&mb| Button::Mouse(mb)));
+        let keys = self.released_keys.iter().map((|&k| Button::Key(k)));
         mouse_buttons.chain(keys).collect::<SmallVec<[Button; 8]>>()
     }
 

--- a/src/ecs/resources/mod.rs
+++ b/src/ecs/resources/mod.rs
@@ -11,6 +11,6 @@ mod broadcaster;
 
 pub use self::broadcaster::Broadcaster;
 pub use self::camera::{Camera, Projection};
-pub use self::input::{Axis, Button, InputHandler};
+pub use self::input::{Axis, Button, InputHandler, ButtonIterator};
 pub use self::screen_dimensions::ScreenDimensions;
 pub use self::time::Time;

--- a/src/ecs/resources/mod.rs
+++ b/src/ecs/resources/mod.rs
@@ -11,6 +11,6 @@ mod broadcaster;
 
 pub use self::broadcaster::Broadcaster;
 pub use self::camera::{Camera, Projection};
-pub use self::input::{Axis, Button, InputHandler, ButtonIterator};
+pub use self::input::{Axis, Button, ButtonIterator, InputHandler};
 pub use self::screen_dimensions::ScreenDimensions;
 pub use self::time::Time;

--- a/src/ecs/resources/mod.rs
+++ b/src/ecs/resources/mod.rs
@@ -11,6 +11,6 @@ mod broadcaster;
 
 pub use self::broadcaster::Broadcaster;
 pub use self::camera::{Camera, Projection};
-pub use self::input::{Axis, Button, Buttons, KeyCodes, MouseButtons, InputHandler};
+pub use self::input::{Axis, Button, Buttons, InputHandler, KeyCodes, MouseButtons};
 pub use self::screen_dimensions::ScreenDimensions;
 pub use self::time::Time;

--- a/src/ecs/resources/mod.rs
+++ b/src/ecs/resources/mod.rs
@@ -11,6 +11,6 @@ mod broadcaster;
 
 pub use self::broadcaster::Broadcaster;
 pub use self::camera::{Camera, Projection};
-pub use self::input::{Axis, Button, ButtonIterator, InputHandler};
+pub use self::input::{Axis, Button, Buttons, KeyCodes, MouseButtons, InputHandler};
 pub use self::screen_dimensions::ScreenDimensions;
 pub use self::time::Time;

--- a/src/ecs/resources/mod.rs
+++ b/src/ecs/resources/mod.rs
@@ -11,6 +11,6 @@ mod broadcaster;
 
 pub use self::broadcaster::Broadcaster;
 pub use self::camera::{Camera, Projection};
-pub use self::input::{Axis, Button, InputHandler, PressedButtons, PressedKeys, PressedMouseButtons};
+pub use self::input::{Axis, Button, InputHandler};
 pub use self::screen_dimensions::ScreenDimensions;
 pub use self::time::Time;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,6 @@ pub extern crate amethyst_renderer as renderer;
 pub extern crate amethyst_config as config;
 
 extern crate cgmath;
-extern crate smallvec;
 extern crate dds;
 extern crate fnv;
 extern crate gfx;
@@ -81,6 +80,7 @@ extern crate genmesh;
 extern crate imagefmt;
 extern crate num_cpus;
 extern crate rayon;
+extern crate smallvec;
 extern crate specs;
 extern crate ticketed_lock;
 extern crate wavefront_obj;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ pub extern crate amethyst_renderer as renderer;
 pub extern crate amethyst_config as config;
 
 extern crate cgmath;
+extern crate smallvec;
 extern crate dds;
 extern crate fnv;
 extern crate gfx;


### PR DESCRIPTION
Things done in this PR

- Use smallvec for InputHandler internals, reducing allocations required.
- Add functions
    - down_buttons
    - released_buttons
    - down_keys
    - released_keys
    - down_mouse_buttons
    - released_mouse_buttons

These functions will be helpful with assigning bindings in the first place when we just need to generically query for "whatever the user pressed."

- Add functions
    - axes
    - actions

These functions will be helpful for figuring out what to display on input rebinding screens.
- Enhance actions API to support multiple bindings per action
- Move private functions into closures
- Remove the opaque wrappers over iterators, return slice iterators where possible and in other places return a single `ButtonIterator` type.
- Change actions and axes to use string keys instead of integer keys.

Eventually there is going to be a phase 3 to make this interact with the asset system, which I plan on doing as soon as [Ron](https://github.com/kvark/ron) is ready for use.