### PR TITLE
Refactor vertex format

### DIFF
--- a/amethyst_renderer/src/mesh.rs
+++ b/amethyst_renderer/src/mesh.rs
@@ -9,12 +9,12 @@ use gfx::Primitive;
 
 use error::Result;
 use types::{Factory, RawBuffer, Slice};
-use vertex::{Attribute, VertexFormat};
+use vertex::{AttributeFormat, VertexFormat};
 
 /// Represents a polygonal mesh.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Mesh {
-    attrs: Vec<Attribute>,
+    attrs: &'static [(&'static str, AttributeFormat)],
     prim: Primitive,
     slice: Slice,
     transform: Matrix4<f32>,
@@ -32,8 +32,8 @@ impl Mesh {
     }
 
     /// Returns a list of all vertex attributes needed by this mesh.
-    pub fn attributes(&self) -> &[Attribute] {
-        self.attrs.as_ref()
+    pub fn attributes(&self) -> &[(&'static str, AttributeFormat)] {
+        self.attrs
     }
 
     /// Returns the mesh's vertex buffer and associated buffer slice.
@@ -144,7 +144,7 @@ where
         };
 
         Ok(Mesh {
-            attrs: V::attributes().as_ref().to_vec(),
+            attrs: V::ATTRIBUTES,
             prim: self.prim,
             slice: slice,
             transform: self.transform,

--- a/amethyst_renderer/src/pass/flat.rs
+++ b/amethyst_renderer/src/pass/flat.rs
@@ -16,7 +16,7 @@ use mtl::Material;
 use pipe::pass::{Pass, PassApply, PassData, Supplier};
 use pipe::{DepthMode, Effect, NewEffect};
 use types::Encoder;
-use vertex::{Attribute, Position, TextureCoord, VertexFormat, WithField};
+use vertex::{AttributeFormat, Position, TexCoord, VertexFormat, With};
 
 static VERT_SRC: &[u8] = include_bytes!("shaders/vertex/basic.glsl");
 static FRAG_SRC: &[u8] = include_bytes!("shaders/fragment/flat.glsl");
@@ -28,13 +28,13 @@ static FRAG_SRC: &[u8] = include_bytes!("shaders/fragment/flat.glsl");
 /// `T` is transform matrix component
 #[derive(Clone, Debug, PartialEq)]
 pub struct DrawFlat<V, M, N, T> {
-    vertex_attributes: [(&'static str, Attribute); 2],
+    vertex_attributes: [(&'static str, AttributeFormat); 2],
     _pd: PhantomData<(V, M, N, T)>,
 }
 
 impl<V, M, N, T> DrawFlat<V, M, N, T>
 where
-    V: VertexFormat + WithField<Position> + WithField<TextureCoord>,
+    V: VertexFormat + With<Position> + With<TexCoord>,
     T: Component + AsRef<[[f32; 4]; 4]> + Send + Sync,
     M: Component + AsRef<Mesh> + Send + Sync,
     N: Component + AsRef<Material> + Send + Sync,
@@ -45,7 +45,7 @@ where
         DrawFlat {
             vertex_attributes: [
                 ("position", V::attribute::<Position>()),
-                ("tex_coord", V::attribute::<TextureCoord>()),
+                ("tex_coord", V::attribute::<TexCoord>()),
             ],
             _pd: PhantomData,
         }
@@ -61,7 +61,7 @@ struct VertexArgs {
 
 impl<'a, V, M, N, T> PassData<'a> for DrawFlat<V, M, N, T>
 where
-    V: VertexFormat + WithField<Position> + WithField<TextureCoord>,
+    V: VertexFormat + With<Position> + With<TexCoord>,
     T: Component + AsRef<[[f32; 4]; 4]> + Send + Sync,
     M: Component + AsRef<Mesh> + Send + Sync,
     N: Component + AsRef<Material> + Send + Sync,
@@ -76,7 +76,7 @@ where
 
 impl<'a, V, M, N, T> PassApply<'a> for DrawFlat<V, M, N, T>
 where
-    V: VertexFormat + WithField<Position> + WithField<TextureCoord>,
+    V: VertexFormat + With<Position> + With<TexCoord>,
     T: Component + AsRef<[[f32; 4]; 4]> + Send + Sync,
     M: Component + AsRef<Mesh> + Send + Sync,
     N: Component + AsRef<Material> + Send + Sync,
@@ -86,7 +86,7 @@ where
 
 impl<V, M, N, T> Pass for DrawFlat<V, M, N, T>
 where
-    V: VertexFormat + WithField<Position> + WithField<TextureCoord>,
+    V: VertexFormat + With<Position> + With<TexCoord>,
     T: Component + AsRef<[[f32; 4]; 4]> + Send + Sync,
     M: Component + AsRef<Mesh> + Send + Sync,
     N: Component + AsRef<Material> + Send + Sync,
@@ -134,7 +134,7 @@ pub struct DrawFlatApply<'a, V, M: Component, N: Component, T: Component> {
 
 impl<'a, V, M, N, T> ParallelIterator for DrawFlatApply<'a, V, M, N, T>
 where
-    V: VertexFormat + WithField<Position> + WithField<TextureCoord>,
+    V: VertexFormat + With<Position> + With<TexCoord>,
     T: Component + AsRef<[[f32; 4]; 4]> + Send + Sync,
     M: Component + AsRef<Mesh> + Send + Sync,
     N: Component + AsRef<Material> + Send + Sync,
@@ -163,7 +163,7 @@ where
                         let mesh = mesh.as_ref();
                         let material = material.as_ref();
 
-                        if mesh.attributes() != V::attributes().as_ref() {
+                        if mesh.attributes() != V::ATTRIBUTES {
                             return;
                         }
 

--- a/amethyst_renderer/src/pass/pbm.rs
+++ b/amethyst_renderer/src/pass/pbm.rs
@@ -19,7 +19,7 @@ use mtl::Material;
 use pipe::{DepthMode, Effect, NewEffect};
 use pipe::pass::{Pass, PassApply, PassData, Supplier};
 use types::Encoder;
-use vertex::{Attribute, Normal, Position, Tangent, TextureCoord, VertexFormat, WithField};
+use vertex::{AttributeFormat, Normal, Position, Tangent, TexCoord, VertexFormat, With};
 
 static VERT_SRC: &[u8] = include_bytes!("shaders/vertex/basic.glsl");
 static FRAG_SRC: &[u8] = include_bytes!("shaders/fragment/pbm.glsl");
@@ -33,17 +33,17 @@ static FRAG_SRC: &[u8] = include_bytes!("shaders/fragment/pbm.glsl");
 /// `L` is `Light` component
 #[derive(Clone, Debug, PartialEq)]
 pub struct DrawPbm<V, A, M, N, T, L> {
-    vertex_attributes: [(&'static str, Attribute); 4],
+    vertex_attributes: [(&'static str, AttributeFormat); 4],
     _pd: PhantomData<(V, A, M, N, T, L)>,
 }
 
 impl<V, A, M, N, T, L> DrawPbm<V, A, M, N, T, L>
 where
     V: VertexFormat
-        + WithField<Position>
-        + WithField<Normal>
-        + WithField<Tangent>
-        + WithField<TextureCoord>,
+        + With<Position>
+        + With<Normal>
+        + With<Tangent>
+        + With<TexCoord>,
     A: AsRef<Rgba> + Send + Sync + 'static,
     T: Component + AsRef<[[f32; 4]; 4]> + Send + Sync,
     M: Component + AsRef<Mesh> + Send + Sync,
@@ -57,7 +57,7 @@ where
                 ("position", V::attribute::<Position>()),
                 ("normal", V::attribute::<Normal>()),
                 ("tangent", V::attribute::<Tangent>()),
-                ("tex_coord", V::attribute::<TextureCoord>()),
+                ("tex_coord", V::attribute::<TexCoord>()),
             ],
             _pd: PhantomData,
         }
@@ -107,10 +107,10 @@ unsafe impl Pod for DirectionalLightPod {}
 impl<'a, V, A, M, N, T, L> PassData<'a> for DrawPbm<V, A, M, N, T, L>
 where
     V: VertexFormat
-        + WithField<Position>
-        + WithField<Normal>
-        + WithField<Tangent>
-        + WithField<TextureCoord>,
+        + With<Position>
+        + With<Normal>
+        + With<Tangent>
+        + With<TexCoord>,
     A: AsRef<Rgba> + Send + Sync + 'static,
     T: Component + AsRef<[[f32; 4]; 4]> + Send + Sync,
     M: Component + AsRef<Mesh> + Send + Sync,
@@ -130,10 +130,10 @@ where
 impl<'a, V, A, M, N, T, L> PassApply<'a> for DrawPbm<V, A, M, N, T, L>
 where
     V: VertexFormat
-        + WithField<Position>
-        + WithField<Normal>
-        + WithField<Tangent>
-        + WithField<TextureCoord>,
+        + With<Position>
+        + With<Normal>
+        + With<Tangent>
+        + With<TexCoord>,
     A: AsRef<Rgba> + Send + Sync + 'static,
     T: Component + AsRef<[[f32; 4]; 4]> + Send + Sync,
     M: Component + AsRef<Mesh> + Send + Sync,
@@ -146,10 +146,10 @@ where
 impl<V, A, M, N, T, L> Pass for DrawPbm<V, A, M, N, T, L>
 where
     V: VertexFormat
-        + WithField<Position>
-        + WithField<Normal>
-        + WithField<Tangent>
-        + WithField<TextureCoord>,
+        + With<Position>
+        + With<Normal>
+        + With<Tangent>
+        + With<TexCoord>,
     A: AsRef<Rgba> + Send + Sync + 'static,
     T: Component + AsRef<[[f32; 4]; 4]> + Send + Sync,
     M: Component + AsRef<Mesh> + Send + Sync,
@@ -216,10 +216,10 @@ pub struct DrawPbmApply<'a, V, A: 'static, M: Component, N: Component, T: Compon
 impl<'a, V, A, M, N, T, L> ParallelIterator for DrawPbmApply<'a, V, A, M, N, T, L>
 where
     V: VertexFormat
-        + WithField<Position>
-        + WithField<Normal>
-        + WithField<Tangent>
-        + WithField<TextureCoord>,
+        + With<Position>
+        + With<Normal>
+        + With<Tangent>
+        + With<TexCoord>,
     A: AsRef<Rgba> + Send + Sync + 'static,
     T: Component + AsRef<[[f32; 4]; 4]> + Send + Sync,
     M: Component + AsRef<Mesh> + Send + Sync,

--- a/amethyst_renderer/src/pass/shaded.rs
+++ b/amethyst_renderer/src/pass/shaded.rs
@@ -19,7 +19,7 @@ use mtl::Material;
 use pipe::{DepthMode, Effect, NewEffect};
 use pipe::pass::{Pass, PassApply, PassData, Supplier};
 use types::Encoder;
-use vertex::{Attribute, Normal, Position, TextureCoord, VertexFormat, WithField};
+use vertex::{AttributeFormat, Normal, Position, TexCoord, VertexFormat, With};
 
 static VERT_SRC: &[u8] = include_bytes!("shaders/vertex/basic.glsl");
 static FRAG_SRC: &[u8] = include_bytes!("shaders/fragment/shaded.glsl");
@@ -33,13 +33,13 @@ static FRAG_SRC: &[u8] = include_bytes!("shaders/fragment/shaded.glsl");
 /// `L` is `Light` component
 #[derive(Clone, Debug, PartialEq)]
 pub struct DrawShaded<V, A, M, N, T, L> {
-    vertex_attributes: [(&'static str, Attribute); 3],
+    vertex_attributes: [(&'static str, AttributeFormat); 3],
     _pd: PhantomData<(V, A, M, N, T, L)>,
 }
 
 impl<V, A, M, N, T, L> DrawShaded<V, A, M, N, T, L>
 where
-    V: VertexFormat + WithField<Position> + WithField<Normal> + WithField<TextureCoord>,
+    V: VertexFormat + With<Position> + With<Normal> + With<TexCoord>,
     A: AsRef<Rgba> + Send + Sync + 'static,
     T: Component + AsRef<[[f32; 4]; 4]> + Send + Sync,
     M: Component + AsRef<Mesh> + Send + Sync,
@@ -52,7 +52,7 @@ where
             vertex_attributes: [
                 ("position", V::attribute::<Position>()),
                 ("normal", V::attribute::<Normal>()),
-                ("tex_coord", V::attribute::<TextureCoord>()),
+                ("tex_coord", V::attribute::<TexCoord>()),
             ],
             _pd: PhantomData,
         }
@@ -101,7 +101,7 @@ unsafe impl Pod for DirectionalLightPod {}
 
 impl<'a, V, A, M, N, T, L> PassData<'a> for DrawShaded<V, A, M, N, T, L>
 where
-    V: VertexFormat + WithField<Position> + WithField<Normal> + WithField<TextureCoord>,
+    V: VertexFormat + With<Position> + With<Normal> + With<TexCoord>,
     A: AsRef<Rgba> + Send + Sync + 'static,
     T: Component + AsRef<[[f32; 4]; 4]> + Send + Sync,
     M: Component + AsRef<Mesh> + Send + Sync,
@@ -120,7 +120,7 @@ where
 
 impl<'a, V, A, M, N, T, L> PassApply<'a> for DrawShaded<V, A, M, N, T, L>
 where
-    V: VertexFormat + WithField<Position> + WithField<Normal> + WithField<TextureCoord>,
+    V: VertexFormat + With<Position> + With<Normal> + With<TexCoord>,
     A: AsRef<Rgba> + Send + Sync + 'static,
     T: Component + AsRef<[[f32; 4]; 4]> + Send + Sync,
     M: Component + AsRef<Mesh> + Send + Sync,
@@ -133,7 +133,7 @@ where
 
 impl<V, A, M, N, T, L> Pass for DrawShaded<V, A, M, N, T, L>
 where
-    V: VertexFormat + WithField<Position> + WithField<Normal> + WithField<TextureCoord>,
+    V: VertexFormat + With<Position> + With<Normal> + With<TexCoord>,
     A: AsRef<Rgba> + Send + Sync + 'static,
     T: Component + AsRef<[[f32; 4]; 4]> + Send + Sync,
     M: Component + AsRef<Mesh> + Send + Sync,
@@ -202,7 +202,7 @@ pub struct DrawShadedApply<
 
 impl<'a, V, A, M, N, T, L> ParallelIterator for DrawShadedApply<'a, V, A, M, N, T, L>
 where
-    V: VertexFormat + WithField<Position> + WithField<Normal> + WithField<TextureCoord>,
+    V: VertexFormat + With<Position> + With<Normal> + With<TexCoord>,
     A: AsRef<Rgba> + Send + Sync + 'static,
     T: Component + AsRef<[[f32; 4]; 4]> + Send + Sync,
     M: Component + AsRef<Mesh> + Send + Sync,

--- a/amethyst_renderer/src/pipe/effect/mod.rs
+++ b/amethyst_renderer/src/pipe/effect/mod.rs
@@ -22,7 +22,7 @@ use error::{Error, Result};
 use mesh::Mesh;
 use pipe::Target;
 use types::{Encoder, Factory, PipelineState, Resources};
-use vertex::Attribute;
+use vertex::AttributeFormat;
 
 mod pso;
 
@@ -236,7 +236,7 @@ impl<'a> EffectBuilder<'a> {
     /// Adds a vertex buffer to this `Effect`.
     pub fn with_raw_vertex_buffer(
         &mut self,
-        attrs: &'a [(&'a str, Attribute)],
+        attrs: &'a [(&'a str, AttributeFormat)],
         stride: ElemStride,
         rate: InstanceRate,
     ) -> &mut Self {

--- a/amethyst_renderer/src/vertex.rs
+++ b/amethyst_renderer/src/vertex.rs
@@ -1,50 +1,78 @@
 //! Built-in vertex formats.
 
-use std::any::Any;
-
-use gfx;
-use gfx::format::Format;
-use gfx::pso::buffer::Structure;
+use gfx::format::{ChannelType, Format, SurfaceType};
+use gfx::pso::buffer::Element;
 use gfx::traits::Pod;
 
-/// Handle to a vertex attribute.
-pub type Attribute = gfx::pso::buffer::Element<Format>;
+/// Format for vertex attribute
+pub type AttributeFormat = Element<Format>;
+
+/// Trait for vertex attributes to implement
+pub trait Attribute {
+    /// Name of the attribute
+    /// It is used to bind to the attributes in shaders
+    const NAME: &'static str;
+
+    /// Format of the attribute defines arity and type
+    const FORMAT: Format;
+
+    /// Size of the attribue
+    const SIZE: u32; // Has to be equal to `std::mem::size_of::<Self::Repr>() as u32`
+
+    /// Representation of the attribute
+    /// usually it is `[f32; N]`
+    type Repr: Pod + Send + Sync;
+}
 
 /// Type for position attribute of vertex
 pub enum Position {}
+impl Attribute for Position {
+    const NAME: &'static str = "position";
+    const FORMAT: Format = Format(SurfaceType::R32_G32_B32, ChannelType::Float);
+    const SIZE: u32 = 12;
+    type Repr = [f32; 3];
+}
 
 /// Type for color attribute of vertex
 pub enum Color {}
+impl Attribute for Color {
+    const NAME: &'static str = "color";
+    const FORMAT: Format = Format(SurfaceType::R32_G32_B32_A32, ChannelType::Unorm);
+    const SIZE: u32 = 16;
+    type Repr = [f32; 4];
+}
 
 /// Type for texture coord attribute of vertex
-pub enum TextureCoord {}
+pub enum TexCoord {}
+impl Attribute for TexCoord {
+    const NAME: &'static str = "tex_coord";
+    const FORMAT: Format = Format(SurfaceType::R32_G32, ChannelType::Float);
+    const SIZE: u32 = 8;
+    type Repr = [f32; 2];
+}
 
 /// Type for texture coord attribute of vertex
 pub enum Normal {}
+impl Attribute for Normal {
+    const NAME: &'static str = "normal";
+    const FORMAT: Format = Format(SurfaceType::R32_G32_B32, ChannelType::Float);
+    const SIZE: u32 = 12;
+    type Repr = [f32; 3];
+}
 
 /// Type for tangent attribute of vertex
 pub enum Tangent {}
-
-/// Trait for mapping attribute type -> name
-pub trait AttributeNames {
-    /// Get name for specified attribute type
-    fn name<A: Any>() -> &'static str;
+impl Attribute for Tangent {
+    const NAME: &'static str = "tangent";
+    const FORMAT: Format = Format(SurfaceType::R32_G32_B32, ChannelType::Float);
+    const SIZE: u32 = 12;
+    type Repr = [f32; 3];
 }
 
 /// Trait implemented by all valid vertex formats.
-pub trait VertexFormat: Pod + Structure<Format> + Sized + Send + Sync {
-    /// Container for attributes of this format
-    type Attributes: AsRef<[Attribute]>;
-
-    /// Container for name+attribute pairs of this format
-    type NamedAttributes: AsRef<[(&'static str, Attribute)]>;
-
-    /// Returns a list of all attributes specified in the vertex.
-    fn attributes() -> Self::Attributes;
-
-    /// Returns a list of all name+attribute pairs specified in the vertex.
-    /// The caller provides attribute type -> Name mapping
-    fn named_attributes<N: AttributeNames>() -> Self::NamedAttributes;
+pub trait VertexFormat: Pod + Sized + Send + Sync {
+    /// List of all attributes formats with name and offset.
+    const ATTRIBUTES: &'static [(&'static str, AttributeFormat)];
 
     /// Returns the size of a single vertex in bytes.
     #[inline]
@@ -55,236 +83,204 @@ pub trait VertexFormat: Pod + Structure<Format> + Sized + Send + Sync {
 
     /// Returns attribute of vertex by type
     #[inline]
-    fn attribute<F>() -> Attribute
+    fn attribute<F>() -> AttributeFormat
     where
-        Self: WithField<F>,
+        Self: With<F>,
     {
-        <Self as WithField<F>>::field_attribute()
+        <Self as With<F>>::FORMAT
     }
 }
 
 /// Trait implemented by all valid vertex formats for each field
-pub trait WithField<F>: VertexFormat {
-    /// Query individual attribute of the field for this format
-    fn field_attribute() -> Attribute;
+pub trait With<F>: VertexFormat {
+    /// Individual format of the attribute for this vertex format
+    const FORMAT: AttributeFormat;
+}
+
+
+/// Vertex format for attributes in separate buffers
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Separate<T: Attribute>(T::Repr);
+unsafe impl<T> Pod for Separate<T> where T: Attribute {}
+impl<T> VertexFormat for Separate<T>
+    where T: Attribute
+{
+    const ATTRIBUTES: &'static [(&'static str, AttributeFormat)] = &[
+        (T::NAME, Element {
+            offset: 0,
+            format: T::FORMAT,
+        })
+    ];
+}
+
+impl<T> With<T> for Separate<T>
+    where T: Attribute
+{
+    const FORMAT: AttributeFormat = Element {
+        offset: 0,
+        format: T::FORMAT,
+    };
 }
 
 /// Vertex format with position and RGBA8 color attributes.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq, VertexData)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PosColor {
     /// Position of the vertex in 3D space.
-    pub a_position: [f32; 3],
+    pub position: [f32; 3],
     /// RGBA color value of the vertex.
-    pub a_color: [f32; 4],
+    pub color: [f32; 4],
 }
+
+unsafe impl Pod for PosColor {}
 
 impl VertexFormat for PosColor {
-    type Attributes = [Attribute; 2];
-    type NamedAttributes = [(&'static str, Attribute); 2];
-
-    #[inline]
-    fn attributes() -> Self::Attributes {
-        [
-            Self::query("a_position").unwrap(),
-            Self::query("a_color").unwrap(),
-        ]
-    }
-
-    #[inline]
-    fn named_attributes<N: AttributeNames>() -> Self::NamedAttributes {
-        [
-            (N::name::<Position>(), Self::query("a_position").unwrap()),
-            (N::name::<Color>(), Self::query("a_color").unwrap()),
-        ]
-    }
+    const ATTRIBUTES: &'static [(&'static str, AttributeFormat)] = &[
+        (Position::NAME, <Self as With<Position>>::FORMAT),
+        (Color::NAME, <Self as With<Color>>::FORMAT),
+    ];
 }
 
-impl WithField<Position> for PosColor {
-    #[inline]
-    fn field_attribute() -> Attribute {
-        Self::query("a_position").unwrap()
-    }
+impl With<Position> for PosColor {
+    const FORMAT: AttributeFormat = Element {
+        offset: 0,
+        format: Position::FORMAT,
+    };
 }
 
-impl WithField<Color> for PosColor {
-    #[inline]
-    fn field_attribute() -> Attribute {
-        Self::query("a_color").unwrap()
-    }
+impl With<Color> for PosColor {
+    const FORMAT: AttributeFormat = Element {
+        offset: Position::SIZE,
+        format: Color::FORMAT,
+    };
 }
 
 /// Vertex format with position and UV texture coordinate attributes.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq, VertexData)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PosTex {
     /// Position of the vertex in 3D space.
-    pub a_position: [f32; 3],
+    pub position: [f32; 3],
     /// UV texture coordinates used by the vertex.
-    pub a_tex_coord: [f32; 2],
+    pub tex_coord: [f32; 2],
 }
+
+unsafe impl Pod for PosTex {}
 
 impl VertexFormat for PosTex {
-    type Attributes = [Attribute; 2];
-    type NamedAttributes = [(&'static str, Attribute); 2];
-
-    #[inline]
-    fn attributes() -> Self::Attributes {
-        [
-            Self::query("a_position").unwrap(),
-            Self::query("a_tex_coord").unwrap(),
-        ]
-    }
-
-    #[inline]
-    fn named_attributes<N: AttributeNames>() -> Self::NamedAttributes {
-        [
-            (N::name::<Position>(), Self::query("a_position").unwrap()),
-            (
-                N::name::<TextureCoord>(),
-                Self::query("a_tex_coord").unwrap(),
-            ),
-        ]
-    }
+    const ATTRIBUTES: &'static [(&'static str, AttributeFormat)] = &[
+        (Position::NAME, <Self as With<Position>>::FORMAT),
+        (TexCoord::NAME, <Self as With<TexCoord>>::FORMAT),
+    ];
 }
 
-impl WithField<Position> for PosTex {
-    #[inline]
-    fn field_attribute() -> Attribute {
-        Self::query("a_position").unwrap()
-    }
+impl With<Position> for PosTex {
+    const FORMAT: AttributeFormat = Element {
+        offset: 0,
+        format: Position::FORMAT,
+    };
 }
 
-impl WithField<TextureCoord> for PosTex {
-    #[inline]
-    fn field_attribute() -> Attribute {
-        Self::query("a_tex_coord").unwrap()
-    }
+impl With<TexCoord> for PosTex {
+    const FORMAT: AttributeFormat = Element {
+        offset: Position::SIZE,
+        format: TexCoord::FORMAT,
+    };
 }
 
 /// Vertex format with position, normal, and UV texture coordinate attributes.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq, VertexData)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PosNormTex {
     /// Position of the vertex in 3D space.
-    pub a_position: [f32; 3],
+    pub position: [f32; 3],
     /// Normal vector of the vertex.
-    pub a_normal: [f32; 3],
+    pub normal: [f32; 3],
     /// UV texture coordinates used by the vertex.
-    pub a_tex_coord: [f32; 2],
+    pub tex_coord: [f32; 2],
 }
+
+unsafe impl Pod for PosNormTex {}
 
 impl VertexFormat for PosNormTex {
-    type Attributes = [Attribute; 3];
-    type NamedAttributes = [(&'static str, Attribute); 3];
-
-    #[inline]
-    fn attributes() -> Self::Attributes {
-        [
-            Self::query("a_position").unwrap(),
-            Self::query("a_normal").unwrap(),
-            Self::query("a_tex_coord").unwrap(),
-        ]
-    }
-
-    #[inline]
-    fn named_attributes<N: AttributeNames>() -> Self::NamedAttributes {
-        [
-            (N::name::<Position>(), Self::query("a_position").unwrap()),
-            (N::name::<Normal>(), Self::query("a_normal").unwrap()),
-            (
-                N::name::<TextureCoord>(),
-                Self::query("a_tex_coord").unwrap(),
-            ),
-        ]
-    }
+    const ATTRIBUTES: &'static [(&'static str, AttributeFormat)] = &[
+        (Position::NAME, <Self as With<Position>>::FORMAT),
+        (Normal::NAME, <Self as With<Normal>>::FORMAT),
+        (TexCoord::NAME, <Self as With<TexCoord>>::FORMAT),
+    ];
 }
 
-impl WithField<Position> for PosNormTex {
-    #[inline]
-    fn field_attribute() -> Attribute {
-        Self::query("a_position").unwrap()
-    }
+impl With<Position> for PosNormTex {
+    const FORMAT: AttributeFormat = Element {
+        offset: 0,
+        format: Position::FORMAT,
+    };
 }
 
-impl WithField<Normal> for PosNormTex {
-    #[inline]
-    fn field_attribute() -> Attribute {
-        Self::query("a_normal").unwrap()
-    }
+impl With<Normal> for PosNormTex {
+    const FORMAT: AttributeFormat = Element {
+        offset: Position::SIZE,
+        format: Normal::FORMAT,
+    };
 }
 
-impl WithField<TextureCoord> for PosNormTex {
-    #[inline]
-    fn field_attribute() -> Attribute {
-        Self::query("a_tex_coord").unwrap()
-    }
+impl With<TexCoord> for PosNormTex {
+    const FORMAT: AttributeFormat = Element {
+        offset: Position::SIZE + Normal::SIZE,
+        format: TexCoord::FORMAT,
+    };
 }
 
 /// Vertex format with position, normal, and UV texture coordinate attributes.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq, VertexData)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PosNormTangTex {
     /// Position of the vertex in 3D space.
-    pub a_position: [f32; 3],
+    pub position: [f32; 3],
     /// Normal vector of the vertex.
-    pub a_normal: [f32; 3],
+    pub normal: [f32; 3],
     /// Tangent vector of the vertex.
-    pub a_tangent: [f32; 3],
+    pub tangent: [f32; 3],
     /// UV texture coordinates used by the vertex.
-    pub a_tex_coord: [f32; 2],
+    pub tex_coord: [f32; 2],
 }
+
+unsafe impl Pod for PosNormTangTex {}
 
 impl VertexFormat for PosNormTangTex {
-    type Attributes = [Attribute; 4];
-    type NamedAttributes = [(&'static str, Attribute); 4];
-    #[inline]
-    fn attributes() -> Self::Attributes {
-        [
-            Self::query("a_position").unwrap(),
-            Self::query("a_normal").unwrap(),
-            Self::query("a_tangent").unwrap(),
-            Self::query("a_tex_coord").unwrap(),
-        ]
-    }
-    #[inline]
-    fn named_attributes<N: AttributeNames>() -> Self::NamedAttributes {
-        [
-            (N::name::<Position>(), Self::query("a_position").unwrap()),
-            (N::name::<Normal>(), Self::query("a_normal").unwrap()),
-            (N::name::<Tangent>(), Self::query("a_tangent").unwrap()),
-            (
-                N::name::<TextureCoord>(),
-                Self::query("a_tex_coord").unwrap(),
-            ),
-        ]
-    }
+    const ATTRIBUTES: &'static [(&'static str, AttributeFormat)] = &[
+        (Position::NAME, <Self as With<Position>>::FORMAT),
+        (Normal::NAME, <Self as With<Normal>>::FORMAT),
+        (Tangent::NAME, <Self as With<Tangent>>::FORMAT),
+        (TexCoord::NAME, <Self as With<TexCoord>>::FORMAT),
+    ];
 }
 
-impl WithField<Position> for PosNormTangTex {
-    #[inline]
-    fn field_attribute() -> Attribute {
-        Self::query("a_position").unwrap()
-    }
+impl With<Position> for PosNormTangTex {
+    const FORMAT: AttributeFormat = Element {
+        offset: 0,
+        format: Position::FORMAT,
+    };
 }
 
-impl WithField<Normal> for PosNormTangTex {
-    #[inline]
-    fn field_attribute() -> Attribute {
-        Self::query("a_normal").unwrap()
-    }
+impl With<Normal> for PosNormTangTex {
+    const FORMAT: AttributeFormat = Element {
+        offset: Position::SIZE,
+        format: Normal::FORMAT,
+    };
 }
 
-impl WithField<Tangent> for PosNormTangTex {
-    #[inline]
-    fn field_attribute() -> Attribute {
-        Self::query("a_tangent").unwrap()
-    }
+impl With<Tangent> for PosNormTangTex {
+    const FORMAT: AttributeFormat = Element {
+        offset: Position::SIZE + Normal::SIZE,
+        format: Tangent::FORMAT,
+    };
 }
 
-impl WithField<TextureCoord> for PosNormTangTex {
-    #[inline]
-    fn field_attribute() -> Attribute {
-        Self::query("a_tex_coord").unwrap()
-    }
+impl With<TexCoord> for PosNormTangTex {
+    const FORMAT: AttributeFormat = Element {
+        offset: Position::SIZE + Normal::SIZE + Tangent::SIZE,
+        format: TexCoord::FORMAT,
+    };
 }

--- a/examples/02_sphere/main.rs
+++ b/examples/02_sphere/main.rs
@@ -145,9 +145,9 @@ fn gen_sphere(u: usize, v: usize) -> Vec<PosNormTex> {
     SphereUV::new(u, v)
         .vertex(|(x, y, z)| {
             PosNormTex {
-                a_position: [x, y, z],
-                a_normal: Vector3::from([x, y, z]).normalize().into(),
-                a_tex_coord: [0.1, 0.1],
+                position: [x, y, z],
+                normal: Vector3::from([x, y, z]).normalize().into(),
+                tex_coord: [0.1, 0.1],
             }
         })
         .triangulate()

--- a/examples/04_pong/main.rs
+++ b/examples/04_pong/main.rs
@@ -297,13 +297,14 @@ where
 impl State for Pong {
     fn on_start(&mut self, engine: &mut Engine) {
         // Hide the cursor
-        engine.world.write_resource::<WindowMessages>().send_command(
-            |win| {
+        engine
+            .world
+            .write_resource::<WindowMessages>()
+            .send_command(|win| {
                 if let Err(err) = win.set_cursor_state(CursorState::Hide) {
                     eprintln!("Unable to make cursor hidden! Error: {:?}", err);
                 }
-            }
-        );
+            });
         // Load audio assets
         // FIXME: do loading with futures, pending the Loading state
         {
@@ -504,34 +505,34 @@ fn main() {
 fn gen_rectangle(w: f32, h: f32) -> Vec<PosNormTex> {
     let data: Vec<PosNormTex> = vec![
         PosNormTex {
-            a_position: [-w / 2., -h / 2., 0.],
-            a_normal: [0., 0., 1.],
-            a_tex_coord: [0., 0.],
+            position: [-w / 2., -h / 2., 0.],
+            normal: [0., 0., 1.],
+            tex_coord: [0., 0.],
         },
         PosNormTex {
-            a_position: [w / 2., -h / 2., 0.],
-            a_normal: [0., 0., 1.],
-            a_tex_coord: [1., 0.],
+            position: [w / 2., -h / 2., 0.],
+            normal: [0., 0., 1.],
+            tex_coord: [1., 0.],
         },
         PosNormTex {
-            a_position: [w / 2., h / 2., 0.],
-            a_normal: [0., 0., 1.],
-            a_tex_coord: [1., 1.],
+            position: [w / 2., h / 2., 0.],
+            normal: [0., 0., 1.],
+            tex_coord: [1., 1.],
         },
         PosNormTex {
-            a_position: [w / 2., h / 2., 0.],
-            a_normal: [0., 0., 1.],
-            a_tex_coord: [1., 1.],
+            position: [w / 2., h / 2., 0.],
+            normal: [0., 0., 1.],
+            tex_coord: [1., 1.],
         },
         PosNormTex {
-            a_position: [-w / 2., h / 2., 0.],
-            a_normal: [0., 0., 1.],
-            a_tex_coord: [0., 1.],
+            position: [-w / 2., h / 2., 0.],
+            normal: [0., 0., 1.],
+            tex_coord: [0., 1.],
         },
         PosNormTex {
-            a_position: [-w / 2., -h / 2., 0.],
-            a_normal: [0., 0., 1.],
-            a_tex_coord: [0., 0.],
+            position: [-w / 2., -h / 2., 0.],
+            normal: [0., 0., 1.],
+            tex_coord: [0., 0.],
         },
     ];
     data

--- a/examples/05_assets/main.rs
+++ b/examples/05_assets/main.rs
@@ -54,9 +54,9 @@ impl Format for Custom {
             ];
 
             result.push(PosNormTex {
-                a_position: vertex,
-                a_normal: normal,
-                a_tex_coord: [0.0, 0.0],
+                position: vertex,
+                normal: normal,
+                tex_coord: [0.0, 0.0],
             });
         }
         Ok(result)

--- a/examples/06_material/main.rs
+++ b/examples/06_material/main.rs
@@ -184,10 +184,10 @@ fn gen_sphere(u: usize, v: usize) -> Vec<PosNormTangTex> {
             let up = Vector3::from([0.0, 1.0, 0.0]);
             let tangent = normal.cross(up).cross(normal);
             PosNormTangTex {
-                a_position: [x, y, z],
-                a_normal: normal.into(),
-                a_tangent: tangent.into(),
-                a_tex_coord: [0.1, 0.1],
+                position: [x, y, z],
+                normal: normal.into(),
+                tangent: tangent.into(),
+                tex_coord: [0.1, 0.1],
             }
         })
         .triangulate()

--- a/src/assets/formats/meshes.rs
+++ b/src/assets/formats/meshes.rs
@@ -77,17 +77,17 @@ fn convert(
     ni: Option<NormalIndex>,
 ) -> PosNormTex {
     PosNormTex {
-        a_position: {
+        position: {
             let vertex: Vertex = object.vertices[vi];
             [vertex.x as f32, vertex.y as f32, vertex.z as f32]
         },
-        a_normal: ni.map(|i| {
+        normal: ni.map(|i| {
             let normal: Normal = object.normals[i];
             Vector3::from([normal.x as f32, normal.y as f32, normal.z as f32])
                 .normalize()
                 .into()
         }).unwrap_or([0.0, 0.0, 0.0]),
-        a_tex_coord: ti.map(|i| {
+        tex_coord: ti.map(|i| {
             let tvertex: TVertex = object.tex_vertices[i];
             [tvertex.u as f32, tvertex.v as f32]
         }).unwrap_or([0.0, 0.0]),


### PR DESCRIPTION
This little refactoring is aimed to increase use of assotiated consts, reduce overhead and simplify upcoming feature to use separate buffers for vertex attributes which will be preferable way to use meshes.