### PR TITLE
Add asset hot reloading

### DIFF
--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -20,6 +20,7 @@ appveyor = { repository = "amethyst/amethyst", branch = "develop" }
 travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
+amethyst_core = { path = "../amethyst_core", version = "0.1" }
 crossbeam = "0.3.0"
 derivative = "1.0"
 fnv = "1"

--- a/amethyst_assets/examples/hl.rs
+++ b/amethyst_assets/examples/hl.rs
@@ -99,10 +99,16 @@ impl<'a> System<'a> for RenderingSystem {
     type SystemData = (
         FetchMut<'a, AssetStorage<MeshAsset>>,
         Fetch<'a, Errors>,
-        Fetch<'a, Arc<ThreadPool>>, /* texture storage, transforms, .. */
+        Fetch<'a, Arc<ThreadPool>>,
+        Option<Fetch<'a, HotReloadStrategy>>,
+        /* texture storage, transforms, .. */
     );
 
-    fn run(&mut self, (mut mesh_storage, errors, pool): Self::SystemData) {
+    fn run(&mut self, (mut mesh_storage, errors, pool, strategy): Self::SystemData) {
+        use std::ops::Deref;
+
+        let strategy = strategy.as_ref().map(Deref::deref);
+
         mesh_storage.process(
             |vertex_data| {
                 // Upload vertex data to GPU and give back an asset
@@ -111,6 +117,7 @@ impl<'a> System<'a> for RenderingSystem {
             },
             &errors,
             &**pool,
+            strategy,
         );
     }
 }

--- a/amethyst_assets/examples/hl.rs
+++ b/amethyst_assets/examples/hl.rs
@@ -74,18 +74,18 @@ impl Asset for MeshAsset {
 }
 
 /// A format the mesh data could be stored with.
+#[derive(Clone)]
 struct Ron;
 
-impl Format<MeshAsset> for Ron {
+impl SimpleFormat<MeshAsset> for Ron {
     const NAME: &'static str = "RON";
 
     type Options = ();
 
-    fn import(&self, name: String, source: Arc<Source>, _: ()) -> Result<VertexData, BoxedErr> {
+    fn import(&self, bytes: Vec<u8>, _: ()) -> Result<VertexData, BoxedErr> {
         use ron::de::from_str;
         use std::str::from_utf8;
 
-        let bytes = source.load(&name)?;
         let s = from_utf8(&bytes).map_err(BoxedErr::new)?;
 
         from_str(s).map_err(BoxedErr::new)

--- a/amethyst_assets/examples/hl.rs
+++ b/amethyst_assets/examples/hl.rs
@@ -33,7 +33,8 @@ impl App {
 
         world.add_resource(Errors::new());
         world.add_resource(AssetStorage::<MeshAsset>::new());
-        world.add_resource(Loader::new(path, pool));
+        world.add_resource(Loader::new(path, pool.clone()));
+        world.add_resource(pool);
 
         App {
             dispatcher,
@@ -98,10 +99,10 @@ impl<'a> System<'a> for RenderingSystem {
     type SystemData = (
         FetchMut<'a, AssetStorage<MeshAsset>>,
         Fetch<'a, Errors>,
-                       /* texture storage, transforms, .. */
+        Fetch<'a, Arc<ThreadPool>>, /* texture storage, transforms, .. */
     );
 
-    fn run(&mut self, (mut mesh_storage, errors): Self::SystemData) {
+    fn run(&mut self, (mut mesh_storage, errors, pool): Self::SystemData) {
         mesh_storage.process(
             |vertex_data| {
                 // Upload vertex data to GPU and give back an asset
@@ -109,6 +110,7 @@ impl<'a> System<'a> for RenderingSystem {
                 Ok(MeshAsset { buffer: () })
             },
             &errors,
+            &**pool,
         );
     }
 }

--- a/amethyst_assets/examples/hl.rs
+++ b/amethyst_assets/examples/hl.rs
@@ -3,6 +3,7 @@
 #![allow(unused)]
 
 extern crate amethyst_assets;
+extern crate amethyst_core;
 extern crate rayon;
 extern crate ron;
 #[macro_use]
@@ -12,6 +13,7 @@ extern crate specs;
 use std::sync::Arc;
 
 use amethyst_assets::*;
+use amethyst_core::Time;
 use rayon::ThreadPool;
 use specs::{DenseVecStorage, Dispatcher, DispatcherBuilder, Fetch, FetchMut, System, World};
 use specs::common::Errors;
@@ -99,12 +101,13 @@ impl<'a> System<'a> for RenderingSystem {
     type SystemData = (
         FetchMut<'a, AssetStorage<MeshAsset>>,
         Fetch<'a, Errors>,
+        Fetch<'a, Time>,
         Fetch<'a, Arc<ThreadPool>>,
         Option<Fetch<'a, HotReloadStrategy>>,
         /* texture storage, transforms, .. */
     );
 
-    fn run(&mut self, (mut mesh_storage, errors, pool, strategy): Self::SystemData) {
+    fn run(&mut self, (mut mesh_storage, errors, time, pool, strategy): Self::SystemData) {
         use std::ops::Deref;
 
         let strategy = strategy.as_ref().map(Deref::deref);
@@ -116,6 +119,7 @@ impl<'a> System<'a> for RenderingSystem {
                 Ok(MeshAsset { buffer: () })
             },
             &errors,
+            time.frame_number,
             &**pool,
             strategy,
         );

--- a/amethyst_assets/examples/ll.rs
+++ b/amethyst_assets/examples/ll.rs
@@ -68,7 +68,11 @@ fn main() {
     let strategy = HotReloadStrategy::every(3);
 
     // Game loop
+    let mut frame_number = 0;
+
     loop {
+        frame_number += 1;
+
         // If loading is done, end the game loop and print the asset
         if progress.is_complete() {
             break;
@@ -84,6 +88,7 @@ fn main() {
                 Ok(DummyAsset(s))
             },
             &errors,
+            frame_number,
             &*pool,
             Some(&strategy),
         );

--- a/amethyst_assets/examples/ll.rs
+++ b/amethyst_assets/examples/ll.rs
@@ -29,10 +29,18 @@ impl Format<DummyAsset> for DummyFormat {
 
     type Options = ();
 
-    fn import(&self, name: String, source: Arc<Source>, _: ()) -> Result<String, BoxedErr> {
-        from_utf8(source.load(&name)?.as_slice())
+    fn import(
+        &self,
+        name: String,
+        source: Arc<Source>,
+        _: (),
+        _create_reload: bool,
+    ) -> Result<(String, Option<Box<Reload<DummyAsset>>>), BoxedErr> {
+        let dummy = from_utf8(source.load(&name)?.as_slice())
             .map(|s| s.to_owned())
-            .map_err(BoxedErr::new)
+            .map_err(BoxedErr::new)?;
+
+        Ok((dummy, None))
     }
 }
 

--- a/amethyst_assets/examples/ll.rs
+++ b/amethyst_assets/examples/ll.rs
@@ -35,12 +35,12 @@ impl Format<DummyAsset> for DummyFormat {
         source: Arc<Source>,
         _: (),
         _create_reload: bool,
-    ) -> Result<(String, Option<Box<Reload<DummyAsset>>>), BoxedErr> {
+    ) -> Result<FormatValue<DummyAsset>, BoxedErr> {
         let dummy = from_utf8(source.load(&name)?.as_slice())
             .map(|s| s.to_owned())
             .map_err(BoxedErr::new)?;
 
-        Ok((dummy, None))
+        Ok(FormatValue::data(dummy))
     }
 }
 

--- a/amethyst_assets/examples/ll.rs
+++ b/amethyst_assets/examples/ll.rs
@@ -51,7 +51,7 @@ fn main() {
     let pool = Arc::new(ThreadPool::new(cfg).expect("Invalid config"));
 
     let mut errors = Errors::new();
-    let loader = Loader::new(&path, pool);
+    let loader = Loader::new(&path, pool.clone());
     let mut storage = AssetStorage::new();
 
     let mut progress = ProgressCounter::new();
@@ -81,6 +81,7 @@ fn main() {
                 Ok(DummyAsset(s))
             },
             &errors,
+            &*pool,
         );
 
         errors.print_and_exit();

--- a/amethyst_assets/examples/ll.rs
+++ b/amethyst_assets/examples/ll.rs
@@ -64,6 +64,9 @@ fn main() {
         &storage,
     );
 
+    // Hot-reload every three seconds.
+    let strategy = HotReloadStrategy::every(3);
+
     // Game loop
     loop {
         // If loading is done, end the game loop and print the asset
@@ -82,6 +85,7 @@ fn main() {
             },
             &errors,
             &*pool,
+            Some(&strategy),
         );
 
         errors.print_and_exit();

--- a/amethyst_assets/src/asset.rs
+++ b/amethyst_assets/src/asset.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use specs::UnprotectedStorage;
 
-use {BoxedErr, Handle, Source};
+use {BoxedErr, Handle, Reload, SingleFile, Source};
 
 /// One of the three core traits of this crate.
 ///
@@ -38,10 +38,64 @@ pub trait Format<A: Asset>: Send + 'static {
     type Options: Send + 'static;
 
     /// Reads the given bytes and produces asset data.
+    ///
+    /// ## Reload
+    ///
+    /// The reload structure has metadata which allows the asset management
+    /// to reload assets if necessary (for hot reloading).
+    /// You should only create this if `create_reload` is `true`.
+    /// Also, the parameter is just a request, which means you can also return `None`.
     fn import(
         &self,
         name: String,
         source: Arc<Source>,
         options: Self::Options,
-    ) -> Result<A::Data, BoxedErr>;
+        create_reload: bool,
+    ) -> Result<(A::Data, Option<Box<Reload<A>>>), BoxedErr>;
+}
+
+/// This is a simplified version of `Format`, which doesn't give you as much as freedom,
+/// but in return is simpler to implement.
+/// All `SimpleFormat` types automatically implement `Format`.
+/// This format assumes that the asset name is the full path and also the only file.
+pub trait SimpleFormat<A: Asset> {
+    /// A unique identifier for this format.
+    const NAME: &'static str;
+    /// Options specific to the format, which are passed to `import`.
+    /// E.g. for textures this would be stuff like mipmap levels and
+    /// sampler info.
+    type Options: Clone + Send + Sync + 'static;
+
+    /// Produces asset data from given bytes.
+    fn import(&self, bytes: Vec<u8>, options: Self::Options) -> Result<A::Data, BoxedErr>;
+}
+
+impl<A, T> Format<A> for T
+where
+    A: Asset,
+    T: SimpleFormat<A> + Clone + Send + Sync + 'static,
+{
+    const NAME: &'static str = T::NAME;
+    type Options = T::Options;
+
+    fn import(
+        &self,
+        name: String,
+        source: Arc<Source>,
+        options: Self::Options,
+        create_reload: bool,
+    ) -> Result<(A::Data, Option<Box<Reload<A>>>), BoxedErr> {
+        if create_reload {
+            let (b, m) = source.load_with_metadata(&name)?;
+            let data = T::import(&self, b, options.clone())?;
+            let reload = SingleFile::new(self.clone(), m, options, name, source);
+
+            Ok((data, Some(Box::new(reload))))
+        } else {
+            let b = source.load(&name)?;
+            let data = T::import(&self, b, options)?;
+
+            Ok((data, None))
+        }
+    }
 }

--- a/amethyst_assets/src/asset.rs
+++ b/amethyst_assets/src/asset.rs
@@ -72,7 +72,8 @@ impl<A: Asset> FormatValue<A> {
 /// This is a simplified version of `Format`, which doesn't give you as much as freedom,
 /// but in return is simpler to implement.
 /// All `SimpleFormat` types automatically implement `Format`.
-/// This format assumes that the asset name is the full path and also the only file.
+/// This format assumes that the asset name is the full path and the asset is only
+/// contained in one file.
 pub trait SimpleFormat<A: Asset> {
     /// A unique identifier for this format.
     const NAME: &'static str;

--- a/amethyst_assets/src/asset.rs
+++ b/amethyst_assets/src/asset.rs
@@ -69,7 +69,7 @@ impl<A: Asset> FormatValue<A> {
     }
 }
 
-/// This is a simplified version of `Format`, which doesn't give you as much as freedom,
+/// This is a simplified version of `Format`, which doesn't give you as much freedom,
 /// but in return is simpler to implement.
 /// All `SimpleFormat` types automatically implement `Format`.
 /// This format assumes that the asset name is the full path and the asset is only

--- a/amethyst_assets/src/error.rs
+++ b/amethyst_assets/src/error.rs
@@ -14,13 +14,13 @@ pub struct AssetError {
     /// The specifier of the asset which failed to load
     pub name: String,
     /// The format identifier.
-    pub format: String,
+    pub format: &'static str,
     /// The error that's been raised.
     pub error: BoxedErr,
 }
 
 impl AssetError {
-    pub(crate) fn new(name: String, format: String, error: BoxedErr) -> Self {
+    pub(crate) fn new(name: String, format: &'static str, error: BoxedErr) -> Self {
         AssetError {
             name,
             format,

--- a/amethyst_assets/src/lib.rs
+++ b/amethyst_assets/src/lib.rs
@@ -26,7 +26,7 @@ pub use loader::Loader;
 pub use progress::{Completion, Progress, ProgressCounter, Tracker};
 pub use reload::{Reload, SingleFile};
 pub use source::{Directory, Source};
-pub use storage::{AssetStorage, Handle, Processor};
+pub use storage::{AssetStorage, Handle, Processor, WeakHandle};
 
 mod asset;
 //mod cache;

--- a/amethyst_assets/src/lib.rs
+++ b/amethyst_assets/src/lib.rs
@@ -9,6 +9,7 @@
 
 #![warn(missing_docs)]
 
+extern crate amethyst_core;
 extern crate crossbeam;
 #[macro_use]
 extern crate derivative;
@@ -24,7 +25,7 @@ pub use asset::{Asset, Format, FormatValue, SimpleFormat};
 pub use error::AssetError;
 pub use loader::Loader;
 pub use progress::{Completion, Progress, ProgressCounter, Tracker};
-pub use reload::{HotReloadStrategy, Reload, SingleFile};
+pub use reload::{HotReloadBundle, HotReloadStrategy, HotReloadSystem, Reload, SingleFile};
 pub use source::{Directory, Source};
 pub use storage::{AssetStorage, Handle, Processor, WeakHandle};
 

--- a/amethyst_assets/src/lib.rs
+++ b/amethyst_assets/src/lib.rs
@@ -20,7 +20,7 @@ extern crate specs;
 
 pub use specs::error::BoxedErr;
 
-pub use asset::{Asset, Format, SimpleFormat};
+pub use asset::{Asset, Format, FormatValue, SimpleFormat};
 pub use error::AssetError;
 pub use loader::Loader;
 pub use progress::{Completion, Progress, ProgressCounter, Tracker};

--- a/amethyst_assets/src/lib.rs
+++ b/amethyst_assets/src/lib.rs
@@ -20,10 +20,11 @@ extern crate specs;
 
 pub use specs::error::BoxedErr;
 
-pub use asset::{Asset, Format};
+pub use asset::{Asset, Format, SimpleFormat};
 pub use error::AssetError;
 pub use loader::Loader;
 pub use progress::{Completion, Progress, ProgressCounter, Tracker};
+pub use reload::{Reload, SingleFile};
 pub use source::{Directory, Source};
 pub use storage::{AssetStorage, Handle, Processor};
 
@@ -32,6 +33,6 @@ mod asset;
 mod error;
 mod loader;
 mod progress;
-//mod reload;
+mod reload;
 mod source;
 mod storage;

--- a/amethyst_assets/src/lib.rs
+++ b/amethyst_assets/src/lib.rs
@@ -24,7 +24,7 @@ pub use asset::{Asset, Format, FormatValue, SimpleFormat};
 pub use error::AssetError;
 pub use loader::Loader;
 pub use progress::{Completion, Progress, ProgressCounter, Tracker};
-pub use reload::{Reload, SingleFile};
+pub use reload::{HotReloadStrategy, Reload, SingleFile};
 pub use source::{Directory, Source};
 pub use storage::{AssetStorage, Handle, Processor, WeakHandle};
 

--- a/amethyst_assets/src/loader.rs
+++ b/amethyst_assets/src/loader.rs
@@ -120,12 +120,11 @@ impl Loader {
                 Err(_) => tracker.fail(),
             }
 
-            processed.push(Processed {
+            processed.push(Processed::NewAsset {
                 data,
                 format: F::NAME.into(),
                 handle,
                 name,
-                reload: false,
             });
         };
         self.pool.spawn(cl);
@@ -139,12 +138,11 @@ impl Loader {
         A: Asset,
     {
         let handle = storage.allocate();
-        storage.processed.push(Processed {
+        storage.processed.push(Processed::NewAsset {
             data: Ok((data, None)),
             format: "".to_owned(),
             handle: handle.clone(),
             name: "<Data>".into(),
-            reload: false,
         });
 
         handle

--- a/amethyst_assets/src/loader.rs
+++ b/amethyst_assets/src/loader.rs
@@ -26,7 +26,7 @@ impl Loader {
     {
         Loader {
             directory: Arc::new(Directory::new(directory)),
-            hot_reload: true, // TODO: allow disabling
+            hot_reload: true,
             pool,
             sources: Default::default(),
         }
@@ -40,6 +40,15 @@ impl Loader {
     {
         self.sources
             .insert(id.into(), Arc::new(source) as Arc<Source>);
+    }
+
+    /// If set to `true`, this `Loader` will ask formats to
+    /// generate "reload instructions" which *allow* reloading.
+    /// Calling `set_hot_reload(true)` does not actually enable
+    /// hot reloading; this is controlled by the `HotReloadStrategy`
+    /// resource.
+    pub fn set_hot_reload(&mut self, value: bool) {
+        self.hot_reload = value;
     }
 
     /// Loads an asset with a given format from the default (directory) source.

--- a/amethyst_assets/src/loader.rs
+++ b/amethyst_assets/src/loader.rs
@@ -122,7 +122,7 @@ impl Loader {
 
             processed.push(Processed::NewAsset {
                 data,
-                format: F::NAME.into(),
+                format: F::NAME,
                 handle,
                 name,
             });
@@ -140,7 +140,7 @@ impl Loader {
         let handle = storage.allocate();
         storage.processed.push(Processed::NewAsset {
             data: Ok(FormatValue::data(data)),
-            format: "".to_owned(),
+            format: "",
             handle: handle.clone(),
             name: "<Data>".into(),
         });

--- a/amethyst_assets/src/loader.rs
+++ b/amethyst_assets/src/loader.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use fnv::FnvHashMap;
 use rayon::ThreadPool;
 
-use {Asset, Directory, Format, Progress, Source};
+use {Asset, Directory, Format, FormatValue, Progress, Source};
 use storage::{AssetStorage, Handle, Processed};
 
 /// The asset loader, holding the sources and a reference to the `ThreadPool`.
@@ -139,7 +139,7 @@ impl Loader {
     {
         let handle = storage.allocate();
         storage.processed.push(Processed::NewAsset {
-            data: Ok((data, None)),
+            data: Ok(FormatValue::data(data)),
             format: "".to_owned(),
             handle: handle.clone(),
             name: "<Data>".into(),

--- a/amethyst_assets/src/reload.rs
+++ b/amethyst_assets/src/reload.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use {Asset, BoxedErr, Format, Source};
 
 /// The `Reload` trait provides a method which checks if an asset needs to be reloaded.
-pub trait Reload<A: Asset>: Send + Sync + 'static {
+pub trait Reload<A: Asset>: ReloadClone<A> + Send + Sync + 'static {
     /// Checks if a reload is necessary.
     fn needs_reload(&self) -> bool;
     /// Returns the asset name.
@@ -14,6 +14,26 @@ pub trait Reload<A: Asset>: Send + Sync + 'static {
     fn format(&self) -> String;
     /// Reloads the asset.
     fn reload(self: Box<Self>) -> Result<(A::Data, Option<Box<Reload<A>>>), BoxedErr>;
+}
+
+pub trait ReloadClone<A> {
+    fn cloned(&self) -> Box<Reload<A>>;
+}
+
+impl<A, T> ReloadClone<A> for T
+where
+    A: Asset,
+    T: Clone + Reload<A>,
+{
+    fn cloned(&self) -> Box<Reload<A>> {
+        Box::new(self.clone())
+    }
+}
+
+impl<A: Asset> Clone for Box<Reload<A>> {
+    fn clone(&self) -> Self {
+        self.cloned()
+    }
 }
 
 /// An implementation of `Reload` which just stores the modification time
@@ -45,11 +65,28 @@ impl<A: Asset, F: Format<A>> SingleFile<A, F> {
     }
 }
 
+impl<A, F> Clone for SingleFile<A, F>
+where
+    A: Asset,
+    F: Clone + Format<A>,
+    F::Options: Clone,
+{
+    fn clone(&self) -> Self {
+        SingleFile {
+            format: self.format.clone(),
+            modified: self.modified,
+            options: self.options.clone(),
+            path: self.path.clone(),
+            source: self.source.clone(),
+        }
+    }
+}
+
 impl<A, F> Reload<A> for SingleFile<A, F>
 where
     A: Asset,
-    F: Format<A> + Sync,
-    <F as Format<A>>::Options: Sync,
+    F: Clone + Format<A> + Sync,
+    <F as Format<A>>::Options: Clone + Sync,
 {
     fn needs_reload(&self) -> bool {
         self.modified != 0 && (self.source.modified(&self.path).unwrap_or(0) > self.modified)

--- a/amethyst_assets/src/reload.rs
+++ b/amethyst_assets/src/reload.rs
@@ -37,6 +37,13 @@ impl HotReloadStrategy {
         }
     }
 
+    /// This allows to use `trigger` for hot reloading.
+    pub fn when_triggered() -> Self {
+        HotReloadStrategy {
+            inner: HotReloadStrategyInner::Trigger { counter: 0 },
+        }
+    }
+
     /// No periodical hot-reloading is performed.
     /// Instead, you can `trigger` it to check for changed assets
     /// in one specific frame.
@@ -47,10 +54,11 @@ impl HotReloadStrategy {
     }
 
     /// The frame after calling this, all changed assets will be reloaded.
+    /// Doesn't do anything if the strategy wasn't created with `when_triggered`.
     pub fn trigger(&mut self) {
         let counter = match self.inner {
-            HotReloadStrategyInner::Trigger { counter } => counter.checked_add(1).unwrap_or(0),
-            _ => 0,
+            HotReloadStrategyInner::Trigger { counter } => counter.wrapping_add(1),
+            _ => return,
         };
 
         self.inner = HotReloadStrategyInner::Trigger { counter };

--- a/amethyst_assets/src/reload.rs
+++ b/amethyst_assets/src/reload.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use {Asset, BoxedErr, Format, Source};
+use {Asset, BoxedErr, Format, FormatValue, Source};
 
 /// The `Reload` trait provides a method which checks if an asset needs to be reloaded.
 pub trait Reload<A: Asset>: ReloadClone<A> + Send + Sync + 'static {
@@ -13,7 +13,7 @@ pub trait Reload<A: Asset>: ReloadClone<A> + Send + Sync + 'static {
     /// Returns the format name.
     fn format(&self) -> String;
     /// Reloads the asset.
-    fn reload(self: Box<Self>) -> Result<(A::Data, Option<Box<Reload<A>>>), BoxedErr>;
+    fn reload(self: Box<Self>) -> Result<FormatValue<A>, BoxedErr>;
 }
 
 pub trait ReloadClone<A> {
@@ -92,7 +92,7 @@ where
         self.modified != 0 && (self.source.modified(&self.path).unwrap_or(0) > self.modified)
     }
 
-    fn reload(self: Box<Self>) -> Result<(A::Data, Option<Box<Reload<A>>>), BoxedErr> {
+    fn reload(self: Box<Self>) -> Result<FormatValue<A>, BoxedErr> {
         let this: SingleFile<_, _> = *self;
         let SingleFile {
             format,

--- a/amethyst_assets/src/reload.rs
+++ b/amethyst_assets/src/reload.rs
@@ -44,9 +44,7 @@ impl HotReloadStrategy {
         }
     }
 
-    /// No periodical hot-reloading is performed.
-    /// Instead, you can `trigger` it to check for changed assets
-    /// in one specific frame.
+    /// Never do any hot-reloading.
     pub fn never() -> Self {
         HotReloadStrategy {
             inner: HotReloadStrategyInner::Never,

--- a/amethyst_assets/src/reload.rs
+++ b/amethyst_assets/src/reload.rs
@@ -1,8 +1,96 @@
 //! Defines the `Reload` trait.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use {Asset, BoxedErr, Format, FormatValue, Source};
+
+/// An ECS resource which allows to configure hot reloading.
+///
+/// ## Examples
+///
+/// ```
+/// # extern crate amethyst_assets;
+/// # extern crate specs;
+/// #
+/// # use amethyst_assets::HotReloadStrategy;
+/// # use specs::World;
+/// #
+/// # fn main() {
+/// let mut world = World::new();
+/// // Assets will be reloaded every two seconds (in case they changed)
+/// world.add_resource(HotReloadStrategy::every(2));
+/// # }
+/// ```
+pub struct HotReloadStrategy {
+    inner: HotReloadStrategyInner,
+}
+
+impl HotReloadStrategy {
+    /// Causes hot reloads every `n` seconds.
+    pub fn every(n: u8) -> Self {
+        HotReloadStrategy {
+            inner: HotReloadStrategyInner::Every {
+                interval: n,
+                start: Instant::now(),
+            },
+        }
+    }
+
+    /// No periodical hot-reloading is performed.
+    /// Instead, you can `trigger` it to check for changed assets
+    /// in one specific frame.
+    pub fn never() -> Self {
+        HotReloadStrategy {
+            inner: HotReloadStrategyInner::Never,
+        }
+    }
+
+    /// The frame after calling this, all changed assets will be reloaded.
+    pub fn trigger(&mut self) {
+        let counter = match self.inner {
+            HotReloadStrategyInner::Trigger { counter } => counter.checked_add(1).unwrap_or(0),
+            _ => 0,
+        };
+
+        self.inner = HotReloadStrategyInner::Trigger { counter };
+    }
+
+    /// Crate-internal method to check if reload is necessary.
+    /// `reload_counter` is a per-storage value which is only used
+    /// for and by this method.
+    pub(crate) fn needs_reload(&self, reload_counter: &mut u64) -> bool {
+        match self.inner {
+            HotReloadStrategyInner::Every { interval, start } => {
+                let now = Instant::now().duration_since(start).as_secs();
+                if now - *reload_counter >= interval as u64 {
+                    *reload_counter = now;
+
+                    true
+                } else {
+                    false
+                }
+            }
+            HotReloadStrategyInner::Trigger { counter } => {
+                let counter = counter as u64;
+                if counter != *reload_counter {
+                    *reload_counter = counter;
+
+                    true
+                } else {
+                    false
+                }
+            }
+            HotReloadStrategyInner::Never => false,
+        }
+    }
+}
+
+enum HotReloadStrategyInner {
+    Every { interval: u8, start: Instant },
+    Trigger { counter: u8 },
+    Never,
+}
 
 /// The `Reload` trait provides a method which checks if an asset needs to be reloaded.
 pub trait Reload<A: Asset>: ReloadClone<A> + Send + Sync + 'static {

--- a/amethyst_assets/src/reload.rs
+++ b/amethyst_assets/src/reload.rs
@@ -1,18 +1,52 @@
-//! MODULE DISABLED, will be reused later!
+//! Defines the `Reload` trait.
 
-use Source;
+use std::sync::Arc;
 
-pub trait Reload {
-    fn needs_reload(&self, source: &Source) -> bool;
+use {Asset, BoxedErr, Format, Source};
+
+/// The `Reload` trait provides a method which checks if an asset needs to be reloaded.
+pub trait Reload<A: Asset>: Send + Sync + 'static {
+    /// Checks if a reload is necessary.
+    fn needs_reload(&self) -> bool;
+    /// Reloads the asset
+    fn reload(self) -> Result<(A::Data, Option<Box<Reload<A>>>), BoxedErr>;
 }
 
-pub struct SingleFile {
+/// An implementation of `Reload` which just stores the modification time
+/// and the path of the file.
+pub struct SingleFile<A: Asset, F: Format<A>> {
+    format: F,
     modified: u64,
+    options: F::Options,
     path: String,
+    source: Arc<Source>,
 }
 
-impl Reload for SingleFile {
-    fn needs_reload(&self, source: &Source) -> bool {
-        self.modified != 0 && source.modified(&self.path).unwrap_or(0) > self.modified
+impl<A: Asset, F: Format<A>> SingleFile<A, F> {
+    /// Creates a new `SingleFile` reload object.
+    pub fn new(format: F, modified: u64, options: F::Options,
+               path: String, source: Arc<Source>) -> Self {
+        SingleFile {
+            format,
+            modified,
+            options,
+            path,
+            source,
+        }
+    }
+}
+
+impl<A, F> Reload<A> for SingleFile<A, F>
+where
+    A: Asset,
+    F: Format<A> + Sync,
+    <F as Format<A>>::Options: Sync,
+{
+    fn needs_reload(&self) -> bool {
+        self.modified != 0 && (self.source.modified(&self.path).unwrap_or(0) > self.modified)
+    }
+
+    fn reload(self) -> Result<(A::Data, Option<Box<Reload<A>>>), BoxedErr> {
+        self.format.import(self.path, self.source, self.options, true)
     }
 }

--- a/amethyst_assets/src/reload.rs
+++ b/amethyst_assets/src/reload.rs
@@ -11,7 +11,7 @@ pub trait Reload<A: Asset>: ReloadClone<A> + Send + Sync + 'static {
     /// Returns the asset name.
     fn name(&self) -> String;
     /// Returns the format name.
-    fn format(&self) -> String;
+    fn format(&self) -> &'static str;
     /// Reloads the asset.
     fn reload(self: Box<Self>) -> Result<FormatValue<A>, BoxedErr>;
 }
@@ -109,7 +109,7 @@ where
         self.path.clone()
     }
 
-    fn format(&self) -> String {
-        F::NAME.to_owned()
+    fn format(&self) -> &'static str {
+        F::NAME
     }
 }

--- a/amethyst_assets/src/source/mod.rs
+++ b/amethyst_assets/src/source/mod.rs
@@ -16,4 +16,14 @@ pub trait Source: Send + Sync + 'static {
     ///
     /// The id should always use `/` as separator in paths.
     fn load(&self, path: &str) -> Result<Vec<u8>, BoxedErr>;
+
+    /// Returns both the result of `load` and `modified` as a tuple.
+    /// There's a default implementation which just calls both methods,
+    /// but you may be able to provide a more optimized version yourself.
+    fn load_with_metadata(&self, path: &str) -> Result<(Vec<u8>, u64), BoxedErr> {
+        let m = self.modified(path)?;
+        let b = self.load(path)?;
+
+        Ok((b, m))
+    }
 }

--- a/amethyst_assets/src/storage.rs
+++ b/amethyst_assets/src/storage.rs
@@ -212,7 +212,9 @@ impl<A: Asset> AssetStorage<A> {
             });
         }
 
-        while let Some(i) = self.handles.iter().position(Handle::is_unique) {
+        let mut skip = 0;
+        while let Some(i) = self.handles.iter().skip(skip).position(Handle::is_unique) {
+            skip = i;
             let handle = self.handles.swap_remove(i);
             let id = handle.id();
             unsafe {

--- a/amethyst_assets/src/storage.rs
+++ b/amethyst_assets/src/storage.rs
@@ -35,7 +35,6 @@ pub struct AssetStorage<A: Asset> {
     handles: Vec<Handle<A>>,
     handle_alloc: Allocator,
     pub(crate) processed: Arc<MsQueue<Processed<A>>>,
-    reload_counter: u64,
     reloads: Vec<(WeakHandle<A>, Box<Reload<A>>)>,
     unused_handles: MsQueue<Handle<A>>,
 }
@@ -43,15 +42,12 @@ pub struct AssetStorage<A: Asset> {
 impl<A: Asset> AssetStorage<A> {
     /// Creates a new asset storage.
     pub fn new() -> Self {
-        use std::u8::MAX;
-
         AssetStorage {
             assets: Default::default(),
             bitset: Default::default(),
             handles: Default::default(),
             handle_alloc: Default::default(),
             processed: Arc::new(MsQueue::new()),
-            reload_counter: MAX as u64 + 1,
             reloads: Vec::new(),
             unused_handles: MsQueue::new(),
         }
@@ -244,7 +240,7 @@ impl<A: Asset> AssetStorage<A> {
         }
 
         if strategy
-            .map(|s| s.needs_reload(&mut self.reload_counter))
+            .map(|s| s.needs_reload())
             .unwrap_or(false)
         {
             self.hot_reload(pool);

--- a/amethyst_assets/src/storage.rs
+++ b/amethyst_assets/src/storage.rs
@@ -135,13 +135,19 @@ impl<A: Asset> AssetStorage<A> {
     ) where
         F: FnMut(A::Data) -> Result<A, BoxedErr>,
     {
-        self.process_custom_drop(f, |_| {}, errors);
+        self.process_custom_drop(f, |_| {}, errors, pool, strategy);
     }
 
     /// Process finished asset data and maintain the storage.
     /// This calls the `drop_fn` closure for assets that were removed from the storage.
-    pub fn process_custom_drop<F, D>(&mut self, mut f: F, mut drop_fn: D, errors: &Errors)
-    where
+    pub fn process_custom_drop<F, D>(
+        &mut self,
+        mut f: F,
+        mut drop_fn: D,
+        errors: &Errors,
+        pool: &ThreadPool,
+        strategy: Option<&HotReloadStrategy>,
+    ) where
         D: FnMut(A),
         F: FnMut(A::Data) -> Result<A, BoxedErr>,
     {

--- a/amethyst_audio/src/formats.rs
+++ b/amethyst_audio/src/formats.rs
@@ -1,45 +1,46 @@
-use std::sync::Arc;
-
 use super::Source as Audio;
 use amethyst_assets::*;
 
 pub struct AudioData(pub Vec<u8>);
 
 /// Loads audio from wav files.
+#[derive(Clone)]
 pub struct WavFormat;
 
-impl Format<Audio> for WavFormat {
+impl SimpleFormat<Audio> for WavFormat {
     const NAME: &'static str = "WAV";
 
     type Options = ();
 
-    fn import(&self, name: String, source: Arc<Source>, _: ()) -> Result<AudioData, BoxedErr> {
-        source.load(&name).map(AudioData)
+    fn import(&self, bytes: Vec<u8>, _: ()) -> Result<AudioData, BoxedErr> {
+        Ok(AudioData(bytes))
     }
 }
 
 /// Loads audio from Ogg Vorbis files
+#[derive(Clone)]
 pub struct OggFormat;
 
-impl Format<Audio> for OggFormat {
+impl SimpleFormat<Audio> for OggFormat {
     const NAME: &'static str = "OGG";
 
     type Options = ();
 
-    fn import(&self, name: String, source: Arc<Source>, _: ()) -> Result<AudioData, BoxedErr> {
-        source.load(&name).map(AudioData)
+    fn import(&self, bytes: Vec<u8>, _: ()) -> Result<AudioData, BoxedErr> {
+        Ok(AudioData(bytes))
     }
 }
 
 /// Loads audio from Flac files.
+#[derive(Clone)]
 pub struct FlacFormat;
 
-impl Format<Audio> for FlacFormat {
+impl SimpleFormat<Audio> for FlacFormat {
     const NAME: &'static str = "FLAC";
 
     type Options = ();
 
-    fn import(&self, name: String, source: Arc<Source>, _: ()) -> Result<AudioData, BoxedErr> {
-        source.load(&name).map(AudioData)
+    fn import(&self, bytes: Vec<u8>, _: ()) -> Result<AudioData, BoxedErr> {
+        Ok(AudioData(bytes))
     }
 }

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -18,6 +18,7 @@ travis-ci = { repository = "amethyst/amethyst" }
 cgmath = "0.14"
 fnv = "1.0"
 hibitset = "0.3.2"
+rayon = "0.8"
 serde = { version = "1", features = ["serde_derive"] }
 shred = "0.5"
 specs = "0.10"

--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -7,9 +7,8 @@ extern crate serde;
 extern crate shred;
 extern crate specs;
 
-#[cfg(test)]
-#[cfg_attr(test, macro_use)]
-extern crate quickcheck;
+//#[cfg(test)]
+//extern crate quickcheck;
 
 pub use bundle::ECSBundle;
 pub use timing::*;

--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate cgmath;
 extern crate fnv;
 extern crate hibitset;
+extern crate rayon;
 #[macro_use]
 extern crate serde;
 extern crate shred;
@@ -14,7 +15,12 @@ pub use bundle::ECSBundle;
 pub use timing::*;
 pub use transform::*;
 
+use std::sync::Arc;
+
 pub mod bundle;
 pub mod transform;
 pub mod timing;
 pub mod frame_limiter;
+
+/// A rayon thread pool wrapped in an `Arc`. This should be used as resource in `World`.
+pub type ThreadPool = Arc<rayon::ThreadPool>;

--- a/amethyst_core/src/transform/components/mod.rs
+++ b/amethyst_core/src/transform/components/mod.rs
@@ -1,7 +1,7 @@
 //! Components for the transform processor.
 
-pub use self::parent::Parent;
 pub use self::local_transform::LocalTransform;
+pub use self::parent::Parent;
 pub use self::transform::Transform;
 
 mod parent;

--- a/amethyst_core/src/transform/components/transform.rs
+++ b/amethyst_core/src/transform/components/transform.rs
@@ -20,7 +20,7 @@ impl Transform {
         for i in 0..4 {
             for j in 0..4 {
                 if !self.0[i][j].is_finite() {
-                    return false
+                    return false;
                 }
             }
         }
@@ -75,4 +75,3 @@ impl Borrow<[[f32; 4]; 4]> for Transform {
         &self.0
     }
 }
-

--- a/amethyst_gltf/src/format/mod.rs
+++ b/amethyst_gltf/src/format/mod.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use self::importer::{get_image_data, import, Buffers, ImageFormat};
-use assets::{BoxedErr, Format, Source};
+use assets::{BoxedErr, Format, Reload, Source};
 use core::transform::LocalTransform;
 use gfx::Primitive;
 use gfx::texture::SamplerInfo;
@@ -105,10 +105,11 @@ impl Format<GltfSceneAsset> for GltfSceneFormat {
         name: String,
         source: Arc<Source>,
         options: GltfSceneOptions,
-    ) -> Result<GltfSceneAsset, BoxedErr> {
+        _create_reload: bool
+    ) -> Result<(GltfSceneAsset, Option<Box<Reload<GltfSceneAsset>>>), BoxedErr> {
         let gltf = load_gltf(source, &name, options).map_err(|err| BoxedErr::new(err))?;
         if gltf.default_scene.is_some() || gltf.scenes.len() == 1 {
-            Ok(gltf)
+            Ok((gltf, None)) // TODO: create `Reload` object
         } else {
             Err(BoxedErr::new(
                 GltfError::InvalidSceneGltf(gltf.scenes.len()),

--- a/amethyst_gltf/src/format/mod.rs
+++ b/amethyst_gltf/src/format/mod.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use self::importer::{get_image_data, import, Buffers, ImageFormat};
-use assets::{BoxedErr, Format, Reload, Source};
+use assets::{BoxedErr, Format, FormatValue, Source};
 use core::transform::LocalTransform;
 use gfx::Primitive;
 use gfx::texture::SamplerInfo;
@@ -106,10 +106,10 @@ impl Format<GltfSceneAsset> for GltfSceneFormat {
         source: Arc<Source>,
         options: GltfSceneOptions,
         _create_reload: bool,
-    ) -> Result<(GltfSceneAsset, Option<Box<Reload<GltfSceneAsset>>>), BoxedErr> {
+    ) -> Result<FormatValue<GltfSceneAsset>, BoxedErr> {
         let gltf = load_gltf(source, &name, options).map_err(|err| BoxedErr::new(err))?;
         if gltf.default_scene.is_some() || gltf.scenes.len() == 1 {
-            Ok((gltf, None)) // TODO: create `Reload` object
+            Ok(FormatValue::data(gltf)) // TODO: create `Reload` object
         } else {
             Err(BoxedErr::new(
                 GltfError::InvalidSceneGltf(gltf.scenes.len()),

--- a/amethyst_gltf/src/format/mod.rs
+++ b/amethyst_gltf/src/format/mod.rs
@@ -105,7 +105,7 @@ impl Format<GltfSceneAsset> for GltfSceneFormat {
         name: String,
         source: Arc<Source>,
         options: GltfSceneOptions,
-        _create_reload: bool
+        _create_reload: bool,
     ) -> Result<(GltfSceneAsset, Option<Box<Reload<GltfSceneAsset>>>), BoxedErr> {
         let gltf = load_gltf(source, &name, options).map_err(|err| BoxedErr::new(err))?;
         if gltf.default_scene.is_some() || gltf.scenes.len() == 1 {

--- a/amethyst_gltf/src/systems.rs
+++ b/amethyst_gltf/src/systems.rs
@@ -1,5 +1,5 @@
 use assets::{AssetStorage, Handle, HotReloadStrategy, Loader};
-use core::ThreadPool;
+use core::{ThreadPool, Time};
 use core::transform::*;
 use renderer::{Material, MaterialDefaults, Mesh, Texture};
 use renderer::ComboMeshCreator;
@@ -38,6 +38,7 @@ impl<'a> System<'a> for GltfSceneLoaderSystem {
         Fetch<'a, Loader>,
         Fetch<'a, Errors>,
         Fetch<'a, MaterialDefaults>,
+        Fetch<'a, Time>,
         Fetch<'a, ThreadPool>,
         Option<Fetch<'a, HotReloadStrategy>>,
         FetchMut<'a, AssetStorage<GltfSceneAsset>>,
@@ -60,6 +61,7 @@ impl<'a> System<'a> for GltfSceneLoaderSystem {
             loader,
             errors,
             material_defaults,
+            time,
             pool,
             strategy,
             mut scene_storage,
@@ -72,7 +74,7 @@ impl<'a> System<'a> for GltfSceneLoaderSystem {
         ) = data;
 
         let strategy = strategy.as_ref().map(Deref::deref);
-        scene_storage.process(Into::into, &errors, &**pool, strategy);
+        scene_storage.process(Into::into, &errors, time.frame_number, &**pool, strategy);
 
         let mut deletes = vec![];
 

--- a/amethyst_gltf/src/systems.rs
+++ b/amethyst_gltf/src/systems.rs
@@ -1,4 +1,4 @@
-use assets::{AssetStorage, Handle, Loader};
+use assets::{AssetStorage, Handle, HotReloadStrategy, Loader};
 use core::ThreadPool;
 use core::transform::*;
 use renderer::{Material, MaterialDefaults, Mesh, Texture};
@@ -39,6 +39,7 @@ impl<'a> System<'a> for GltfSceneLoaderSystem {
         Fetch<'a, Errors>,
         Fetch<'a, MaterialDefaults>,
         Fetch<'a, ThreadPool>,
+        Option<Fetch<'a, HotReloadStrategy>>,
         FetchMut<'a, AssetStorage<GltfSceneAsset>>,
         WriteStorage<'a, Handle<GltfSceneAsset>>,
         WriteStorage<'a, Handle<Mesh>>,
@@ -50,6 +51,8 @@ impl<'a> System<'a> for GltfSceneLoaderSystem {
 
     #[allow(unused)]
     fn run(&mut self, data: Self::SystemData) {
+        use std::ops::Deref;
+
         let (
             entities,
             mesh_storage,
@@ -58,6 +61,7 @@ impl<'a> System<'a> for GltfSceneLoaderSystem {
             errors,
             material_defaults,
             pool,
+            strategy,
             mut scene_storage,
             mut scenes,
             mut meshes,
@@ -67,7 +71,8 @@ impl<'a> System<'a> for GltfSceneLoaderSystem {
             mut materials,
         ) = data;
 
-        scene_storage.process(Into::into, &errors, &**pool);
+        let strategy = strategy.as_ref().map(Deref::deref);
+        scene_storage.process(Into::into, &errors, &**pool, strategy);
 
         let mut deletes = vec![];
 
@@ -215,7 +220,12 @@ fn load_node(
     // Load child entities
     for child_node_index in &node.children {
         let child_entity = entities.create();
-        parents.insert(child_entity, Parent { entity: *node_entity });
+        parents.insert(
+            child_entity,
+            Parent {
+                entity: *node_entity,
+            },
+        );
         transforms.insert(child_entity, Transform::default());
         load_node(
             *child_node_index,
@@ -261,7 +271,12 @@ fn load_node(
                 let primitive_entity = entities.create();
                 local_transforms.insert(primitive_entity, LocalTransform::default());
                 transforms.insert(primitive_entity, Transform::default());
-                parents.insert(primitive_entity, Parent { entity: *node_entity });
+                parents.insert(
+                    primitive_entity,
+                    Parent {
+                        entity: *node_entity,
+                    },
+                );
                 load_primitive(
                     node_index,
                     primitive_index,

--- a/amethyst_gltf/src/systems.rs
+++ b/amethyst_gltf/src/systems.rs
@@ -1,4 +1,5 @@
 use assets::{AssetStorage, Handle, Loader};
+use core::ThreadPool;
 use core::transform::*;
 use renderer::{Material, MaterialDefaults, Mesh, Texture};
 use renderer::ComboMeshCreator;
@@ -37,6 +38,7 @@ impl<'a> System<'a> for GltfSceneLoaderSystem {
         Fetch<'a, Loader>,
         Fetch<'a, Errors>,
         Fetch<'a, MaterialDefaults>,
+        Fetch<'a, ThreadPool>,
         FetchMut<'a, AssetStorage<GltfSceneAsset>>,
         WriteStorage<'a, Handle<GltfSceneAsset>>,
         WriteStorage<'a, Handle<Mesh>>,
@@ -55,6 +57,7 @@ impl<'a> System<'a> for GltfSceneLoaderSystem {
             loader,
             errors,
             material_defaults,
+            pool,
             mut scene_storage,
             mut scenes,
             mut meshes,
@@ -64,7 +67,7 @@ impl<'a> System<'a> for GltfSceneLoaderSystem {
             mut materials,
         ) = data;
 
-        scene_storage.process(Into::into, &errors);
+        scene_storage.process(Into::into, &errors, &**pool);
 
         let mut deletes = vec![];
 

--- a/amethyst_renderer/src/formats/mesh.rs
+++ b/amethyst_renderer/src/formats/mesh.rs
@@ -2,9 +2,8 @@ use std::error::Error;
 use std::fmt::{self, Display, Formatter};
 use std::fmt::Debug;
 use std::string::FromUtf8Error;
-use std::sync::Arc;
 
-use amethyst_assets::{Asset, BoxedErr, Format, Source};
+use amethyst_assets::{Asset, BoxedErr, SimpleFormat};
 use cgmath::{InnerSpace, Vector3};
 use specs::DenseVecStorage;
 use wavefront_obj::ParseError;
@@ -108,15 +107,16 @@ impl Asset for Mesh {
 
 /// Allows loading from Wavefront files
 /// see: https://en.wikipedia.org/wiki/Wavefront_.obj_file
+#[derive(Clone)]
 pub struct ObjFormat;
 
-impl Format<Mesh> for ObjFormat {
+impl SimpleFormat<Mesh> for ObjFormat {
     const NAME: &'static str = "WAVEFRONT_OBJ";
 
     type Options = ();
 
-    fn import(&self, name: String, source: Arc<Source>, _: ()) -> Result<MeshData, BoxedErr> {
-        String::from_utf8(source.load(&name)?)
+    fn import(&self, bytes: Vec<u8>, _: ()) -> Result<MeshData, BoxedErr> {
+        String::from_utf8(bytes)
             .map_err(ObjError::Utf8)
             .and_then(|string| parse(string).map_err(ObjError::Parse))
             .map(|set| from_data(set).into())

--- a/amethyst_renderer/src/formats/texture.rs
+++ b/amethyst_renderer/src/formats/texture.rs
@@ -3,10 +3,9 @@ pub use imagefmt::Error as ImageError;
 use std::error::Error;
 use std::fmt::{self, Display, Formatter};
 use std::io::Cursor;
-use std::sync::Arc;
 
 use Renderer;
-use amethyst_assets::{BoxedErr, Format, Source};
+use amethyst_assets::{BoxedErr, SimpleFormat};
 use gfx::format::{ChannelType, SurfaceType};
 use gfx::texture::SamplerInfo;
 use gfx::traits::Pod;
@@ -130,6 +129,7 @@ pub struct ImageData {
     pub raw: Image<u8>,
 }
 /// Allows loading of jpg or jpeg files.
+#[derive(Clone)]
 pub struct JpgFormat;
 
 impl JpgFormat {
@@ -145,22 +145,22 @@ impl JpgFormat {
     }
 }
 
-impl Format<Texture> for JpgFormat {
+impl SimpleFormat<Texture> for JpgFormat {
     const NAME: &'static str = "JPEG";
 
     type Options = TextureMetadata;
 
     fn import(
         &self,
-        name: String,
-        source: Arc<Source>,
+        bytes: Vec<u8>,
         options: TextureMetadata,
     ) -> Result<TextureData, BoxedErr> {
-        self.from_data(source.load(&name)?, options)
+        self.from_data(bytes, options)
     }
 }
 
 /// Allows loading of PNG files.
+#[derive(Clone)]
 pub struct PngFormat;
 
 impl PngFormat {
@@ -176,36 +176,35 @@ impl PngFormat {
     }
 }
 
-impl Format<Texture> for PngFormat {
+impl SimpleFormat<Texture> for PngFormat {
     const NAME: &'static str = "JPEG";
 
     type Options = TextureMetadata;
 
     fn import(
         &self,
-        name: String,
-        source: Arc<Source>,
+        bytes: Vec<u8>,
         options: TextureMetadata,
     ) -> Result<TextureData, BoxedErr> {
-        self.from_data(source.load(&name)?, options)
+        self.from_data(bytes, options)
     }
 }
 
 /// Allows loading of BMP files.
+#[derive(Clone)]
 pub struct BmpFormat;
 
-impl Format<Texture> for BmpFormat {
+impl SimpleFormat<Texture> for BmpFormat {
     const NAME: &'static str = "BMP";
 
     type Options = TextureMetadata;
 
     fn import(
         &self,
-        name: String,
-        source: Arc<Source>,
+        bytes: Vec<u8>,
         options: TextureMetadata,
     ) -> Result<TextureData, BoxedErr> {
-        imagefmt::bmp::read(&mut Cursor::new(source.load(&name)?), ColFmt::RGBA)
+        imagefmt::bmp::read(&mut Cursor::new(bytes), ColFmt::RGBA)
             .map(|raw| TextureData::Image(ImageData { raw }, options))
             .map_err(BoxedErr::new)
     }

--- a/amethyst_renderer/src/formats/texture.rs
+++ b/amethyst_renderer/src/formats/texture.rs
@@ -150,11 +150,7 @@ impl SimpleFormat<Texture> for JpgFormat {
 
     type Options = TextureMetadata;
 
-    fn import(
-        &self,
-        bytes: Vec<u8>,
-        options: TextureMetadata,
-    ) -> Result<TextureData, BoxedErr> {
+    fn import(&self, bytes: Vec<u8>, options: TextureMetadata) -> Result<TextureData, BoxedErr> {
         self.from_data(bytes, options)
     }
 }
@@ -181,11 +177,7 @@ impl SimpleFormat<Texture> for PngFormat {
 
     type Options = TextureMetadata;
 
-    fn import(
-        &self,
-        bytes: Vec<u8>,
-        options: TextureMetadata,
-    ) -> Result<TextureData, BoxedErr> {
+    fn import(&self, bytes: Vec<u8>, options: TextureMetadata) -> Result<TextureData, BoxedErr> {
         self.from_data(bytes, options)
     }
 }
@@ -199,11 +191,7 @@ impl SimpleFormat<Texture> for BmpFormat {
 
     type Options = TextureMetadata;
 
-    fn import(
-        &self,
-        bytes: Vec<u8>,
-        options: TextureMetadata,
-    ) -> Result<TextureData, BoxedErr> {
+    fn import(&self, bytes: Vec<u8>, options: TextureMetadata) -> Result<TextureData, BoxedErr> {
         imagefmt::bmp::read(&mut Cursor::new(bytes), ColFmt::RGBA)
             .map(|raw| TextureData::Image(ImageData { raw }, options))
             .map_err(BoxedErr::new)

--- a/amethyst_renderer/src/formats/texture.rs
+++ b/amethyst_renderer/src/formats/texture.rs
@@ -192,6 +192,8 @@ impl SimpleFormat<Texture> for BmpFormat {
     type Options = TextureMetadata;
 
     fn import(&self, bytes: Vec<u8>, options: TextureMetadata) -> Result<TextureData, BoxedErr> {
+        // TODO: consider reading directly into GPU-visible memory
+        // TODO: as noted by @omni-viral.
         imagefmt::bmp::read(&mut Cursor::new(bytes), ColFmt::RGBA)
             .map(|raw| TextureData::Image(ImageData { raw }, options))
             .map_err(BoxedErr::new)

--- a/amethyst_renderer/src/lib.rs
+++ b/amethyst_renderer/src/lib.rs
@@ -61,8 +61,8 @@ pub use cam::{ActiveCamera, Camera, Projection};
 pub use color::Rgba;
 pub use config::DisplayConfig;
 pub use formats::{build_mesh_with_combo, create_mesh_asset, create_texture_asset, BmpFormat,
-                  ImageData, ImageError, JpgFormat, MeshData, ObjError, ObjFormat, PngFormat,
-                  TextureData, TextureMetadata, ComboMeshCreator, MeshCreator};
+                  ComboMeshCreator, ImageData, ImageError, JpgFormat, MeshCreator, MeshData,
+                  ObjError, ObjFormat, PngFormat, TextureData, TextureMetadata};
 pub use input::{ElementState, Event, KeyboardInput, MouseButton, VirtualKeyCode, WindowEvent};
 pub use light::{DirectionalLight, Light, PointLight, SpotLight, SunLight};
 pub use mesh::{vertex_data, Mesh, MeshHandle, VertexBuffer};

--- a/amethyst_renderer/src/system.rs
+++ b/amethyst_renderer/src/system.rs
@@ -5,6 +5,7 @@ use std::mem;
 use std::sync::Arc;
 
 use amethyst_assets::{AssetStorage, HotReloadStrategy};
+use amethyst_core::Time;
 use rayon::ThreadPool;
 use shred::Resources;
 use shrev::EventChannel;
@@ -68,7 +69,7 @@ where
 
     fn do_asset_loading(
         &mut self,
-        (errors, pool, strategy, mut mesh_storage, mut texture_storage): AssetLoadingData,
+        (errors, time, pool, strategy, mut mesh_storage, mut texture_storage): AssetLoadingData,
     ) {
         use std::ops::Deref;
 
@@ -77,6 +78,7 @@ where
         mesh_storage.process(
             |d| create_mesh_asset(d, &mut self.renderer),
             &errors,
+            time.frame_number,
             &**pool,
             strategy,
         );
@@ -84,6 +86,7 @@ where
         texture_storage.process(
             |d| create_texture_asset(d, &mut self.renderer),
             &errors,
+            time.frame_number,
             &**pool,
             strategy,
         );
@@ -145,6 +148,7 @@ where
 
 type AssetLoadingData<'a> = (
     Fetch<'a, Errors>,
+    Fetch<'a, Time>,
     Fetch<'a, Arc<ThreadPool>>,
     Option<Fetch<'a, HotReloadStrategy>>,
     FetchMut<'a, AssetStorage<Mesh>>,

--- a/examples/03_renderable/main.rs
+++ b/examples/03_renderable/main.rs
@@ -7,7 +7,7 @@ extern crate amethyst;
 extern crate cgmath;
 
 use amethyst::{Application, Error, State, Trans};
-use amethyst::assets::Loader;
+use amethyst::assets::{HotReloadBundle, Loader};
 use amethyst::config::Config;
 use amethyst::core::timing::Time;
 use amethyst::core::transform::{LocalTransform, Transform, TransformBundle};
@@ -369,6 +369,7 @@ fn run() -> Result<(), Error> {
         .with::<ExampleSystem>(ExampleSystem, "example_system", &[])
         .with_bundle(TransformBundle::new().with_dep(&["example_system"]))?
         .with_bundle(RenderBundle::new())?
+        .with_bundle(HotReloadBundle::default())?
         .with_local(RenderSystem::build(pipeline_builder, Some(display_config))?)
         .build()?;
 

--- a/examples/05_assets/main.rs
+++ b/examples/05_assets/main.rs
@@ -5,10 +5,8 @@ extern crate amethyst;
 extern crate cgmath;
 extern crate rayon;
 
-use std::sync::Arc;
-
 use amethyst::{Application, Error, State, Trans};
-use amethyst::assets::{BoxedErr, Format, Loader, Source};
+use amethyst::assets::{BoxedErr, Loader, SimpleFormat};
 use amethyst::config::Config;
 use amethyst::core::transform::{LocalTransform, Transform, TransformBundle};
 use amethyst::ecs::World;
@@ -19,16 +17,16 @@ use amethyst::renderer::{Camera, DisplayConfig as DisplayConfig, DrawShaded, Eve
                          PosNormTex, Projection, RenderBundle, RenderSystem, Rgba, Stage,
                          VirtualKeyCode, WindowEvent};
 
+#[derive(Clone)]
 struct Custom;
 
-impl Format<Mesh> for Custom {
+impl SimpleFormat<Mesh> for Custom {
     const NAME: &'static str = "CUSTOM";
 
     type Options = ();
 
     /// Reads the given bytes and produces asset data.
-    fn import(&self, name: String, source: Arc<Source>, _: ()) -> Result<MeshData, BoxedErr> {
-        let bytes = source.load(&name)?;
+    fn import(&self, bytes: Vec<u8>, _: ()) -> Result<MeshData, BoxedErr> {
         let data: String = String::from_utf8(bytes).unwrap();
 
         let trimmed: Vec<&str> = data.lines().filter(|line| line.len() >= 1).collect();

--- a/src/app.rs
+++ b/src/app.rs
@@ -338,6 +338,7 @@ impl<'a, 'b, T> ApplicationBuilder<'a, 'b, T> {
         let reader_id = events.register_reader();
         world.add_resource(events);
         world.add_resource(Errors::new());
+        world.add_resource(pool.clone());
 
         Ok(ApplicationBuilder {
             disp_builder: DispatcherBuilder::new(),


### PR DESCRIPTION
* Adds a new resource to the world, `Arc<rayon::ThreadPool>` (or short: `core::ThreadPool`)
* Adds `WeakHandle`s
* Automatically reloads assets (checked every second)

Fixes #266 

## Problems

* ~~If a file has been written only partially and the asset storage tries to load it, it fails :( I'm not sure if there's a check we can do~~ Fixed by using fallback