### PR TITLE
Made it possible to define external texture formats

### DIFF
--- a/src/assets/formats/textures.rs
+++ b/src/assets/formats/textures.rs
@@ -14,7 +14,8 @@ use assets::{Format, SpawnedFuture};
 /// ImageData provided by formats, can be interpreted as a texture.
 #[derive(Clone, Debug)]
 pub struct ImageData {
-    pub(crate) raw: Image<u8>,
+    /// The raw image data.
+    pub raw: Image<u8>,
 }
 
 /// A future which will eventually have an image available.


### PR DESCRIPTION
Just setting the raw image data to pub instead of pub(crate) allows external users to define custom formats and makes my life easier to test the new TTF loader and format.

This change would be temporary as @Xaeroxe wants to make a more complex wrapper. But, because it is clearly no a priority, this allows the feature to be exposed with minimal effort.

You if don't want this included, refuse the pr and close it.

Thanks!