### PR TITLE
Add frame_number to Time resource

### DIFF
--- a/amethyst_core/src/timing.rs
+++ b/amethyst_core/src/timing.rs
@@ -11,6 +11,8 @@ pub struct Time {
     pub fixed_step: Duration,
     /// Time at which `State::fixed_update` was last called.
     pub last_fixed_update: Instant,
+    /// The total number of frames that have been played in this session.
+    pub frame_number: u64,
 }
 
 impl Default for Time {
@@ -19,6 +21,7 @@ impl Default for Time {
             delta_time: Duration::from_secs(0),
             fixed_step: Duration::new(0, 16666666),
             last_fixed_update: Instant::now(),
+            frame_number: 0,
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -154,6 +154,7 @@ impl<'a, 'b> Application<'a, 'b> {
     fn advance_frame(&mut self) {
         {
             let mut time = self.engine.world.write_resource::<Time>();
+            time.frame_number += 1;
             time.delta_time = self.time.delta_time;
             time.fixed_step = self.time.fixed_step;
             time.last_fixed_update = self.time.last_fixed_update;


### PR DESCRIPTION
This PR adds how many frames have been simulated to the Time resource, which may be helpful for execution order scheduling (such as what's needed in https://github.com/amethyst/amethyst/pull/445) and it also helps with timing for fixed framerate videogames.

Note: This won't overflow, if the game runs at 1000 FPS the u64 won't over flow for >500 million years.

2^64 / 1000 / 60 / 60 / 24 / 365  >500 million