### PR TITLE
Remove OSX from travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,9 @@ branches:
     - master
     - /release-.*/
 
-# Test on both Linux and OS X.
+# Test on Linux - OSX builds take in excess of 5 hours to start as of 2017-09-19.
 os:
   - linux
-  - osx
 
 # Install ALSA development libraries before compiling on Linux.
 addons:


### PR DESCRIPTION
Travis can take in excess of 5 hours to start OSX builds and most PRs aren't likely to break OSX builds specifically, so I propose we remove this from our travis and just make sure we test on mac ourselves if we're worried about a PR breaking OSX.