### PR TITLE
Add error printing and remove warnings from source

### DIFF
--- a/src/audio/play.rs
+++ b/src/audio/play.rs
@@ -2,7 +2,7 @@
 
 use std::io::Cursor;
 
-use rodio::{Decoder, play_once as rplay_once, Sink, Source as RSource};
+use rodio::{Decoder, Sink, Source as RSource};
 
 use super::DecoderError;
 use super::output::Output;
@@ -12,7 +12,7 @@ use super::source::Source;
 ///
 /// This will return an Error if the loaded audio file in source could not be decoded.
 pub fn try_play_once(source: &Source, volume: f32, endpoint: &Output) -> Result<(), DecoderError> {
-    let mut sink = Sink::new(&endpoint.endpoint);
+    let sink = Sink::new(&endpoint.endpoint);
     match Decoder::new(Cursor::new(source.clone())) {
         Ok(source) => {
             sink.append(source.amplify(volume));
@@ -34,16 +34,18 @@ pub fn try_play_once(source: &Source, volume: f32, endpoint: &Output) -> Result<
 ///
 /// This may silently fail, in order to get error information use `try_play_once`.
 pub fn play_once(source: &Source, volume: f32, endpoint: &Output) {
-    // This absurd construct is here to keep warnings about an unused result from appearing.
-    let _ = try_play_once(source, volume, endpoint);
+    if let Err(err) = try_play_once(source, volume, endpoint) {
+        eprintln!("An error occurred while trying to play a sound: {:?}", err);
+    }
 }
 
 /// Play a sound n times.  A volume of 1.0 is unchanged, while 0.0 is silent.
 ///
 /// This may silently fail, in order to get error information use `try_play_n_times`.
 pub fn play_n_times(source: &Source, volume: f32, endpoint: &Output, n: u16) {
-    // This absurd construct is here to keep warnings about an unused result from appearing.
-    let _ = try_play_n_times(source, volume, endpoint, n);
+    if let Err(err) = try_play_n_times(source, volume, endpoint, n) {
+        eprintln!("An error occurred while trying to play a sound: {:?}", err);
+    }
 }
 
 /// Play a sound n times.  A volume of 1.0 is unchanged, while 0.0 is silent.
@@ -55,7 +57,7 @@ pub fn try_play_n_times(
     endpoint: &Output,
     n: u16,
 ) -> Result<(), DecoderError> {
-    let mut sink = Sink::new(&endpoint.endpoint);
+    let sink = Sink::new(&endpoint.endpoint);
     for _ in 0..n {
         sink.append(
             Decoder::new(Cursor::new(source.clone()))


### PR DESCRIPTION
This PR adds printing of any errors that may occur and also removes some of the code warnings

Fixes #346 

