### PR TITLE
Upgrade and use cgmath

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,7 @@ thread_profiler = { version = "0.1", optional = true }
 
 [dev-dependencies]
 amethyst_gltf = { path = "amethyst_gltf", version = "0.1" }
-cgmath = "0.14"
-genmesh = "0.4"
+cgmath = { version = "0.15", features = ["serde", "mint"] }genmesh = "0.4"
 
 [build-dependencies]
 vergen = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ amethyst_core = { path = "amethyst_core", version = "0.1.0" }
 amethyst_renderer = { path = "amethyst_renderer", version = "0.5" }
 amethyst_input = { path = "amethyst_input", version = "0.1" }
 amethyst_utils = { path = "amethyst_utils", version = "0.1" }
+cgmath = { version = "0.15", features = ["serde", "mint"] }
 derivative = "1.0"
 rayon = "0.8"
 shred = "0.5"
@@ -40,7 +41,7 @@ thread_profiler = { version = "0.1", optional = true }
 
 [dev-dependencies]
 amethyst_gltf = { path = "amethyst_gltf", version = "0.1" }
-cgmath = { version = "0.15", features = ["serde", "mint"] }genmesh = "0.4"
+genmesh = "0.4"
 
 [build-dependencies]
 vergen = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ amethyst_core = { path = "amethyst_core", version = "0.1.0" }
 amethyst_renderer = { path = "amethyst_renderer", version = "0.5" }
 amethyst_input = { path = "amethyst_input", version = "0.1" }
 amethyst_utils = { path = "amethyst_utils", version = "0.1" }
-cgmath = { version = "0.15", features = ["serde", "mint"] }
 derivative = "1.0"
 rayon = "0.8"
 shred = "0.5"

--- a/amethyst_assets/src/reload.rs
+++ b/amethyst_assets/src/reload.rs
@@ -75,7 +75,10 @@ impl HotReloadStrategy {
         use std::u64::MAX;
 
         HotReloadStrategy {
-            inner: HotReloadStrategyInner::Trigger { triggered: false, frame_number: MAX },
+            inner: HotReloadStrategyInner::Trigger {
+                triggered: false,
+                frame_number: MAX,
+            },
         }
     }
 
