### PR TITLE
Remove documention build, set warnings as errors

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,6 @@
 # Set up the build environment.
 environment:
+  RUSTFLAGS: "-D warnings"
   matrix:
     - channel: stable
       target: x86_64-pc-windows-msvc
@@ -13,9 +14,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - channel: nightly
-    
-environment:
-  RUSTFLAGS: "-D warnings"
 
 # Set up the Rust toolchain.
 install:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,6 +13,9 @@ matrix:
   fast_finish: true
   allow_failures:
     - channel: nightly
+    
+environment:
+  RUSTFLAGS: "-D warnings"
 
 # Set up the Rust toolchain.
 install:
@@ -43,6 +46,5 @@ build: false
 
 # Generate documentation, compile the engine, run tests.
 test_script:
-  - cargo doc --all --no-deps -v
   - cargo test --all -v
   - cargo test --all -v --features profiler

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rust:
   - stable
   - beta
   - nightly
+env:
+  - RUSTFLAGS="-D warnings"
 
 # Allow for occasional compiler breakage on nightly Rust.
 matrix:
@@ -45,7 +47,6 @@ before_script:
 
 # Generate documentation, compile the engine, run tests.
 script: |
-  cargo doc --all --no-deps -v &&
   # Build and test without profiler
   cargo test --all -v &&
   # Build and test with profiler


### PR DESCRIPTION
By removing the documentation build our travis becomes faster, and by preventing Travis from passing with warnings we keep our code cleaner.