### PR TITLE
[wip] Implement error handling using error-chain

### DIFF
--- a/amethyst_renderer/Cargo.toml
+++ b/amethyst_renderer/Cargo.toml
@@ -37,6 +37,7 @@ rayon = "0.8"
 serde = "1.0"
 serde_derive = "1.0"
 winit = "0.7"
+error-chain = "0.10"
 
 gfx_device_gl = { version = "0.14", optional = true }
 gfx_window_glutin = { version = "0.17", optional = true }

--- a/amethyst_renderer/examples/window.rs
+++ b/amethyst_renderer/examples/window.rs
@@ -1,5 +1,6 @@
 //! Launches a new renderer window.
 
+#[macro_use] extern crate error_chain;
 extern crate amethyst_renderer as renderer;
 extern crate winit;
 
@@ -7,11 +8,12 @@ use std::time::{Duration, Instant};
 
 use winit::{Event, EventsLoop, WindowEvent};
 use renderer::prelude::*;
+use renderer::Result;
 
-fn main() {
+fn run() -> Result<()> {
     let mut events = EventsLoop::new();
-    let mut renderer = Renderer::new(&events).unwrap();
-    let pipe = renderer.create_pipe(Pipeline::forward::<PosTex>()).unwrap();
+    let mut renderer = Renderer::new(&events)?;
+    let pipe = renderer.create_pipe(Pipeline::forward::<PosTex>())?;
     let scene = Scene::default();
 
     let mut delta = Duration::from_secs(0);
@@ -30,7 +32,10 @@ fn main() {
             _ => (),
         });
 
-        renderer.draw(&scene, &pipe, delta);
+        renderer.draw(&scene, &pipe, delta)?;
         delta = Instant::now() - start;
     }
+    Ok(())
 }
+
+quick_main!(run);