@@ -89,7 +92,10 @@ impl HotReloadStrategy {
     /// The frame after calling this, all changed assets will be reloaded.
     /// Doesn't do anything if the strategy wasn't created with `when_triggered`.
     pub fn trigger(&mut self) {
-        if let HotReloadStrategyInner::Trigger { ref mut triggered, .. } = self.inner {
+        if let HotReloadStrategyInner::Trigger {
+            ref mut triggered, ..
+        } = self.inner
+        {
             *triggered = true;
         }
     }

--- a/amethyst_audio/Cargo.toml
+++ b/amethyst_audio/Cargo.toml
@@ -21,7 +21,7 @@ travis-ci = { repository = "amethyst/amethyst" }
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.2.0"}
 amethyst_core = { path = "../amethyst_core", version = "0.1.0"}
-cgmath = "0.14"
+cgmath = { version = "0.15", features = ["serde", "mint"] }
 cpal = "0.4"
 rodio = "0.5.1"
 shred = "0.5"

--- a/amethyst_audio/Cargo.toml
+++ b/amethyst_audio/Cargo.toml
@@ -21,7 +21,6 @@ travis-ci = { repository = "amethyst/amethyst" }
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.2.0"}
 amethyst_core = { path = "../amethyst_core", version = "0.1.0"}
-cgmath = { version = "0.15", features = ["serde", "mint"] }
 cpal = "0.4"
 rodio = "0.5.1"
 shred = "0.5"

--- a/amethyst_audio/src/components/audio_listener.rs
+++ b/amethyst_audio/src/components/audio_listener.rs
@@ -1,3 +1,4 @@
+use cgmath::Point3;
 use specs::{Component, HashMapStorage};
 
 use output::Output;
@@ -8,9 +9,9 @@ pub struct AudioListener {
     /// Output used by this listener to emit sounds to
     pub output: Output,
     /// Position of the left_ear relative to the global transform on this entity.
-    pub left_ear: [f32; 3],
+    pub left_ear: Point3<f32>,
     /// Position of the right ear relative to the global transform on this entity.
-    pub right_ear: [f32; 3],
+    pub right_ear: Point3<f32>,
 }
 
 impl Component for AudioListener {

--- a/amethyst_audio/src/components/audio_listener.rs
+++ b/amethyst_audio/src/components/audio_listener.rs
@@ -1,4 +1,4 @@
-use cgmath::Point3;
+use amethyst_core::cgmath::Point3;
 use specs::{Component, HashMapStorage};
 
 use output::Output;

--- a/amethyst_audio/src/lib.rs
+++ b/amethyst_audio/src/lib.rs
@@ -1,7 +1,6 @@
 //! Loading and playing of audio files.
 extern crate amethyst_assets;
 extern crate amethyst_core;
-extern crate cgmath;
 extern crate cpal;
 extern crate rodio;
 extern crate shred;

--- a/amethyst_audio/src/systems/audio.rs
+++ b/amethyst_audio/src/systems/audio.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use amethyst_core::transform::Transform as TransformComponent;
-use cgmath::{Matrix4, Point3, Transform};
+use cgmath::Transform;
 use rodio::{Sample, Source, SpatialSink};
 use specs::{Entity, Fetch, Join, ReadStorage, System, WriteStorage};
 
@@ -94,12 +94,12 @@ impl<'a> System<'a> for AudioSystem {
         // Process emitters and listener.
         if let Some(listener) = listener.get(select_listener.0) {
             if let Some(listener_transform) = transform.get(select_listener.0) {
-                let listener_transform = Matrix4::from(listener_transform.0);
+                let listener_transform = listener_transform.0;
                 let left_ear_position = listener_transform
-                    .transform_point(Point3::from(listener.left_ear))
+                    .transform_point(listener.left_ear)
                     .into();
                 let right_ear_position = listener_transform
-                    .transform_point(Point3::from(listener.right_ear))
+                    .transform_point(listener.right_ear)
                     .into();
                 for (transform, mut audio_emitter) in (&transform, &mut audio_emitter).join() {
                     let x = transform.0[3][0];

--- a/amethyst_audio/src/systems/audio.rs
+++ b/amethyst_audio/src/systems/audio.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use amethyst_core::transform::Transform as TransformComponent;
-use cgmath::Transform;
+use amethyst_core::cgmath::Transform;
 use rodio::{Sample, Source, SpatialSink};
 use specs::{Entity, Fetch, Join, ReadStorage, System, WriteStorage};
 

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -15,7 +15,7 @@ appveyor = { repository = "amethyst/amethyst" }
 travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
-cgmath = "0.14"
+cgmath = { version = "0.15", features = ["serde", "mint"] }
 fnv = "1.0"
 hibitset = "0.3.2"
 rayon = "0.8"

--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -1,5 +1,5 @@
 
-extern crate cgmath;
+pub extern crate cgmath;
 extern crate fnv;
 extern crate hibitset;
 extern crate rayon;

--- a/amethyst_core/src/orientation.rs
+++ b/amethyst_core/src/orientation.rs
@@ -16,9 +16,9 @@ pub struct Orientation {
 impl Default for Orientation {
     fn default() -> Self {
         Self {
-            forward: [1.0, 0.0, 0.0].into(),
-            right: [0.0, -1.0, 0.0].into(),
-            up: [0.0, 0.0, 1.0].into(),
+            forward: Vector3::unit_x(),
+            right: -Vector3::unit_y(),
+            up: Vector3::unit_z(),
         }
     }
 }

--- a/amethyst_core/src/orientation.rs
+++ b/amethyst_core/src/orientation.rs
@@ -1,23 +1,24 @@
 //! Orientation of objects
 
+use cgmath::Vector3;
 
 /// Orientation struct.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Orientation {
     /// Forward vector [x, y, z]
-    pub forward: [f32; 3],
+    pub forward: Vector3<f32>,
     /// Right vector [x, y, z]
-    pub right: [f32; 3],
+    pub right: Vector3<f32>,
     /// Up vector [x, y, z]
-    pub up: [f32; 3],
+    pub up: Vector3<f32>,
 }
 
 impl Default for Orientation {
     fn default() -> Self {
         Self {
-            forward: [1.0, 0.0, 0.0],
-            right: [0.0, -1.0, 0.0],
-            up: [0.0, 0.0, 1.0],
+            forward: [1.0, 0.0, 0.0].into(),
+            right: [0.0, -1.0, 0.0].into(),
+            up: [0.0, 0.0, 1.0].into(),
         }
     }
 }

--- a/amethyst_core/src/timing.rs
+++ b/amethyst_core/src/timing.rs
@@ -20,7 +20,6 @@ pub struct Time {
 }
 
 impl Time {
-
     /// Gets the time difference between frames in seconds
     pub fn delta_seconds(&self) -> f32 {
         self.delta_seconds

--- a/amethyst_core/src/transform/components/local_transform.rs
+++ b/amethyst_core/src/transform/components/local_transform.rs
@@ -1,7 +1,7 @@
 //! Local transform component.
 
-use cgmath::{Deg, EuclideanSpace, InnerSpace, Matrix3, Matrix4, Point3, Quaternion, Rotation,
-             Rotation3, Vector3};
+use cgmath::{Array, Deg, EuclideanSpace, InnerSpace, Matrix3, Matrix4, One, Point3, Quaternion, Rotation,
+             Rotation3, SquareMatrix, Vector3, Zero};
 use orientation::Orientation;
 use specs::{Component, DenseVecStorage, FlaggedStorage};
 
@@ -35,11 +35,7 @@ impl LocalTransform {
     #[inline]
     pub fn matrix(&self) -> Matrix4<f32> {
         let quat: Matrix3<f32> = Quaternion::from(self.rotation).into();
-        let scale: Matrix3<f32> = Matrix3::<f32> {
-            x: [self.scale[0], 0.0, 0.0].into(),
-            y: [0.0, self.scale[1], 0.0].into(),
-            z: [0.0, 0.0, self.scale[2]].into(),
-        };
+        let scale: Matrix3<f32> = Matrix3::from_diagonal(self.scale);
         let mut matrix: Matrix4<f32> = (&quat * scale).into();
         matrix.w = self.translation.extend(1.0f32);
         matrix
@@ -164,9 +160,9 @@ impl LocalTransform {
 impl Default for LocalTransform {
     fn default() -> Self {
         LocalTransform {
-            translation: [0.0, 0.0, 0.0].into(),
-            rotation: [1.0, 0.0, 0.0, 0.0].into(),
-            scale: [1.0, 1.0, 1.0].into(),
+            translation: Vector3::zero(),
+            rotation: Quaternion::one(),
+            scale: Vector3::from_value(1.),
         }
     }
 }

--- a/amethyst_core/src/transform/components/transform.rs
+++ b/amethyst_core/src/transform/components/transform.rs
@@ -2,7 +2,7 @@
 
 use std::borrow::Borrow;
 
-use cgmath::Matrix4;
+use cgmath::{Matrix4, One};
 use specs::{Component, DenseVecStorage, FlaggedStorage};
 
 /// Performs a global transformation on the entity (transform from origin).
@@ -36,14 +36,7 @@ impl Component for Transform {
 
 impl Default for Transform {
     fn default() -> Self {
-        Transform(
-            [
-                [1.0, 0.0, 0.0, 0.0],
-                [0.0, 1.0, 0.0, 0.0],
-                [0.0, 0.0, 1.0, 0.0],
-                [0.0, 0.0, 0.0, 1.0],
-            ].into(),
-        )
+        Transform(Matrix4::one())
     }
 }
 

--- a/amethyst_core/src/transform/components/transform.rs
+++ b/amethyst_core/src/transform/components/transform.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Borrow;
 
+use cgmath::Matrix4;
 use specs::{Component, DenseVecStorage, FlaggedStorage};
 
 /// Performs a global transformation on the entity (transform from origin).
@@ -12,7 +13,7 @@ use specs::{Component, DenseVecStorage, FlaggedStorage};
 /// on the `FlaggedStorage` at the appropriate times (before updating any `Transform` in the frame).
 /// See documentation on `FlaggedStorage` for more information.
 #[derive(Debug, Copy, Clone)]
-pub struct Transform(pub [[f32; 4]; 4]);
+pub struct Transform(pub Matrix4<f32>);
 
 impl Transform {
     /// Checks whether each `f32` of the `Transform` is finite (not NaN or inf).
@@ -40,7 +41,7 @@ impl Default for Transform {
             [0.0, 1.0, 0.0, 0.0],
             [0.0, 0.0, 1.0, 0.0],
             [0.0, 0.0, 0.0, 1.0],
-        ])
+        ].into())
     }
 }
 
@@ -53,25 +54,25 @@ impl Transform {
 
 impl From<[[f32; 4]; 4]> for Transform {
     fn from(matrix: [[f32; 4]; 4]) -> Self {
-        Transform(matrix)
+        Transform(matrix.into())
     }
 }
 
 impl Into<[[f32; 4]; 4]> for Transform {
     fn into(self) -> [[f32; 4]; 4] {
-        self.0
+        self.0.into()
     }
 }
 
 impl AsRef<[[f32; 4]; 4]> for Transform {
     fn as_ref(&self) -> &[[f32; 4]; 4] {
-        &self.0
+        self.0.as_ref()
     }
 }
 
 
 impl Borrow<[[f32; 4]; 4]> for Transform {
     fn borrow(&self) -> &[[f32; 4]; 4] {
-        &self.0
+        self.0.as_ref()
     }
 }

--- a/amethyst_core/src/transform/components/transform.rs
+++ b/amethyst_core/src/transform/components/transform.rs
@@ -36,12 +36,14 @@ impl Component for Transform {
 
 impl Default for Transform {
     fn default() -> Self {
-        Transform([
-            [1.0, 0.0, 0.0, 0.0],
-            [0.0, 1.0, 0.0, 0.0],
-            [0.0, 0.0, 1.0, 0.0],
-            [0.0, 0.0, 0.0, 1.0],
-        ].into())
+        Transform(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ].into(),
+        )
     }
 }
 

--- a/amethyst_core/src/transform/systems.rs
+++ b/amethyst_core/src/transform/systems.rs
@@ -149,7 +149,7 @@ impl<'a> System<'a> for TransformSystem {
                         };
 
                         if let Some(global) = globals.get_mut(entity) {
-                            global.0 = combined_transform;
+                            global.0 = combined_transform.into();
                         }
                     }
                 }
@@ -182,7 +182,7 @@ impl<'a> System<'a> for TransformSystem {
 
 #[cfg(test)]
 mod tests {
-    use cgmath::{Decomposed, Matrix4, Quaternion, Vector3};
+    use cgmath::{Decomposed, EuclideanSpace, Matrix4, Point3, Quaternion, Vector3};
     use shred::RunNow;
     use specs::World;
     use transform::{LocalTransform, Parent, Transform, TransformSystem};
@@ -192,19 +192,18 @@ mod tests {
     #[test]
     fn transform_matrix() {
         let mut transform = LocalTransform::default();
-        transform.translation = [5.0, 2.0, -0.5];
-        transform.rotation = [1.0, 0.0, 0.0, 0.0];
-        transform.scale = [2.0, 2.0, 2.0];
+        transform.translation = Point3::new(5.0, 2.0, -0.5);
+        transform.rotation = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        transform.scale = Vector3::new(2.0, 2.0, 2.0);
 
         let decomposed = Decomposed {
-            rot: Quaternion::from(transform.rotation),
-            disp: Vector3::from(transform.translation),
+            rot: transform.rotation,
+            disp: transform.translation.to_vec(),
             scale: 2.0,
         };
 
         let matrix = transform.matrix();
         let cg_matrix: Matrix4<f32> = decomposed.into();
-        let cg_matrix: [[f32; 4]; 4] = cg_matrix.into();
 
         assert_eq!(matrix, cg_matrix);
     }
@@ -213,10 +212,10 @@ mod tests {
     fn into_from() {
         let transform = Transform::default();
         let primitive: [[f32; 4]; 4] = transform.into();
-        assert_eq!(primitive, transform.0);
+        assert_eq!(primitive, <Matrix4<f32> as Into<[[f32; 4]; 4]>>::into(transform.0));
 
         let transform: Transform = primitive.into();
-        assert_eq!(primitive, transform.0);
+        assert_eq!(primitive, <Matrix4<f32> as Into<[[f32; 4]; 4]>>::into(transform.0));
     }
 
     fn transform_world<'a, 'b>() -> (World, TransformSystem) {
@@ -238,8 +237,8 @@ mod tests {
         let (mut world, mut system) = transform_world();
 
         let mut transform = LocalTransform::default();
-        transform.translation = [0.0, 0.0, 0.0];
-        transform.rotation = [1.0, 0.0, 0.0, 0.0];
+        transform.translation = Point3::new(0.0, 0.0, 0.0);
+        transform.rotation = Quaternion::new(1.0, 0.0, 0.0, 0.0);
 
         let e1 = world
             .create_entity()
@@ -263,8 +262,8 @@ mod tests {
         let (mut world, mut system) = transform_world();
 
         let mut local = LocalTransform::default();
-        local.translation = [5.0, 5.0, 5.0];
-        local.rotation = [1.0, 0.5, 0.5, 0.0];
+        local.translation = Point3::new(5.0, 5.0, 5.0);
+        local.rotation = Quaternion::new(1.0, 0.5, 0.5, 0.0);
 
         let e1 = world
             .create_entity()
@@ -286,8 +285,8 @@ mod tests {
         let (mut world, mut system) = transform_world();
 
         let mut local1 = LocalTransform::default();
-        local1.translation = [5.0, 5.0, 5.0];
-        local1.rotation = [1.0, 0.5, 0.5, 0.0];
+        local1.translation = Point3::new(5.0, 5.0, 5.0);
+        local1.rotation = Quaternion::new(1.0, 0.5, 0.5, 0.0);
 
         let e1 = world
             .create_entity()
@@ -296,8 +295,8 @@ mod tests {
             .build();
 
         let mut local2 = LocalTransform::default();
-        local2.translation = [5.0, 5.0, 5.0];
-        local2.rotation = [1.0, 0.5, 0.5, 0.0];
+        local2.translation = Point3::new(5.0, 5.0, 5.0);
+        local2.rotation = Quaternion::new(1.0, 0.5, 0.5, 0.0);
 
         let e2 = world
             .create_entity()
@@ -307,8 +306,8 @@ mod tests {
             .build();
 
         let mut local3 = LocalTransform::default();
-        local3.translation = [5.0, 5.0, 5.0];
-        local3.rotation = [1.0, 0.5, 0.5, 0.0];
+        local3.translation = Point3::new(5.0, 5.0, 5.0);
+        local3.rotation = Quaternion::new(1.0, 0.5, 0.5, 0.0);
 
         let e3 = world
             .create_entity()
@@ -352,8 +351,8 @@ mod tests {
         let (mut world, mut system) = transform_world();
 
         let mut local3 = LocalTransform::default();
-        local3.translation = [5.0, 5.0, 5.0];
-        local3.rotation = [1.0, 0.5, 0.5, 0.0];
+        local3.translation = Point3::new(5.0, 5.0, 5.0);
+        local3.rotation = Quaternion::new(1.0, 0.5, 0.5, 0.0);
 
         let e3 = world
             .create_entity()
@@ -362,8 +361,8 @@ mod tests {
             .build();
 
         let mut local2 = LocalTransform::default();
-        local2.translation = [5.0, 5.0, 5.0];
-        local2.rotation = [1.0, 0.5, 0.5, 0.0];
+        local2.translation = Point3::new(5.0, 5.0, 5.0);
+        local2.rotation = Quaternion::new(1.0, 0.5, 0.5, 0.0);
 
         let e2 = world
             .create_entity()
@@ -372,8 +371,8 @@ mod tests {
             .build();
 
         let mut local1 = LocalTransform::default();
-        local1.translation = [5.0, 5.0, 5.0];
-        local1.rotation = [1.0, 0.5, 0.5, 0.0];
+        local1.translation = Point3::new(5.0, 5.0, 5.0);
+        local1.rotation = Quaternion::new(1.0, 0.5, 0.5, 0.0);
 
         let e1 = world
             .create_entity()
@@ -423,7 +422,7 @@ mod tests {
 
         let mut local = LocalTransform::default();
         // Release the indeterminate forms!
-        local.translation = [0.0 / 0.0, 0.0 / 0.0, 0.0 / 0.0];
+        local.translation = Point3::new(0.0 / 0.0, 0.0 / 0.0, 0.0 / 0.0);
 
         world
             .create_entity()
@@ -441,7 +440,7 @@ mod tests {
 
         let mut local = LocalTransform::default();
         // Release the indeterminate forms!
-        local.translation = [1.0 / 0.0, 1.0 / 0.0, 1.0 / 0.0];
+        local.translation = Point3::new(1.0 / 0.0, 1.0 / 0.0, 1.0 / 0.0);
         world
             .create_entity()
             .with(local.clone())

--- a/amethyst_core/src/transform/systems.rs
+++ b/amethyst_core/src/transform/systems.rs
@@ -181,7 +181,7 @@ impl<'a> System<'a> for TransformSystem {
 
 #[cfg(test)]
 mod tests {
-    use cgmath::{Decomposed, Matrix4, Quaternion, Vector3, Zero};
+    use cgmath::{Decomposed, Matrix4, One, Quaternion, Vector3, Zero};
     use shred::RunNow;
     use specs::World;
     use transform::{LocalTransform, Parent, Transform, TransformSystem};
@@ -243,7 +243,7 @@ mod tests {
 
         let mut transform = LocalTransform::default();
         transform.translation = Vector3::zero();
-        transform.rotation = Quaternion::new(1.0, 0.0, 0.0, 0.0);
+        transform.rotation = Quaternion::one();
 
         let e1 = world
             .create_entity()

--- a/amethyst_core/src/transform/systems.rs
+++ b/amethyst_core/src/transform/systems.rs
@@ -233,7 +233,7 @@ mod tests {
     }
 
     fn together(transform: Transform, local: LocalTransform) -> [[f32; 4]; 4] {
-        (Matrix4::from(transform.0) * Matrix4::from(local.matrix())).into()
+        (transform.0 * local.matrix()).into()
     }
 
     // Basic default LocalTransform -> Transform (Should just be identity)

--- a/amethyst_gltf/src/format/mod.rs
+++ b/amethyst_gltf/src/format/mod.rs
@@ -403,10 +403,10 @@ fn load_node(
 
     let (translation, rotation, scale) = node.transform().decomposed();
     let mut local_transform = LocalTransform::default();
-    local_transform.translation = translation;
+    local_transform.translation = translation.into();
     // gltf quat format: [x, y, z, w], our quat format: [w, x, y, z]
-    local_transform.rotation = [rotation[3], rotation[0], rotation[1], rotation[2]];
-    local_transform.scale = scale;
+    local_transform.rotation = [rotation[3], rotation[0], rotation[1], rotation[2]].into();
+    local_transform.scale = scale.into();
 
 
     Ok(GltfNode {

--- a/amethyst_renderer/Cargo.toml
+++ b/amethyst_renderer/Cargo.toml
@@ -28,7 +28,6 @@ opengl = ["gfx_device_gl", "gfx_window_glutin", "glutin"]
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.2.0" }
 amethyst_core = { path = "../amethyst_core", version = "0.1.0" }
-cgmath = { version = "0.15", features = ["serde", "mint"] }
 derivative = "1.0"
 fnv = "1.0"
 gfx = { version = "0.16", features = ["serialize"] }

--- a/amethyst_renderer/Cargo.toml
+++ b/amethyst_renderer/Cargo.toml
@@ -28,11 +28,11 @@ opengl = ["gfx_device_gl", "gfx_window_glutin", "glutin"]
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.2.0" }
 amethyst_core = { path = "../amethyst_core", version = "0.1.0" }
-cgmath = { version = "0.14", features = ["eders"] }
+cgmath = { version = "0.15", features = ["serde", "mint"] }
 derivative = "1.0"
 fnv = "1.0"
-gfx = { version = "0.16", features = ["cgmath-types", "serialize"] }
-gfx_core = { version = "0.7", features = ["cgmath-types", "serialize"] }
+gfx = { version = "0.16", features = ["serialize"] }
+gfx_core = { version = "0.7", features = ["serialize"] }
 gfx_macros = "0.2"
 imagefmt = "4.0"
 num_cpus = "1.0"

--- a/amethyst_renderer/src/cam.rs
+++ b/amethyst_renderer/src/cam.rs
@@ -1,6 +1,6 @@
 //! Camera type with support for perspective and orthographic projections.
 
-use cgmath::{Deg, Matrix4, Ortho, PerspectiveFov};
+use amethyst_core::cgmath::{Deg, Matrix4, Ortho, PerspectiveFov};
 use specs::{Component, DenseVecStorage, Entity};
 
 /// The projection mode of a `Camera`.
@@ -82,7 +82,7 @@ impl Camera {
     /// of view of 60 degrees.
     /// View transformation will be multiplicative identity.
     pub fn standard_3d(width: f32, height: f32) -> Self {
-        use cgmath::Deg;
+        use amethyst_core::cgmath::Deg;
         Self::from(Projection::perspective(width / height, Deg(60.)))
     }
 }

--- a/amethyst_renderer/src/formats/mesh.rs
+++ b/amethyst_renderer/src/formats/mesh.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 use std::string::FromUtf8Error;
 
 use amethyst_assets::{Asset, BoxedErr, SimpleFormat};
-use cgmath::{InnerSpace, Vector3};
+use amethyst_core::cgmath::{InnerSpace, Vector3};
 use specs::DenseVecStorage;
 use wavefront_obj::ParseError;
 use wavefront_obj::obj::{parse, Normal, NormalIndex, ObjSet, Object, Primitive, TVertex,

--- a/amethyst_renderer/src/lib.rs
+++ b/amethyst_renderer/src/lib.rs
@@ -11,7 +11,6 @@
 
 extern crate amethyst_assets;
 extern crate amethyst_core;
-extern crate cgmath;
 #[macro_use]
 extern crate derivative;
 extern crate fnv;

--- a/amethyst_renderer/src/light.rs
+++ b/amethyst_renderer/src/light.rs
@@ -2,7 +2,6 @@
 //!
 //! TODO: Remove redundant padding once `#[repr(align(...))]` stabilizes.
 
-use cgmath::{Deg, Point3, Vector3};
 use gfx;
 use specs::{Component, DenseVecStorage};
 
@@ -31,14 +30,14 @@ pub struct DirectionalLight {
     /// Color of the light in RGBA8 format.
     pub color: Rgba,
     /// Direction that the light is pointing.
-    pub direction: Vector3<f32>,
+    pub direction: [f32; 3],
 }
 
 impl Default for DirectionalLight {
     fn default() -> Self {
         DirectionalLight {
             color: Rgba::default(),
-            direction: Vector3::new(-1.0, -1.0, -1.0),
+            direction: [-1.0, -1.0, -1.0],
         }
     }
 }
@@ -73,7 +72,7 @@ impl From<DirectionalLight> for Light {
 #[derive(Clone, ConstantBuffer, Debug, Deserialize, PartialEq, Serialize)]
 pub struct PointLight {
     /// Location of the light source in three dimensional space.
-    pub center: Point3<f32>,
+    pub center: [f32; 3],
     /// Color of the light in RGBA8 format.
     pub color: Rgba,
     /// Brightness of the light source, in lumens.
@@ -88,7 +87,7 @@ pub struct PointLight {
 impl Default for PointLight {
     fn default() -> Self {
         PointLight {
-            center: Point3::new(0.0, 0.0, 0.0),
+            center: [0.0, 0.0, 0.0],
             color: Rgba::default(),
             intensity: 10.0,
             radius: 10.0,
@@ -107,14 +106,14 @@ impl From<PointLight> for Light {
 #[repr(C)]
 #[derive(Clone, ConstantBuffer, Debug, Deserialize, PartialEq, Serialize)]
 pub struct SpotLight {
-    /// Opening angle of the light cone.
-    pub angle: Deg<f32>,
+    /// Opening angle of the light cone in degrees.
+    pub angle: f32,
     /// Location of the light source in three dimensional space.
-    pub center: Point3<f32>,
+    pub center: [f32; 3],
     /// Color of the light in RGBA8 format.
     pub color: Rgba,
     /// Direction that the light is pointing.
-    pub direction: Vector3<f32>,
+    pub direction: [f32; 3],
     /// Brightness of the light source, in lumens.
     pub intensity: f32,
     /// Maximum radius of the point light's affected area.
@@ -127,10 +126,10 @@ pub struct SpotLight {
 impl Default for SpotLight {
     fn default() -> Self {
         SpotLight {
-            angle: Deg(60.0),
-            center: Point3::new(0.0, 1.0, 0.0),
+            angle: 60.0,
+            center: [0.0, 1.0, 0.0],
             color: Rgba::default(),
-            direction: Vector3::new(0.0, -1.0, 0.0),
+            direction: [0.0, -1.0, 0.0],
             intensity: 10.0,
             radius: 10.0,
             smoothness: 4.0,
@@ -148,12 +147,12 @@ impl From<SpotLight> for Light {
 #[repr(C)]
 #[derive(Clone, ConstantBuffer, Debug, Deserialize, PartialEq, Serialize)]
 pub struct SunLight {
-    /// The sun's angular radius.
-    pub ang_rad: Deg<f32>,
+    /// The sun's angular radius in degrees.
+    pub ang_rad: f32,
     /// Color of the light in RGBA8 format.
     pub color: Rgba,
     /// Direction that the light is pointing.
-    pub direction: Vector3<f32>,
+    pub direction: [f32; 3],
     /// Brightness of the sun light, in lux.
     pub intensity: f32,
 }
@@ -161,9 +160,9 @@ pub struct SunLight {
 impl Default for SunLight {
     fn default() -> Self {
         SunLight {
-            ang_rad: Deg(0.0093),
+            ang_rad: 0.0093,
             color: Rgba::default(),
-            direction: Vector3::new(-1.0, -1.0, -1.0),
+            direction: [-1.0, -1.0, -1.0],
             intensity: 64_000.0,
         }
     }

--- a/amethyst_renderer/src/light.rs
+++ b/amethyst_renderer/src/light.rs
@@ -30,7 +30,7 @@ pub struct DirectionalLight {
     /// Color of the light in RGBA8 format.
     pub color: Rgba,
     /// Direction that the light is pointing.
-    pub direction: [f32; 3],
+    pub direction: [f32; 3], //TODO: Replace with a cgmath type when gfx version > 0.16
 }
 
 impl Default for DirectionalLight {
@@ -72,7 +72,7 @@ impl From<DirectionalLight> for Light {
 #[derive(Clone, ConstantBuffer, Debug, Deserialize, PartialEq, Serialize)]
 pub struct PointLight {
     /// Location of the light source in three dimensional space.
-    pub center: [f32; 3],
+    pub center: [f32; 3], //TODO: Replace with a cgmath type when gfx version > 0.16
     /// Color of the light in RGBA8 format.
     pub color: Rgba,
     /// Brightness of the light source, in lumens.
@@ -107,13 +107,13 @@ impl From<PointLight> for Light {
 #[derive(Clone, ConstantBuffer, Debug, Deserialize, PartialEq, Serialize)]
 pub struct SpotLight {
     /// Opening angle of the light cone in degrees.
-    pub angle: f32,
+    pub angle: f32, //TODO: Replace with a cgmath type when gfx version > 0.16
     /// Location of the light source in three dimensional space.
-    pub center: [f32; 3],
+    pub center: [f32; 3], //TODO: Replace with a cgmath type when gfx version > 0.16
     /// Color of the light in RGBA8 format.
     pub color: Rgba,
     /// Direction that the light is pointing.
-    pub direction: [f32; 3],
+    pub direction: [f32; 3], //TODO: Replace with a cgmath type when gfx version > 0.16
     /// Brightness of the light source, in lumens.
     pub intensity: f32,
     /// Maximum radius of the point light's affected area.
@@ -148,11 +148,11 @@ impl From<SpotLight> for Light {
 #[derive(Clone, ConstantBuffer, Debug, Deserialize, PartialEq, Serialize)]
 pub struct SunLight {
     /// The sun's angular radius in degrees.
-    pub ang_rad: f32,
+    pub ang_rad: f32, //TODO: Replace with a cgmath type when gfx version > 0.16
     /// Color of the light in RGBA8 format.
     pub color: Rgba,
     /// Direction that the light is pointing.
-    pub direction: [f32; 3],
+    pub direction: [f32; 3], //TODO: Replace with a cgmath type when gfx version > 0.16
     /// Brightness of the sun light, in lux.
     pub intensity: f32,
 }

--- a/amethyst_renderer/src/mesh.rs
+++ b/amethyst_renderer/src/mesh.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 
 use amethyst_assets::Handle;
 
-use cgmath::{Deg, Matrix4, Point3, Transform, Vector3};
+use amethyst_core::cgmath::{Deg, Matrix4, Point3, Transform, Vector3};
 use gfx::Primitive;
 
 use error::Result;
@@ -204,7 +204,7 @@ where
 {
     /// Creates a new `MeshBuilder` with the given vertices.
     pub fn new(verts: D) -> Self {
-        use cgmath::SquareMatrix;
+        use amethyst_core::cgmath::SquareMatrix;
         assert!(check_attributes_are_sorted(V::ATTRIBUTES));
         MeshBuilder {
             prim: Primitive::TriangleList,
@@ -242,7 +242,7 @@ where
 
     /// Sets the position of the mesh in 3D space.
     pub fn with_position<P: Into<Point3<f32>>>(mut self, pos: P) -> Self {
-        use cgmath::EuclideanSpace;
+        use amethyst_core::cgmath::EuclideanSpace;
 
         let trans = Matrix4::from_translation(pos.into().to_vec());
         self.transform.concat_self(&trans);

--- a/amethyst_renderer/src/pass/flat/interleaved.rs
+++ b/amethyst_renderer/src/pass/flat/interleaved.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 use amethyst_assets::AssetStorage;
 use amethyst_core::transform::Transform;
-use cgmath::{Matrix4, One, SquareMatrix};
+use amethyst_core::cgmath::{Matrix4, One, SquareMatrix};
 use gfx::pso::buffer::ElemStride;
 
 use rayon::iter::ParallelIterator;

--- a/amethyst_renderer/src/pass/flat/interleaved.rs
+++ b/amethyst_renderer/src/pass/flat/interleaved.rs
@@ -174,7 +174,7 @@ where
                             .map(|&(ref cam, ref transform)| {
                                 VertexArgs {
                                     proj: cam.proj.into(),
-                                    view: Matrix4::from(transform.0).invert().unwrap().into(),
+                                    view: transform.0.invert().unwrap().into(),
                                     model: *global.as_ref(),
                                 }
                             })

--- a/amethyst_renderer/src/pass/flat/separate.rs
+++ b/amethyst_renderer/src/pass/flat/separate.rs
@@ -167,7 +167,7 @@ impl<'a> ParallelIterator for DrawFlatSeparateApply<'a> {
                             .map(|&(ref cam, ref transform)| {
                                 VertexArgs {
                                     proj: cam.proj.into(),
-                                    view: Matrix4::from(transform.0).invert().unwrap().into(),
+                                    view: transform.0.invert().unwrap().into(),
                                     model: *global.as_ref(),
                                 }
                             })

--- a/amethyst_renderer/src/pass/flat/separate.rs
+++ b/amethyst_renderer/src/pass/flat/separate.rs
@@ -2,7 +2,7 @@
 
 use amethyst_assets::AssetStorage;
 use amethyst_core::transform::Transform;
-use cgmath::{Matrix4, One, SquareMatrix};
+use amethyst_core::cgmath::{Matrix4, One, SquareMatrix};
 use gfx::pso::buffer::ElemStride;
 
 use rayon::iter::ParallelIterator;

--- a/amethyst_renderer/src/pass/pbm/interleaved.rs
+++ b/amethyst_renderer/src/pass/pbm/interleaved.rs
@@ -196,7 +196,7 @@ where
                             .map(|&(ref cam, ref transform)| {
                                 VertexArgs {
                                     proj: cam.proj.into(),
-                                    view: Matrix4::from(transform.0).invert().unwrap().into(),
+                                    view: transform.0.invert().unwrap().into(),
                                     model: *global.as_ref(),
                                 }
                             })

--- a/amethyst_renderer/src/pass/pbm/interleaved.rs
+++ b/amethyst_renderer/src/pass/pbm/interleaved.rs
@@ -95,8 +95,18 @@ where
     fn apply<'a, 'b: 'a>(
         &'a mut self,
         supplier: Supplier<'a>,
-        (active, camera, ambient, mesh_storage, tex_storage, material_defaults,
-            mesh, material, global, light): (
+        (
+            active,
+            camera,
+            ambient,
+            mesh_storage,
+            tex_storage,
+            material_defaults,
+            mesh,
+            material,
+            global,
+            light,
+        ): (
             Option<Fetch<'a, ActiveCamera>>,
             ReadStorage<'a, Camera>,
             Fetch<'a, AmbientColor>,
@@ -108,7 +118,7 @@ where
             ReadStorage<'a, Transform>,
             ReadStorage<'a, Light>,
         ),
-) -> DrawPbmApply<'a, V>{
+    ) -> DrawPbmApply<'a, V> {
         DrawPbmApply {
             active,
             camera,

--- a/amethyst_renderer/src/pass/pbm/interleaved.rs
+++ b/amethyst_renderer/src/pass/pbm/interleaved.rs
@@ -5,7 +5,7 @@ use std::mem;
 
 use amethyst_assets::AssetStorage;
 use amethyst_core::transform::Transform;
-use cgmath::{Matrix4, One, SquareMatrix};
+use amethyst_core::cgmath::{Matrix4, One, SquareMatrix};
 use gfx::pso::buffer::ElemStride;
 use rayon::iter::ParallelIterator;
 use rayon::iter::internal::UnindexedConsumer;

--- a/amethyst_renderer/src/pass/pbm/separate.rs
+++ b/amethyst_renderer/src/pass/pbm/separate.rs
@@ -203,7 +203,7 @@ impl<'a> ParallelIterator for DrawPbmSeparateApply<'a> {
                             .map(|&(ref cam, ref transform)| {
                                 VertexArgs {
                                     proj: cam.proj.into(),
-                                    view: Matrix4::from(transform.0).invert().unwrap().into(),
+                                    view: transform.0.invert().unwrap().into(),
                                     model: *global.as_ref(),
                                 }
                             })

--- a/amethyst_renderer/src/pass/pbm/separate.rs
+++ b/amethyst_renderer/src/pass/pbm/separate.rs
@@ -99,8 +99,18 @@ impl Pass for DrawPbmSeparate {
     fn apply<'a, 'b: 'a>(
         &'a mut self,
         supplier: Supplier<'a>,
-        (active, camera, ambient, mesh_storage, tex_storage, material_defaults,
-            mesh, material, global, light): (
+        (
+            active,
+            camera,
+            ambient,
+            mesh_storage,
+            tex_storage,
+            material_defaults,
+            mesh,
+            material,
+            global,
+            light,
+        ): (
             Option<Fetch<'a, ActiveCamera>>,
             ReadStorage<'a, Camera>,
             Fetch<'a, AmbientColor>,
@@ -112,7 +122,7 @@ impl Pass for DrawPbmSeparate {
             ReadStorage<'a, Transform>,
             ReadStorage<'a, Light>,
         ),
-) -> DrawPbmSeparateApply<'a>{
+    ) -> DrawPbmSeparateApply<'a> {
         DrawPbmSeparateApply {
             active,
             camera,

--- a/amethyst_renderer/src/pass/pbm/separate.rs
+++ b/amethyst_renderer/src/pass/pbm/separate.rs
@@ -4,7 +4,7 @@ use std::mem;
 
 use amethyst_assets::AssetStorage;
 use amethyst_core::transform::Transform;
-use cgmath::{Matrix4, One, SquareMatrix};
+use amethyst_core::cgmath::{Matrix4, One, SquareMatrix};
 use gfx::pso::buffer::ElemStride;
 use rayon::iter::ParallelIterator;
 use rayon::iter::internal::UnindexedConsumer;

--- a/amethyst_renderer/src/pass/shaded/interleaved.rs
+++ b/amethyst_renderer/src/pass/shaded/interleaved.rs
@@ -5,7 +5,7 @@ use std::mem;
 
 use amethyst_assets::AssetStorage;
 use amethyst_core::transform::Transform;
-use cgmath::{Matrix4, One, SquareMatrix};
+use amethyst_core::cgmath::{Matrix4, One, SquareMatrix};
 use gfx::pso::buffer::ElemStride;
 use rayon::iter::ParallelIterator;
 use rayon::iter::internal::UnindexedConsumer;

--- a/amethyst_renderer/src/pass/shaded/interleaved.rs
+++ b/amethyst_renderer/src/pass/shaded/interleaved.rs
@@ -192,7 +192,7 @@ where
                             .map(|&(ref cam, ref transform)| {
                                 VertexArgs {
                                     proj: cam.proj.into(),
-                                    view: Matrix4::from(transform.0).invert().unwrap().into(),
+                                    view: transform.0.invert().unwrap().into(),
                                     model: *global.as_ref(),
                                 }
                             })

--- a/amethyst_renderer/src/pass/shaded/interleaved.rs
+++ b/amethyst_renderer/src/pass/shaded/interleaved.rs
@@ -91,8 +91,18 @@ where
     fn apply<'a, 'b: 'a>(
         &'a mut self,
         supplier: Supplier<'a>,
-        (active,camera, ambient, mesh_storage, tex_storage, material_defaults,
-            mesh, material, global, light): (
+        (
+            active,
+            camera,
+            ambient,
+            mesh_storage,
+            tex_storage,
+            material_defaults,
+            mesh,
+            material,
+            global,
+            light,
+        ): (
             Option<Fetch<'a, ActiveCamera>>,
             ReadStorage<'a, Camera>,
             Fetch<'a, AmbientColor>,
@@ -104,7 +114,7 @@ where
             ReadStorage<'a, Transform>,
             ReadStorage<'a, Light>,
         ),
-) -> DrawShadedApply<'a, V>{
+    ) -> DrawShadedApply<'a, V> {
         DrawShadedApply {
             active,
             camera,

--- a/amethyst_renderer/src/pass/shaded/separate.rs
+++ b/amethyst_renderer/src/pass/shaded/separate.rs
@@ -190,7 +190,7 @@ impl<'a> ParallelIterator for DrawShadedSeparateApply<'a> {
                             .map(|&(ref cam, ref transform)| {
                                 VertexArgs {
                                     proj: cam.proj.into(),
-                                    view: Matrix4::from(transform.0).invert().unwrap().into(),
+                                    view: transform.0.invert().unwrap().into(),
                                     model: *global.as_ref(),
                                 }
                             })

--- a/amethyst_renderer/src/pass/shaded/separate.rs
+++ b/amethyst_renderer/src/pass/shaded/separate.rs
@@ -4,7 +4,7 @@ use std::mem;
 
 use amethyst_assets::AssetStorage;
 use amethyst_core::transform::Transform;
-use cgmath::{Matrix4, One, SquareMatrix};
+use amethyst_core::cgmath::{Matrix4, One, SquareMatrix};
 use gfx::pso::buffer::ElemStride;
 use rayon::iter::ParallelIterator;
 use rayon::iter::internal::UnindexedConsumer;

--- a/amethyst_renderer/src/pass/shaded/separate.rs
+++ b/amethyst_renderer/src/pass/shaded/separate.rs
@@ -87,8 +87,18 @@ impl Pass for DrawShadedSeparate {
     fn apply<'a, 'b: 'a>(
         &'a mut self,
         supplier: Supplier<'a>,
-        (active, camera, ambient, mesh_storage, tex_storage, material_defaults,
-            mesh, material, global, light): (
+        (
+            active,
+            camera,
+            ambient,
+            mesh_storage,
+            tex_storage,
+            material_defaults,
+            mesh,
+            material,
+            global,
+            light,
+        ): (
             Option<Fetch<'a, ActiveCamera>>,
             ReadStorage<'a, Camera>,
             Fetch<'a, AmbientColor>,
@@ -100,7 +110,7 @@ impl Pass for DrawShadedSeparate {
             ReadStorage<'a, Transform>,
             ReadStorage<'a, Light>,
         ),
-) -> DrawShadedSeparateApply<'a>{
+    ) -> DrawShadedSeparateApply<'a> {
         DrawShadedSeparateApply {
             active,
             camera,

--- a/examples/02_sphere/main.rs
+++ b/examples/02_sphere/main.rs
@@ -58,10 +58,7 @@ fn run() -> Result<(), amethyst::Error> {
         env!("CARGO_MANIFEST_DIR")
     );
 
-    let resources = format!(
-        "{}/examples/assets/",
-        env!("CARGO_MANIFEST_DIR")
-    );
+    let resources = format!("{}/examples/assets/", env!("CARGO_MANIFEST_DIR"));
 
     let pipe = Pipeline::build().with_stage(
         Stage::with_backbuffer()

--- a/examples/02_sphere/main.rs
+++ b/examples/02_sphere/main.rs
@@ -1,7 +1,6 @@
 //! Displays a shaded sphere to the user.
 
 extern crate amethyst;
-extern crate cgmath;
 extern crate genmesh;
 
 use amethyst::assets::Loader;
@@ -11,8 +10,8 @@ use amethyst::prelude::*;
 use amethyst::renderer::{AmbientColor, Camera, DisplayConfig, DrawShaded, Event, KeyboardInput,
                          Light, Mesh, Pipeline, PointLight, PosNormTex, Projection, RenderBundle,
                          RenderSystem, Rgba, Stage, VirtualKeyCode, WindowEvent};
-use cgmath::{Deg, Vector3};
-use cgmath::prelude::InnerSpace;
+use amethyst::core::cgmath::{Deg, Vector3};
+use amethyst::core::cgmath::prelude::InnerSpace;
 use genmesh::{MapToVertices, Triangulate, Vertices};
 use genmesh::generators::SphereUV;
 
@@ -154,7 +153,7 @@ fn initialise_lights(world: &mut World) {
 
 /// This function initialises a camera and adds it to the world.
 fn initialise_camera(world: &mut World) {
-    use cgmath::Matrix4;
+    use amethyst::core::cgmath::Matrix4;
     let transform =
         Matrix4::from_translation([0.0, 0.0, -4.0].into()) * Matrix4::from_angle_y(Deg(180.));
     world

--- a/examples/03_renderable/main.rs
+++ b/examples/03_renderable/main.rs
@@ -4,11 +4,11 @@
 //! TODO: Rewrite for new renderer.
 
 extern crate amethyst;
-extern crate cgmath;
 
 use amethyst::{Application, Error, State, Trans};
 use amethyst::assets::{HotReloadBundle, Loader};
 use amethyst::config::Config;
+use amethyst::core::cgmath::{Array, Deg, Euler, Quaternion, Rad, Rotation, Rotation3, Vector3};
 use amethyst::core::timing::Time;
 use amethyst::core::transform::{LocalTransform, Transform, TransformBundle};
 use amethyst::ecs::{Fetch, FetchMut, Join, ReadStorage, System, World, WriteStorage};
@@ -18,7 +18,6 @@ use amethyst::renderer::{AmbientColor, Camera, DirectionalLight, DisplayConfig a
                          MaterialDefaults, MeshHandle, ObjFormat, Pipeline, PngFormat, PointLight,
                          PosNormTex, Projection, RenderBundle, RenderSystem, Rgba, Stage,
                          VirtualKeyCode, WindowEvent};
-use cgmath::{Deg, EuclideanSpace, Euler, Point3, Quaternion, Rad, Rotation, Rotation3, Vector3};
 
 struct DemoState {
     light_angle: f32,
@@ -57,7 +56,7 @@ impl<'a> System<'a> for ExampleSystem {
         for (_, transform) in (&camera, &mut transforms).join() {
             // rotate the camera, using the origin as a pivot point
             transform.translation = delta_rot
-                .rotate_point(Point3::from_vec(transform.translation)).to_vec();
+                .rotate_vector(transform.translation);
             // add the delta rotation for the frame to the total rotation (quaternion multiplication
             // is the same as rotational addition)
             transform.rotation = (delta_rot * Quaternion::from(transform.rotation)).into();
@@ -145,7 +144,7 @@ impl State for Example {
 
         // Create base rectangle as floor
         let mut trans = LocalTransform::default();
-        trans.scale = [10.0; 3].into();
+        trans.scale = Vector3::from_value(10.);
 
         engine
             .world

--- a/examples/03_renderable/main.rs
+++ b/examples/03_renderable/main.rs
@@ -18,7 +18,7 @@ use amethyst::renderer::{AmbientColor, Camera, DirectionalLight, DisplayConfig a
                          MaterialDefaults, MeshHandle, ObjFormat, Pipeline, PngFormat, PointLight,
                          PosNormTex, Projection, RenderBundle, RenderSystem, Rgba, Stage,
                          VirtualKeyCode, WindowEvent};
-use cgmath::{Deg, Euler, Point3, Quaternion, Rad, Rotation, Rotation3};
+use cgmath::{Deg, EuclideanSpace, Euler, Point3, Quaternion, Rad, Rotation, Rotation3, Vector3};
 
 struct DemoState {
     light_angle: f32,
@@ -52,12 +52,12 @@ impl<'a> System<'a> for ExampleSystem {
         state.light_angle += light_angular_velocity * time.delta_seconds();
         state.camera_angle += camera_angular_velocity * time.delta_seconds();
 
-        let delta_rot = Quaternion::from_angle_z(Rad(camera_angular_velocity * time.delta_seconds()));
+        let delta_rot =
+            Quaternion::from_angle_z(Rad(camera_angular_velocity * time.delta_seconds()));
         for (_, transform) in (&camera, &mut transforms).join() {
             // rotate the camera, using the origin as a pivot point
             transform.translation = delta_rot
-                .rotate_point(Point3::from(transform.translation))
-                .into();
+                .rotate_point(Point3::from_vec(transform.translation)).to_vec();
             // add the delta rotation for the frame to the total rotation (quaternion multiplication
             // is the same as rotational addition)
             transform.rotation = (delta_rot * Quaternion::from(transform.rotation)).into();
@@ -91,7 +91,7 @@ impl State for Example {
         for mesh in vec![assets.lid.clone(), assets.teapot.clone()] {
             let mut trans = LocalTransform::default();
             trans.rotation = Quaternion::from(Euler::new(Deg(90.0), Deg(-90.0), Deg(0.0))).into();
-            trans.translation = Point3::new(5.0, 5.0, 0.0);
+            trans.translation = Vector3::new(5.0, 5.0, 0.0);
 
             engine
                 .world
@@ -105,7 +105,7 @@ impl State for Example {
 
         // Add cube to scene
         let mut trans = LocalTransform::default();
-        trans.translation = Point3::new(5.0, -5.0, 2.0);
+        trans.translation = Vector3::new(5.0, -5.0, 2.0);
         trans.scale = [2.0; 3].into();
 
         engine
@@ -119,7 +119,7 @@ impl State for Example {
 
         // Add cone to scene
         let mut trans = LocalTransform::default();
-        trans.translation = Point3::new(-5.0, 5.0, 0.0);
+        trans.translation = Vector3::new(-5.0, 5.0, 0.0);
         trans.scale = [2.0; 3].into();
 
         engine
@@ -133,7 +133,7 @@ impl State for Example {
 
         // Add custom cube object to scene
         let mut trans = LocalTransform::default();
-        trans.translation = Point3::new(-5.0, -5.0, 1.0);
+        trans.translation = Vector3::new(-5.0, -5.0, 1.0);
         engine
             .world
             .create_entity()
@@ -377,7 +377,7 @@ fn run() -> Result<(), Error> {
 
 fn initialise_camera(world: &mut World) {
     let mut local = LocalTransform::default();
-    local.translation = Point3::new(0., -20., 10.);
+    local.translation = Vector3::new(0., -20., 10.);
     local.rotation = Quaternion::from_angle_x(Deg(75.)).into();
     world
         .create_entity()

--- a/examples/03_renderable/main.rs
+++ b/examples/03_renderable/main.rs
@@ -91,7 +91,7 @@ impl State for Example {
         for mesh in vec![assets.lid.clone(), assets.teapot.clone()] {
             let mut trans = LocalTransform::default();
             trans.rotation = Quaternion::from(Euler::new(Deg(90.0), Deg(-90.0), Deg(0.0))).into();
-            trans.translation = [5.0, 5.0, 0.0];
+            trans.translation = Point3::new(5.0, 5.0, 0.0);
 
             engine
                 .world
@@ -105,8 +105,8 @@ impl State for Example {
 
         // Add cube to scene
         let mut trans = LocalTransform::default();
-        trans.translation = [5.0, -5.0, 2.0];
-        trans.scale = [2.0; 3];
+        trans.translation = Point3::new(5.0, -5.0, 2.0);
+        trans.scale = [2.0; 3].into();
 
         engine
             .world
@@ -119,8 +119,8 @@ impl State for Example {
 
         // Add cone to scene
         let mut trans = LocalTransform::default();
-        trans.translation = [-5.0, 5.0, 0.0];
-        trans.scale = [2.0; 3];
+        trans.translation = Point3::new(-5.0, 5.0, 0.0);
+        trans.scale = [2.0; 3].into();
 
         engine
             .world
@@ -133,7 +133,7 @@ impl State for Example {
 
         // Add custom cube object to scene
         let mut trans = LocalTransform::default();
-        trans.translation = [-5.0, -5.0, 1.0];
+        trans.translation = Point3::new(-5.0, -5.0, 1.0);
         engine
             .world
             .create_entity()
@@ -145,7 +145,7 @@ impl State for Example {
 
         // Create base rectangle as floor
         let mut trans = LocalTransform::default();
-        trans.scale = [10.0; 3];
+        trans.scale = [10.0; 3].into();
 
         engine
             .world
@@ -167,7 +167,7 @@ impl State for Example {
 
         let light: Light = DirectionalLight {
             color: [0.2; 4].into(),
-            direction: [-1.0; 3].into(),
+            direction: [-1.0; 3],
         }.into();
 
         engine.world.create_entity().with(light).build();
@@ -377,7 +377,7 @@ fn run() -> Result<(), Error> {
 
 fn initialise_camera(world: &mut World) {
     let mut local = LocalTransform::default();
-    local.translation = [0., -20., 10.];
+    local.translation = Point3::new(0., -20., 10.);
     local.rotation = Quaternion::from_angle_x(Deg(75.)).into();
     world
         .create_entity()

--- a/examples/04_pong/main.rs
+++ b/examples/04_pong/main.rs
@@ -1,7 +1,6 @@
 //! TODO: Rewrite for new renderer.
 
 extern crate amethyst;
-extern crate cgmath;
 
 mod pong;
 mod systems;

--- a/examples/04_pong/pong.rs
+++ b/examples/04_pong/pong.rs
@@ -7,7 +7,7 @@ use amethyst::prelude::*;
 use amethyst::renderer::{Camera, Event, KeyboardInput, Material, MeshHandle, PosTex, Projection,
                          VirtualKeyCode, WindowEvent, WindowMessages};
 
-use cgmath::Point3;
+use cgmath::Vector3;
 
 pub struct Pong;
 
@@ -80,8 +80,8 @@ fn initialise_paddles(world: &mut World) {
 
     // Correctly position the paddles.
     let y = (ARENA_HEIGHT - PADDLE_HEIGHT) / 2.0;
-    left_transform.translation = Point3::new(0.0, y, 0.0);
-    right_transform.translation = Point3::new(ARENA_WIDTH - PADDLE_WIDTH, y, 0.0);
+    left_transform.translation = Vector3::new(0.0, y, 0.0);
+    right_transform.translation = Vector3::new(ARENA_WIDTH - PADDLE_WIDTH, y, 0.0);
 
     // Create the mesh and the material needed.
     let mesh = create_mesh(
@@ -130,7 +130,7 @@ fn initialise_balls(world: &mut World) {
     let mesh = create_mesh(world, generate_circle_vertices(BALL_RADIUS, 16));
     let material = create_colour_material(world, BALL_COLOUR);
     let mut local_transform = LocalTransform::default();
-    local_transform.translation = Point3::new(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
+    local_transform.translation = Vector3::new(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
 
     world
         .create_entity()

--- a/examples/04_pong/pong.rs
+++ b/examples/04_pong/pong.rs
@@ -2,12 +2,11 @@ use {ARENA_HEIGHT, ARENA_WIDTH};
 use {Ball, Paddle, Side};
 use amethyst::assets::Loader;
 use amethyst::core::transform::{LocalTransform, Transform};
+use amethyst::core::cgmath::Vector3;
 use amethyst::ecs::World;
 use amethyst::prelude::*;
 use amethyst::renderer::{Camera, Event, KeyboardInput, Material, MeshHandle, PosTex, Projection,
                          VirtualKeyCode, WindowEvent, WindowMessages};
-
-use cgmath::Vector3;
 
 pub struct Pong;
 
@@ -43,7 +42,7 @@ impl State for Pong {
 
 /// Initialise the camera.
 fn initialise_camera(world: &mut World) {
-    use cgmath::{Matrix4, Vector3};
+    use amethyst::core::cgmath::{Matrix4, Vector3};
     world
         .create_entity()
         .with(Camera::from(Projection::orthographic(

--- a/examples/04_pong/pong.rs
+++ b/examples/04_pong/pong.rs
@@ -7,6 +7,8 @@ use amethyst::prelude::*;
 use amethyst::renderer::{Camera, Event, KeyboardInput, Material, MeshHandle, PosTex, Projection,
                          VirtualKeyCode, WindowEvent, WindowMessages};
 
+use cgmath::Point3;
+
 pub struct Pong;
 
 impl State for Pong {
@@ -78,8 +80,8 @@ fn initialise_paddles(world: &mut World) {
 
     // Correctly position the paddles.
     let y = (ARENA_HEIGHT - PADDLE_HEIGHT) / 2.0;
-    left_transform.translation = [0.0, y, 0.0];
-    right_transform.translation = [ARENA_WIDTH - PADDLE_WIDTH, y, 0.0];
+    left_transform.translation = Point3::new(0.0, y, 0.0);
+    right_transform.translation = Point3::new(ARENA_WIDTH - PADDLE_WIDTH, y, 0.0);
 
     // Create the mesh and the material needed.
     let mesh = create_mesh(
@@ -128,7 +130,7 @@ fn initialise_balls(world: &mut World) {
     let mesh = create_mesh(world, generate_circle_vertices(BALL_RADIUS, 16));
     let material = create_colour_material(world, BALL_COLOUR);
     let mut local_transform = LocalTransform::default();
-    local_transform.translation = [ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0];
+    local_transform.translation = Point3::new(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
 
     world
         .create_entity()

--- a/examples/04_pong/systems/paddle.rs
+++ b/examples/04_pong/systems/paddle.rs
@@ -29,7 +29,8 @@ impl<'s> System<'s> for PaddleSystem {
 
             if let Some(movement) = opt_movement {
                 use ARENA_HEIGHT;
-                transform.translation[1] += paddle.velocity * time.delta_seconds() * movement as f32;
+                transform.translation[1] +=
+                    paddle.velocity * time.delta_seconds() * movement as f32;
 
                 // We make sure the paddle remains in the arena.
                 transform.translation[1] = transform.translation[1]

--- a/examples/05_assets/main.rs
+++ b/examples/05_assets/main.rs
@@ -2,12 +2,12 @@
 // TODO: Add asset loader directory store for the meshes.
 
 extern crate amethyst;
-extern crate cgmath;
 extern crate rayon;
 
 use amethyst::{Application, Error, State, Trans};
 use amethyst::assets::{BoxedErr, Loader, SimpleFormat};
 use amethyst::config::Config;
+use amethyst::core::cgmath::{Array, Vector3};
 use amethyst::core::transform::{LocalTransform, Transform, TransformBundle};
 use amethyst::ecs::World;
 use amethyst::input::InputBundle;
@@ -17,7 +17,7 @@ use amethyst::renderer::{Camera, DisplayConfig as DisplayConfig, DrawShaded, Eve
                          PosNormTex, Projection, RenderBundle, RenderSystem, Rgba, Stage,
                          VirtualKeyCode, WindowEvent};
 
-use cgmath::Vector3;
+
 
 #[derive(Clone)]
 struct Custom;
@@ -90,7 +90,7 @@ impl State for AssetsExample {
 
         let mut trans = LocalTransform::default();
         trans.translation = Vector3::new(-5.0, 0.0, 0.0);
-        trans.scale = [2.0; 3].into();
+        trans.scale = Vector3::from_value(2.);
         engine
             .world
             .create_entity()
@@ -163,7 +163,7 @@ fn run() -> Result<(), Error> {
 }
 
 fn initialise_camera(world: &mut World) {
-    use cgmath::{Deg, Matrix4};
+    use amethyst::core::cgmath::{Deg, Matrix4};
     let transform =
         Matrix4::from_translation([0., -20., 10.].into()) * Matrix4::from_angle_x(Deg(75.96));
     world

--- a/examples/05_assets/main.rs
+++ b/examples/05_assets/main.rs
@@ -17,6 +17,8 @@ use amethyst::renderer::{Camera, DisplayConfig as DisplayConfig, DrawShaded, Eve
                          PosNormTex, Projection, RenderBundle, RenderSystem, Rgba, Stage,
                          VirtualKeyCode, WindowEvent};
 
+use cgmath::Point3;
+
 #[derive(Clone)]
 struct Custom;
 
@@ -87,8 +89,8 @@ impl State for AssetsExample {
         };
 
         let mut trans = LocalTransform::default();
-        trans.translation = [-5.0, 0.0, 0.0];
-        trans.scale = [2.0, 2.0, 2.0];
+        trans.translation = Point3::new(-5.0, 0.0, 0.0);
+        trans.scale = [2.0; 3].into();
         engine
             .world
             .create_entity()

--- a/examples/05_assets/main.rs
+++ b/examples/05_assets/main.rs
@@ -17,7 +17,7 @@ use amethyst::renderer::{Camera, DisplayConfig as DisplayConfig, DrawShaded, Eve
                          PosNormTex, Projection, RenderBundle, RenderSystem, Rgba, Stage,
                          VirtualKeyCode, WindowEvent};
 
-use cgmath::Point3;
+use cgmath::Vector3;
 
 #[derive(Clone)]
 struct Custom;
@@ -89,7 +89,7 @@ impl State for AssetsExample {
         };
 
         let mut trans = LocalTransform::default();
-        trans.translation = Point3::new(-5.0, 0.0, 0.0);
+        trans.translation = Vector3::new(-5.0, 0.0, 0.0);
         trans.scale = [2.0; 3].into();
         engine
             .world

--- a/examples/06_material/main.rs
+++ b/examples/06_material/main.rs
@@ -1,15 +1,13 @@
 //! Displays spheres with physically based materials.
 
 extern crate amethyst;
-extern crate cgmath;
 extern crate genmesh;
 
 use amethyst::assets::Loader;
 use amethyst::core::transform::Transform;
 use amethyst::prelude::*;
 use amethyst::renderer::*;
-use cgmath::{Deg, Matrix4, Vector3};
-use cgmath::prelude::InnerSpace;
+use amethyst::core::cgmath::{Deg, InnerSpace, Matrix4, Vector3};
 use genmesh::{MapToVertices, Triangulate, Vertices};
 use genmesh::generators::SphereUV;
 

--- a/examples/06_material/main.rs
+++ b/examples/06_material/main.rs
@@ -128,10 +128,7 @@ fn run() -> Result<(), amethyst::Error> {
     );
     let config = DisplayConfig::load(&path);
 
-    let resources = format!(
-        "{}/examples/assets/",
-        env!("CARGO_MANIFEST_DIR")
-    );
+    let resources = format!("{}/examples/assets/", env!("CARGO_MANIFEST_DIR"));
 
     let pipe = Pipeline::build().with_stage(
         Stage::with_backbuffer()

--- a/examples/07_separate_sphere/main.rs
+++ b/examples/07_separate_sphere/main.rs
@@ -57,10 +57,7 @@ fn run() -> Result<(), amethyst::Error> {
         env!("CARGO_MANIFEST_DIR")
     );
 
-    let resources = format!(
-        "{}/examples/assets/",
-        env!("CARGO_MANIFEST_DIR")
-    );
+    let resources = format!("{}/examples/assets/", env!("CARGO_MANIFEST_DIR"));
 
     let pipe = Pipeline::build().with_stage(
         Stage::with_backbuffer()

--- a/examples/07_separate_sphere/main.rs
+++ b/examples/07_separate_sphere/main.rs
@@ -1,7 +1,6 @@
 //! Displays a shaded sphere to the user.
 
 extern crate amethyst;
-extern crate cgmath;
 extern crate genmesh;
 
 use amethyst::assets::Loader;
@@ -9,8 +8,7 @@ use amethyst::core::transform::Transform;
 use amethyst::ecs::World;
 use amethyst::prelude::*;
 use amethyst::renderer::*;
-use cgmath::{Deg, Vector3};
-use cgmath::prelude::InnerSpace;
+use amethyst::core::cgmath::{Deg, InnerSpace, Vector3};
 use genmesh::{MapToVertices, Triangulate, Vertices};
 use genmesh::generators::SphereUV;
 
@@ -165,7 +163,7 @@ fn initialise_lights(world: &mut World) {
 
 /// This function initialises a camera and adds it to the world.
 fn initialise_camera(world: &mut World) {
-    use cgmath::Matrix4;
+    use amethyst::core::cgmath::Matrix4;
     let transform =
         Matrix4::from_translation([0.0, 0.0, -4.0].into()) * Matrix4::from_angle_y(Deg(180.));
     world

--- a/examples/08_gltf/main.rs
+++ b/examples/08_gltf/main.rs
@@ -9,7 +9,7 @@ use amethyst::core::transform::{LocalTransform, Transform, TransformBundle};
 use amethyst_gltf::{GltfSceneAsset, GltfSceneFormat, GltfSceneLoaderSystem, GltfSceneOptions};
 use amethyst::prelude::*;
 use amethyst::renderer::*;
-use cgmath::{Deg, Quaternion, Rotation3};
+use cgmath::{Deg, Point3, Quaternion, Rotation3};
 
 struct Example;
 
@@ -58,7 +58,7 @@ impl State for Example {
         println!("Put camera");
 
         let mut camera_transform = LocalTransform::default();
-        camera_transform.translation = [-2.0, 2.0, 2.0];
+        camera_transform.translation = Point3::new(-2.0, 2.0, 2.0);
         let camera_orientation =
             Quaternion::from_angle_y(Deg(-45.)) * Quaternion::from_angle_x(Deg(-35.));
         camera_transform.rotation = camera_orientation.into();

--- a/examples/08_gltf/main.rs
+++ b/examples/08_gltf/main.rs
@@ -2,14 +2,13 @@
 
 extern crate amethyst;
 extern crate amethyst_gltf;
-extern crate cgmath;
 
 use amethyst::assets::{AssetStorage, Handle, Loader};
+use amethyst::core::cgmath::{Deg, Quaternion, Rotation3, Vector3};
 use amethyst::core::transform::{LocalTransform, Transform, TransformBundle};
 use amethyst_gltf::{GltfSceneAsset, GltfSceneFormat, GltfSceneLoaderSystem, GltfSceneOptions};
 use amethyst::prelude::*;
 use amethyst::renderer::*;
-use cgmath::{Deg, Quaternion, Rotation3, Vector3};
 
 struct Example;
 

--- a/examples/08_gltf/main.rs
+++ b/examples/08_gltf/main.rs
@@ -9,7 +9,7 @@ use amethyst::core::transform::{LocalTransform, Transform, TransformBundle};
 use amethyst_gltf::{GltfSceneAsset, GltfSceneFormat, GltfSceneLoaderSystem, GltfSceneOptions};
 use amethyst::prelude::*;
 use amethyst::renderer::*;
-use cgmath::{Deg, Point3, Quaternion, Rotation3};
+use cgmath::{Deg, Quaternion, Rotation3, Vector3};
 
 struct Example;
 
@@ -58,7 +58,7 @@ impl State for Example {
         println!("Put camera");
 
         let mut camera_transform = LocalTransform::default();
-        camera_transform.translation = Point3::new(-2.0, 2.0, 2.0);
+        camera_transform.translation = Vector3::new(-2.0, 2.0, 2.0);
         let camera_orientation =
             Quaternion::from_angle_y(Deg(-45.)) * Quaternion::from_angle_x(Deg(-35.));
         camera_transform.rotation = camera_orientation.into();

--- a/src/app.rs
+++ b/src/app.rs
@@ -157,7 +157,6 @@ impl<'a, 'b> Application<'a, 'b> {
 
     /// Advances the game world by one tick.
     fn advance_frame(&mut self) {
-
         {
             let engine = &mut self.engine;
             let states = &mut self.states;
@@ -195,7 +194,10 @@ impl<'a, 'b> Application<'a, 'b> {
             profile_scope!("fixed_update");
             if do_fixed {
                 self.states.fixed_update(&mut self.engine);
-                self.engine.world.write_resource::<Time>().finish_fixed_update();
+                self.engine
+                    .world
+                    .write_resource::<Time>()
+                    .finish_fixed_update();
             }
 
             #[cfg(feature = "profiler")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ pub extern crate amethyst_core as core;
 pub extern crate amethyst_input as input;
 pub extern crate amethyst_renderer as renderer;
 pub extern crate amethyst_utils as utils;
+pub extern crate cgmath;
 pub extern crate shred;
 pub extern crate shrev;
 pub extern crate specs as ecs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,6 @@ pub extern crate amethyst_core as core;
 pub extern crate amethyst_input as input;
 pub extern crate amethyst_renderer as renderer;
 pub extern crate amethyst_utils as utils;
-pub extern crate cgmath;
 pub extern crate shred;
 pub extern crate shrev;
 pub extern crate specs as ecs;


### PR DESCRIPTION
This upgrades us to cgmath 0.15, uses it where appropriate, and enables the mint feature for it.

You may have noticed that the renderer actually lost cgmath types in this PR, this was a necessary sacrifice to upgrade to 0.15. 0.15 is the only version released with mint support.  Our current gfx version uses cgmath 0.14 so the gfx trait implementations were not compatible with cgmath 0.15.

Closes #452
Closes #200 
Closes #236
