### PR TITLE
Add more docs to assets crate and add AssetsDeserializer

### DIFF
--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -29,8 +29,6 @@ hibitset = "0.3.1"
 log = "0.3.8"
 parking_lot = "0.4.4"
 rayon = "0.8"
-specs = { version = "0.10", features = ["common"] }
-
-[dev-dependencies]
 ron = "0.1.4"
 serde = { version = "1", features = ["serde_derive"] }
+specs = { version = "0.10", features = ["common"] }

--- a/amethyst_assets/examples/ll.rs
+++ b/amethyst_assets/examples/ll.rs
@@ -35,8 +35,7 @@ impl Format<DummyAsset> for DummyFormat {
         _: (),
         _create_reload: bool,
     ) -> Result<FormatValue<DummyAsset>> {
-        let dummy = from_utf8(source.load(&name)?.as_slice())
-            .map(|s| s.to_owned())?;
+        let dummy = from_utf8(source.load(&name)?.as_slice()).map(|s| s.to_owned())?;
 
         Ok(FormatValue::data(dummy))
     }

--- a/amethyst_assets/src/dyn.rs
+++ b/amethyst_assets/src/dyn.rs
@@ -1,0 +1,182 @@
+#![allow(unused)] // TODO: remove
+
+use std::fmt;
+use std::marker::PhantomData;
+
+use fnv::FnvHashMap;
+use ron::de::{from_str, Error as RonError};
+use serde::{Deserialize, Deserializer};
+use serde::de::DeserializeSeed;
+
+use {Asset, AssetStorage, ErrorKind, Format, Handle, Loader, Progress, Result, ResultExt};
+
+/// An assets deserializer, allowing to load assets from RON files.
+pub struct AssetsDeserializer<'a, A: Asset> {
+    collection: FormatCollection<A>,
+    loader: &'a Loader,
+    progress: DynProgress,
+    storage: &'a AssetStorage<A>,
+}
+
+impl<'a, A> AssetsDeserializer<'a, A>
+where
+    A: Asset,
+{
+    /// Creates a new instance of `AssetsDeserializer`.
+    pub fn new(loader: &'a Loader, storage: &'a AssetStorage<A>) -> Self {
+        AssetsDeserializer {
+            collection: FormatCollection::new(),
+            loader,
+            progress: DynProgress::new(),
+            storage,
+        }
+    }
+
+    /// Adds a format with `name`. Only added formats can be specified
+    /// in the RON file.
+    pub fn with_format<N, T>(&mut self, name: N, format: T) -> &mut Self
+    where
+        N: Into<String>,
+        T: Format<A> + Clone,
+        T::Options: Default,
+    {
+        self.collection.add(name.into(), format);
+
+        self
+    }
+
+    /// Loads a mapping of `String` to asset handles from a given `source`.
+    pub fn load_from(&mut self, name: &str, source: &str) -> Result<FnvHashMap<String, Handle<A>>> {
+        let bytes = self.loader.source(source).load(name)?;
+        let s = String::from_utf8(bytes)?;
+        // TODO: optimize
+        from_str::<FnvHashMap<String, Descriptor>>(s.as_ref())
+            .chain_err(|| "Failed to deserialize assets file")?
+            .into_iter()
+            .map(|(key, value)| {
+                Ok((
+                    key,
+                    self.collection.load(
+                        self.loader,
+                        value.name,
+                        &value.format,
+                        value.source,
+                        &mut self.progress,
+                        self.storage,
+                    )?,
+                ))
+            })
+            .collect()
+    }
+}
+
+#[derive(Deserialize)]
+struct Descriptor {
+    name: String,
+    format: String,
+    #[serde(default = "String::new")]
+    source: String,
+}
+
+/// A dynamic format, stored in the `FormatCollection::map` field.
+/// There's only one implementation of this trait,
+/// for `(F, D) where D: OptionsDeserializer<..>, F: Format<..>,`.
+trait DynFormat<A: Asset> {
+    /// Only returns `Err` if the deserialization of `options` failed.
+    fn visit_loader(
+        &self,
+        loader: &Loader,
+        name: String,
+        source: String,
+        progress: &mut DynProgress,
+        storage: &AssetStorage<A>,
+    ) -> Result<Handle<A>>;
+}
+
+impl<A, F> DynFormat<A> for F
+where
+    A: Asset,
+    F: Format<A> + Clone,
+    F::Options: Default,
+{
+    fn visit_loader(
+        &self,
+        loader: &Loader,
+        name: String,
+        source: String,
+        progress: &mut DynProgress,
+        storage: &AssetStorage<A>,
+    ) -> Result<Handle<A>> {
+        let format = self.clone();
+        let options = Default::default(); // TODO: allow deserializing options
+        let handle = loader.load_from(name, format, options, &source, progress, storage);
+
+        // TODO: this technically does not need to return `Result`,
+        // TODO: but it will for deserialization.
+
+        Ok(handle)
+    }
+}
+
+/// A collection of formats, allowing to choose a format
+/// dynamically which is useful for deserialization.
+///
+/// The type parameter `A` is the asset type.
+#[derive(Derivative)]
+#[derivative(Default(bound = ""))]
+struct FormatCollection<A: Asset> {
+    map: FnvHashMap<String, Box<DynFormat<A>>>,
+}
+
+impl<A: Asset> FormatCollection<A> {
+    /// Creates a new, empty format collection.
+    fn new() -> Self {
+        Default::default()
+    }
+
+    /// Add a format to the format collection.
+    fn add<F>(&mut self, id: String, format: F)
+    where
+        F: Format<A> + Clone,
+        F::Options: Default,
+    {
+        let dyn = Box::new(format);
+
+        self.map.insert(id, dyn);
+    }
+
+    fn load(
+        &self,
+        loader: &Loader,
+        name: String,
+        format: &str,
+        source: String,
+        progress: &mut DynProgress,
+        storage: &AssetStorage<A>,
+    ) -> Result<Handle<A>> {
+        self.map
+            .get(format)
+            .chain_err(|| ErrorKind::NoSuchFormat(format.to_owned()))?
+            .visit_loader(loader, name, source, progress, storage)
+    }
+}
+
+struct DynProgress {} // TODO: add fields
+
+impl DynProgress {
+    fn new() -> Self {
+        DynProgress {}
+    }
+}
+
+impl<'a> Progress for &'a mut DynProgress {
+    type Tracker = ();
+
+    fn add_assets(&mut self, _num: usize) {
+        unimplemented!()
+    }
+
+    fn create_tracker(self) -> Self::Tracker {
+        unimplemented!()
+    }
+}

