### PR TITLE
A little tweak in amethyst_assets public interface

### DIFF
--- a/amethyst_assets/examples/asset.rs
+++ b/amethyst_assets/examples/asset.rs
@@ -14,6 +14,10 @@ use rayon::{Configuration, ThreadPool};
 struct DummyAsset(String);
 
 impl Asset for DummyAsset {
+    type Context = DummyContext;
+    type Data = String;
+    type Error = NoError;
+    
     fn is_shared(&self) -> bool {
         false
     }
@@ -63,9 +67,9 @@ fn main() {
     let alloc = Allocator::new();
     let mut loader = Loader::new(&alloc, &path, pool);
 
-    loader.register(DummyContext(">> "));
+    loader.register::<DummyAsset>(DummyContext(">> "));
 
-    let dummy = loader.load::<DummyContext, _, _>("whatever", DummyFormat);
+    let dummy = loader.load("whatever", DummyFormat);
     let dummy: DummyAsset = dummy.wait().expect("Failed to load dummy asset");
 
     println!("dummy: {:?}", dummy);

--- a/amethyst_assets/examples/asset.rs
+++ b/amethyst_assets/examples/asset.rs
@@ -17,7 +17,7 @@ impl Asset for DummyAsset {
     type Context = DummyContext;
     type Data = String;
     type Error = NoError;
-    
+
     fn is_shared(&self) -> bool {
         false
     }
@@ -67,7 +67,7 @@ fn main() {
     let alloc = Allocator::new();
     let mut loader = Loader::new(&alloc, &path, pool);
 
-    loader.register::<DummyAsset>(DummyContext(">> "));
+    loader.register(DummyContext(">> "));
 
     let dummy = loader.load("whatever", DummyFormat);
     let dummy: DummyAsset = dummy.wait().expect("Failed to load dummy asset");

--- a/amethyst_assets/examples/cache.rs
+++ b/amethyst_assets/examples/cache.rs
@@ -51,6 +51,10 @@ impl Context for DummyContext {
 struct DummyAsset(Arc<String>);
 
 impl Asset for DummyAsset {
+    type Context = DummyContext;
+    type Data = String;
+    type Error = NoError;
+
     fn is_shared(&self) -> bool {
         Arc::strong_count(&self.0) > 1
     }
@@ -82,12 +86,12 @@ fn main() {
     let alloc = Allocator::new();
     let mut loader = Loader::new(&alloc, &path, pool);
 
-    loader.register::<DummyContext>(DummyContext {
+    loader.register::<DummyAsset>(DummyContext {
         cache: Cache::new(),
         prepend: ">> ",
     });
 
-    let dummy = loader.load::<DummyContext, _, _>("whatever", DummyFormat);
+    let dummy = loader.load("whatever", DummyFormat);
     let dummy: DummyAsset = dummy.wait().expect("Failed to load dummy asset");
 
     println!("dummy: {:?}", dummy);

--- a/amethyst_assets/examples/cache.rs
+++ b/amethyst_assets/examples/cache.rs
@@ -86,7 +86,7 @@ fn main() {
     let alloc = Allocator::new();
     let mut loader = Loader::new(&alloc, &path, pool);
 
-    loader.register::<DummyAsset>(DummyContext {
+    loader.register(DummyContext {
         cache: Cache::new(),
         prepend: ">> ",
     });

--- a/amethyst_assets/src/asset.rs
+++ b/amethyst_assets/src/asset.rs
@@ -23,6 +23,15 @@ pub trait Asset
 where
     Self: Clone + Sized,
 {
+    /// The `Context` type that can produce this asset
+    type Context: Context<Asset=Self, Data=Self::Data, Error=Self::Error>;
+
+    /// The `Data` type the asset can be created from.
+    type Data;
+
+    /// The error that may be returned from `Self::Context::from_data`.
+    type Error: Error;
+
     /// Returns `true` if another asset points to the same
     /// internal data.
     ///

--- a/amethyst_assets/src/loader.rs
+++ b/amethyst_assets/src/loader.rs
@@ -137,9 +137,9 @@ impl Loader {
     }
 
     /// Registers an asset and inserts a context into the map.
-    pub fn register<A>(&mut self, context: A::Context)
+    pub fn register<A, C>(&mut self, context: C)
         where A: Asset + 'static,
-              A::Context: Context + 'static,
+              C: Context<Asset=A> + 'static,
     {
         self.contexts
             .insert(TypeId::of::<A>(), Box::new(Arc::new(context)));


### PR DESCRIPTION
Make `Asset` type appear in public methods parameters instead of its `Context`