### PR TITLE
Edit window properties through events

### DIFF
--- a/amethyst_renderer/src/lib.rs
+++ b/amethyst_renderer/src/lib.rs
@@ -77,4 +77,4 @@ mod mesh;
 mod mtl;
 mod renderer;
 mod tex;
-mod types;
+pub mod types;

--- a/amethyst_renderer/src/lib.rs
+++ b/amethyst_renderer/src/lib.rs
@@ -67,7 +67,7 @@ pub mod pass;
 pub mod prelude;
 pub mod pipe;
 pub mod vertex;
-
+pub mod types;
 
 mod cam;
 mod color;
@@ -77,4 +77,3 @@ mod mesh;
 mod mtl;
 mod renderer;
 mod tex;
-pub mod types;

--- a/amethyst_renderer/src/renderer.rs
+++ b/amethyst_renderer/src/renderer.rs
@@ -41,7 +41,7 @@ impl Renderer {
     }
 
     /// Gets a mutable window to modify
-    pub fn window_mut(&mut self)->&mut Window{
+    pub fn window_mut(&mut self) -> &mut Window {
         &mut self.window
     }
 

--- a/amethyst_renderer/src/renderer.rs
+++ b/amethyst_renderer/src/renderer.rs
@@ -40,6 +40,11 @@ impl Renderer {
         RendererBuilder::new(el)
     }
 
+    /// Gets a mutable window to modify
+    pub fn window_mut(&mut self)->&mut Window{
+        &mut self.window
+    }
+
     /// Builds a new mesh from the given vertices.
     pub fn create_mesh<D, T>(&mut self, mb: MeshBuilder<D, T>) -> Result<Mesh>
     where

--- a/amethyst_renderer/src/types/mod.rs
+++ b/amethyst_renderer/src/types/mod.rs
@@ -25,7 +25,9 @@ mod vulkan;
 
 /// Color buffer format.
 pub type SurfaceFormat = gfx::format::R8_G8_B8_A8;
+/// Channel Format
 pub type ChannelFormat = gfx::format::Unorm;
+/// Color Format
 pub type ColorFormat = (SurfaceFormat, ChannelFormat);
 
 /// Depth buffer format.

--- a/examples/04_pong/main.rs
+++ b/examples/04_pong/main.rs
@@ -2,6 +2,7 @@
 
 extern crate amethyst;
 extern crate futures;
+extern crate winit;
 
 use amethyst::{ApplicationBuilder, Result};
 use amethyst::assets::{AssetFuture, BoxedErr};
@@ -15,10 +16,12 @@ use amethyst::ecs::{Component, DenseVecStorage, ECSBundle, Fetch, FetchMut, Join
 use amethyst::ecs::audio::DjBundle;
 use amethyst::ecs::input::{InputBundle, InputHandler};
 use amethyst::ecs::rendering::{Factory, MaterialComponent, MeshComponent, RenderBundle};
+use amethyst::ecs::rendering::events::WindowModifierEvent;
 use amethyst::ecs::transform::{LocalTransform, Transform, TransformBundle};
 use amethyst::prelude::*;
 use amethyst::renderer::Config as DisplayConfig;
 use amethyst::renderer::prelude::*;
+use amethyst::shrev::EventHandler;
 use amethyst::timing::Time;
 use futures::{Future, IntoFuture};
 
@@ -335,6 +338,20 @@ impl State for Pong {
                 bounce_sfx,
                 score_sfx,
             });
+            // Sets the cursor hidden when the mouse is hovering the pong window.
+            if let Some(mut window_events) = engine
+                .world
+                .res
+                .try_fetch_mut::<EventHandler<WindowModifierEvent>>(0)
+            {
+                window_events.write_single(WindowModifierEvent {
+                    modify: |win| {
+                        win.set_cursor_state(winit::CursorState::Hide)
+                            .ok()
+                            .expect("could not grab mouse cursor")
+                    },
+                });
+            }
 
             let have_output = engine.world.read_resource::<Option<Output>>().is_some();
 

--- a/examples/04_pong/main.rs
+++ b/examples/04_pong/main.rs
@@ -345,11 +345,11 @@ impl State for Pong {
                 .try_fetch_mut::<EventHandler<WindowModifierEvent>>(0)
             {
                 window_events.write_single(WindowModifierEvent {
-                    modify: |win| {
+                    modify: Box::new(|win| {
                         win.set_cursor_state(winit::CursorState::Hide)
                             .ok()
-                            .expect("could not grab mouse cursor")
-                    },
+                            .expect("Could not hide mouse cursor")
+                    }),
                 });
             }
 

--- a/src/ecs/rendering/bundle.rs
+++ b/src/ecs/rendering/bundle.rs
@@ -95,7 +95,7 @@ where
             up: [0.0, 1.0, 0.0].into(),
         };
 
-        let window_events = EventHandler::<WindowModifierEvent>::new();
+        let window_events = EventHandler::<WindowModifierEvent>::with_capacity(20);
         let reader_id = window_events.register_reader();
 
         builder = builder

--- a/src/ecs/rendering/bundle.rs
+++ b/src/ecs/rendering/bundle.rs
@@ -14,6 +14,9 @@ use ecs::rendering::systems::RenderSystem;
 use ecs::transform::components::*;
 use error::{Error, Result};
 
+use shrev::EventHandler;
+
+use ecs::rendering::events::WindowModifierEvent;
 /// Rendering bundle
 ///
 /// Will register all necessary components needed for rendering, along with any resources.
@@ -92,10 +95,14 @@ where
             up: [0.0, 1.0, 0.0].into(),
         };
 