--- a/amethyst_assets/src/dyn.rs
+++ b/amethyst_assets/src/dyn.rs
@@ -45,7 +45,12 @@ where
         self
     }
 
-    /// Loads a mapping of `String` to asset handles from a given `source`.
+    /// Loads a mapping of `String` to `Handle<A>` from the default directory source.
+    pub fn load(&mut self, name: &str) -> Result<FnvHashMap<String, Handle<A>>> {
+        self.load_from(name, "")
+    }
+
+    /// Loads a mapping of `String` to `Handle<A>` from a given `source`.
     pub fn load_from(&mut self, name: &str, source: &str) -> Result<FnvHashMap<String, Handle<A>>> {
         let bytes = self.loader.source(source).load(name)?;
         let s = String::from_utf8(bytes)?;
@@ -173,10 +178,10 @@ impl<'a> Progress for &'a mut DynProgress {
     type Tracker = ();
 
     fn add_assets(&mut self, _num: usize) {
-        unimplemented!()
+        // TODO
     }
 
     fn create_tracker(self) -> Self::Tracker {
-        unimplemented!()
+        ()
     }
 }

--- a/amethyst_assets/src/error.rs
+++ b/amethyst_assets/src/error.rs
@@ -24,5 +24,12 @@ error_chain! {
             description("Format could not load asset")
             display("Format {:?} could not load asset", format)
         }
+
+        /// Returned from `AssetsDeserializer` if the assets file
+        /// specified a format which is not registered.
+        NoSuchFormat(format: String) {
+            description("Assets file specified format which is not registered")
+            display("Format {:?} is not registered", format)
+        }
     }
 }

--- a/amethyst_assets/src/lib.rs
+++ b/amethyst_assets/src/lib.rs
@@ -6,6 +6,18 @@
 //! * extensibility
 //! * asynchronous & parallel using rayon
 //! * allow different sources
+//!
+//! # Overview
+//!
+//! The most important type of this crate is the `AssetStorage`.
+//! It's the place where all the assets are located; it only gives you
+//! `Handle`s to them which you can use to get a reference to the actual asset.
+//! The `Loader` is responsible for loading asset data, an intermediate format in asset loading.
+//! Asset data will then be pushed to a queue which the `AssetStorage` has access to.
+//! After that, we of course need to transform asset data into an asset, which happens
+//! by calling `AssetStorage::process`. After the data is processed, the handle will
+//! allow you to access the stored asset.
+//!
 
 #![warn(missing_docs)]
 
@@ -19,10 +31,14 @@ extern crate fnv;
 extern crate hibitset;
 extern crate parking_lot;
 extern crate rayon;
+extern crate ron;
+#[macro_use]
+extern crate serde;
 extern crate specs;
 
 pub use asset::{Asset, Format, FormatValue, SimpleFormat};
 pub use cache::Cache;
+pub use dyn::AssetsDeserializer;
 pub use error::{Error, ErrorKind, Result, ResultExt};
 pub use loader::Loader;
 pub use progress::{Completion, Progress, ProgressCounter, Tracker};
@@ -32,6 +48,7 @@ pub use storage::{AssetStorage, Handle, Processor, WeakHandle};
 
 mod asset;
 mod cache;
