### PR TITLE
Multibuffer

### DIFF
--- a/amethyst_renderer/Cargo.toml
+++ b/amethyst_renderer/Cargo.toml
@@ -37,6 +37,7 @@ rayon = "0.7"
 rayon-core = "1.2"
 serde = "1.0"
 serde_derive = "1.0"
+smallvec = "0.4.2"
 winit = "0.7"
 
 gfx_device_gl = { version = "0.14", optional = true }
@@ -57,9 +58,6 @@ gfx_window_dxgi = { version = "0.7", optional = true }
 
 [dependencies.hetseq]
 version = "0.1.5"
-
-[dependencies.smallvec]
-version = "0.4.2"
 
 [dependencies.specs]
 version = "0.9.5"

--- a/amethyst_renderer/Cargo.toml
+++ b/amethyst_renderer/Cargo.toml
@@ -58,6 +58,9 @@ gfx_window_dxgi = { version = "0.7", optional = true }
 [dependencies.hetseq]
 version = "0.1.5"
 
+[dependencies.smallvec]
+version = "0.4.2"
+
 [dependencies.specs]
 version = "0.9.5"
 

--- a/amethyst_renderer/Cargo.toml
+++ b/amethyst_renderer/Cargo.toml
@@ -37,7 +37,6 @@ rayon = "0.7"
 rayon-core = "1.2"
 serde = "1.0"
 serde_derive = "1.0"
-smallvec = "0.4.2"
 winit = "0.7"
 
 gfx_device_gl = { version = "0.14", optional = true }

--- a/amethyst_renderer/src/lib.rs
+++ b/amethyst_renderer/src/lib.rs
@@ -24,7 +24,6 @@ extern crate rayon_core;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate smallvec;
 extern crate specs;
 extern crate winit;
 

--- a/amethyst_renderer/src/lib.rs
+++ b/amethyst_renderer/src/lib.rs
@@ -24,6 +24,7 @@ extern crate rayon_core;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+extern crate smallvec;
 extern crate specs;
 extern crate winit;
 
@@ -63,6 +64,7 @@ pub use types::{Encoder, Factory};
 pub use vertex::VertexFormat;
 
 pub mod light;
+pub mod mesh;
 pub mod pass;
 pub mod prelude;
 pub mod pipe;
@@ -73,7 +75,6 @@ mod cam;
 mod color;
 mod config;
 mod error;
-mod mesh;
 mod mtl;
 mod renderer;
 mod tex;

--- a/amethyst_renderer/src/mesh.rs
+++ b/amethyst_renderer/src/mesh.rs
@@ -1,6 +1,6 @@
 //! Mesh resource.
 
-use std::iter::{Chain, once, Once};
+use std::iter::{once, Chain, Once};
 use std::marker::PhantomData;
 
 use specs::{Component, DenseVecStorage};
