### PR TITLE
[style] Consolidating formatting between renderer crate and all other crates

### DIFF
--- a/amethyst_renderer/rustfmt.toml
+++ b/amethyst_renderer/rustfmt.toml
@@ -1,2 +1,0 @@
-reorder_imported_names = true
-take_source_hints = true

--- a/amethyst_renderer/src/formats/mesh.rs
+++ b/amethyst_renderer/src/formats/mesh.rs
@@ -9,9 +9,9 @@ use wavefront_obj::ParseError;
 use wavefront_obj::obj::{parse, Normal, NormalIndex, ObjSet, Object, Primitive, TVertex,
                          TextureIndex, Vertex, VertexIndex};
 
+use Renderer;
 use mesh::{Mesh, MeshBuilder};
 use vertex::*;
-use Renderer;
 
 /// Error type of `ObjFormat`
 #[derive(Debug)]

--- a/amethyst_renderer/src/formats/texture.rs
+++ b/amethyst_renderer/src/formats/texture.rs
@@ -5,14 +5,14 @@ use std::fmt::{self, Display, Formatter};
 use std::io::Cursor;
 use std::sync::Arc;
 
+use Renderer;
 use amethyst_assets::{BoxedErr, Format, Source};
-use imagefmt;
-use imagefmt::{ColFmt, Image};
 use gfx::format::{ChannelType, SurfaceType};
 use gfx::texture::SamplerInfo;
 use gfx::traits::Pod;
+use imagefmt;
+use imagefmt::{ColFmt, Image};
 use tex::{Texture, TextureBuilder};