+        let window_events = EventHandler::<WindowModifierEvent>::new();
+        let reader_id = window_events.register_reader();
+
         builder = builder
             .with_resource(Factory::new())
             .with_resource(cam)
             .with_resource(AmbientColor(Rgba::from([0.01; 3])))
+            .with_resource(window_events)
             .register::<Transform>()
             .register::<LightComponent>()
             .register::<MaterialComponent>()
@@ -128,7 +135,7 @@ where
                 .with(Merge::<AssetFuture<TextureComponent>>::new(), "", &[]);
         }
 
-        builder = builder.with_thread_local(RenderSystem::new(pipe, renderer));
+        builder = builder.with_thread_local(RenderSystem::new(pipe, renderer, reader_id));
 
         Ok(builder)
     }

--- a/src/ecs/rendering/events.rs
+++ b/src/ecs/rendering/events.rs
@@ -2,8 +2,8 @@
 
 use renderer::types::Window;
 
-/// Even to modify a window.
+/// Event to modify a window. Basically message passing through events.
 pub struct WindowModifierEvent {
     /// The closure that modifies the window
-    pub modify: fn(&mut Window) -> (),
+    pub modify: Box<Fn(&mut Window) -> () + Send + Sync + 'static>,
 }

--- a/src/ecs/rendering/events.rs
+++ b/src/ecs/rendering/events.rs
@@ -1,0 +1,9 @@
+//! Events of the rendering system
+
+use renderer::types::Window;
+
+/// Even to modify a window.
+pub struct WindowModifierEvent {
+    /// The closure that modifies the window
+    pub modify: fn(&mut Window) -> (),
+}

--- a/src/ecs/rendering/mod.rs
+++ b/src/ecs/rendering/mod.rs
@@ -2,6 +2,7 @@
 
 pub use self::bundle::RenderBundle;
 pub use self::components::*;
+pub use self::events::*;
 pub use self::resources::*;
 pub use self::systems::*;
 
@@ -9,3 +10,4 @@ pub mod components;
 pub mod resources;
 pub mod systems;
 pub mod bundle;
+pub mod events;

--- a/src/ecs/rendering/systems.rs
+++ b/src/ecs/rendering/systems.rs
@@ -1,9 +1,11 @@
 //! Rendering system.
 
-use ecs::{Fetch, System};
+use ecs::{Fetch, FetchMut, System};
+use ecs::rendering::events::WindowModifierEvent;
 use ecs::rendering::resources::Factory;
 use renderer::Renderer;
 use renderer::pipe::{PipelineData, PolyPipeline};
+use shrev::{EventHandler, EventReadData, ReaderId};
 
 /// Rendering system.
 #[derive(Derivative)]
@@ -12,6 +14,7 @@ pub struct RenderSystem<P> {
     pipe: P,
     #[derivative(Debug = "ignore")]
     renderer: Renderer,
+    reader_id: ReaderId,
 }
 
 impl<P> RenderSystem<P>
@@ -19,8 +22,12 @@ where
     P: PolyPipeline,
 {
     /// Create a new render system
-    pub fn new(pipe: P, renderer: Renderer) -> Self {
-        Self { pipe, renderer }
+    pub fn new(pipe: P, renderer: Renderer, reader_id: ReaderId) -> Self {
+        Self {
+            pipe,
+            renderer,
+            reader_id,
+        }
     }
 }
 
@@ -28,9 +35,25 @@ impl<'a, P> System<'a> for RenderSystem<P>
 where
     P: PolyPipeline,
 {
-    type SystemData = (Fetch<'a, Factory>, <P as PipelineData<'a>>::Data);
+    type SystemData = (
+        Fetch<'a, Factory>,
+        <P as PipelineData<'a>>::Data,
+        FetchMut<'a, EventHandler<WindowModifierEvent>>,
+    );
 
-    fn run(&mut self, (factory, data): Self::SystemData) {
+    fn run(&mut self, (factory, data, events): Self::SystemData) {
+        //Read all window-modifying events
+        match events.read(&mut self.reader_id) {
+            Ok(EventReadData::Data(data)) => {
+                let mut win = self.renderer.window_mut();
+                for ev in data.collect::<Vec<_>>() {
+                    let closure = ev.modify;
+                    closure(win);
+                }
+            }
+            _ => {}
+        }
+
         #[cfg(feature = "profiler")]
         profile_scope!("render_system");
         use std::time::Duration;


### PR DESCRIPTION
Added event handler to RenderSystem. 

Consume events that contains a closure of type fn(&mut Window)->()

See an example in pong, where I set the cursor to be hidden.