+mod dyn;
 mod error;
 mod loader;
 mod progress;

--- a/amethyst_assets/src/loader.rs
+++ b/amethyst_assets/src/loader.rs
@@ -106,10 +106,7 @@ impl Loader {
     {
         use progress::Tracker;
 
-        let source = match source.as_ref() {
-            "" => self.directory.clone(),
-            source => self.source(source),
-        };
+        let source = self.source(source.as_ref());
 
         progress.add_assets(1);
         let tracker = progress.create_tracker();
@@ -164,8 +161,13 @@ impl Loader {
         handle
     }
 
-    // TODO: consider exposing
-    pub(crate) fn source(&self, source: &str) -> Arc<Source> {
+    /// Retrieves an assset source with a given name.
+    /// If `source` is an empty string, the default directory store will be returned.
+    pub fn source(&self, source: &str) -> Arc<Source> {
+        if source.is_empty() {
+            return self.directory.clone();
+        }
+
         self.sources
             .get(source)
             .expect("No such source. Maybe you forgot to add it with `Loader::add_source`?")

--- a/amethyst_assets/src/loader.rs
+++ b/amethyst_assets/src/loader.rs
@@ -164,7 +164,8 @@ impl Loader {
         handle
     }
 
-    fn source(&self, source: &str) -> Arc<Source> {
+    // TODO: consider exposing
+    pub(crate) fn source(&self, source: &str) -> Arc<Source> {
         self.sources
             .get(source)
             .expect("No such source. Maybe you forgot to add it with `Loader::add_source`?")

--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -1,5 +1,6 @@
 
 pub extern crate cgmath;
+
 #[macro_use]
 extern crate error_chain;
 extern crate fnv;

--- a/examples/03_renderable/main.rs
+++ b/examples/03_renderable/main.rs
@@ -290,6 +290,8 @@ struct Assets {
 }
 
 fn load_assets(world: &World) -> Assets {
+    use amethyst::assets::AssetsDeserializer;
+
     let mesh_storage = world.read_resource();
     let tex_storage = world.read_resource();
     let mat_defaults = world.read_resource::<MaterialDefaults>();
@@ -318,11 +320,17 @@ fn load_assets(world: &World) -> Assets {
         ..mat_defaults.0.clone()
     };
 
-    let cube = loader.load("mesh/cube.obj", ObjFormat, (), (), &mesh_storage);
-    let cone = loader.load("mesh/cone.obj", ObjFormat, (), (), &mesh_storage);
-    let lid = loader.load("mesh/lid.obj", ObjFormat, (), (), &mesh_storage);
-    let teapot = loader.load("mesh/teapot.obj", ObjFormat, (), (), &mesh_storage);
-    let rectangle = loader.load("mesh/rectangle.obj", ObjFormat, (), (), &mesh_storage);
+    // You can also specify meshes in a RON file:
+    let meshes = AssetsDeserializer::new(&loader, &mesh_storage)
+        .with_format("obj", ObjFormat)
+        .load("mesh/renderable_collection.ron")
+        .expect("Failed to decode");
+
+    let cube = meshes.get("cube").unwrap().clone();
+    let cone = meshes.get("cone").unwrap().clone();
+    let lid = meshes.get("lid").unwrap().clone();
+    let teapot = meshes.get("teapot").unwrap().clone();
+    let rectangle = meshes.get("rectangle").unwrap().clone();
 
     Assets {
         cube,

--- a/examples/05_assets/main.rs
+++ b/examples/05_assets/main.rs
@@ -5,7 +5,7 @@ extern crate amethyst;
 extern crate rayon;
 
 use amethyst::{Application, Error, State, Trans};
-use amethyst::assets::{Loader, Result as AssetResult, ResultExt, SimpleFormat};
+use amethyst::assets::{Loader, Result as AssetResult, SimpleFormat};
 use amethyst::config::Config;
 use amethyst::core::cgmath::{Array, Vector3};
 use amethyst::core::transform::{LocalTransform, Transform, TransformBundle};

--- a/examples/assets/mesh/renderable_collection.ron
+++ b/examples/assets/mesh/renderable_collection.ron
@@ -1,0 +1,7 @@
+{
+    "cube": (name: "mesh/cube.obj", format: "obj"),
+    "cone": (name: "mesh/cone.obj", format: "obj"),
+    "teapot": (name: "mesh/teapot.obj", format: "obj"),
+    "lid": (name: "mesh/lid.obj", format: "obj"),
+    "rectangle": (name: "mesh/rectangle.obj", format: "obj"),
+}


### PR DESCRIPTION
Didn't try if this works and I have to write better docs for it.

This is an example of a `meshes.ron`:

```rust
{
    "cube": (name: "cube.obj", format: "obj"),
    "sphere": (name: "sphere.fbx", format: "fbx"),
    "dungeon": (name: "dungeon_01", format: "fbx", source: "net"),
}
```

You would then just get a mapping for `String` -> `Handle<Mesh>`.