-use Renderer;
 
 /// Texture metadata, used while loading
 pub struct TextureMetadata {

--- a/amethyst_renderer/src/light.rs
+++ b/amethyst_renderer/src/light.rs
@@ -2,8 +2,8 @@
 //!
 //! TODO: Remove redundant padding once `#[repr(align(...))]` stabilizes.
 
-use gfx;
 use cgmath::{Deg, Point3, Vector3};
+use gfx;
 use specs::{Component, DenseVecStorage};
 
 use color::Rgba;

--- a/amethyst_renderer/src/mesh.rs
+++ b/amethyst_renderer/src/mesh.rs
@@ -53,8 +53,8 @@ where
 
     fn build(&self, factory: &mut Factory) -> Result<VertexBuffer> {
         use gfx::Factory;
-        use gfx::memory::{cast_slice, Bind};
         use gfx::buffer::Role;
+        use gfx::memory::{cast_slice, Bind};
 
         let verts = self.0.as_ref();
         let slice = cast_slice(verts);

--- a/amethyst_renderer/src/pass/flat/interleaved.rs
+++ b/amethyst_renderer/src/pass/flat/interleaved.rs
@@ -11,16 +11,16 @@ use rayon::iter::ParallelIterator;
 use rayon::iter::internal::UnindexedConsumer;
 use specs::{Fetch, ParJoin, ReadStorage};
 
+use super::*;
 use cam::Camera;
 use error::Result;
 use mesh::{Mesh, MeshHandle};
 use mtl::{Material, MaterialDefaults};
-use pipe::pass::{Pass, PassApply, PassData, Supplier};
 use pipe::{DepthMode, Effect, NewEffect};
+use pipe::pass::{Pass, PassApply, PassData, Supplier};
 use tex::Texture;
 use types::Encoder;
 use vertex::{Position, Query, TexCoord};
-use super::*;
 
 /// Draw mesh without lighting
 /// `V` is `VertexFormat`

--- a/amethyst_renderer/src/pass/flat/separate.rs
+++ b/amethyst_renderer/src/pass/flat/separate.rs
@@ -9,16 +9,16 @@ use rayon::iter::ParallelIterator;
 use rayon::iter::internal::UnindexedConsumer;
 use specs::{Fetch, ParJoin, ReadStorage};
 
+use super::*;
 use cam::Camera;
 use error::Result;
 use mesh::{Mesh, MeshHandle};
 use mtl::{Material, MaterialDefaults};
-use pipe::pass::{Pass, PassApply, PassData, Supplier};
 use pipe::{DepthMode, Effect, NewEffect};
+use pipe::pass::{Pass, PassApply, PassData, Supplier};
 use tex::Texture;
 use types::Encoder;
 use vertex::{Position, Separate, TexCoord, VertexFormat};
-use super::*;
 
 /// Draw mesh without lighting
 #[derive(Clone, Debug, PartialEq)]

--- a/amethyst_renderer/src/pass/pbm/interleaved.rs
+++ b/amethyst_renderer/src/pass/pbm/interleaved.rs
@@ -11,6 +11,7 @@ use rayon::iter::ParallelIterator;
 use rayon::iter::internal::UnindexedConsumer;
 use specs::{Fetch, Join, ParJoin, ReadStorage};
 
+use super::*;
 use cam::Camera;
 use error::Result;
 use light::{DirectionalLight, Light, PointLight};
@@ -22,7 +23,6 @@ use resources::AmbientColor;
 use tex::Texture;
 use types::Encoder;
 use vertex::{Normal, Position, Query, Tangent, TexCoord};
-use super::*;
 
 /// Draw mesh with physically based lighting
 /// `V` is `VertexFormat`

--- a/amethyst_renderer/src/pass/pbm/separate.rs
+++ b/amethyst_renderer/src/pass/pbm/separate.rs
@@ -10,6 +10,7 @@ use rayon::iter::ParallelIterator;
 use rayon::iter::internal::UnindexedConsumer;
 use specs::{Fetch, Join, ParJoin, ReadStorage};
 
+use super::*;
 use cam::Camera;
 use error::Result;
 use light::{DirectionalLight, Light, PointLight};
@@ -21,7 +22,6 @@ use resources::AmbientColor;
 use tex::Texture;
 use types::Encoder;
 use vertex::{Normal, Position, Separate, Tangent, TexCoord, VertexFormat};
-use super::*;
 
 /// Draw mesh with physically based lighting
 #[derive(Clone, Debug, PartialEq)]

--- a/amethyst_renderer/src/pass/shaded/interleaved.rs
+++ b/amethyst_renderer/src/pass/shaded/interleaved.rs
@@ -11,6 +11,7 @@ use rayon::iter::ParallelIterator;
 use rayon::iter::internal::UnindexedConsumer;
 use specs::{Fetch, Join, ParJoin, ReadStorage};
 
+use super::*;
 use cam::Camera;
 use error::Result;
 use light::{DirectionalLight, Light, PointLight};
@@ -19,10 +20,9 @@ use mtl::{Material, MaterialDefaults};
 use pipe::{DepthMode, Effect, NewEffect};
 use pipe::pass::{Pass, PassApply, PassData, Supplier};
 use resources::AmbientColor;
-use types::Encoder;
 use tex::Texture;
+use types::Encoder;
 use vertex::{Normal, Position, Query, TexCoord};
-use super::*;
 
 /// Draw mesh with simple lighting technique
 /// `V` is `VertexFormat`

--- a/amethyst_renderer/src/pass/shaded/separate.rs
+++ b/amethyst_renderer/src/pass/shaded/separate.rs
@@ -10,18 +10,18 @@ use rayon::iter::ParallelIterator;
 use rayon::iter::internal::UnindexedConsumer;
 use specs::{Fetch, Join, ParJoin, ReadStorage};
 
+use super::*;
 use cam::Camera;
-use resources::AmbientColor;
 use error::Result;
 use light::{DirectionalLight, Light, PointLight};
 use mesh::{Mesh, MeshHandle};
 use mtl::{Material, MaterialDefaults};
 use pipe::{DepthMode, Effect, NewEffect};
 use pipe::pass::{Pass, PassApply, PassData, Supplier};
-use types::Encoder;
+use resources::AmbientColor;
 use tex::Texture;
+use types::Encoder;
 use vertex::{Normal, Position, Separate, TexCoord, VertexFormat};
-use super::*;
 
 /// Draw mesh with simple lighting technique
 #[derive(Clone, Debug, PartialEq)]

--- a/amethyst_renderer/src/pipe/effect/mod.rs
+++ b/amethyst_renderer/src/pipe/effect/mod.rs
@@ -5,10 +5,10 @@
 use std::mem;
 
 use fnv::FnvHashMap as HashMap;
+use gfx::{Primitive, ShaderSet};
 use gfx::Bind;
 use gfx::buffer::{Info as BufferInfo, Role as BufferRole};
 use gfx::memory::Usage;
-use gfx::{Primitive, ShaderSet};
 use gfx::preset::depth::{LESS_EQUAL_TEST, LESS_EQUAL_WRITE};
 use gfx::pso::buffer::{ElemStride, InstanceRate};
 use gfx::shade::{ProgramError, ToUniform};

--- a/amethyst_renderer/src/pipe/mod.rs
+++ b/amethyst_renderer/src/pipe/mod.rs
@@ -17,10 +17,10 @@
 //! ```
 
 pub use self::effect::{DepthMode, Effect, EffectBuilder, NewEffect};
-pub use self::stage::{PolyStage, Stage, StageBuilder};
-pub use self::target::{ColorBuffer, DepthBuffer, Target, TargetBuilder, Targets};
 pub use self::pipe::{Pipeline, PipelineApply, PipelineBuild, PipelineBuilder, PipelineData,
                      PolyPipeline, PolyStages};
+pub use self::stage::{PolyStage, Stage, StageBuilder};
+pub use self::target::{ColorBuffer, DepthBuffer, Target, TargetBuilder, Targets};
 
 pub mod pass;
 

--- a/amethyst_renderer/src/pipe/stage.rs
+++ b/amethyst_renderer/src/pipe/stage.rs
@@ -3,9 +3,9 @@
 use hetseq::*;
 
 use error::{Error, Result};
+use fnv::FnvHashMap as HashMap;
 use pipe::{Target, Targets};
 use pipe::pass::{CompiledPass, Pass, PassApply, PassData};
-use fnv::FnvHashMap as HashMap;
 use rayon::iter::{Chain, ParallelIterator};
 use specs::SystemData;
 

--- a/amethyst_renderer/src/prelude.rs
+++ b/amethyst_renderer/src/prelude.rs
@@ -3,17 +3,17 @@
 pub use gfx::traits::Pod;
 
 pub use Renderer;
-pub use color::Rgba;
 pub use cam::{Camera, Projection};
+pub use color::Rgba;
+pub use formats::{MeshData, TextureData, TextureMetadata};
+pub use input;
 pub use light::*;
 pub use mesh::{Mesh, MeshBuilder, MeshHandle};
 pub use mtl::{Material, MaterialDefaults};
-pub use pipe::{Pipeline, PipelineBuilder, PolyPipeline, PolyStage, Stage, StageBuilder, Target};
-pub use tex::{Texture, TextureBuilder, TextureHandle};
 pub use pass;
-pub use vertex::{Color, Normal, PosColor, PosNormTangTex, PosNormTex, PosTex, Position, Separate,
-                 Tangent, TexCoord, VertexBufferCombination, VertexFormat};
-pub use formats::{MeshData, TextureData, TextureMetadata};
+pub use pipe::{Pipeline, PipelineBuilder, PolyPipeline, PolyStage, Stage, StageBuilder, Target};
 pub use resources::*;
 pub use system::RenderSystem;
-pub use input;
+pub use tex::{Texture, TextureBuilder, TextureHandle};
+pub use vertex::{Color, Normal, PosColor, PosNormTangTex, PosNormTex, PosTex, Position, Separate,
+                 Tangent, TexCoord, VertexBufferCombination, VertexFormat};

--- a/amethyst_renderer/src/renderer.rs
+++ b/amethyst_renderer/src/renderer.rs
@@ -3,18 +3,18 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use gfx::memory::Pod;
-use num_cpus;
-use rayon::{self, ThreadPool};
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use config::Config;
 use error::{Error, Result};
+use fnv::FnvHashMap as HashMap;
+use gfx::memory::Pod;
 use mesh::{Mesh, MeshBuilder, VertexDataSet};
+use num_cpus;
 use pipe::{ColorBuffer, DepthBuffer, PipelineBuild, PipelineData, PolyPipeline, Target,
            TargetBuilder};
+use rayon::{self, ThreadPool};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use tex::{Texture, TextureBuilder};
 use types::{ColorFormat, DepthFormat, Device, Encoder, Factory, Window};
-use fnv::FnvHashMap as HashMap;
 use winit::{self, EventsLoop, Window as WinitWindow, WindowBuilder};
 
 /// Generic renderer.
@@ -322,8 +322,8 @@ fn init_backend(wb: WindowBuilder, el: &EventsLoop, config: &Config) -> Result<B
 /// Creates the OpenGL backend.
 #[cfg(feature = "opengl")]
 fn init_backend(wb: WindowBuilder, el: &EventsLoop, config: &Config) -> Result<Backend> {
-    use glutin::{self, GlProfile, GlRequest};
     use gfx_window_glutin as win;
+    use glutin::{self, GlProfile, GlRequest};
 
     let ctx = glutin::ContextBuilder::new()
         .with_multisampling(config.multisampling)

--- a/amethyst_renderer/src/system.rs
+++ b/amethyst_renderer/src/system.rs
@@ -6,18 +6,18 @@ use std::mem;
 use amethyst_assets::AssetStorage;
 use shred::Resources;
 use shrev::EventChannel;
+use specs::{Fetch, FetchMut, RunNow, SystemData};
 use specs::common::Errors;
 use winit::{DeviceEvent, Event, WindowEvent};
-use specs::{Fetch, FetchMut, RunNow, SystemData};
 
-use resources::{ScreenDimensions, WindowMessages};
-use mesh::Mesh;
-use renderer::Renderer;
-use tex::Texture;
-use formats::{create_mesh_asset, create_texture_asset};
-use pipe::{PipelineBuild, PipelineData, PolyPipeline};
 use config::Config;
 use error::Result;
+use formats::{create_mesh_asset, create_texture_asset};
+use mesh::Mesh;
+use pipe::{PipelineBuild, PipelineData, PolyPipeline};
+use renderer::Renderer;
+use resources::{ScreenDimensions, WindowMessages};
+use tex::Texture;
 
 /// Rendering system.
 #[derive(Derivative)]

--- a/amethyst_renderer/src/tex.rs
+++ b/amethyst_renderer/src/tex.rs
@@ -84,9 +84,9 @@ where
     /// Creates a new `TextureBuilder` with the given raw texture data.
     pub fn new(data: D) -> Self {
         use gfx::SHADER_RESOURCE;
+        use gfx::format::{ChannelTyped, SurfaceTyped};
         use gfx::memory::Usage;
         use gfx::texture::{AaMode, Kind};
-        use gfx::format::{ChannelTyped, SurfaceTyped};
 
         TextureBuilder {
             data: data,

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,7 @@
 reorder_imports = true
 reorder_import_names = true
+reorder_imported_names = true
 reorder_imports_in_group = true
 attributes_on_same_line_as_variant = false
 attributes_on_same_line_as_field = false
+take_source_hints = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -5,3 +5,4 @@ reorder_imports_in_group = true
 attributes_on_same_line_as_variant = false
 attributes_on_same_line_as_field = false
 take_source_hints = true
+error_on_line_overflow_comments = false


### PR DESCRIPTION
Also making so comments that are overflowing aren't considered an error by rustfmt. This PR is dependent on #431.