### PR TITLE
Clear textures and samplers from data for all passes

### DIFF
--- a/amethyst_renderer/src/pass/pbm.rs
+++ b/amethyst_renderer/src/pass/pbm.rs
@@ -282,9 +282,6 @@ impl<'a, V, A, M, N, T, L> ParallelIterator for DrawPbmApply<'a, V, A, M, N, T, 
                 ),
             );
 
-            effect.data.textures.clear();
-            effect.data.samplers.clear();
-
             effect.data.textures.push(
                 material.as_ref().roughness.view().clone(),
             );

--- a/amethyst_renderer/src/pass/shaded.rs
+++ b/amethyst_renderer/src/pass/shaded.rs
@@ -275,9 +275,6 @@ impl<'a, V, A, M, N, T, L> ParallelIterator for DrawShadedApply<'a, V, A, M, N, 
                 ),
             );
 
-            effect.data.textures.clear();
-            effect.data.samplers.clear();
-
             effect.data.textures.push(
                 material.as_ref()
                     .emission

--- a/amethyst_renderer/src/pipe/effect/mod.rs
+++ b/amethyst_renderer/src/pipe/effect/mod.rs
@@ -100,7 +100,7 @@ impl Effect {
     }
 
     /// FIXME: Update raw buffer without transmute, use `Result` somehow.
-    pub fn update_buffer<N, T>(&self, name: N, data: &[T], enc: &mut Encoder)
+    pub fn update_buffer<N, T>(&mut self, name: N, data: &[T], enc: &mut Encoder)
     where
         N: AsRef<str>,
         T: Pod,
@@ -115,7 +115,7 @@ impl Effect {
     }
 
     /// FIXME: Update raw buffer without transmute.
-    pub fn update_constant_buffer<N, T>(&self, name: N, data: &T, enc: &mut Encoder)
+    pub fn update_constant_buffer<N, T>(&mut self, name: N, data: &T, enc: &mut Encoder)
     where
         N: AsRef<str>,
         T: Copy,
@@ -126,6 +126,11 @@ impl Effect {
         }
         // FIXME: Don't silently ignore unknown update.
         // maybe `.expect(...)` would fit here
+    }
+
+    pub fn clear(&mut self) {
+        self.data.textures.clear();
+        self.data.samplers.clear();
     }
 
     pub fn draw(&self, mesh: &Mesh, enc: &mut Encoder) {

--- a/amethyst_renderer/src/pipe/pass.rs
+++ b/amethyst_renderer/src/pipe/pass.rs
@@ -73,6 +73,7 @@ impl<'a, I> ParallelIterator for Apply<'a, I>
         let Apply { inner, supplier } = self;
         inner.map(move |f| {
             let (encoder, effect) = unsafe { supplier.get() };
+            effect.clear();
             f(encoder, effect);
         }).drive_unindexed(consumer)
     }


### PR DESCRIPTION
`textures` and `samplers` vectors from `pso::Data` should be cleared for each pass