### PR TITLE
Add blending for transparency

### DIFF
--- a/amethyst_renderer/src/pipe/effect/mod.rs
+++ b/amethyst_renderer/src/pipe/effect/mod.rs
@@ -13,7 +13,7 @@ use gfx::preset::depth::{LESS_EQUAL_TEST, LESS_EQUAL_WRITE};
 use gfx::pso::buffer::{ElemStride, InstanceRate};
 use gfx::shade::{ProgramError, ToUniform};
 use gfx::shade::core::UniformValue;
-use gfx::state::{Rasterizer, Stencil};
+use gfx::state::{Blend, BlendValue, ColorMask, Equation, Factor, Rasterizer, Stencil};
 use gfx::traits::Pod;
 
 use self::pso::{Data, Init, Meta};
@@ -226,7 +226,7 @@ impl<'a> EffectBuilder<'a> {
                 Stencil::default(),
             ));
         }
-        self.init.out_colors.push(name);
+        self.init.out_colors.push((name, ColorMask::all(), Blend::new(Equation::Add, Factor::One, Factor::OneMinus(BlendValue::SourceAlpha))));
         self
     }
 

--- a/amethyst_renderer/src/pipe/effect/pso.rs
+++ b/amethyst_renderer/src/pipe/effect/pso.rs
@@ -10,7 +10,7 @@ use types::{ColorFormat, DepthFormat, Resources};
 type AccessInfo = pso::AccessInfo<Resources>;
 type DepthStencilTarget = target::DepthStencilTarget<DepthFormat>;
 type Manager = handle::Manager<Resources>;
-type RenderTarget = target::RenderTarget<ColorFormat>;
+type BlendTarget = target::BlendTarget<ColorFormat>;
 type RawDataSet = pso::RawDataSet<Resources>;
 type InitResult<'r, M> = Result<M, InitError<&'r str>>;
 
@@ -18,7 +18,7 @@ type InitResult<'r, M> = Result<M, InitError<&'r str>>;
 pub struct Meta {
     const_bufs: Vec<RawConstantBuffer>,
     globals: Vec<RawGlobal>,
-    out_colors: Vec<RenderTarget>,
+    out_colors: Vec<BlendTarget>,
     out_depth: Option<DepthStencilTarget>,
     samplers: Vec<Sampler>,
     textures: Vec<RawShaderResource>,
@@ -30,7 +30,7 @@ pub struct Meta {
 pub struct Init<'d> {
     pub const_bufs: Vec<<RawConstantBuffer as DataLink<'d>>::Init>,
     pub globals: Vec<<RawGlobal as DataLink<'d>>::Init>,
-    pub out_colors: Vec<<RenderTarget as DataLink<'d>>::Init>,
+    pub out_colors: Vec<<BlendTarget as DataLink<'d>>::Init>,
     pub out_depth: Option<<DepthStencilTarget as DataLink<'d>>::Init>,
     pub samplers: Vec<<Sampler as DataLink<'d>>::Init>,
     pub textures: Vec<<RawShaderResource as DataLink<'d>>::Init>,
@@ -71,7 +71,7 @@ impl<'d> PipelineInit for Init<'d> {
         }
 
         for color in self.out_colors.iter() {
-            let mut meta_color = <RenderTarget as DataLink<'d>>::new();
+            let mut meta_color = <BlendTarget as DataLink<'d>>::new();
             for info in info.outputs.iter() {
                 if let Some(res) = meta_color.link_output(info, color) {
                     let d = res.map_err(
@@ -93,7 +93,7 @@ impl<'d> PipelineInit for Init<'d> {
             };
 
             for color in self.out_colors.iter() {
-                let mut meta_color = <RenderTarget as DataLink<'d>>::new();
+                let mut meta_color = <BlendTarget as DataLink<'d>>::new();
                 if let Some(res) = meta_color.link_output(&info, color) {
                     let d = res.map_err(|e| InitError::PixelExport("", Some(e)))?;
                     desc.color_targets[info.slot as usize] = Some(d);
@@ -161,7 +161,7 @@ impl<'d> PipelineInit for Init<'d> {
 pub struct Data {
     pub const_bufs: Vec<<RawConstantBuffer as DataBind<Resources>>::Data>,
     pub globals: Vec<<RawGlobal as DataBind<Resources>>::Data>,
-    pub out_colors: Vec<<RenderTarget as DataBind<Resources>>::Data>,
+    pub out_colors: Vec<<BlendTarget as DataBind<Resources>>::Data>,
     pub out_depth: Option<<DepthStencilTarget as DataBind<Resources>>::Data>,
     pub samplers: Vec<<Sampler as DataBind<Resources>>::Data>,
     pub textures: Vec<<RawShaderResource as DataBind<Resources>>::Data>,

--- a/amethyst_renderer/src/pipe/pipe.rs
+++ b/amethyst_renderer/src/pipe/pipe.rs
@@ -242,7 +242,7 @@ impl<'a, Q, L, Z, R> HetFnOnce<(StageBuilder<Q>,)> for BuildStage<'a>
           R: Passes,
 {
     type Output = Result<Stage<R>>;
-    fn call_once(mut self, (stage,): (StageBuilder<Q>,)) -> Result<Stage<R>> {
+    fn call_once(self, (stage,): (StageBuilder<Q>,)) -> Result<Stage<R>> {
         stage.build(self.factory, self.targets)
     }
 }

--- a/amethyst_renderer/src/pipe/stage.rs
+++ b/amethyst_renderer/src/pipe/stage.rs
@@ -259,7 +259,7 @@ impl<'a, P> HetFnOnce<(P,)> for CompilePass<'a>
     where P: Pass,
 {
     type Output = Result<CompiledPass<P>>;
-    fn call_once(mut self, (pass,): (P,)) -> Result<CompiledPass<P>> {
+    fn call_once(self, (pass,): (P,)) -> Result<CompiledPass<P>> {
         CompiledPass::compile(pass, self.factory, self.target)
     }
 }


### PR DESCRIPTION
This PR updates the amethyst renderer blending algorithm to permit transparency.  It also removes a couple warning from amethyst_renderer in regards to unnecessary mutability of self parameters.

Fixes https://github.com/amethyst/amethyst/issues/357