### PR TITLE
Skip doc test in src/lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! # Example
 //!
-//! ```rust
+//! ```rust,no_run
 //! extern crate amethyst;
 //!
 //! use amethyst::prelude::*;


### PR DESCRIPTION
This makes travis happy, because this example can't run headless.