### PR TITLE
Add WindowMessages resource

### DIFF
--- a/amethyst_renderer/src/renderer.rs
+++ b/amethyst_renderer/src/renderer.rs
@@ -15,7 +15,7 @@ use pipe::{ColorBuffer, DepthBuffer, PipelineBuild, PipelineData, PolyPipeline, 
 use tex::{Texture, TextureBuilder};
 use types::{ColorFormat, DepthFormat, Device, Encoder, Factory, Window};
 use vertex::VertexFormat;
-use winit::{self, EventsLoop, WindowBuilder};
+use winit::{self, EventsLoop, Window as WinitWindow, WindowBuilder};
 
 /// Generic renderer.
 pub struct Renderer {
@@ -134,6 +134,25 @@ impl Renderer {
         self.window
             .swap_buffers()
             .expect("OpenGL context has been lost");
+    }
+
+    /// Retrieves an immutable borrow of the window.
+    ///
+    /// No operations require a mutable borrow as of 2017-10-02
+    #[cfg(feature = "opengl")]
+    pub fn window(&self) -> &WinitWindow {
+        self.window.window()
+    }
+
+    #[cfg(feature = "metal")]
+    #[cfg(feature = "vulkan")]
+    pub fn window(&self) -> &WinitWindow {
+        &self.window.0
+    }
+
+    #[cfg(feature = "d3d11")]
+    pub fn window(&self) -> &WinitWindow {
+        &*self.window.0
     }
 }
 

--- a/examples/04_pong/main.rs
+++ b/examples/04_pong/main.rs
@@ -15,11 +15,13 @@ use amethyst::ecs::{Component, DenseVecStorage, ECSBundle, Fetch, FetchMut, Join
 use amethyst::ecs::audio::DjBundle;
 use amethyst::ecs::input::{InputBundle, InputHandler};
 use amethyst::ecs::rendering::{Factory, MaterialComponent, MeshComponent, RenderBundle};
+use amethyst::ecs::rendering::resources::WindowMessages;
 use amethyst::ecs::transform::{LocalTransform, Transform, TransformBundle};
 use amethyst::prelude::*;
 use amethyst::renderer::Config as DisplayConfig;
 use amethyst::renderer::prelude::*;
 use amethyst::timing::Time;
+use amethyst::winit::CursorState;
 use futures::{Future, IntoFuture};
 
 struct Pong;
@@ -294,6 +296,14 @@ where
 
 impl State for Pong {
     fn on_start(&mut self, engine: &mut Engine) {
+        // Hide the cursor
+        engine.world.write_resource::<WindowMessages>().send_command(
+            |win| {
+                if let Err(err) = win.set_cursor_state(CursorState::Hide) {
+                    eprintln!("Unable to make cursor hidden! Error: {:?}", err);
+                }
+            }
+        );
         // Load audio assets
         // FIXME: do loading with futures, pending the Loading state
         {

--- a/src/ecs/rendering/bundle.rs
+++ b/src/ecs/rendering/bundle.rs
@@ -9,7 +9,7 @@ use app::ApplicationBuilder;
 use assets::{AssetFuture, BoxedErr, Loader};
 use ecs::ECSBundle;
 use ecs::rendering::components::*;
-use ecs::rendering::resources::{AmbientColor, Factory};
+use ecs::rendering::resources::{AmbientColor, Factory, WindowMessages};
 use ecs::rendering::systems::RenderSystem;
 use ecs::transform::components::*;
 use error::{Error, Result};
@@ -96,6 +96,7 @@ where
             .with_resource(Factory::new())
             .with_resource(cam)
             .with_resource(AmbientColor(Rgba::from([0.01; 3])))
+            .with_resource(WindowMessages::new())
             .register::<Transform>()
             .register::<LightComponent>()
             .register::<MaterialComponent>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ pub extern crate amethyst_config as config;
 pub extern crate amethyst_input as input;
 pub extern crate amethyst_renderer as renderer;
 pub extern crate shrev;
+pub extern crate winit;
 
 extern crate amethyst_assets;
 extern crate cgmath;
@@ -77,7 +78,6 @@ extern crate shred;
 extern crate smallvec;
 extern crate specs;
 extern crate wavefront_obj;
-extern crate winit;
 
 pub use self::app::{Application, ApplicationBuilder};
 pub use self::engine::Engine;


### PR DESCRIPTION
This is my take on https://github.com/amethyst/amethyst/pull/386

So there's a few benefits to this approach:

- We can be optimistic and only allocate space for 2 boxes rather than being forced to be pessimistic and allocate space for 20 boxes.  Thanks to SmallVec, 99.99% of the time this won't even be an extra allocation.
- Resulting syntax is much less verbose
- We can use the same winit::Window type rather than having the type change every time the backend changes
- We can use FnMut instead of Fn.  Technically there's no reason we couldn't use FnOnce but rustc stable doesn't support it at the moment.  This is a small advantage as most of the time it won't be needed, but it's there in case my imagination has failed me.

cc @Rhuagh @jojolepro 