### PR TITLE
Use serde to (de)serialize entities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,11 @@ futures = "0.1.14"
 gfx = "0.16"
 genmesh = "0.4"
 imagefmt = "4.0"
-shred = "0.4"
 rayon = "0.7"
 rodio = "0.5.1"
+serde = "1.0"
+serde_derive = "1.0"
+shred = "0.4"
 specs = "0.9.5"
 ticketed_lock = "0.1"
 wavefront_obj = "5.0"
@@ -48,6 +50,9 @@ thread_profiler = { version = "0.1", optional = true }
 [dependencies.smallvec]
 version = "0.4.2"
 features = ["serde"]
+
+[dev-dependencies]
+ron = "0.1"
 
 [[example]]
 name = "hello_world"

--- a/src/app.rs
+++ b/src/app.rs
@@ -302,9 +302,9 @@ impl<'a, 'b, T> ApplicationBuilder<'a, 'b, T> {
         let cfg = cfg.start_handler(|index| {
             register_thread_with_profiler(format!("thread_pool{}", index));
         });
-        let pool = ThreadPool::new(cfg).map(|p| Arc::new(p)).map_err(|_| {
-            Error::Application
-        })?;
+        let pool = ThreadPool::new(cfg)
+            .map(|p| Arc::new(p))
+            .map_err(|_| Error::Application)?;
         let mut world = World::new();
         let base_path = format!("{}/resources", env!("CARGO_MANIFEST_DIR"));
         world.add_resource(Loader::new(base_path, pool.clone()));

--- a/src/ecs/mod.rs
+++ b/src/ecs/mod.rs
@@ -5,8 +5,9 @@ pub use specs::*;
 pub mod audio;
 pub mod input;
 pub mod rendering;
-pub mod util;
+pub mod saveload;
 pub mod transform;
+pub mod util;
 
 use app::ApplicationBuilder;
 use error::Result;

--- a/src/ecs/saveload/de.rs
+++ b/src/ecs/saveload/de.rs
@@ -1,0 +1,179 @@
+
+use std::error::Error;
+use std::fmt::{self, Formatter};
+use std::marker::PhantomData;
+
+use serde::de::{self, Deserialize, DeserializeSeed, Deserializer, SeqAccess, Visitor};
+
+use shred::{ResourceId, Resources, SystemData};
+use specs::{Entities, FetchMut, WriteStorage};
+
+use super::{Components, EntityData, Storages};
+use super::marker::{Marker, MarkerAllocator};
+
+
+/// Wrapper for `Entity` and tuple of `WriteStorage`s that implements `serde::Deserialize`
+struct DeserializeEntity<'a, 'b: 'a, M: Marker, E: Error, T: Components<M::Identifier, E>> {
+    entities: &'a Entities<'b>,
+    storages: &'a mut <T as Storages<'b>>::WriteStorages,
+    markers: &'a mut WriteStorage<'b, M>,
+    allocator: &'a mut FetchMut<'b, M::Allocator>,
+    pd: PhantomData<(M, E, T)>,
+}
+
+impl<'de, 'a, 'b: 'a, M, E, T> DeserializeSeed<'de> for DeserializeEntity<'a, 'b, M, E, T>
+where
+    M: Marker,
+    E: Error,
+    T: Components<M::Identifier, E>,
+{
+    type Value = ();
+    fn deserialize<D>(self, deserializer: D) -> Result<(), D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let DeserializeEntity {
+            entities,
+            storages,
+            markers,
+            allocator,
+            ..
+        } = self;
+        let data = EntityData::<M, E, T>::deserialize(deserializer)?;
+        let entity = allocator.marked(data.marker.id(), entities, markers);
+        markers
+            .get_mut(entity)
+            .ok_or("Allocator is broken")
+            .map_err(de::Error::custom)?
+            .update(data.marker);
+        let ids = |marker: M::Identifier| Some(allocator.marked(marker, entities, markers));
+        T::load(entity, data.components, storages, ids).map_err(de::Error::custom)?;
+        Ok(())
+    }
+}
+
+
+/// Wrapper for `Entities` and tuple of `WriteStorage`s that implements `serde::Deserialize`
+struct VisitEntities<'a, 'b: 'a, M: Marker, E: Error, T: Components<M::Identifier, E>> {
+    entities: &'a Entities<'b>,
+    storages: &'a mut <T as Storages<'b>>::WriteStorages,
+    markers: &'a mut WriteStorage<'b, M>,
+    allocator: &'a mut FetchMut<'b, M::Allocator>,
+    pd: PhantomData<(M, E, T)>,
+}
+
+impl<'de, 'a, 'b: 'a, M, E, T> Visitor<'de> for VisitEntities<'a, 'b, M, E, T>
+where
+    M: Marker,
+    E: Error,
+    T: Components<M::Identifier, E>,
+{
+    type Value = ();
+
+    fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "Sequence of serialized entities")
+    }
+
+    fn visit_seq<A>(mut self, mut seq: A) -> Result<(), A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        while let Some(()) = seq.next_element_seed(DeserializeEntity {
+            entities: self.entities,
+            storages: self.storages,
+            markers: self.markers,
+            allocator: self.allocator,
+            pd: self.pd,
+        })? {}
+
+        Ok(())
+    }
+}
+
+
+/// Deserialize entities
+pub fn deserialize<'a, 'de, D, M, E, T>(
+    entities: &Entities<'a>,
+    storages: &mut <T as Storages<'a>>::WriteStorages,
+    markers: &mut WriteStorage<'a, M>,
+    allocator: &mut FetchMut<'a, M::Allocator>,
+    deserializer: D,
+) -> Result<(), D::Error>
+where
+    M: Marker,
+    E: Error,
+    T: Components<M::Identifier, E>,
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_seq(VisitEntities::<M, E, T> {
+        entities: entities,
+        storages: storages,
+        markers: markers,
+        allocator: allocator,
+        pd: PhantomData,
+    })
+}
+
+
+/// `DeerializeSeed` implementation for `World`
+//#[derive(SystemData)]
+pub struct WorldDeserialize<'a, M: Marker, E: Error, T: Components<M::Identifier, E>> {
+    entities: Entities<'a>,
+    storages: <T as Storages<'a>>::WriteStorages,
+    markers: WriteStorage<'a, M>,
+    allocator: FetchMut<'a, M::Allocator>,
+    pd: PhantomData<E>,
+}
+
+impl<'a, M, E, T> SystemData<'a> for WorldDeserialize<'a, M, E, T>
+where
+    M: Marker,
+    E: Error,
+    T: Components<M::Identifier, E>,
+{
+    fn fetch(res: &'a Resources, id: usize) -> Self {
+        WorldDeserialize {
+            entities: Entities::<'a>::fetch(res, id),
+            storages: <T as Storages<'a>>::WriteStorages::fetch(res, id),
+            markers: WriteStorage::<'a, M>::fetch(res, id),
+            allocator: FetchMut::<'a, M::Allocator>::fetch(res, id),
+            pd: PhantomData,
+        }
+    }
+    fn reads(id: usize) -> Vec<ResourceId> {
+        let mut reads = Entities::<'a>::reads(id);
+        reads.extend(<T as Storages<'a>>::WriteStorages::reads(id));
+        reads.extend(WriteStorage::<'a, M>::reads(id));
+        reads.extend(FetchMut::<'a, M::Allocator>::reads(id));
+        reads
+    }
+    fn writes(id: usize) -> Vec<ResourceId> {
+        let mut writes = Entities::<'a>::writes(id);
+        writes.extend(<T as Storages<'a>>::WriteStorages::writes(id));
+        writes.extend(WriteStorage::<'a, M>::writes(id));
+        writes.extend(FetchMut::<'a, M::Allocator>::writes(id));
+        writes
+    }
+}
+
+impl<'de, 'a, M, E, T> DeserializeSeed<'de> for WorldDeserialize<'a, M, E, T>
+where
+    M: Marker,
+    E: Error,
+    T: Components<M::Identifier, E>,
+{
+    type Value = ();
+
+    fn deserialize<D>(mut self, deserializer: D) -> Result<(), D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize::<D, M, E, T>(
+            &mut self.entities,
+            &mut self.storages,
+            &mut self.markers,
+            &mut self.allocator,
+            deserializer,
+        )
+    }
+}

--- a/src/ecs/saveload/details.rs
+++ b/src/ecs/saveload/details.rs
@@ -1,0 +1,199 @@
+
+
+
+use std::error::Error;
+use std::fmt::{self, Formatter};
+
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
+
+use specs::{Component, Entity, ReadStorage, SystemData, WriteStorage};
+
+use super::marker::Marker;
+
+#[derive(Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct EntityData<M: Marker, E: Error, T: Components<M::Identifier, E>> {
+    pub marker: M,
+    pub components: T::Data,
+}
+
+/// Trivial component is anything that is Component + Copy + DeserializeOwned + Serialize
+pub trait SerializableComponent: Component + DeserializeOwned + Serialize {}
+impl<C> SerializableComponent for C
+where
+    C: Component + DeserializeOwned + Serialize,
+{
+}
+
+/// This trait should be implemented in order to allow component
+/// to be serializeble with `SerializeSystem`.
+/// It is automatically implemented for all `SerializableComponent`s
+pub trait SaveLoadComponent<M>: Component {
+    /// Serializable data representation for component
+    type Data: Serialize + DeserializeOwned;
+
+    /// Error may occur duing serialization or deserialization of component
+    type Error: Error;
+
+    /// Convert this component into serializable form (`Data`) using
+    /// entity to marker mapping function
+    fn save<F>(&self, ids: F) -> Result<Self::Data, Self::Error>
+    where
+        F: FnMut(Entity) -> Option<M>;
+
+    /// Convert this component into deserializable form (`Data`) using
+    /// marker to entity mapping function
+    fn load<F>(data: Self::Data, ids: F) -> Result<Self, Self::Error>
+    where
+        F: FnMut(M) -> Option<Entity>;
+}
+
+/// An error type which cannot be instantiated.
+/// Used as a placeholder for associated error types if
+/// something cannot fail.
+#[derive(Debug)]
+pub enum NoError {}
+
+impl fmt::Display for NoError {
+    fn fmt(&self, _: &mut Formatter) -> fmt::Result {
+        match *self {}
+    }
+}
+
+impl Error for NoError {
+    fn description(&self) -> &str {
+        match *self {}
+    }
+}
+
+impl<C, M> SaveLoadComponent<M> for C
+where
+    C: SerializableComponent + Copy,
+{
+    type Data = Self;
+    type Error = NoError;
+
+    fn save<F>(&self, _ids: F) -> Result<Self::Data, NoError> {
+        Ok(*self)
+    }
+
+    fn load<F>(data: Self, _ids: F) -> Result<Self, NoError> {
+        Ok(data)
+    }
+}
+
+
+
+/// Helper trait defines storages tuples for components tuple
+pub trait Storages<'a> {
+    /// Storages for read
+    type ReadStorages: SystemData<'a> + 'a;
+    /// Storages for write
+    type WriteStorages: SystemData<'a> + 'a;
+}
+
+/// This trait is implemented by any tuple where all elements are
+/// `Component + Serialize + DeserializeOwned`
+pub trait Components<M, E: Error>: for<'a> Storages<'a> {
+    /// Serializable and deserializable intermediate representation
+    type Data: Serialize + DeserializeOwned;
+
+    /// Saves `Component`s of entity into `Intermediate` serializable representation
+    fn save<'a, F>(
+        entity: Entity,
+        storages: &<Self as Storages<'a>>::ReadStorages,
+        ids: F,
+    ) -> Result<Self::Data, E>
+    where
+        F: FnMut(Entity) -> Option<M>;
+
+    /// Loads `Component`s to entity from `Intermediate` deserializable representation
+    fn load<'a, F>(
+        entity: Entity,
+        components: Self::Data,
+        storages: &mut <Self as Storages<'a>>::WriteStorages,
+        ids: F,
+    ) -> Result<(), E>
+    where
+        F: FnMut(M) -> Option<Entity>;
+}
+
+macro_rules! impl_components {
+    ($($a:ident|$b:ident),*) => {
+        impl<'a, $($a),*> Storages<'a> for ($($a,)*)
+            where $(
+                $a: Component,
+            )*
+        {
+            type ReadStorages = ($(ReadStorage<'a, $a>,)*);
+            type WriteStorages = ($(WriteStorage<'a, $a>,)*);
+        }
+
+        impl<M, E $(,$a)*> Components<M, E> for ($($a,)*)
+            where E: Error,
+            $(
+                $a: SaveLoadComponent<M>,
+                E: From<$a::Error>,
+            )*
+        {
+            type Data = ($(Option<$a::Data>,)*);
+
+            #[allow(unused_variables, unused_mut, non_snake_case)]
+            fn save<'a, F>(entity: Entity, storages: &($(ReadStorage<'a, $a>,)*), mut ids: F)
+                -> Result<($(Option<$a::Data>,)*), E>
+                where F: FnMut(Entity) -> Option<M>
+            {
+                let ($(ref $b,)*) = *storages;
+                Ok(($(
+                    $b.get(entity).map(|c| c.save(&mut ids).map(Some)).unwrap_or(Ok(None))?,
+                )*))
+            }
+
+            #[allow(unused_variables, unused_mut, non_snake_case)]
+            fn load<'a, F>(entity: Entity, components: ($(Option<$a::Data>,)*),
+                           storages: &mut ($(WriteStorage<'a, $a>,)*), mut ids: F)
+                -> Result<(), E>
+                where F: FnMut(M) -> Option<Entity>
+            {
+                let ($($a,)*) = components;
+                let ($(ref mut $b,)*) = *storages;
+                $(
+                    if let Some(a) = $a {
+                        $b.insert(entity, $a::load(a, &mut ids)?);
+                    } else {
+                        $b.remove(entity);
+                    }
+                )*
+                Ok(())
+            }
+        }
+
+        impl_components!(@ $($a|$b),*);
+    };
+
+    (@) => {};
+
+    (@ $ah:ident|$bh:ident $(,$a:ident|$b:ident)*) => {
+        impl_components!($($a|$b),*);
+    };
+}
+
+//impl_components!(LA|LB);
+impl_components!(
+    LA | LB,
+    MA | MB,
+    NA | NB,
+    OA | OB,
+    PA | PB,
+    QA | QB,
+    RA | RB,
+    SA | SB,
+    TA | TB,
+    UA | UB,
+    VA | VB,
+    WA | WB,
+    XA | XB,
+    YA | YB,
+    ZA | ZB
+);

--- a/src/ecs/saveload/marker.rs
+++ b/src/ecs/saveload/marker.rs
@@ -1,0 +1,209 @@
+//! Provides with `Marker` and `MarkerAllocator` traits
+
+use std::collections::HashMap;
+use std::hash::Hash;
+
+use shred::Resource;
+use specs::{Component, DenseVecStorage, Entities, Entity, Join, ReadStorage, WriteStorage};
+
+use super::SerializableComponent;
+
+
+/// This trait should be implemetened by component which is gonna be used as marker.
+/// This marker should be set to entity that should be serialized.
+/// If serialization strategy needs to set marker to some entity it should use
+/// new marker allocated for `Marker::Allocator`.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// extern crate amethyst;
+/// #[macro_use] extern crate serde_derive;
+/// use std::collections::HashMap;
+/// use std::ops::Range;
+/// use amethyst::ecs::{Component, Entity, DenseVecStorage};
+/// use amethyst::ecs::saveload::marker::{Marker, MarkerAllocator};
+///
+/// // Marker for entities that should be synced over network
+/// #[derive(Clone, Copy, Serialize, Deserialize)]
+/// struct NetMarker {
+///     id: u64,
+///     seq: u64,
+/// }
+///
+/// impl Component for NetMarker {
+///     type Storage = DenseVecStorage<Self>;
+/// }
+///
+/// impl Marker for NetMarker {
+///     type Identifier = u64;
+///     type Allocator = NetNode;
+///
+///     fn id(&self) -> u64 {
+///         self.id
+///     }
+///
+///     // Updates sequence id.
+///     // Entities with too old sequence id get deleted.
+///     fn update(&mut self, update: Self) {
+///         assert_eq!(self.id, update.id);
+///         self.seq = update.seq;
+///     }
+/// }
+///
+/// // Each client and server has one
+/// // Contains id range and `NetMarker -> Entity` mapping
+/// struct NetNode {
+///     range: Range<u64>,
+///     mapping: HashMap<u64, Entity>,
+/// }
+///
+/// impl MarkerAllocator<NetMarker> for NetNode {
+///     fn allocate(&mut self, entity: Entity, id: Option<u64>) -> NetMarker {
+///         let id = id.unwrap_or_else(|| {
+///             self.range.next().expect("Id range must be virtually endless")
+///         });
+///         let marker = NetMarker {
+///             id: id,
+///             seq: 0,
+///         };
+///         self.mapping.insert(id, entity);
+///         marker
+///     }
+///
+///     fn get(&self, id: u64) -> Option<Entity> {
+///         self.mapping.get(&id).cloned()
+///     }
+/// }
+///
+/// fn main() {}
+/// ```
+pub trait Marker: SerializableComponent + Copy {
+    /// Id of the marker
+    type Identifier: Copy + ::std::fmt::Debug + Eq + Hash;
+
+    /// Allocator for this `Marker`
+    type Allocator: MarkerAllocator<Self>;
+
+    /// Get this marker internal id
+    fn id(&self) -> Self::Identifier;
+
+    /// Update marker with new value.
+    /// It must preserve internal `Identifier`.
+    ///
+    /// # Panics
+    ///
+    /// Allowed to panic if `self.id() != update.id()`.
+    /// But usually implementer may ignore `update.id()` value
+    /// as deserialization algorithm ensures `id()`'s match.
+    fn update(&mut self, update: Self) {
+        ::std::mem::drop(update);
+    }
+}
+
+/// This allocator is used with `Marker` trait
+/// It provides method for allocation of `Marker`s
+/// And also should provide `Marker -> Entity` mapping
+/// `maintain` method can be implemented for cleanup and actualization
+/// # Example
+/// see docs for `Marker`
+pub trait MarkerAllocator<M: Marker>: Resource {
+    /// Allocate new `Marker`.
+    /// Stores mapping `Marker` -> `Entity`.
+    fn allocate(&mut self, entity: Entity, id: Option<M::Identifier>) -> M;
+
+    /// Get `Entity` by `Marker::Identifier`
+    fn get(&self, id: M::Identifier) -> Option<Entity>;
+
+    /// Create new unique marker `M` and attach it to entity.
+    /// Or get old marker if already marked.
+    fn mark<'a>(&mut self, entity: Entity, storage: &mut WriteStorage<'a, M>) -> M {
+        if let Some(marker) = storage.get(entity).cloned() {
+            marker
+        } else {
+            let marker = self.allocate(entity, None);
+            storage.insert(entity, marker);
+            marker
+        }
+    }
+
+    /// Find `Entity` by `Marker` with same id and update `Marker` attached instance.
+    /// Or create new and mark it.
+    fn marked<'a>(
+        &mut self,
+        id: M::Identifier,
+        entities: &Entities<'a>,
+        storage: &mut WriteStorage<'a, M>,
+    ) -> Entity {
+        if let Some(entity) = self.get(id) {
+            if entities.is_alive(entity) {
+                return entity;
+            }
+        }
+
+        let entity = entities.create();
+        let marker = self.allocate(entity, Some(id));
+        storage.insert(entity, marker);
+        entity
+    }
+
+    /// Maintain internal data. Cleanup if necessary.
+    fn maintain<'a>(&mut self, _entities: &Entities<'a>, _storage: &ReadStorage<'a, M>) {}
+}
+
+/// Basic marker implementation usable for saving and loading
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct U64Marker(pub u64);
+impl Component for U64Marker {
+    type Storage = DenseVecStorage<Self>;
+}
+
+impl Marker for U64Marker {
+    type Identifier = u64;
+    type Allocator = U64MarkerAllocator;
+    fn id(&self) -> u64 {
+        self.0
+    }
+}
+
+/// Basic marker allocator
+#[derive(Clone, Debug)]
+pub struct U64MarkerAllocator {
+    index: u64,
+    mapping: HashMap<u64, Entity>,
+}
+
+impl U64MarkerAllocator {
+    /// Create new `U64MarkerAllocator` which will yield `U64Marker`s starting with `0`
+    pub fn new() -> Self {
+        U64MarkerAllocator {
+            index: 0,
+            mapping: HashMap::new(),
+        }
+    }
+}
+
+impl MarkerAllocator<U64Marker> for U64MarkerAllocator {
+    fn allocate(&mut self, entity: Entity, id: Option<u64>) -> U64Marker {
+        let marker = if let Some(id) = id {
+            U64Marker(id)
+        } else {
+            self.index += 1;
+            U64Marker(self.index - 1)
+        };
+        self.mapping.insert(marker.id(), entity);
+        marker
+    }
+
+    fn get(&self, id: u64) -> Option<Entity> {
+        self.mapping.get(&id).cloned()
+    }
+
+    fn maintain<'a>(&mut self, entities: &Entities<'a>, storage: &ReadStorage<'a, U64Marker>) {
+        // FIXME: may be too slow
+        self.mapping = (&**entities, storage)
+            .join()
+            .map(|(e, m)| (m.id(), e))
+            .collect();
+    }
+}

--- a/src/ecs/saveload/mod.rs
+++ b/src/ecs/saveload/mod.rs
@@ -1,0 +1,13 @@
+//! Save and load entites from various formats with serde
+
+mod de;
+mod ser;
+mod details;
+
+use self::details::{Components, EntityData, SerializableComponent, Storages};
+
+pub mod marker;
+
+pub use self::de::{deserialize, WorldDeserialize};
+pub use self::details::{NoError, SaveLoadComponent};
+pub use self::ser::{serialize, serialize_recursive, WorldSerialize};

--- a/src/ecs/saveload/ser.rs
+++ b/src/ecs/saveload/ser.rs
@@ -1,0 +1,160 @@
+use std::error::Error;
+use std::marker::PhantomData;
+
+use serde::ser::{self, Serialize, SerializeSeq, Serializer};
+
+use shred::{ResourceId, Resources, SystemData};
+use specs::{Entities, FetchMut, Join, ReadStorage, WriteStorage};
+
+use super::{Components, EntityData, Storages};
+use super::marker::{Marker, MarkerAllocator};
+
+
+/// Serialize components in tuple `T` of entities marked by `M`
+/// with serializer `S`
+/// All entities referenced in serialized get marked and serialized recursively
+/// For serializing without such recursion see `serialize` function.
+pub fn serialize_recursive<'a, M, E, T, S>(
+    entities: &Entities<'a>,
+    storages: &<T as Storages<'a>>::ReadStorages,
+    markers: &mut WriteStorage<'a, M>,
+    allocator: &mut FetchMut<'a, M::Allocator>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    M: Marker,
+    E: Error,
+    T: Components<M::Identifier, E>,
+    S: Serializer,
+{
+    let mut serseq = serializer.serialize_seq(None)?;
+    let mut to_serialize = (&**entities, &*markers)
+        .join()
+        .map(|(e, m)| (e, *m))
+        .collect::<Vec<_>>();
+    loop {
+        if to_serialize.is_empty() {
+            break;
+        }
+        let mut add = vec![];
+        {
+            let mut ids = |entity| -> Option<M::Identifier> {
+                match markers.get(entity).cloned() {
+                    Some(marker) => Some(marker.id()),
+                    None => {
+                        let marker = allocator.mark(entity, markers);
+                        add.push((entity, marker));
+                        Some(marker.id())
+                    }
+                }
+            };
+            for (entity, marker) in to_serialize.into_iter() {
+                serseq.serialize_element(&EntityData::<M, E, T> {
+                    marker: marker,
+                    components: T::save(entity, storages, &mut ids).map_err(ser::Error::custom)?,
+                })?;
+            }
+        }
+        to_serialize = add;
+    }
+    serseq.end()
+}
+
+
+
+/// Serialize components in tuple `T` of entities marked by `M`
+/// with serializer `S`
+/// Doesn't recursively mark referenced entities.
+/// Closure passed in `SerializableComponent::save` returns `None` for unmarked `Entity`
+/// In this case `SerializableComponent::save` may perform workaround
+/// (forget about `Entity`) or fail
+/// For recursive marking see `serialize_recursive`
+pub fn serialize<'a, M, E, T, S>(
+    entities: &Entities<'a>,
+    storages: &<T as Storages<'a>>::ReadStorages,
+    markers: &ReadStorage<'a, M>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    M: Marker,
+    E: Error,
+    T: Components<M::Identifier, E>,
+    S: Serializer,
+{
+    let mut serseq = serializer.serialize_seq(None)?;
+    let ids = |entity| -> Option<M::Identifier> { markers.get(entity).map(Marker::id) };
+    for (entity, marker) in (&**entities, &*markers).join() {
+        serseq.serialize_element(&EntityData::<M, E, T> {
+            marker: *marker,
+            components: T::save(entity, storages, &ids).map_err(ser::Error::custom)?,
+        })?;
+    }
+    serseq.end()
+}
+
+/// This type implements `Serialize` so that it may be used in generic environment
+/// where `Serialize` implementer is expected
+/// It may be constructed manually (TODO: Add `new` function)
+/// Or fetched by `System` as `SystemData`
+/// Serializes components in tuple `T` with marker `M`
+pub struct WorldSerialize<'a, M: Marker, E: Error, T: Components<M::Identifier, E>> {
+    entities: Entities<'a>,
+    storages: <T as Storages<'a>>::ReadStorages,
+    markers: ReadStorage<'a, M>,
+    pd: PhantomData<E>,
+}
+
+impl<'a, M, E, T> WorldSerialize<'a, M, E, T>
+where
+    M: Marker,
+    E: Error,
+    T: Components<M::Identifier, E>,
+{
+    /// Remove all marked entities
+    /// Use it if you want to delete entities that was just serialized
+    pub fn remove_serialized(&mut self) {
+        for (entity, _) in (&*self.entities, &self.markers.check()).join() {
+            self.entities.delete(entity);
+        }
+    }
+}
+
+
+impl<'a, M, E, T> SystemData<'a> for WorldSerialize<'a, M, E, T>
+where
+    M: Marker,
+    E: Error,
+    T: Components<M::Identifier, E>,
+{
+    fn fetch(res: &'a Resources, id: usize) -> Self {
+        WorldSerialize {
+            entities: Entities::<'a>::fetch(res, id),
+            storages: <T as Storages<'a>>::ReadStorages::fetch(res, id),
+            markers: ReadStorage::<'a, M>::fetch(res, id),
+            pd: PhantomData,
+        }
+    }
+    fn reads(id: usize) -> Vec<ResourceId> {
+        let mut reads = Entities::<'a>::reads(id);
+        reads.extend(<T as Storages<'a>>::ReadStorages::reads(id));
+        reads.extend(ReadStorage::<'a, M>::reads(id));
+        reads
+    }
+    fn writes(_id: usize) -> Vec<ResourceId> {
+        Vec::new()
+    }
+}
+
+impl<'a, M, E, T> Serialize for WorldSerialize<'a, M, E, T>
+where
+    M: Marker,
+    E: Error,
+    T: Components<M::Identifier, E>,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize::<M, E, T, S>(&self.entities, &self.storages, &self.markers, serializer)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,9 @@ extern crate gfx;
 extern crate imagefmt;
 extern crate rayon;
 extern crate rodio;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
 extern crate shred;
 extern crate smallvec;
 extern crate specs;


### PR DESCRIPTION
Add (de)serialization support for entities to Amethyst.
Main parts are:
* `Marker` trair.
`Marker` is used for several purposes:
  * Mark which entities should be serialized.
  * It contains ID to replace `Entity` stored in `Component`s during serialization process.
  * It may contain additional data to be used for tracking owner of the component
(future `NetMarker` 🌍)
* `MarkerAllocator` trait for allocating `Marker`s, storing `Marker -> Entity` mapping and other stuff.
* `SerializableComponent` trait that is auto implemented by components if they implements `Serialize`, `DeserializeOwned` and `Copy` (later is rather strict, maybe it should be replaced with `Clone` or removed somehow).
Mainly `Component` implements `SerializableComponent` manually when it contains `Entity`.
`Component` should replace `Entity` with provided `Marker` in `SerializableComponent::save` function. And replace `Marker` with `Entity` in `SerializableComponent::load` function.
* `Components` trait is implemented for tuples of `SerializableComponent`s
It allows to save all existing and mentioned in tuple components of one entity from `ReadStorage`s into serializable structure. And load it into `WriteStorage`s again.

Helper types `WorldSerialize` and `WorldDeserialize` are good example how to use this facility.

JFF. Pong 🏓 example:
- [x] Fixed corner camping due to linear ball velocity never changing angle
- [x] Added cheat functions. Saving by `F5` key and loading by `F7`