### PR TITLE
Use multiple extensions for formats

### DIFF
--- a/amethyst_assets/examples/asset.rs
+++ b/amethyst_assets/examples/asset.rs
@@ -43,13 +43,10 @@ impl Context for DummyContext {
 struct DummyFormat;
 
 impl Format for DummyFormat {
+    const EXTENSIONS: &'static [&'static str] = &["dum"];
     type Result = Result<String, Utf8Error>;
     type Data = String;
     type Error = Utf8Error;
-
-    fn extension() -> &'static str {
-        "dum"
-    }
 
     fn parse(&self, bytes: Vec<u8>, _: &ThreadPool) -> Self::Result {
         from_utf8(bytes.as_slice()).map(|s| s.to_owned())

--- a/amethyst_assets/examples/cache.rs
+++ b/amethyst_assets/examples/cache.rs
@@ -62,13 +62,10 @@ impl Asset for DummyAsset {
 struct DummyFormat;
 
 impl Format for DummyFormat {
+    const EXTENSIONS: &'static [&'static str] = &["dum"];
     type Data = String;
     type Error = Utf8Error;
     type Result = Result<Self::Data, Self::Error>;
-
-    fn extension() -> &'static str {
-        "dum"
-    }
 
     fn parse(&self, bytes: Vec<u8>, _: &ThreadPool) -> Result<Self::Data, Self::Error> {
         from_utf8(bytes.as_slice()).map(|s| s.to_owned())

--- a/amethyst_assets/src/asset.rs
+++ b/amethyst_assets/src/asset.rs
@@ -91,8 +91,8 @@ impl<A> From<Shared<Box<Future<Item = A, Error = BoxedErr>>>> for AssetFuture<A>
 /// * the storage it was loaded from
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct AssetSpec {
-    /// The extension of this asset
-    pub ext: &'static str,
+    /// The possible extensions of this asset
+    pub exts: &'static [&'static str],
     /// The name of this asset.
     pub name: String,
     /// Unique identifier indicating the Storage from which the asset was loaded.
@@ -101,8 +101,8 @@ pub struct AssetSpec {
 
 impl AssetSpec {
     /// Creates a new asset specifier from the given parameters.
-    pub fn new(name: String, ext: &'static str, store: StoreId) -> Self {
-        AssetSpec { ext, name, store }
+    pub fn new(name: String, exts: &'static [&'static str], store: StoreId) -> Self {
+        AssetSpec { exts, name, store }
     }
 }
 
@@ -166,6 +166,14 @@ pub trait Context: Send + Sync + 'static {
 /// in turn accepted by `Asset::from_data`. Examples for formats are
 /// `Png`, `Obj` and `Wave`.
 pub trait Format {
+    /// A list of the extensions (without `.`).
+    ///
+    /// ## Examples
+    ///
+    /// * `"png"`
+    /// * `"obj"`
+    /// * `"wav"`
+    const EXTENSIONS: &'static [&'static str];
     /// The data type this format is able to load.
     type Data;
     /// The error that may be returned from `Format::parse`.
@@ -174,14 +182,7 @@ pub trait Format {
     /// `IntoFuture`.
     type Result: IntoFuture<Item = Self::Data, Error = Self::Error>;
 
-    /// Returns the extension (without `.`).
-    ///
-    /// ## Examples
-    ///
-    /// * `"png"`
-    /// * `"obj"`
-    /// * `"wav"`
-    fn extension() -> &'static str;
+
 
     /// Reads the given bytes and produces asset data.
     fn parse(&self, bytes: Vec<u8>, pool: &ThreadPool) -> Self::Result;

--- a/amethyst_assets/src/error.rs
+++ b/amethyst_assets/src/error.rs
@@ -30,9 +30,9 @@ where
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         write!(
             f,
-            "Failed to load asset \"{}\" of format \"{}\" from storage with id \"{}\": {}",
+            "Failed to load asset \"{}\" of format \"{:?}\" from storage with id \"{}\": {}",
             &self.asset.name,
-            &self.asset.ext,
+            &self.asset.exts,
             &self.asset.store.id(),
             &self.error
         )

--- a/amethyst_assets/src/loader.rs
+++ b/amethyst_assets/src/loader.rs
@@ -271,7 +271,7 @@ where
 {
     let name = name.into();
 
-    let spec = AssetSpec::new(name.clone(), F::extension(), store_id);
+    let spec = AssetSpec::new(name.clone(), F::EXTENSIONS, store_id);
 
     context.retrieve(&spec).unwrap_or_else(move || {
         load_asset_inner(context, format, spec, storage, pool)
@@ -302,7 +302,7 @@ where
 {
     let name = name.into();
 
-    let spec = AssetSpec::new(name.clone(), F::extension(), store_id);
+    let spec = AssetSpec::new(name.clone(), F::EXTENSIONS, store_id);
 
     load_asset_inner(context, format, spec, storage, pool)
 }
@@ -329,7 +329,7 @@ where
     let pool = pool.clone();
     let pool_clone = pool.clone();
     let future = store
-        .load(context.category(), &spec.name, spec.ext)
+        .load(context.category(), &spec.name, spec.exts)
         .into_future()
         .map_err(LoadError::StorageError::<C::Error, F::Error, S::Error>)
         .map_err(move |e| AssetError::new(spec_store_err, e))

--- a/amethyst_assets/src/store/mod.rs
+++ b/amethyst_assets/src/store/mod.rs
@@ -18,7 +18,7 @@ pub trait AnyStore: Send + Sync {
         &self,
         category: &str,
         id: &str,
-        ext: &str,
+        exts: &[&str],
     ) -> Box<Future<Item = Vec<u8>, Error = BoxedErr>>;
 }
 
@@ -34,9 +34,9 @@ where
         &self,
         category: &str,
         id: &str,
-        ext: &str,
+        exts: &[&str],
     ) -> Box<Future<Item = Vec<u8>, Error = BoxedErr>> {
-        Box::new(T::load(self, category, id, ext).into_future().map_err(
+        Box::new(T::load(self, category, id, exts).into_future().map_err(
             BoxedErr::new,
         ))
     }
@@ -54,8 +54,8 @@ where
         AnyStore::modified(self, category, id, ext)
     }
 
-    fn load(&self, category: &str, id: &str, ext: &str) -> Self::Result {
-        AnyStore::load(&**self, category, id, ext)
+    fn load(&self, category: &str, id: &str, exts: &[&str]) -> Self::Result {
+        AnyStore::load(&**self, category, id, exts)
     }
 }
 
@@ -76,5 +76,5 @@ pub trait Store {
     /// Loads the bytes given a category, id and extension of the asset.
     ///
     /// The id should always use `/`as separator in paths.
-    fn load(&self, category: &str, id: &str, ext: &str) -> Self::Result;
+    fn load(&self, category: &str, id: &str, exts: &[&str]) -> Self::Result;
 }

--- a/examples/05_assets/main.rs
+++ b/examples/05_assets/main.rs
@@ -25,13 +25,10 @@ use rayon::ThreadPool;
 struct Custom;
 
 impl Format for Custom {
+    const EXTENSIONS: &'static [&'static str] = &["custom"];
     type Data = Vec<PosNormTex>;
     type Error = NoError;
     type Result = Result<Vec<PosNormTex>, NoError>;
-
-    fn extension() -> &'static str {
-        "custom"
-    }
 
     fn parse(&self, bytes: Vec<u8>, _: &ThreadPool) -> Self::Result {
         let data: String = String::from_utf8(bytes).unwrap();

--- a/src/assets/formats/audio.rs
+++ b/src/assets/formats/audio.rs
@@ -8,13 +8,10 @@ use assets::*;
 pub struct WavFormat;
 
 impl Format for WavFormat {
+    const EXTENSIONS: &'static [&'static str] = &["wav"];
     type Data = Vec<u8>;
     type Error = NoError;
     type Result = Result<Self::Data, Self::Error>;
-
-    fn extension() -> &'static str {
-        "wav"
-    }
 
     fn parse(&self, bytes: Vec<u8>, _: &ThreadPool) -> Self::Result {
         Ok(bytes)
@@ -25,13 +22,10 @@ impl Format for WavFormat {
 pub struct OggFormat;
 
 impl Format for OggFormat {
+    const EXTENSIONS: &'static [&'static str] = &["ogg"];
     type Data = Vec<u8>;
     type Error = NoError;
     type Result = Result<Self::Data, Self::Error>;
-
-    fn extension() -> &'static str {
-        "ogg"
-    }
 
     fn parse(&self, bytes: Vec<u8>, _: &ThreadPool) -> Self::Result {
         Ok(bytes)
@@ -42,13 +36,10 @@ impl Format for OggFormat {
 pub struct FlacFormat;
 
 impl Format for FlacFormat {
+    const EXTENSIONS: &'static [&'static str] = &["flac"];
     type Data = Vec<u8>;
     type Error = NoError;
     type Result = Result<Self::Data, Self::Error>;
-
-    fn extension() -> &'static str {
-        "flac"
-    }
 
     fn parse(&self, bytes: Vec<u8>, _: &ThreadPool) -> Self::Result {
         Ok(bytes)

--- a/src/assets/formats/meshes.rs
+++ b/src/assets/formats/meshes.rs
@@ -53,13 +53,10 @@ impl Display for ObjError {
 pub struct ObjFormat;
 
 impl Format for ObjFormat {
+    const EXTENSIONS: &'static [&'static str] = &["obj"];
     type Data = Vec<PosNormTex>;
     type Error = ObjError;
     type Result = VerticesFuture<PosNormTex>;
-
-    fn extension() -> &'static str {
-        "obj"
-    }
 
     fn parse(&self, bytes: Vec<u8>, pool: &ThreadPool) -> Self::Result {
         VerticesFuture::spawn(pool, move || {

--- a/src/assets/formats/textures.rs
+++ b/src/assets/formats/textures.rs
@@ -20,43 +20,19 @@ pub struct ImageData {
 /// A future which will eventually have an image available.
 pub type ImageFuture = SpawnedFuture<ImageData, ImageError>;
 
-fn parse_jpeg(bytes: Vec<u8>, pool: &ThreadPool) -> ImageFuture {
-    ImageFuture::spawn(pool, move || {
-        imagefmt::jpeg::read(&mut Cursor::new(bytes), ColFmt::RGBA).map(|raw| ImageData { raw })
-    })
-}
-
-/// Allows loading of Jpeg files.
-pub struct JpegFormat;
-
-impl Format for JpegFormat {
-    type Data = ImageData;
-    type Error = ImageError;
-    type Result = ImageFuture;
-
-    fn extension() -> &'static str {
-        "jpeg"
-    }
-
-    fn parse(&self, bytes: Vec<u8>, pool: &ThreadPool) -> Self::Result {
-        parse_jpeg(bytes, pool)
-    }
-}
-
-/// Allows loading of Jpg files.
+/// Allows loading of jpg or jpeg files.
 pub struct JpgFormat;
 
 impl Format for JpgFormat {
+    const EXTENSIONS: &'static [&'static str] = &["jpg", "jpeg"];
     type Data = ImageData;
     type Error = ImageError;
     type Result = ImageFuture;
 
-    fn extension() -> &'static str {
-        "jpg"
-    }
-
     fn parse(&self, bytes: Vec<u8>, pool: &ThreadPool) -> Self::Result {
-        parse_jpeg(bytes, pool)
+        ImageFuture::spawn(pool, move || {
+            imagefmt::jpeg::read(&mut Cursor::new(bytes), ColFmt::RGBA).map(|raw| ImageData { raw })
+        })
     }
 }
 
@@ -64,13 +40,10 @@ impl Format for JpgFormat {
 pub struct PngFormat;
 
 impl Format for PngFormat {
+    const EXTENSIONS: &'static [&'static str] = &["png"];
     type Data = ImageData;
     type Error = ImageError;
     type Result = ImageFuture;
-
-    fn extension() -> &'static str {
-        "png"
-    }
 
     fn parse(&self, bytes: Vec<u8>, pool: &ThreadPool) -> Self::Result {
         ImageFuture::spawn(pool, move || {
@@ -83,13 +56,10 @@ impl Format for PngFormat {
 pub struct BmpFormat;
 
 impl Format for BmpFormat {
+    const EXTENSIONS: &'static [&'static str] = &["bmp"];
     type Data = ImageData;
     type Error = ImageError;
     type Result = ImageFuture;
-
-    fn extension() -> &'static str {
-        "bmp"
-    }
 
     fn parse(&self, bytes: Vec<u8>, pool: &ThreadPool) -> Self::Result {
         ImageFuture::spawn(pool, move || {


### PR DESCRIPTION
Some formats (such as jpeg) have multiple file extensions that could be considered valid.  This slight ergonomics improvement allows end users to not have to know exactly what extension their file is using if there's any room for ambiguity.  (Only works with Rust 1.20, which was made stable today.)