### PR TITLE
Remove `Error` and `Result` from prelude

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,6 +3,5 @@
 pub use app::{Application, ApplicationBuilder};
 pub use engine::Engine;
 pub use config::Config;
-pub use error::{Error, Result};
 pub use event::*;
 pub use state::{State, Trans};


### PR DESCRIPTION
See [comment on #285][comment].

[comment]: https://github.com/amethyst/amethyst/pull/285#issuecomment-323360153