### PR TITLE
Small fixes to 03_renderable and 04_pong examples [non breaking]

### DIFF
--- a/examples/03_renderable/main.rs
+++ b/examples/03_renderable/main.rs
@@ -45,12 +45,19 @@ impl<'a> System<'a> for ExampleSystem {
     fn run(&mut self, (mut lights, time, mut camera, mut state): Self::SystemData) {
         let delta_time = time.delta_time.subsec_nanos() as f32 / 1.0e9;
 
-        state.light_angle -= delta_time;
-        state.camera_angle += delta_time / 10.0;
+        let light_angular_velocity = -1.0;
+        let light_orbit_radius = 15.0;
+        let light_z = 6.0;
+
+        let camera_angular_velocity = 0.1;
+        let camera_orbit_radius = 20.0;
+
+        state.light_angle += light_angular_velocity * delta_time;
+        state.camera_angle += camera_angular_velocity * delta_time;
 
         let target = camera.eye + camera.forward;
-        camera.eye[0] = 20.0 * state.camera_angle.cos();
-        camera.eye[1] = 20.0 * state.camera_angle.sin();
+        camera.eye[0] = camera_orbit_radius * state.camera_angle.cos();
+        camera.eye[1] = camera_orbit_radius * state.camera_angle.sin();
         camera.forward = target - camera.eye;
 
         for point_light in (&mut lights).join().filter_map(|light| {
@@ -61,9 +68,9 @@ impl<'a> System<'a> for ExampleSystem {
             }
         })
         {
-            point_light.center[0] = 15.0 * state.light_angle.cos();
-            point_light.center[1] = 15.0 * state.light_angle.sin();
-            point_light.center[2] = 6.0;
+            point_light.center[0] = light_orbit_radius * state.light_angle.cos();
+            point_light.center[1] = light_orbit_radius * state.light_angle.sin();
+            point_light.center[2] = light_z;
 
             point_light.color = state.light_color.into();
         }

--- a/examples/04_pong/main.rs
+++ b/examples/04_pong/main.rs
@@ -50,16 +50,16 @@ enum Side {
     Right,
 }
 
-struct Plank {
+struct Paddle {
     pub position: f32,
     pub velocity: f32,
     pub dimensions: [f32; 2],
     pub side: Side,
 }
 
-impl Plank {
-    pub fn new(side: Side) -> Plank {
-        Plank {
+impl Paddle {
+    pub fn new(side: Side) -> Paddle {
+        Paddle {
             position: 0.,
             velocity: 1.,
             dimensions: [1., 1.],
@@ -68,8 +68,8 @@ impl Plank {
     }
 }
 
-impl Component for Plank {
-    type Storage = VecStorage<Plank>;
+impl Component for Paddle {
+    type Storage = VecStorage<Paddle>;
 }
 
 struct PongSystem {
@@ -95,7 +95,7 @@ impl Score {
 // Pong game system
 impl<'a> System<'a> for PongSystem {
     type SystemData = (WriteStorage<'a, Ball>,
-     WriteStorage<'a, Plank>,
+     WriteStorage<'a, Paddle>,
      WriteStorage<'a, LocalTransform>,
      Fetch<'a, Camera>,
      Fetch<'a, Time>,
@@ -333,7 +333,7 @@ impl State for Pong {
             .build();
 
         // Create a left plank entity
-        let mut plank = Plank::new(Side::Left);
+        let mut plank = Paddle::new(Side::Left);
         plank.dimensions[0] = 0.01;
         plank.dimensions[1] = 0.1;
         plank.velocity = 1.;
@@ -347,7 +347,7 @@ impl State for Pong {
             .build();
 
         // Create right plank entity
-        let mut plank = Plank::new(Side::Right);
+        let mut plank = Paddle::new(Side::Right);
         plank.dimensions[0] = 0.01;
         plank.dimensions[1] = 0.1;
         plank.velocity = 1.;
@@ -438,7 +438,7 @@ fn run() -> Result<(), amethyst::Error> {
     let mut game = Application::build(Pong)
         .unwrap()
         .register::<Ball>()
-        .register::<Plank>()
+        .register::<Paddle>()
         .with::<PongSystem>(pong, "pong_system", &[])
         .with::<TransformSystem>(TransformSystem::new(), "transform_system", &["pong_system"])
         .with_renderer(


### PR DESCRIPTION
* Get rid of magic numbers in `ExampleSystem::run` method in 03_renderable
* Rename `Plank` to `Paddle` in 04_pong