### PR TITLE
Add Loading state

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -528,9 +528,6 @@ impl<'a, 'b, T: State + 'a> ApplicationBuilder<'a, 'b, T> {
         })
     }
 
-
-
-
     /// Register new context within the loader
     fn register_mesh_asset(self) -> Self {
         use ecs::rendering::{MeshComponent, MeshContext, Factory};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ extern crate winit;
 pub use self::app::{Application, ApplicationBuilder};
 pub use self::engine::Engine;
 pub use self::error::{Error, Result};
-pub use self::state::{State, StateMachine, Trans};
+pub use self::state::{Loading, State, StateMachine, Trans};
 
 pub mod assets;
 pub mod audio;


### PR DESCRIPTION
That's about the concept I imagined. I did not try it out e.g. by creating examples yet.

One thing I noticed (which should be done anyways, even without this PR) is that we should have the music (IIRC in the pong example) as a resource (instead of inside a system). It would be better to just have a `Vec` of `Source`s IMO, which would also allow adding the music later.