--- a/amethyst_renderer/src/error.rs
+++ b/amethyst_renderer/src/error.rs
@@ -5,52 +5,37 @@ use gfx_core;
 use glutin;
 
 error_chain! {
+
+    foreign_links {
+
+        BufferCreation(gfx::buffer::CreationError)
+            #[doc="Error occured during buffer creation"];
+        PipelineState(gfx::PipelineStateError<String>)
+            #[doc="Error occured in pipeline state"];
+        PsoCreation(gfx_core::pso::CreationError)
+            #[doc="Error occured during pipeline state object creation"];
+        ShaderProgram(gfx::shade::ProgramError)
+            #[doc="Error occured during shader compilation"];
+        ResourceView(gfx::ResourceViewError)
+            #[doc="Error occured in resource view"];
+        GfxCombined(gfx::CombinedError)
+            #[doc="Gfx combined error type"];
+        TextureCreation(gfx::texture::CreationError)
+            #[doc="Error occured during texture creation"];
+        GlutinContext(glutin::ContextError) // todo #[cfg(glutin)] only
+            #[doc="(gl specific) Error occured in gl context"];
+    }
+
     errors {
-        /// Failed to create a buffer.
-        BufferCreation(e: gfx::buffer::CreationError) {
-            description("Failed to create buffer!")
-            display("Buffer creation failed: {}", e)
-        }
         /// A render target with the given name does not exist.
         NoSuchTarget(e: String) {
             description("Target with this name does not exist!")
             display("Nonexistent target: {}", e)
         }
-        /// Failed to initialize a render pass.
-        PassInit(e: gfx::PipelineStateError<String>) {
-            description("Failed to initialize render pass!")
-            display("Pass initialization failed: {}", e)
-        }
-        /// Failed to create a pipeline state object (PSO).
-        PipelineCreation(e: gfx_core::pso::CreationError) {
-            description("Failed to create PSO!")
-            display("PSO creation failed: {}", e)
-        }
         /// Failed to create thread pool.
         PoolCreation(e: String) {
             description("Failed to create thread pool!")
             display("Thread pool creation failed: {}", e)
-        }
-        /// Failed to create and link a shader program.
-        ProgramCreation(e: gfx::shade::ProgramError) {
-            description("Failed to create shader program!")
-            display("Program compilation failed: {}", e)
-        }
-        /// Failed to create a resource view.
-        ResViewCreation(e: gfx::ResourceViewError) {
-            description("Failed to create resource view!")
-            display("Resource view creation failed: {}", e)
-        }
-
-        /// Failed to create a render target.
-        TargetCreation(e: gfx::CombinedError) {
-            description("Failed to create render target!")
-            display("Target creation failed: {}", e)
-        }
-        /// Failed to create a texture resource.
-        TextureCreation(e: gfx::texture::CreationError) {
-            description("Failed to create texture!")
-            display("Texture creation failed: {}", e)
         }
         /// An error occuring in buffer/texture updates.
         BufTexUpdate {
@@ -71,11 +56,6 @@ error_chain! {
             description("No constant buffer was found with the given name")
             display(r#"No constant buffer was found with the name "{}""#, name)
         }
-        /// (GL only) An error occured swapping buffers
-        BufferSwapFailed(e: glutin::ContextError) {
-            description("An error occured swapping the buffers")
-            display("An error occured swapping the buffers: {}", e)
-        }
         /// A list of all errors that occured during render
         DrawErrors(errors: Vec<Error>) {
             description("One or more errors occured during drawing")
@@ -88,44 +68,3 @@ error_chain! {
     }
 }
 
-impl From<gfx::CombinedError> for Error {
-    fn from(e: gfx::CombinedError) -> Error {
-        ErrorKind::TargetCreation(e).into()
-    }
-}
-
-impl From<gfx::PipelineStateError<String>> for Error {
-    fn from(e: gfx::PipelineStateError<String>) -> Error {
-        ErrorKind::PassInit(e).into()
-    }
-}
-
-impl From<gfx::ResourceViewError> for Error {
-    fn from(e: gfx::ResourceViewError) -> Error {
-        ErrorKind::ResViewCreation(e).into()
-    }
-}
-
-impl From<gfx::buffer::CreationError> for Error {
-    fn from(e: gfx::buffer::CreationError) -> Error {
-        ErrorKind::BufferCreation(e).into()
-    }
-}
-
-impl From<gfx::shade::ProgramError> for Error {
-    fn from(e: gfx::shade::ProgramError) -> Error {
-        ErrorKind::ProgramCreation(e).into()
-    }
-}
-
-impl From<gfx::texture::CreationError> for Error {
-    fn from(e: gfx::texture::CreationError) -> Error {
-        ErrorKind::TextureCreation(e).into()
-    }
-}
-
-impl From<gfx_core::pso::CreationError> for Error {
-    fn from(e: gfx_core::pso::CreationError) -> Error {
-        ErrorKind::PipelineCreation(e).into()
-    }
-}

--- a/amethyst_renderer/src/lib.rs
+++ b/amethyst_renderer/src/lib.rs
@@ -65,6 +65,11 @@
 #![deny(missing_docs)]
 #![doc(html_logo_url = "https://tinyurl.com/jtmm43a")]
 
+// for error-chain
+#![recursion_limit="4096"]
+
+#[macro_use]
+extern crate error_chain;
 extern crate cgmath;
 #[macro_use]
 extern crate derivative;
@@ -104,7 +109,7 @@ extern crate gfx_window_vulkan;
 pub use cam::{Camera, Projection};
 pub use color::Rgba;
 pub use config::Config;
-pub use error::{Error, Result};
+pub use error::{Error, ErrorKind, Result};
 pub use light::Light;
 pub use mesh::{Mesh, MeshBuilder};
 pub use mtl::{Material, MaterialBuilder};
@@ -211,7 +216,7 @@ impl Renderer {
     }
 
     /// Draws a scene with the given pipeline.
-    pub fn draw(&mut self, scene: &Scene, pipe: &Pipeline, _delta: Duration) {
+    pub fn draw(&mut self, scene: &Scene, pipe: &Pipeline, _delta: Duration) -> Result<()> {
         use gfx::Device;
         #[cfg(feature = "opengl")]
         use glutin::GlContext;
@@ -234,7 +239,7 @@ impl Renderer {
 
         {
             let mut encoders = self.encoders.iter_mut();
-            self.pool.install(move || {
+            self.pool.install(move || -> Result<()> {
                 let mut updates = Vec::new();
                 for stage in pipe.enabled_stages() {
                     let needed = stage.encoders_required(num_threads);
@@ -244,12 +249,29 @@ impl Renderer {
                     updates.push(stage.apply(taken, scene));
                 }
 
-                updates.into_par_iter().flat_map(|update| update).for_each(
-                    |(pass, models, enc)| for model in models {
-                        pass.apply(enc, scene, model);
+                let errors = updates.into_par_iter().flat_map(|update| update).fold(
+                    || Vec::new(),
+                    |mut acc, (pass, models, enc)| {
+                        for model in models {
+                            if let Err(e) = pass.apply(enc, scene, model) {
+                                acc.push(e);
+                            };
+                        }
+                        acc
                     },
+                ).reduce(
+                    || Vec::new(),
+                    |mut acc, res| {
+                        acc.extend(res.into_iter());
+                        acc
+                    }
                 );
-            });
+
+                if errors.len() > 0 {
+                    bail!(ErrorKind::DrawErrors(errors));
+                }
+                Ok(())
+            })?;
         }
 
         for enc in self.encoders.iter_mut() {
@@ -259,9 +281,8 @@ impl Renderer {
         self.device.cleanup();
 
         #[cfg(feature = "opengl")]
-        self.window.swap_buffers().expect(
-            "OpenGL context has been lost",
-        );
+        self.window.swap_buffers().map_err(|e| Error::from(ErrorKind::BufferSwapFailed(e)))?;
+        Ok(())
     }
 }
 
@@ -345,7 +366,7 @@ impl<'a> RendererBuilder<'a> {
         let pool = self.pool.clone().map(|p| Ok(p)).unwrap_or_else(|| {
             let cfg = rayon::Configuration::new().num_threads(num_cores);
             ThreadPool::new(cfg).map(|p| Arc::new(p)).map_err(|e| {
-                Error::PoolCreation(format!("{}", e))
+                Error::from(ErrorKind::PoolCreation(format!("{}", e)))
             })
         })?;
 
@@ -428,7 +449,7 @@ fn init_backend(wb: WindowBuilder, el: &EventsLoop, config: &Config) -> Result<B
         .with_gl(GlRequest::Latest);
 
     let (win, dev, fac, color, depth) = win::init::<ColorFormat, DepthFormat>(wb, ctx, el);
-    let size = win.get_inner_size_points().ok_or(Error::WindowDestroyed)?;
+    let size = win.get_inner_size_points().ok_or(Error::from(ErrorKind::WindowDestroyed))?;
     let main_target = Target::new(
         ColorBuffer {
             as_input: None,

--- a/amethyst_renderer/src/lib.rs
+++ b/amethyst_renderer/src/lib.rs
@@ -281,7 +281,7 @@ impl Renderer {
         self.device.cleanup();
 
         #[cfg(feature = "opengl")]
-        self.window.swap_buffers().map_err(|e| Error::from(ErrorKind::BufferSwapFailed(e)))?;
+        self.window.swap_buffers()?;
         Ok(())
     }
 }

--- a/amethyst_renderer/src/pass/flat.rs
+++ b/amethyst_renderer/src/pass/flat.rs
@@ -57,7 +57,9 @@ impl<V: VertexFormat> Pass for DrawFlat<V> {
             .build()
     }
 
-    fn apply(&self, enc: &mut Encoder, effect: &mut Effect, scene: &Scene, model: &Model) {
+    fn apply(&self, enc: &mut Encoder, effect: &mut Effect, scene: &Scene, model: &Model)
+        -> Result<()>
+    {
         let vertex_args = scene
             .active_camera()
             .map(|cam| {
@@ -75,7 +77,7 @@ impl<V: VertexFormat> Pass for DrawFlat<V> {
                 }
             });
 
-        effect.update_constant_buffer("VertexArgs", &vertex_args, enc);
+        effect.update_constant_buffer("VertexArgs", &vertex_args, enc)?;
         effect.data.textures.push(
             model.material.albedo.view().clone(),
         );
@@ -84,5 +86,6 @@ impl<V: VertexFormat> Pass for DrawFlat<V> {
         );
 
         effect.draw(model, enc);
+        Ok(())
     }
 }

--- a/amethyst_renderer/src/pass/shaded.rs
+++ b/amethyst_renderer/src/pass/shaded.rs
@@ -93,7 +93,9 @@ impl<V: VertexFormat> Pass for DrawShaded<V> {
             .build()
     }
 
-    fn apply(&self, enc: &mut Encoder, effect: &mut Effect, scene: &Scene, model: &Model) {
+    fn apply(&self, enc: &mut Encoder, effect: &mut Effect, scene: &Scene, model: &Model)
+        -> Result<()>
+    {
         use rayon::prelude::*;
 
         let vertex_args = scene
@@ -112,7 +114,7 @@ impl<V: VertexFormat> Pass for DrawShaded<V> {
                     model: model.pos.into(),
                 }
             });
-        effect.update_constant_buffer("VertexArgs", &vertex_args, enc);
+        effect.update_constant_buffer("VertexArgs", &vertex_args, enc)?;
 
         let point_lights: Vec<PointLight2> = scene
             .par_iter_lights()
@@ -142,20 +144,20 @@ impl<V: VertexFormat> Pass for DrawShaded<V> {
             directional_light_count: directional_lights.len() as i32,
         };
 
-        effect.update_constant_buffer("FragmentArgs", &fragment_args, enc);
-        effect.update_buffer("PointLights", &point_lights[..], enc);
-        effect.update_buffer("DirectionalLights", &directional_lights[..], enc);
+        effect.update_constant_buffer("FragmentArgs", &fragment_args, enc)?;
+        effect.update_buffer("PointLights", &point_lights[..], enc)?;
+        effect.update_buffer("DirectionalLights", &directional_lights[..], enc)?;
 
         effect.update_global(
             "ambient_color",
             Into::<[f32; 3]>::into(scene.ambient_color()),
-        );
+        )?;
         effect.update_global(
             "camera_position",
             scene.active_camera().map(|cam| cam.eye.into()).unwrap_or(
                 [0.0; 3],
             ),
-        );
+        )?;
         effect.data.textures.push(
             model.material.emission.view().clone(),
         );
@@ -174,5 +176,6 @@ impl<V: VertexFormat> Pass for DrawShaded<V> {
         );
 
         effect.draw(model, enc);
+        Ok(())
     }
 }

--- a/amethyst_renderer/src/pipe/pass.rs
+++ b/amethyst_renderer/src/pipe/pass.rs
@@ -12,7 +12,8 @@ use types::{Encoder, Factory};
 
 pub trait Pass: Send + Sync {
     fn compile(&self, effect: NewEffect) -> Result<Effect>;
-    fn apply(&self, enc: &mut Encoder, effect: &mut Effect, scene: &Scene, model: &Model);
+    fn apply(&self, enc: &mut Encoder, effect: &mut Effect, scene: &Scene, model: &Model)
+        -> Result<()>;
 }
 
 #[derive(Clone)]
@@ -46,14 +47,14 @@ pub struct CompiledPass {
 }
 
 impl CompiledPass {
-    pub fn apply(&self, enc: &mut Encoder, scene: &Scene, model: &Model) {
+    pub fn apply(&self, enc: &mut Encoder, scene: &Scene, model: &Model) -> Result<()> {
         // TODO: Eliminate this clone.
         self.inner.apply(
             enc,
             &mut self.effect.clone(),
             scene,
             model,
-        );
+        )
     }
 }
 

--- a/amethyst_renderer/src/pipe/stage.rs
+++ b/amethyst_renderer/src/pipe/stage.rs
@@ -5,7 +5,7 @@ use rayon::iter::internal::UnindexedConsumer;
 use rayon::slice::{Chunks, IterMut as ParIterMut};
 use rayon::vec::IntoIter;
 
-use error::{Error, Result};
+use error::{Error, ErrorKind, Result};
 use pipe::{Target, Targets};
 use pipe::pass::{CompiledPass, Description, Pass};
 use scene::{Model, Scene};
@@ -161,9 +161,9 @@ impl StageBuilder {
     /// Builds and returns the stage.
     pub(crate) fn build(mut self, fac: &mut Factory, targets: &Targets) -> Result<Stage> {
         let out = targets.get(&self.target_name).cloned().ok_or(
-            Error::NoSuchTarget(
+            Error::from(ErrorKind::NoSuchTarget(
                 self.target_name,
-            ),
+            )),
         )?;
 
         let passes = self.passes


### PR DESCRIPTION
This PR demonstrates the kind of way you would use `error-chain` to handle errors, and replaces all calls to expect/unwrap in the code and examples. Where I've created new error names to catch errors that were previously panicking, I'm not sure I've picked the right name, or that I'm capturing the right data, but at least this PR gives you a sense of how error handling could work.

It collects any errors in the parallel draw call into a vector.

The examples have been updated to use `quick_main` macro, which allows the "main" function to return a `Result`. If you run with `RUST_BACKTRACE=1 cargo run ...`, then whenever an error-chain error is created, a backtrace is attached, and reported if using quick_main.