@@ -35,15 +35,17 @@ pub trait VertexData {
 
 /// Construct new vertex data from raw data and vertex format
 pub fn vertex_data<D, V>(data: D) -> (D, PhantomData<V>)
-    where D: AsRef<[V]>,
-          V: VertexFormat,
+where
+    D: AsRef<[V]>,
+    V: VertexFormat,
 {
     (data, PhantomData)
 }
 
 impl<D, V> VertexData for (D, PhantomData<V>)
-    where D: AsRef<[V]>,
-          V: VertexFormat,
+where
+    D: AsRef<[V]>,
+    V: VertexFormat,
 {
     const ATTRIBUTES: Attributes<'static> = V::ATTRIBUTES;
 
@@ -53,7 +55,7 @@ impl<D, V> VertexData for (D, PhantomData<V>)
 
     fn build(&self, factory: &mut Factory) -> Result<VertexBuffer> {
         use gfx::Factory;
-        use gfx::memory::{Bind, cast_slice};
+        use gfx::memory::{cast_slice, Bind};
         use gfx::buffer::Role;
 
         let verts = self.0.as_ref();
@@ -74,7 +76,7 @@ impl<D, V> VertexData for (D, PhantomData<V>)
 #[doc(hidden)]
 pub trait VertexDataSet {
     /// Iterator for `VertexBuffer`s built
-    type VertexBufferIter: Iterator<Item=VertexBuffer>;
+    type VertexBufferIter: Iterator<Item = VertexBuffer>;
 
     /// Get smalles vertex count across buffers
     fn len(&self) -> usize;
@@ -84,7 +86,8 @@ pub trait VertexDataSet {
 }
 
 impl<H> VertexDataSet for (H, ())
-    where H: VertexData,
+where
+    H: VertexData,
 {
     type VertexBufferIter = Once<VertexBuffer>;
 
@@ -99,8 +102,9 @@ impl<H> VertexDataSet for (H, ())
 }
 
 impl<H, T> VertexDataSet for (H, T)
-    where H: VertexData,
-          T: VertexDataSet,
+where
+    H: VertexData,
+    T: VertexDataSet,
 {
     type VertexBufferIter = Chain<Once<VertexBuffer>, T::VertexBufferIter>;
 
@@ -148,10 +152,10 @@ impl Mesh {
                             // continue searching
                             i += 1;
                         }
-                    },
+                    }
                     None => {
                         // All atributes found
-                        return Some(&vbuf.raw)
+                        return Some(&vbuf.raw);
                     }
                 }
             }
@@ -189,8 +193,9 @@ pub struct MeshBuilder<T> {
 }
 
 impl<D, V> MeshBuilder<((D, PhantomData<V>), ())>
-    where D: AsRef<[V]>,
-          V: VertexFormat,
+where
+    D: AsRef<[V]>,
+    V: VertexFormat,
 {
     /// Creates a new `MeshBuilder` with the given vertices.
     pub fn new(verts: D) -> Self {
@@ -205,12 +210,14 @@ impl<D, V> MeshBuilder<((D, PhantomData<V>), ())>
 }
 
 impl<T> MeshBuilder<T>
-    where T: VertexDataSet,
+where
+    T: VertexDataSet,
 {
     /// Add another vertices to the `MeshBuilder`
     pub fn with_buffer<D, V>(self, verts: D) -> MeshBuilder<((D, PhantomData<V>), T)>
-        where D: AsRef<[V]>,
-              V: VertexFormat,
+    where
+        D: AsRef<[V]>,
+        V: VertexFormat,
     {
         assert!(check_attributes_are_sorted(V::ATTRIBUTES));
         MeshBuilder {

--- a/amethyst_renderer/src/mesh.rs
+++ b/amethyst_renderer/src/mesh.rs
@@ -1,44 +1,169 @@
 //! Mesh resource.
 
+use std::iter::{Chain, once, Once};
 use std::marker::PhantomData;
 
 use specs::{Component, DenseVecStorage};
 
 use cgmath::{Deg, Matrix4, Point3, Transform, Vector3};
 use gfx::Primitive;
+use smallvec::SmallVec;
 
 use error::Result;
 use types::{Factory, RawBuffer, Slice};
-use vertex::{AttributeFormat, VertexFormat};
+use vertex::{Attributes, VertexFormat};
+
+
+/// Raw buffer with its attributes
+#[derive(Clone, Debug)]
+pub struct VertexBuffer {
+    attrs: Attributes<'static>,
+    raw: RawBuffer,
+}
+
+/// Vertex data that can be built into `VertexBuffer`
+#[doc(hidden)]
+pub trait VertexData {
+    const ATTRIBUTES: Attributes<'static>;
+
+    /// Get vertex count in buffer
+    fn len(&self) -> usize;
+
+    /// Build `VertexBuffer`
+    fn build(&self, factory: &mut Factory) -> Result<VertexBuffer>;
+}
+
+/// Construct new vertex data from raw data and vertex format
+pub fn vertex_data<D, V>(data: D) -> (D, PhantomData<V>)
+    where D: AsRef<[V]>,
+          V: VertexFormat,
+{
+    (data, PhantomData)
+}
+
+impl<D, V> VertexData for (D, PhantomData<V>)
+    where D: AsRef<[V]>,
+          V: VertexFormat,
+{
+    const ATTRIBUTES: Attributes<'static> = V::ATTRIBUTES;
+
+    fn len(&self) -> usize {
+        self.0.as_ref().len()
+    }
+
+    fn build(&self, factory: &mut Factory) -> Result<VertexBuffer> {
+        use gfx::Factory;
+        use gfx::memory::{Bind, cast_slice};
+        use gfx::buffer::Role;
+
+        let verts = self.0.as_ref();
+        let slice = cast_slice(verts);
+        let stride = slice.len() / verts.len();
+        let role = Role::Vertex;
+        let bind = Bind::empty();
+
+        let vbuf = factory.create_buffer_immutable_raw(slice, stride, role, bind)?;
+        Ok(VertexBuffer {
+            attrs: V::ATTRIBUTES,
+            raw: vbuf,
+        })
+    }
+}
+
+/// Set of vertex data
+#[doc(hidden)]
+pub trait VertexDataSet {
+    /// Iterator for `VertexBuffer`s built
+    type VertexBufferIter: Iterator<Item=VertexBuffer>;
+
+    /// Get smalles vertex count across buffers
+    fn len(&self) -> usize;
+
+    /// Build `VertexBuffer`s
+    fn build(&self, factory: &mut Factory) -> Result<Self::VertexBufferIter>;
+}
+
+impl<H> VertexDataSet for (H, ())
+    where H: VertexData,
+{
+    type VertexBufferIter = Once<VertexBuffer>;
+
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn build(&self, factory: &mut Factory) -> Result<Self::VertexBufferIter> {
+        let (ref head, _) = *self;
+        Ok(once(head.build(factory)?))
+    }
+}
+
+impl<H, T> VertexDataSet for (H, T)
+    where H: VertexData,
+          T: VertexDataSet,
+{
+    type VertexBufferIter = Chain<Once<VertexBuffer>, T::VertexBufferIter>;
+
+    fn len(&self) -> usize {
+        use std::cmp::min;
+        min(self.0.len(), self.1.len())
+    }
+
+    fn build(&self, factory: &mut Factory) -> Result<Self::VertexBufferIter> {
+        let (ref head, ref tail) = *self;
+        Ok(once(head.build(factory)?).chain(tail.build(factory)?))
+    }
+}
+
 
 /// Represents a polygonal mesh.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct Mesh {
-    attrs: &'static [(&'static str, AttributeFormat)],
-    prim: Primitive,
     slice: Slice,
     transform: Matrix4<f32>,
-    vbuf: RawBuffer,
+    vbufs: SmallVec<[VertexBuffer; 4]>,
 }
 
 impl Mesh {
-    /// Builds a new mesh from the given vertices.
-    pub fn build<D, V>(verts: D) -> MeshBuilder<D, V>
-    where
-        D: AsRef<[V]>,
-        V: VertexFormat,
-    {
-        MeshBuilder::new(verts)
+    /// Returns the mesh's vertex buffer which matches requested attributes
+    pub fn buffer(&self, attributes: Attributes) -> Option<&RawBuffer> {
+        for vbuf in self.vbufs.iter() {
+            let mut find = attributes.iter();
+            let mut next = find.next();
+            let mut i = 0;
+            let mut j = 0;
+            loop {
+                let attrs = vbuf.attrs;
+                match next {
+                    Some(&attr) => {
+                        if i == attrs.len() {
+                            // try next vbuf
+                            break;
+                        } else if attrs[(i + j) % attrs.len()] == attr {
+                            // match. search next attribute
+                            next = find.next();
+                            j = i;
+                            i = 0;
+                        } else {
+                            // continue searching
+                            i += 1;
+                        }
+                    },
+                    None => {
+                        // All atributes found
+                        return Some(&vbuf.raw)
+                    }
+                }
+            }
+        }
+
+        // None of the vertex buffers match requested attributes
+        None
     }
 
-    /// Returns a list of all vertex attributes needed by this mesh.
-    pub fn attributes(&self) -> &[(&'static str, AttributeFormat)] {
-        self.attrs
-    }
-
-    /// Returns the mesh's vertex buffer and associated buffer slice.
-    pub fn geometry(&self) -> (&RawBuffer, &Slice) {
-        (&self.vbuf, &self.slice)
+    /// Returns assotiated `Slice`
+    pub fn slice(&self) -> &Slice {
+        &self.slice
     }
 
     /// Returns the transformation matrix of the mesh.
@@ -51,29 +176,47 @@ impl Mesh {
     }
 }
 
-/// Builds new meshes.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct MeshBuilder<D, V> {
-    prim: Primitive,
-    transform: Matrix4<f32>,
-    vertices: D,
-    pd: PhantomData<V>,
+impl Component for Mesh {
+    type Storage = DenseVecStorage<Self>;
 }
 
-impl<D, V> MeshBuilder<D, V>
-where
-    D: AsRef<[V]>,
-    V: VertexFormat,
+/// Builds new meshes.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct MeshBuilder<T> {
+    prim: Primitive,
+    transform: Matrix4<f32>,
+    vertices: T,
+}
+
+impl<D, V> MeshBuilder<((D, PhantomData<V>), ())>
+    where D: AsRef<[V]>,
+          V: VertexFormat,
 {
     /// Creates a new `MeshBuilder` with the given vertices.
     pub fn new(verts: D) -> Self {
         use cgmath::SquareMatrix;
-
+        assert!(check_attributes_are_sorted(V::ATTRIBUTES));
         MeshBuilder {
             prim: Primitive::TriangleList,
             transform: Matrix4::identity(),
-            vertices: verts,
-            pd: PhantomData,
+            vertices: (vertex_data(verts), ()),
+        }
+    }
+}
+
+impl<T> MeshBuilder<T>
+    where T: VertexDataSet,
+{
+    /// Add another vertices to the `MeshBuilder`
+    pub fn with_buffer<D, V>(self, verts: D) -> MeshBuilder<((D, PhantomData<V>), T)>
+        where D: AsRef<[V]>,
+              V: VertexFormat,
+    {
+        assert!(check_attributes_are_sorted(V::ATTRIBUTES));
+        MeshBuilder {
+            prim: self.prim,
+            transform: self.transform,
+            vertices: (vertex_data(verts), self.vertices),
         }
     }
 
@@ -124,17 +267,9 @@ where
 
     /// Builds and returns the new mesh.
     pub fn build(self, fac: &mut Factory) -> Result<Mesh> {
-        use gfx::{Bind, Factory, IndexBuffer};
-        use gfx::buffer::Role;
-        use gfx::memory::cast_slice;
+        use gfx::IndexBuffer;
+        let count = self.vertices.len();
 
-        let verts = cast_slice(self.vertices.as_ref());
-        let count = self.vertices.as_ref().len();
-        let stride = verts.len() / count;
-        let role = Role::Vertex;
-        let bind = Bind::empty();
-
-        let vbuf = fac.create_buffer_immutable_raw(verts, stride, role, bind)?;
         let slice = Slice {
             start: 0,
             end: count as u32,
@@ -144,15 +279,21 @@ where
         };
 
         Ok(Mesh {
-            attrs: V::ATTRIBUTES,
-            prim: self.prim,
             slice: slice,
             transform: self.transform,
-            vbuf: vbuf,
+            vbufs: self.vertices.build(fac)?.collect(),
         })
     }
 }
 
-impl Component for Mesh {
-    type Storage = DenseVecStorage<Self>;
+/// Check that attributes are sorted
+fn check_attributes_are_sorted(attrs: Attributes) -> bool {
+    let mut last = 0;
+    for attr in attrs {
+        if last > attr.1.offset {
+            return false;
+        }
+        last = attr.1.offset;
+    }
+    true
 }

--- a/amethyst_renderer/src/mesh.rs
+++ b/amethyst_renderer/src/mesh.rs
@@ -129,6 +129,14 @@ pub struct Mesh {
 }
 
 impl Mesh {
+    /// Builds a new mesh from the given vertices.
+    pub fn build<D, V>(verts: D) -> MeshBuilder<((D, PhantomData<V>), ())>
+        where D: AsRef<[V]>,
+              V: VertexFormat,
+    {
+        MeshBuilder::new(verts)
+    }
+
     /// Returns the mesh's vertex buffer which matches requested attributes
     pub fn buffer(&self, attributes: Attributes) -> Option<&RawBuffer> {
         for vbuf in self.vbufs.iter() {
@@ -165,7 +173,7 @@ impl Mesh {
         None
     }
 
-    /// Returns assotiated `Slice`
+    /// Returns associated `Slice`
     pub fn slice(&self) -> &Slice {
         &self.slice
     }

--- a/amethyst_renderer/src/mesh.rs
+++ b/amethyst_renderer/src/mesh.rs
@@ -131,8 +131,9 @@ pub struct Mesh {
 impl Mesh {
     /// Builds a new mesh from the given vertices.
     pub fn build<D, V>(verts: D) -> MeshBuilder<((D, PhantomData<V>), ())>
-        where D: AsRef<[V]>,
-              V: VertexFormat,
+    where
+        D: AsRef<[V]>,
+        V: VertexFormat,
     {
         MeshBuilder::new(verts)
     }

--- a/amethyst_renderer/src/mesh.rs
+++ b/amethyst_renderer/src/mesh.rs
@@ -7,7 +7,6 @@ use specs::{Component, DenseVecStorage};
 
 use cgmath::{Deg, Matrix4, Point3, Transform, Vector3};
 use gfx::Primitive;
-use smallvec::SmallVec;
 
 use error::Result;
 use types::{Factory, RawBuffer, Slice};
@@ -125,7 +124,7 @@ where
 pub struct Mesh {
     slice: Slice,
     transform: Matrix4<f32>,
-    vbufs: SmallVec<[VertexBuffer; 4]>,
+    vbufs: Vec<VertexBuffer>,
 }
 
 impl Mesh {

--- a/amethyst_renderer/src/pass/flat.rs
+++ b/amethyst_renderer/src/pass/flat.rs
@@ -16,7 +16,7 @@ use mtl::Material;
 use pipe::pass::{Pass, PassApply, PassData, Supplier};
 use pipe::{DepthMode, Effect, NewEffect};
 use types::Encoder;
-use vertex::{Position, TexCoord, Query};
+use vertex::{Position, Query, TexCoord};
 
 static VERT_SRC: &[u8] = include_bytes!("shaders/vertex/basic.glsl");
 static FRAG_SRC: &[u8] = include_bytes!("shaders/fragment/flat.glsl");
@@ -41,9 +41,7 @@ where
 {
     /// Create instance of `DrawFlat` pass
     pub fn new() -> Self {
-        DrawFlat {
-            _pd: PhantomData,
-        }
+        DrawFlat { _pd: PhantomData }
     }
 }
 
@@ -156,7 +154,7 @@ where
                 move |(mesh, material, global)| {
                     move |encoder: &mut Encoder, effect: &mut Effect| {
                         let mesh = mesh.as_ref();
-                        
+
                         let vbuf = match mesh.buffer(V::QUERIED_ATTRIBUTES) {
                             Some(vbuf) => vbuf.clone(),
                             None => return,
@@ -183,7 +181,7 @@ where
                         effect.update_constant_buffer("VertexArgs", &vertex_args, encoder);
                         effect.data.textures.push(material.albedo.view().clone());
                         effect.data.samplers.push(material.albedo.sampler().clone());
-                        
+
                         effect.data.vertex_bufs.push(vbuf);
 
                         effect.draw(mesh.slice(), encoder);

--- a/amethyst_renderer/src/pass/pbm.rs
+++ b/amethyst_renderer/src/pass/pbm.rs
@@ -19,7 +19,7 @@ use mtl::Material;
 use pipe::{DepthMode, Effect, NewEffect};
 use pipe::pass::{Pass, PassApply, PassData, Supplier};
 use types::Encoder;
-use vertex::{Normal, Position, Tangent, TexCoord, Query};
+use vertex::{Normal, Position, Query, Tangent, TexCoord};
 
 static VERT_SRC: &[u8] = include_bytes!("shaders/vertex/basic.glsl");
 static FRAG_SRC: &[u8] = include_bytes!("shaders/fragment/pbm.glsl");
@@ -47,9 +47,7 @@ where
 {
     /// Create instance of `DrawPbm` pass
     pub fn new() -> Self {
-        DrawPbm {
-            _pd: PhantomData,
-        }
+        DrawPbm { _pd: PhantomData }
     }
 }
 
@@ -224,9 +222,8 @@ where
             .supply((&mesh, &material, &global).par_join().map(
                 |(mesh, material, global)| {
                     move |encoder: &mut Encoder, effect: &mut Effect| {
-
                         let mesh = mesh.as_ref();
-                        
+
                         let vbuf = match mesh.buffer(V::QUERIED_ATTRIBUTES) {
                             Some(vbuf) => vbuf.clone(),
                             None => return,
@@ -302,26 +299,14 @@ where
                                 .unwrap_or([0.0; 3]),
                         );
 
-                        effect
-                            .data
-                            .textures
-                            .push(material.roughness.view().clone());
+                        effect.data.textures.push(material.roughness.view().clone());
                         effect
                             .data
                             .samplers
                             .push(material.roughness.sampler().clone());
-                        effect
-                            .data
-                            .textures
-                            .push(material.caveat.view().clone());
-                        effect
-                            .data
-                            .samplers
-                            .push(material.caveat.sampler().clone());
-                        effect
-                            .data
-                            .textures
-                            .push(material.metallic.view().clone());
+                        effect.data.textures.push(material.caveat.view().clone());
+                        effect.data.samplers.push(material.caveat.sampler().clone());
+                        effect.data.textures.push(material.metallic.view().clone());
                         effect
                             .data
                             .samplers
@@ -334,31 +319,16 @@ where
                             .data
                             .samplers
                             .push(material.ambient_occlusion.sampler().clone());
-                        effect
-                            .data
-                            .textures
-                            .push(material.emission.view().clone());
+                        effect.data.textures.push(material.emission.view().clone());
                         effect
                             .data
                             .samplers
                             .push(material.emission.sampler().clone());
-                        effect
-                            .data
-                            .textures
-                            .push(material.normal.view().clone());
-                        effect
-                            .data
-                            .samplers
-                            .push(material.normal.sampler().clone());
-                        effect
-                            .data
-                            .textures
-                            .push(material.albedo.view().clone());
-                        effect
-                            .data
-                            .samplers
-                            .push(material.albedo.sampler().clone());
-                        
+                        effect.data.textures.push(material.normal.view().clone());
+                        effect.data.samplers.push(material.normal.sampler().clone());
+                        effect.data.textures.push(material.albedo.view().clone());
+                        effect.data.samplers.push(material.albedo.sampler().clone());
+
                         effect.data.vertex_bufs.push(vbuf);
 
                         effect.draw(mesh.slice(), encoder);

--- a/amethyst_renderer/src/pass/shaded.rs
+++ b/amethyst_renderer/src/pass/shaded.rs
@@ -19,7 +19,7 @@ use mtl::Material;
 use pipe::{DepthMode, Effect, NewEffect};
 use pipe::pass::{Pass, PassApply, PassData, Supplier};
 use types::Encoder;
-use vertex::{Normal, Position, TexCoord, Query};
+use vertex::{Normal, Position, Query, TexCoord};
 
 static VERT_SRC: &[u8] = include_bytes!("shaders/vertex/basic.glsl");
 static FRAG_SRC: &[u8] = include_bytes!("shaders/fragment/shaded.glsl");
@@ -47,9 +47,7 @@ where
 {
     /// Create instance of `DrawShaded` pass
     pub fn new() -> Self {
-        DrawShaded {
-            _pd: PhantomData,
-        }
+        DrawShaded { _pd: PhantomData }
     }
 }
 
@@ -228,9 +226,8 @@ where
             .supply((&mesh, &material, &global).par_join().map(
                 |(mesh, material, global)| {
                     move |encoder: &mut Encoder, effect: &mut Effect| {
-
                         let mesh = mesh.as_ref();
-                        
+
                         let vbuf = match mesh.buffer(V::QUERIED_ATTRIBUTES) {
                             Some(vbuf) => vbuf.clone(),
                             None => return,
@@ -305,25 +302,16 @@ where
                                 .unwrap_or([0.0; 3]),
                         );
 
-                        effect
-                            .data
-                            .textures
-                            .push(material.emission.view().clone());
+                        effect.data.textures.push(material.emission.view().clone());
 
                         effect
                             .data
                             .samplers
                             .push(material.emission.sampler().clone());
 
-                        effect
-                            .data
-                            .textures
-                            .push(material.albedo.view().clone());
+                        effect.data.textures.push(material.albedo.view().clone());
 
-                        effect
-                            .data
-                            .samplers
-                            .push(material.albedo.sampler().clone());
+                        effect.data.samplers.push(material.albedo.sampler().clone());
 
                         effect.data.vertex_bufs.push(vbuf);
 

--- a/amethyst_renderer/src/pass/shaded.rs
+++ b/amethyst_renderer/src/pass/shaded.rs
@@ -19,7 +19,7 @@ use mtl::Material;
 use pipe::{DepthMode, Effect, NewEffect};
 use pipe::pass::{Pass, PassApply, PassData, Supplier};
 use types::Encoder;
-use vertex::{AttributeFormat, Normal, Position, TexCoord, VertexFormat, With};
+use vertex::{Normal, Position, TexCoord, Query};
 
 static VERT_SRC: &[u8] = include_bytes!("shaders/vertex/basic.glsl");
 static FRAG_SRC: &[u8] = include_bytes!("shaders/fragment/shaded.glsl");
@@ -33,13 +33,12 @@ static FRAG_SRC: &[u8] = include_bytes!("shaders/fragment/shaded.glsl");
 /// `L` is `Light` component
 #[derive(Clone, Debug, PartialEq)]
 pub struct DrawShaded<V, A, M, N, T, L> {
-    vertex_attributes: [(&'static str, AttributeFormat); 3],
     _pd: PhantomData<(V, A, M, N, T, L)>,
 }
 
 impl<V, A, M, N, T, L> DrawShaded<V, A, M, N, T, L>
 where
-    V: VertexFormat + With<Position> + With<Normal> + With<TexCoord>,
+    V: Query<(Position, Normal, TexCoord)>,
     A: AsRef<Rgba> + Send + Sync + 'static,
     T: Component + AsRef<[[f32; 4]; 4]> + Send + Sync,
     M: Component + AsRef<Mesh> + Send + Sync,
@@ -49,11 +48,6 @@ where
     /// Create instance of `DrawShaded` pass
     pub fn new() -> Self {
         DrawShaded {
-            vertex_attributes: [
-                ("position", V::attribute::<Position>()),
-                ("normal", V::attribute::<Normal>()),
-                ("tex_coord", V::attribute::<TexCoord>()),
-            ],
             _pd: PhantomData,
         }
     }
@@ -101,7 +95,7 @@ unsafe impl Pod for DirectionalLightPod {}
 
 impl<'a, V, A, M, N, T, L> PassData<'a> for DrawShaded<V, A, M, N, T, L>
 where
-    V: VertexFormat + With<Position> + With<Normal> + With<TexCoord>,
+    V: Query<(Position, Normal, TexCoord)>,
     A: AsRef<Rgba> + Send + Sync + 'static,
     T: Component + AsRef<[[f32; 4]; 4]> + Send + Sync,
     M: Component + AsRef<Mesh> + Send + Sync,
@@ -120,7 +114,7 @@ where
 
 impl<'a, V, A, M, N, T, L> PassApply<'a> for DrawShaded<V, A, M, N, T, L>
 where
-    V: VertexFormat + With<Position> + With<Normal> + With<TexCoord>,
+    V: Query<(Position, Normal, TexCoord)>,
     A: AsRef<Rgba> + Send + Sync + 'static,
     T: Component + AsRef<[[f32; 4]; 4]> + Send + Sync,
     M: Component + AsRef<Mesh> + Send + Sync,
@@ -133,7 +127,7 @@ where
 
 impl<V, A, M, N, T, L> Pass for DrawShaded<V, A, M, N, T, L>
 where
-    V: VertexFormat + With<Position> + With<Normal> + With<TexCoord>,
+    V: Query<(Position, Normal, TexCoord)>,
     A: AsRef<Rgba> + Send + Sync + 'static,
     T: Component + AsRef<[[f32; 4]; 4]> + Send + Sync,
     M: Component + AsRef<Mesh> + Send + Sync,
@@ -143,7 +137,7 @@ where
     fn compile(&self, effect: NewEffect) -> Result<Effect> {
         effect
             .simple(VERT_SRC, FRAG_SRC)
-            .with_raw_vertex_buffer(self.vertex_attributes.as_ref(), V::size() as ElemStride, 0)
+            .with_raw_vertex_buffer(V::QUERIED_ATTRIBUTES, V::size() as ElemStride, 0)
             .with_raw_constant_buffer("VertexArgs", mem::size_of::<VertexArgs>(), 1)
             .with_raw_constant_buffer("FragmentArgs", mem::size_of::<FragmentArgs>(), 1)
             .with_raw_constant_buffer("PointLights", mem::size_of::<PointLight>(), 512)
@@ -202,7 +196,7 @@ pub struct DrawShadedApply<
 
 impl<'a, V, A, M, N, T, L> ParallelIterator for DrawShadedApply<'a, V, A, M, N, T, L>
 where
-    V: VertexFormat + With<Position> + With<Normal> + With<TexCoord>,
+    V: Query<(Position, Normal, TexCoord)>,
     A: AsRef<Rgba> + Send + Sync + 'static,
     T: Component + AsRef<[[f32; 4]; 4]> + Send + Sync,
     M: Component + AsRef<Mesh> + Send + Sync,
@@ -234,6 +228,16 @@ where
             .supply((&mesh, &material, &global).par_join().map(
                 |(mesh, material, global)| {
                     move |encoder: &mut Encoder, effect: &mut Effect| {
+
+                        let mesh = mesh.as_ref();
+                        
+                        let vbuf = match mesh.buffer(V::QUERIED_ATTRIBUTES) {
+                            Some(vbuf) => vbuf.clone(),
+                            None => return,
+                        };
+
+                        let material = material.as_ref();
+
                         let vertex_args = camera
                             .as_ref()
                             .map(|cam| {
@@ -304,24 +308,26 @@ where
                         effect
                             .data
                             .textures
-                            .push(material.as_ref().emission.view().clone());
+                            .push(material.emission.view().clone());
 
                         effect
                             .data
                             .samplers
-                            .push(material.as_ref().emission.sampler().clone());
+                            .push(material.emission.sampler().clone());
 
                         effect
                             .data
                             .textures
-                            .push(material.as_ref().albedo.view().clone());
+                            .push(material.albedo.view().clone());
 
                         effect
                             .data
                             .samplers
-                            .push(material.as_ref().albedo.sampler().clone());
+                            .push(material.albedo.sampler().clone());
 
-                        effect.draw(mesh.as_ref(), encoder);
+                        effect.data.vertex_bufs.push(vbuf);
+
+                        effect.draw(mesh.slice(), encoder);
                     }
                 },
             ))

--- a/amethyst_renderer/src/pipe/effect/mod.rs
+++ b/amethyst_renderer/src/pipe/effect/mod.rs
@@ -19,10 +19,9 @@ use gfx::traits::Pod;
 use self::pso::{Data, Init, Meta};
 
 use error::{Error, Result};
-use mesh::Mesh;
 use pipe::Target;
-use types::{Encoder, Factory, PipelineState, Resources};
-use vertex::AttributeFormat;
+use types::{Encoder, Factory, PipelineState, Resources, Slice};
+use vertex::Attributes;
 
 mod pso;
 
@@ -122,15 +121,11 @@ impl Effect {
     pub fn clear(&mut self) {
         self.data.textures.clear();
         self.data.samplers.clear();
+        self.data.vertex_bufs.clear();
     }
 
-    pub fn draw(&self, mesh: &Mesh, enc: &mut Encoder) {
-        let mut data = self.data.clone();
-
-        let (vbuf, slice) = mesh.geometry();
-        data.vertex_bufs.push(vbuf.clone());
-
-        enc.draw(&slice, &self.pso, &data);
+    pub fn draw(&mut self, slice: &Slice, enc: &mut Encoder) {
+        enc.draw(&slice, &self.pso, &self.data);
     }
 }
 
@@ -236,7 +231,7 @@ impl<'a> EffectBuilder<'a> {
     /// Adds a vertex buffer to this `Effect`.
     pub fn with_raw_vertex_buffer(
         &mut self,
-        attrs: &'a [(&'a str, AttributeFormat)],
+        attrs: Attributes<'a>,
         stride: ElemStride,
         rate: InstanceRate,
     ) -> &mut Self {

--- a/amethyst_renderer/src/renderer.rs
+++ b/amethyst_renderer/src/renderer.rs
@@ -9,12 +9,11 @@ use rayon::{self, ThreadPool};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use config::Config;
 use error::{Error, Result};
-use mesh::{Mesh, MeshBuilder};
+use mesh::{Mesh, MeshBuilder, VertexDataSet};
 use mtl::{Material, MaterialBuilder};
 use pipe::{ColorBuffer, DepthBuffer, PipelineBuild, PipelineData, PolyPipeline, Target};
 use tex::{Texture, TextureBuilder};
 use types::{ColorFormat, DepthFormat, Device, Encoder, Factory, Window};
-use vertex::VertexFormat;
 use winit::{self, EventsLoop, Window as WinitWindow, WindowBuilder};
 
 /// Generic renderer.
@@ -41,10 +40,8 @@ impl Renderer {
     }
 
     /// Builds a new mesh from the given vertices.
-    pub fn create_mesh<D, T>(&mut self, mb: MeshBuilder<D, T>) -> Result<Mesh>
-    where
-        D: AsRef<[T]>,
-        T: VertexFormat,
+    pub fn create_mesh<T>(&mut self, mb: MeshBuilder<T>) -> Result<Mesh>
+        where T: VertexDataSet,
     {
         mb.build(&mut self.factory)
     }

--- a/amethyst_renderer/src/renderer.rs
+++ b/amethyst_renderer/src/renderer.rs
@@ -41,7 +41,8 @@ impl Renderer {
 
     /// Builds a new mesh from the given vertices.
     pub fn create_mesh<T>(&mut self, mb: MeshBuilder<T>) -> Result<Mesh>
-        where T: VertexDataSet,
+    where
+        T: VertexDataSet,
     {
         mb.build(&mut self.factory)
     }

--- a/amethyst_renderer/src/vertex.rs
+++ b/amethyst_renderer/src/vertex.rs
@@ -328,4 +328,31 @@ macro_rules! impl_query {
     };
 }
 
-impl_query!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
+impl_query!(
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
+    I,
+    J,
+    K,
+    L,
+    M,
+    N,
+    O,
+    P,
+    Q,
+    R,
+    S,
+    T,
+    U,
+    V,
+    W,
+    X,
+    Y,
+    Z
+);

--- a/amethyst_renderer/src/vertex.rs
+++ b/amethyst_renderer/src/vertex.rs
@@ -105,20 +105,29 @@ pub trait With<F: Attribute>: VertexFormat {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Separate<T: Attribute>(T::Repr);
-unsafe impl<T> Pod for Separate<T> where T: Attribute {}
+unsafe impl<T> Pod for Separate<T>
+where
+    T: Attribute,
+{
+}
 impl<T> VertexFormat for Separate<T>
-    where T: Attribute
+where
+    T: Attribute,
 {
     const ATTRIBUTES: Attributes<'static> = &[
-        (T::NAME, Element {
-            offset: 0,
-            format: T::FORMAT,
-        })
+        (
+            T::NAME,
+            Element {
+                offset: 0,
+                format: T::FORMAT,
+            },
+        ),
     ];
 }
 
 impl<T> With<T> for Separate<T>
-    where T: Attribute
+where
+    T: Attribute,
 {
     const FORMAT: AttributeFormat = Element {
         offset: 0,

--- a/amethyst_renderer/src/vertex.rs
+++ b/amethyst_renderer/src/vertex.rs
@@ -306,16 +306,16 @@ pub trait Query<T>: VertexFormat {
 
 macro_rules! impl_query {
     ($($a:ident),*) => {
-        impl<V $(,$a)*> Query<($($a,)*)> for V
-            where V: VertexFormat,
+        impl<VF $(,$a)*> Query<($($a,)*)> for VF
+            where VF: VertexFormat,
             $(
                 $a: Attribute,
-                V: With<$a>,
+                VF: With<$a>,
             )*
         {
             const QUERIED_ATTRIBUTES: Attributes<'static> = &[
                 $(
-                    ($a::NAME, <V as With<$a>>::FORMAT),
+                    ($a::NAME, <VF as With<$a>>::FORMAT),
                 )*
             ];
         }
@@ -328,4 +328,4 @@ macro_rules! impl_query {
     };
 }
 
-impl_query!(A, B, C, D);
+impl_query!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);

--- a/amethyst_renderer/src/vertex.rs
+++ b/amethyst_renderer/src/vertex.rs
@@ -7,6 +7,9 @@ use gfx::traits::Pod;
 /// Format for vertex attribute
 pub type AttributeFormat = Element<Format>;
 
+/// Slice of attributes
+pub type Attributes<'a> = &'a [(&'a str, AttributeFormat)];
+
 /// Trait for vertex attributes to implement
 pub trait Attribute {
     /// Name of the attribute
@@ -72,7 +75,7 @@ impl Attribute for Tangent {
 /// Trait implemented by all valid vertex formats.
 pub trait VertexFormat: Pod + Sized + Send + Sync {
     /// List of all attributes formats with name and offset.
-    const ATTRIBUTES: &'static [(&'static str, AttributeFormat)];
+    const ATTRIBUTES: Attributes<'static>;
 
     /// Returns the size of a single vertex in bytes.
     #[inline]
@@ -85,6 +88,7 @@ pub trait VertexFormat: Pod + Sized + Send + Sync {
     #[inline]
     fn attribute<F>() -> AttributeFormat
     where
+        F: Attribute,
         Self: With<F>,
     {
         <Self as With<F>>::FORMAT
@@ -92,11 +96,10 @@ pub trait VertexFormat: Pod + Sized + Send + Sync {
 }
 
 /// Trait implemented by all valid vertex formats for each field
-pub trait With<F>: VertexFormat {
+pub trait With<F: Attribute>: VertexFormat {
     /// Individual format of the attribute for this vertex format
     const FORMAT: AttributeFormat;
 }
-
 
 /// Vertex format for attributes in separate buffers
 #[repr(C)]
@@ -106,7 +109,7 @@ unsafe impl<T> Pod for Separate<T> where T: Attribute {}
 impl<T> VertexFormat for Separate<T>
     where T: Attribute
 {
-    const ATTRIBUTES: &'static [(&'static str, AttributeFormat)] = &[
+    const ATTRIBUTES: Attributes<'static> = &[
         (T::NAME, Element {
             offset: 0,
             format: T::FORMAT,
@@ -136,7 +139,7 @@ pub struct PosColor {
 unsafe impl Pod for PosColor {}
 
 impl VertexFormat for PosColor {
-    const ATTRIBUTES: &'static [(&'static str, AttributeFormat)] = &[
+    const ATTRIBUTES: Attributes<'static> = &[
         (Position::NAME, <Self as With<Position>>::FORMAT),
         (Color::NAME, <Self as With<Color>>::FORMAT),
     ];
@@ -169,7 +172,7 @@ pub struct PosTex {
 unsafe impl Pod for PosTex {}
 
 impl VertexFormat for PosTex {
-    const ATTRIBUTES: &'static [(&'static str, AttributeFormat)] = &[
+    const ATTRIBUTES: Attributes<'static> = &[
         (Position::NAME, <Self as With<Position>>::FORMAT),
         (TexCoord::NAME, <Self as With<TexCoord>>::FORMAT),
     ];
@@ -204,7 +207,7 @@ pub struct PosNormTex {
 unsafe impl Pod for PosNormTex {}
 
 impl VertexFormat for PosNormTex {
-    const ATTRIBUTES: &'static [(&'static str, AttributeFormat)] = &[
+    const ATTRIBUTES: Attributes<'static> = &[
         (Position::NAME, <Self as With<Position>>::FORMAT),
         (Normal::NAME, <Self as With<Normal>>::FORMAT),
         (TexCoord::NAME, <Self as With<TexCoord>>::FORMAT),
@@ -249,7 +252,7 @@ pub struct PosNormTangTex {
 unsafe impl Pod for PosNormTangTex {}
 
 impl VertexFormat for PosNormTangTex {
-    const ATTRIBUTES: &'static [(&'static str, AttributeFormat)] = &[
+    const ATTRIBUTES: Attributes<'static> = &[
         (Position::NAME, <Self as With<Position>>::FORMAT),
         (Normal::NAME, <Self as With<Normal>>::FORMAT),
         (Tangent::NAME, <Self as With<Tangent>>::FORMAT),
@@ -284,3 +287,36 @@ impl With<TexCoord> for PosNormTangTex {
         format: TexCoord::FORMAT,
     };
 }
+
+
+/// Allows to query specific `Attribute`s of `VertexFormat`
+pub trait Query<T>: VertexFormat {
+    /// Attributes from tuple `T`
+    const QUERIED_ATTRIBUTES: Attributes<'static>;
+}
+
+macro_rules! impl_query {
+    ($($a:ident),*) => {
+        impl<V $(,$a)*> Query<($($a,)*)> for V
+            where V: VertexFormat,
+            $(
+                $a: Attribute,
+                V: With<$a>,
+            )*
+        {
+            const QUERIED_ATTRIBUTES: Attributes<'static> = &[
+                $(
+                    ($a::NAME, <V as With<$a>>::FORMAT),
+                )*
+            ];
+        }
+
+        impl_query!(@ $($a),*);
+    };
+    (@) => {};
+    (@ $head:ident $(,$tail:ident)*) => {
+        impl_query!($($tail),*);
+    };
+}
+
+impl_query!(A, B, C, D);

--- a/src/ecs/rendering/resources.rs
+++ b/src/ecs/rendering/resources.rs
@@ -7,8 +7,8 @@ use futures::{Async, Future, Poll};
 use futures::sync::oneshot::{channel, Receiver, Sender};
 use gfx::traits::Pod;
 use renderer::{Error, Material, MaterialBuilder, Texture, TextureBuilder};
-use renderer::mesh::{Mesh, MeshBuilder, VertexDataSet};
 use renderer::Rgba;
+use renderer::mesh::{Mesh, MeshBuilder, VertexDataSet};
 use smallvec::SmallVec;
 use winit::Window;
 
@@ -48,7 +48,8 @@ impl Factory {
 
     /// Creates a mesh asynchronously.
     pub fn create_mesh<T>(&self, mb: MeshBuilder<T>) -> MeshFuture
-        where T: VertexDataSet + Send + 'static,
+    where
+        T: VertexDataSet + Send + 'static,
     {
         self.execute(move |f| mb.build(f))
     }


### PR DESCRIPTION
Allow `Mesh` to have multiple buffers.
Passes fetches buffers by required formatted attributes.
Mostly it will be:
* One buffer with all attributes.
  Format differs for `PosNormTex` and `PosTex` even if only `Position` and `TexCoord` is queried by `Pass`. So if you have both you need `Pass` for each `VertexFormat`
* Each attribute in its own buffer.
  Single `Pass` can draw all meshes that have all attributes required. No matter if they have some more. No matter of ordering.
  @Rhuagh  reported that most of glTf assets contains buffer per attribute.

I haven't test it for more than one buffer yet 😛 

Bonus: I've removed some unnecessary `Sync` bounds.