### PR TITLE
Add vergen to project

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ thread_profiler = { version = "0.1", optional = true }
 version = "0.4.2"
 features = ["serde"]
 
+[build-dependencies]
+vergen = "0.1"
+
 [[example]]
 name = "hello_world"
 path = "examples/00_hello_world/main.rs"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+extern crate vergen;
+
+fn main() {
+    if let Err(err) = vergen::vergen(vergen::OutputFns::all()) {
+        panic!("Vergen crate failed to generate version information! {:?}", err);
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -17,6 +17,7 @@ use engine::Engine;
 use error::{Error, Result};
 use state::{State, StateMachine};
 use timing::{Stopwatch, Time};
+use vergen;
 
 /// An Application is the root object of the game engine. It binds the OS
 /// event loop, state machines, timers and other core components in a central place.
@@ -281,7 +282,10 @@ impl<'a, 'b, T> ApplicationBuilder<'a, 'b, T> {
 
     pub fn new(initial_state: T) -> Result<Self> {
         use rayon::Configuration;
-
+        println!("Initializing Amethyst...");
+        println!("Version: {}", vergen::semver());
+        println!("Platform: {}", vergen::target());
+        println!("Git commit: {}", vergen::sha());
         let cfg = Configuration::new();
         #[cfg(feature = "profiler")]
         let cfg = cfg.start_handler(|index| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,5 +94,6 @@ pub mod util;
 
 mod app;
 mod engine;
-mod state;
 mod error;
+mod state;
+mod vergen;

--- a/src/vergen.rs
+++ b/src/vergen.rs
@@ -1,0 +1,5 @@
+//! This module is auto populated by the build script using the vergen crate.
+//! It is used to print version information at start.
+
+#![allow(dead_code)]
+include!(concat!(env!("OUT_DIR"), "/version.rs"));


### PR DESCRIPTION
This pull request adds the `vergen` crate to our build process, which allows us to see what version users who submit console printouts are using.