### PR TITLE
Improve error handling for assets

### DIFF
--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -23,6 +23,7 @@ travis-ci = { repository = "amethyst/amethyst" }
 amethyst_core = { path = "../amethyst_core", version = "0.1" }
 crossbeam = "0.3.0"
 derivative = "1.0"
+error-chain = "0.11"
 fnv = "1"
 hibitset = "0.3.1"
 log = "0.3.8"

--- a/amethyst_assets/examples/hl.rs
+++ b/amethyst_assets/examples/hl.rs
@@ -89,7 +89,7 @@ impl SimpleFormat<MeshAsset> for Ron {
         use ron::de::from_str;
         use std::str::from_utf8;
 
-        let s = from_utf8(&bytes).chain_err(|| "Bytes are invalid UTF-8")?;
+        let s = from_utf8(&bytes)?;
 
         from_str(s).chain_err(|| "Failed to decode mesh file")
     }

--- a/amethyst_assets/examples/hl.rs
+++ b/amethyst_assets/examples/hl.rs
@@ -85,13 +85,13 @@ impl SimpleFormat<MeshAsset> for Ron {
 
     type Options = ();
 
-    fn import(&self, bytes: Vec<u8>, _: ()) -> Result<VertexData, BoxedErr> {
+    fn import(&self, bytes: Vec<u8>, _: ()) -> Result<VertexData> {
         use ron::de::from_str;
         use std::str::from_utf8;
 
-        let s = from_utf8(&bytes).map_err(BoxedErr::new)?;
+        let s = from_utf8(&bytes).chain_err(|| "Bytes are invalid UTF-8")?;
 
-        from_str(s).map_err(BoxedErr::new)
+        from_str(s).chain_err(|| "Failed to decode mesh file")
     }
 }
 
@@ -100,14 +100,13 @@ pub struct RenderingSystem;
 impl<'a> System<'a> for RenderingSystem {
     type SystemData = (
         FetchMut<'a, AssetStorage<MeshAsset>>,
-        Fetch<'a, Errors>,
         Fetch<'a, Time>,
         Fetch<'a, Arc<ThreadPool>>,
         Option<Fetch<'a, HotReloadStrategy>>,
         /* texture storage, transforms, .. */
     );
 
-    fn run(&mut self, (mut mesh_storage, errors, time, pool, strategy): Self::SystemData) {
+    fn run(&mut self, (mut mesh_storage, time, pool, strategy): Self::SystemData) {
         use std::ops::Deref;
 
         let strategy = strategy.as_ref().map(Deref::deref);
@@ -118,7 +117,6 @@ impl<'a> System<'a> for RenderingSystem {
 
                 Ok(MeshAsset { buffer: () })
             },
-            &errors,
             time.frame_number(),
             &**pool,
             strategy,

--- a/amethyst_assets/examples/ll.rs
+++ b/amethyst_assets/examples/ll.rs
@@ -12,7 +12,6 @@ use std::time::Duration;
 use amethyst_assets::*;
 use rayon::{Configuration, ThreadPool};
 use specs::DenseVecStorage;
-use specs::common::Errors;
 
 #[derive(Clone, Debug)]
 struct DummyAsset(String);
@@ -35,10 +34,10 @@ impl Format<DummyAsset> for DummyFormat {
         source: Arc<Source>,
         _: (),
         _create_reload: bool,
-    ) -> Result<FormatValue<DummyAsset>, BoxedErr> {
+    ) -> Result<FormatValue<DummyAsset>> {
         let dummy = from_utf8(source.load(&name)?.as_slice())
             .map(|s| s.to_owned())
-            .map_err(BoxedErr::new)?;
+            .chain_err(|| "Bytes are invalid UTF-8")?;
 
         Ok(FormatValue::data(dummy))
     }
@@ -50,7 +49,6 @@ fn main() {
     let cfg = Configuration::new().num_threads(8);
     let pool = Arc::new(ThreadPool::new(cfg).expect("Invalid config"));
 
-    let mut errors = Errors::new();
     let loader = Loader::new(&path, pool.clone());
     let mut storage = AssetStorage::new();
 
@@ -87,13 +85,10 @@ fn main() {
 
                 Ok(DummyAsset(s))
             },
-            &errors,
             frame_number,
             &*pool,
             Some(&strategy),
         );
-
-        errors.print_and_exit();
     }
 
     println!("dummy: {:?}", storage.get(&dummy));

--- a/amethyst_assets/examples/ll.rs
+++ b/amethyst_assets/examples/ll.rs
@@ -36,8 +36,7 @@ impl Format<DummyAsset> for DummyFormat {
         _create_reload: bool,
     ) -> Result<FormatValue<DummyAsset>> {
         let dummy = from_utf8(source.load(&name)?.as_slice())
-            .map(|s| s.to_owned())
-            .chain_err(|| "Bytes are invalid UTF-8")?;
+            .map(|s| s.to_owned())?;
 
         Ok(FormatValue::data(dummy))
     }

--- a/amethyst_assets/src/error.rs
+++ b/amethyst_assets/src/error.rs
@@ -1,5 +1,12 @@
+use std::str::Utf8Error;
+use std::string::FromUtf8Error;
 
 error_chain! {
+    foreign_links {
+        FromUtf8(FromUtf8Error) #[doc = "Wraps a UTF-8 error"];
+        Utf8(Utf8Error) #[doc = "Wraps a UTF-8 error"];
+    }
+
     errors {
         /// Returned if an asset with a given name failed to load.
         Asset(name: String) {

--- a/amethyst_assets/src/error.rs
+++ b/amethyst_assets/src/error.rs
@@ -1,52 +1,21 @@
-use std::error::Error;
-use std::fmt::{Display, Formatter, Result as FmtResult};
 
-use BoxedErr;
-
-/// Error type returned when loading an asset.
-/// Includes
-///
-/// * the `name` of the asset,
-/// * the `format` identifier and
-/// * and the error that occurred during loading.
-#[derive(Debug)]
-pub struct AssetError {
-    /// The specifier of the asset which failed to load
-    pub name: String,
-    /// The format identifier.
-    pub format: &'static str,
-    /// The error that's been raised.
-    pub error: BoxedErr,
-}
-
-impl AssetError {
-    pub(crate) fn new(name: String, format: &'static str, error: BoxedErr) -> Self {
-        AssetError {
-            name,
-            format,
-            error,
+error_chain! {
+    errors {
+        /// Returned if an asset with a given name failed to load.
+        Asset(name: String) {
+            description("Failed to load asset")
+            display("Failed to load asset with name {:?}", name)
         }
-    }
-}
 
-impl Display for AssetError {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        write!(
-            f,
-            "Failed to load asset {:?} of format {:?}: {}",
-            &self.name,
-            &self.format,
-            &self.error
-        )
-    }
-}
+        /// Returned if a source could not retrieve something.
+        Source {
+            description("Failed to load bytes from source")
+        }
 
-impl Error for AssetError {
-    fn description(&self) -> &str {
-        self.error.description()
-    }
-
-    fn cause(&self) -> Option<&Error> {
-        Some(&self.error)
+        /// Returned if a format failed to load the asset data.
+        Format(format: &'static str) {
+            description("Format could not load asset")
+            display("Format {:?} could not load asset", format)
+        }
     }
 }

--- a/amethyst_assets/src/lib.rs
+++ b/amethyst_assets/src/lib.rs
@@ -13,17 +13,17 @@ extern crate amethyst_core;
 extern crate crossbeam;
 #[macro_use]
 extern crate derivative;
+#[macro_use]
+extern crate error_chain;
 extern crate fnv;
 extern crate hibitset;
 extern crate parking_lot;
 extern crate rayon;
 extern crate specs;
 
-pub use specs::error::BoxedErr;
-
 pub use asset::{Asset, Format, FormatValue, SimpleFormat};
 pub use cache::Cache;
-pub use error::AssetError;
+pub use error::{Error, ErrorKind, Result, ResultExt};
 pub use loader::Loader;
 pub use progress::{Completion, Progress, ProgressCounter, Tracker};
 pub use reload::{HotReloadBundle, HotReloadStrategy, HotReloadSystem, Reload, SingleFile};

--- a/amethyst_assets/src/reload.rs
+++ b/amethyst_assets/src/reload.rs
@@ -3,10 +3,11 @@
 use std::sync::Arc;
 use std::time::Instant;
 
+use amethyst_core as core;
 use amethyst_core::{ECSBundle, Time};
 use specs::{DispatcherBuilder, Fetch, FetchMut, System, World};
 
-use {Asset, BoxedErr, Format, FormatValue, Loader, Source};
+use {Asset, Format, FormatValue, Loader, Result, Source};
 
 /// This bundle activates hot reload for the `Loader`,
 /// adds a `HotReloadStrategy` and the `HotReloadSystem`.
@@ -27,7 +28,7 @@ impl<'a, 'b> ECSBundle<'a, 'b> for HotReloadBundle {
         self,
         world: &mut World,
         dispatcher: DispatcherBuilder<'a, 'b>,
-    ) -> Result<DispatcherBuilder<'a, 'b>, BoxedErr> {
+    ) -> core::Result<DispatcherBuilder<'a, 'b>> {
         world.write_resource::<Loader>().set_hot_reload(true);
         world.add_resource(self.strategy);
 
@@ -167,7 +168,7 @@ pub trait Reload<A: Asset>: ReloadClone<A> + Send + Sync + 'static {
     /// Returns the format name.
     fn format(&self) -> &'static str;
     /// Reloads the asset.
-    fn reload(self: Box<Self>) -> Result<FormatValue<A>, BoxedErr>;
+    fn reload(self: Box<Self>) -> Result<FormatValue<A>>;
 }
 
 pub trait ReloadClone<A> {
@@ -246,7 +247,7 @@ where
         self.modified != 0 && (self.source.modified(&self.path).unwrap_or(0) > self.modified)
     }
 
-    fn reload(self: Box<Self>) -> Result<FormatValue<A>, BoxedErr> {
+    fn reload(self: Box<Self>) -> Result<FormatValue<A>> {
         let this: SingleFile<_, _> = *self;
         let SingleFile {
             format,

--- a/amethyst_assets/src/source/mod.rs
+++ b/amethyst_assets/src/source/mod.rs
@@ -1,6 +1,6 @@
 pub use self::dir::Directory;
 
-use BoxedErr;
+use Result;
 
 mod dir;
 
@@ -10,17 +10,17 @@ pub trait Source: Send + Sync + 'static {
     /// This is called to check if an asset has been modified.
     ///
     /// Returns the modification time as seconds since `UNIX_EPOCH`.
-    fn modified(&self, path: &str) -> Result<u64, BoxedErr>;
+    fn modified(&self, path: &str) -> Result<u64>;
 
     /// Loads the bytes given a path.
     ///
     /// The id should always use `/` as separator in paths.
-    fn load(&self, path: &str) -> Result<Vec<u8>, BoxedErr>;
+    fn load(&self, path: &str) -> Result<Vec<u8>>;
 
     /// Returns both the result of `load` and `modified` as a tuple.
     /// There's a default implementation which just calls both methods,
     /// but you may be able to provide a more optimized version yourself.
-    fn load_with_metadata(&self, path: &str) -> Result<(Vec<u8>, u64), BoxedErr> {
+    fn load_with_metadata(&self, path: &str) -> Result<(Vec<u8>, u64)> {
         let m = self.modified(path)?;
         let b = self.load(path)?;
 

--- a/amethyst_audio/src/formats.rs
+++ b/amethyst_audio/src/formats.rs
@@ -12,7 +12,7 @@ impl SimpleFormat<Audio> for WavFormat {
 
     type Options = ();
 
-    fn import(&self, bytes: Vec<u8>, _: ()) -> Result<AudioData, BoxedErr> {
+    fn import(&self, bytes: Vec<u8>, _: ()) -> Result<AudioData> {
         Ok(AudioData(bytes))
     }
 }
@@ -26,7 +26,7 @@ impl SimpleFormat<Audio> for OggFormat {
 
     type Options = ();
 
-    fn import(&self, bytes: Vec<u8>, _: ()) -> Result<AudioData, BoxedErr> {
+    fn import(&self, bytes: Vec<u8>, _: ()) -> Result<AudioData> {
         Ok(AudioData(bytes))
     }
 }
@@ -40,7 +40,7 @@ impl SimpleFormat<Audio> for FlacFormat {
 
     type Options = ();
 
-    fn import(&self, bytes: Vec<u8>, _: ()) -> Result<AudioData, BoxedErr> {
+    fn import(&self, bytes: Vec<u8>, _: ()) -> Result<AudioData> {
         Ok(AudioData(bytes))
     }
 }

--- a/amethyst_audio/src/source.rs
+++ b/amethyst_audio/src/source.rs
@@ -1,6 +1,6 @@
 //! Provides structures used to load audio files.
 
-use amethyst_assets::{Asset, BoxedErr, Handle};
+use amethyst_assets::{Asset, Handle, Result};
 use specs::DenseVecStorage;
 
 use formats::AudioData;
@@ -26,8 +26,8 @@ impl Asset for Source {
     type HandleStorage = DenseVecStorage<SourceHandle>;
 }
 
-impl Into<Result<Source, BoxedErr>> for AudioData {
-    fn into(self) -> Result<Source, BoxedErr> {
+impl Into<Result<Source>> for AudioData {
+    fn into(self) -> Result<Source> {
         Ok(Source { bytes: self.0 })
     }
 }

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -16,6 +16,7 @@ travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
 cgmath = { version = "0.15", features = ["serde", "mint"] }
+error-chain = "0.11"
 fnv = "1.0"
 hibitset = "0.3.2"
 rayon = "0.8"

--- a/amethyst_core/src/bundle.rs
+++ b/amethyst_core/src/bundle.rs
@@ -1,10 +1,6 @@
-use std::result::Result as StdResult;
-
 use specs::{DispatcherBuilder, World};
-use specs::error::BoxedErr;
 
-/// Bundle result type.
-pub type Result<T> = StdResult<T, BoxedErr>;
+error_chain! {}
 
 /// A bundle of ECS components, resources and systems.
 pub trait ECSBundle<'a, 'b> {

--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -1,5 +1,7 @@
 
 pub extern crate cgmath;
+#[macro_use]
+extern crate error_chain;
 extern crate fnv;
 extern crate hibitset;
 extern crate rayon;
@@ -11,7 +13,7 @@ extern crate specs;
 //#[cfg(test)]
 //extern crate quickcheck;
 
-pub use bundle::ECSBundle;
+pub use bundle::{ECSBundle, Error, ErrorKind, Result};
 pub use timing::*;
 pub use transform::*;
 

--- a/amethyst_gltf/src/format/importer.rs
+++ b/amethyst_gltf/src/format/importer.rs
@@ -4,8 +4,7 @@ use std::fmt;
 use std::path::Path;
 use std::sync::Arc;
 
-use assets::BoxedErr;
-use assets::Source as AssetSource;
+use assets::{Error as AssetError, Result as AssetResult, Source as AssetSource};
 use base64;
 use gltf;
 use gltf::Gltf;
@@ -75,7 +74,7 @@ where
     }
 }
 
-fn read_to_end<P: AsRef<Path>>(source: Arc<AssetSource>, path: P) -> Result<Vec<u8>, BoxedErr> {
+fn read_to_end<P: AsRef<Path>>(source: Arc<AssetSource>, path: P) -> AssetResult<Vec<u8>> {
     let path = path.as_ref();
     Ok(source.load(path.to_str().unwrap())?)
 }
@@ -236,13 +235,13 @@ pub enum Error {
     /// The .gltf data is invalid.
     Validation(Vec<(json::Path, validation::Error)>),
 
-    /// Load error
-    Load(BoxedErr),
+    /// Asset error
+    Asset(AssetError),
 }
 
-impl From<BoxedErr> for Error {
-    fn from(err: BoxedErr) -> Self {
-        Error::Load(err)
+impl From<AssetError> for Error {
+    fn from(err: AssetError) -> Self {
+        Error::Asset(err)
     }
 }
 
@@ -299,7 +298,7 @@ impl StdError for Error {
             Gltf(_) => "Error from gltf crate",
             MalformedJson(_) => "Malformed .gltf / .glb JSON",
             Validation(_) => "Asset failed validation tests",
-            Load(_) => "Failed loading file from source",
+            Asset(_) => "Failed loading file from source",
         }
     }
 

--- a/amethyst_gltf/src/lib.rs
+++ b/amethyst_gltf/src/lib.rs
@@ -12,7 +12,7 @@ extern crate specs;
 pub use format::GltfSceneFormat;
 pub use systems::GltfSceneLoaderSystem;
 
-use assets::{Asset, BoxedErr, Handle};
+use assets::{Asset, Error as AssetError, Handle};
 use core::transform::LocalTransform;
 use gfx::Primitive;
 use renderer::{MeshHandle, TextureData, TextureHandle, VertexBufferCombination};
@@ -96,8 +96,8 @@ pub struct GltfSceneAsset {
     pub options: GltfSceneOptions,
 }
 
-impl Into<Result<GltfSceneAsset, BoxedErr>> for GltfSceneAsset {
-    fn into(self) -> Result<GltfSceneAsset, BoxedErr> {
+impl Into<Result<GltfSceneAsset, AssetError>> for GltfSceneAsset {
+    fn into(self) -> Result<GltfSceneAsset, AssetError> {
         Ok(self)
     }
 }

--- a/amethyst_renderer/Cargo.toml
+++ b/amethyst_renderer/Cargo.toml
@@ -29,6 +29,7 @@ opengl = ["gfx_device_gl", "gfx_window_glutin", "glutin"]
 amethyst_assets = { path = "../amethyst_assets", version = "0.2.0" }
 amethyst_core = { path = "../amethyst_core", version = "0.1.0" }
 derivative = "1.0"
+error-chain = "0.11"
 fnv = "1.0"
 gfx = { version = "0.16", features = ["serialize"] }
 gfx_core = { version = "0.7", features = ["serialize"] }

--- a/amethyst_renderer/src/bundle.rs
+++ b/amethyst_renderer/src/bundle.rs
@@ -65,13 +65,13 @@ fn create_default_mat(world: &World) -> Material {
 
     let tex_storage = world.read_resource();
 
-    let albedo = loader.load_from_data(albedo, &tex_storage);
-    let emission = loader.load_from_data(emission, &tex_storage);
-    let normal = loader.load_from_data(normal, &tex_storage);
-    let metallic = loader.load_from_data(metallic, &tex_storage);
-    let roughness = loader.load_from_data(roughness, &tex_storage);
-    let ambient_occlusion = loader.load_from_data(ambient_occlusion, &tex_storage);
-    let caveat = loader.load_from_data(caveat, &tex_storage);
+    let albedo = loader.load_from_data(albedo, (), &tex_storage);
+    let emission = loader.load_from_data(emission, (), &tex_storage);
+    let normal = loader.load_from_data(normal, (), &tex_storage);
+    let metallic = loader.load_from_data(metallic, (), &tex_storage);
+    let roughness = loader.load_from_data(roughness, (), &tex_storage);
+    let ambient_occlusion = loader.load_from_data(ambient_occlusion, (), &tex_storage);
+    let caveat = loader.load_from_data(caveat, (), &tex_storage);
 
     Material {
         albedo,

--- a/amethyst_renderer/src/formats/mesh.rs
+++ b/amethyst_renderer/src/formats/mesh.rs
@@ -79,9 +79,10 @@ impl SimpleFormat<Mesh> for ObjFormat {
 
     fn import(&self, bytes: Vec<u8>, _: ()) -> Result<MeshData> {
         String::from_utf8(bytes)
-            .chain_err(|| "Bytes are invalid UTF-8")
+            .map_err(Into::into)
             .and_then(|string| {
-                parse(string).map_err(|e| Error::from(format!("In line {}: {:?}", e.line_number, e.message)))
+                parse(string)
+                    .map_err(|e| Error::from(format!("In line {}: {:?}", e.line_number, e.message)))
                     .chain_err(|| "Failed to parse OBJ")
             })
             .map(|set| from_data(set).into())

--- a/amethyst_renderer/src/lib.rs
+++ b/amethyst_renderer/src/lib.rs
@@ -13,6 +13,8 @@ extern crate amethyst_assets;
 extern crate amethyst_core;
 #[macro_use]
 extern crate derivative;
+#[macro_use]
+extern crate error_chain;
 extern crate fnv;
 extern crate gfx;
 extern crate gfx_core;
@@ -61,7 +63,7 @@ pub use color::Rgba;
 pub use config::DisplayConfig;
 pub use formats::{build_mesh_with_combo, create_mesh_asset, create_texture_asset, BmpFormat,
                   ComboMeshCreator, ImageData, ImageError, JpgFormat, MeshCreator, MeshData,
-                  ObjError, ObjFormat, PngFormat, TextureData, TextureMetadata};
+                  ObjFormat, PngFormat, TextureData, TextureMetadata};
 pub use input::{ElementState, Event, KeyboardInput, MouseButton, VirtualKeyCode, WindowEvent};
 pub use light::{DirectionalLight, Light, PointLight, SpotLight, SunLight};
 pub use mesh::{vertex_data, Mesh, MeshHandle, VertexBuffer};

--- a/amethyst_renderer/src/system.rs
+++ b/amethyst_renderer/src/system.rs
@@ -10,7 +10,6 @@ use rayon::ThreadPool;
 use shred::Resources;
 use shrev::EventChannel;
 use specs::{Fetch, FetchMut, RunNow, SystemData};
-use specs::common::Errors;
 use winit::{DeviceEvent, Event, WindowEvent};
 
 use config::DisplayConfig;
@@ -69,7 +68,7 @@ where
 
     fn do_asset_loading(
         &mut self,
-        (errors, time, pool, strategy, mut mesh_storage, mut texture_storage): AssetLoadingData,
+        (time, pool, strategy, mut mesh_storage, mut texture_storage): AssetLoadingData,
     ) {
         use std::ops::Deref;
 
@@ -77,7 +76,6 @@ where
 
         mesh_storage.process(
             |d| create_mesh_asset(d, &mut self.renderer),
-            &errors,
             time.frame_number(),
             &**pool,
             strategy,
@@ -85,7 +83,6 @@ where
 
         texture_storage.process(
             |d| create_texture_asset(d, &mut self.renderer),
-            &errors,
             time.frame_number(),
             &**pool,
             strategy,
@@ -147,7 +144,6 @@ where
 }
 
 type AssetLoadingData<'a> = (
-    Fetch<'a, Errors>,
     Fetch<'a, Time>,
     Fetch<'a, Arc<ThreadPool>>,
     Option<Fetch<'a, HotReloadStrategy>>,

--- a/examples/02_sphere/main.rs
+++ b/examples/02_sphere/main.rs
@@ -106,14 +106,14 @@ fn initialise_sphere(world: &mut World) {
         let loader = world.read_resource::<Loader>();
 
         let mesh: Handle<Mesh> =
-            loader.load_from_data(gen_sphere(32, 32).into(), &world.read_resource());
+            loader.load_from_data(gen_sphere(32, 32).into(), (), &world.read_resource());
 
         let albedo = SPHERE_COLOUR.into();
 
         let tex_storage = world.read_resource();
         let mat_defaults = world.read_resource::<MaterialDefaults>();
 
-        let albedo = loader.load_from_data(albedo, &tex_storage);
+        let albedo = loader.load_from_data(albedo, (), &tex_storage);
 
         let mat = Material {
             albedo,

--- a/examples/03_renderable/main.rs
+++ b/examples/03_renderable/main.rs
@@ -295,13 +295,13 @@ fn load_assets(world: &World) -> Assets {
     let mat_defaults = world.read_resource::<MaterialDefaults>();
     let loader = world.read_resource::<Loader>();
 
-    let red = loader.load_from_data([1.0, 0.0, 0.0, 1.0].into(), &tex_storage);
+    let red = loader.load_from_data([1.0, 0.0, 0.0, 1.0].into(), (), &tex_storage);
     let red = Material {
         albedo: red,
         ..mat_defaults.0.clone()
     };
 
-    let white = loader.load_from_data([1.0, 1.0, 1.0, 1.0].into(), &tex_storage);
+    let white = loader.load_from_data([1.0, 1.0, 1.0, 1.0].into(), (), &tex_storage);
     let white = Material {
         albedo: white,
         ..mat_defaults.0.clone()

--- a/examples/04_pong/pong.rs
+++ b/examples/04_pong/pong.rs
@@ -147,7 +147,7 @@ fn initialise_balls(world: &mut World) {
 /// Converts a vector of vertices into a mesh.
 fn create_mesh(world: &World, vertices: Vec<PosTex>) -> MeshHandle {
     let loader = world.read_resource::<Loader>();
-    loader.load_from_data(vertices.into(), &world.read_resource())
+    loader.load_from_data(vertices.into(), (), &world.read_resource())
 }
 
 /// Creates a solid material of the specified colour.
@@ -159,7 +159,7 @@ fn create_colour_material(world: &World, colour: [f32; 4]) -> Material {
     let mat_defaults = world.read_resource::<MaterialDefaults>();
     let loader = world.read_resource::<Loader>();
 
-    let albedo = loader.load_from_data(colour.into(), &world.read_resource());
+    let albedo = loader.load_from_data(colour.into(), (), &world.read_resource());
 
     Material {
         albedo,

--- a/examples/05_assets/main.rs
+++ b/examples/05_assets/main.rs
@@ -5,7 +5,7 @@ extern crate amethyst;
 extern crate rayon;
 
 use amethyst::{Application, Error, State, Trans};
-use amethyst::assets::{BoxedErr, Loader, SimpleFormat};
+use amethyst::assets::{Loader, Result as AssetResult, ResultExt, SimpleFormat};
 use amethyst::config::Config;
 use amethyst::core::cgmath::{Array, Vector3};
 use amethyst::core::transform::{LocalTransform, Transform, TransformBundle};
@@ -28,8 +28,8 @@ impl SimpleFormat<Mesh> for Custom {
     type Options = ();
 
     /// Reads the given bytes and produces asset data.
-    fn import(&self, bytes: Vec<u8>, _: ()) -> Result<MeshData, BoxedErr> {
-        let data: String = String::from_utf8(bytes).unwrap();
+    fn import(&self, bytes: Vec<u8>, _: ()) -> AssetResult<MeshData> {
+        let data: String = String::from_utf8(bytes).chain_err(|| "Bytes are invalid UTF-8")?;
 
         let trimmed: Vec<&str> = data.lines().filter(|line| line.len() >= 1).collect();
 
@@ -79,7 +79,7 @@ impl State for AssetsExample {
             let textures = &engine.world.read_resource();
 
             let mesh = loader.load("mesh/cuboid.custom", Custom, (), (), meshes);
-            let albedo = loader.load_from_data([0.0, 0.0, 1.0, 0.0].into(), textures);
+            let albedo = loader.load_from_data([0.0, 0.0, 1.0, 0.0].into(), (), textures);
             let mat = Material {
                 albedo,
                 ..mat_defaults.0.clone()

--- a/examples/05_assets/main.rs
+++ b/examples/05_assets/main.rs
@@ -29,7 +29,7 @@ impl SimpleFormat<Mesh> for Custom {
 
     /// Reads the given bytes and produces asset data.
     fn import(&self, bytes: Vec<u8>, _: ()) -> AssetResult<MeshData> {
-        let data: String = String::from_utf8(bytes).chain_err(|| "Bytes are invalid UTF-8")?;
+        let data: String = String::from_utf8(bytes)?;
 
         let trimmed: Vec<&str> = data.lines().filter(|line| line.len() >= 1).collect();
 

--- a/examples/06_material/main.rs
+++ b/examples/06_material/main.rs
@@ -25,8 +25,8 @@ impl State for Example {
 
             let meshes = &engine.world.read_resource();
             let textures = &engine.world.read_resource();
-            let mesh: MeshHandle = loader.load_from_data(verts, meshes);
-            let albedo = loader.load_from_data(albedo, textures);
+            let mesh: MeshHandle = loader.load_from_data(verts, (), meshes);
+            let albedo = loader.load_from_data(albedo, (), textures);
 
             (mesh, albedo)
         };
@@ -47,8 +47,8 @@ impl State for Example {
                     let loader = engine.world.read_resource::<Loader>();
                     let textures = &engine.world.read_resource();
 
-                    let metallic = loader.load_from_data(metallic, textures);
-                    let roughness = loader.load_from_data(roughness, textures);
+                    let metallic = loader.load_from_data(metallic, (), textures);
+                    let roughness = loader.load_from_data(roughness, (), textures);
 
                     (metallic, roughness)
                 };

--- a/examples/07_separate_sphere/main.rs
+++ b/examples/07_separate_sphere/main.rs
@@ -116,14 +116,14 @@ fn initialise_sphere(world: &mut World) {
         let loader = world.read_resource::<Loader>();
 
         let mesh: Handle<Mesh> =
-            loader.load_from_data(gen_sphere(32, 32).into(), &world.read_resource());
+            loader.load_from_data(gen_sphere(32, 32).into(), (), &world.read_resource());
 
         let albedo = SPHERE_COLOUR.into();
 
         let tex_storage = world.read_resource();
         let mat_defaults = world.read_resource::<MaterialDefaults>();
 
-        let albedo = loader.load_from_data(albedo, &tex_storage);
+        let albedo = loader.load_from_data(albedo, (), &tex_storage);
 
         let mat = Material {
             albedo,

--- a/examples/08_gltf/main.rs
+++ b/examples/08_gltf/main.rs
@@ -6,9 +6,9 @@ extern crate amethyst_gltf;
 use amethyst::assets::{AssetStorage, Handle, Loader};
 use amethyst::core::cgmath::{Deg, Quaternion, Rotation3, Vector3};
 use amethyst::core::transform::{LocalTransform, Transform, TransformBundle};
-use amethyst_gltf::{GltfSceneAsset, GltfSceneFormat, GltfSceneLoaderSystem, GltfSceneOptions};
 use amethyst::prelude::*;
 use amethyst::renderer::*;
+use amethyst_gltf::{GltfSceneAsset, GltfSceneFormat, GltfSceneLoaderSystem, GltfSceneOptions};
 
 struct Example;
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -689,7 +689,7 @@ impl<'a, 'b, T> ApplicationBuilder<'a, 'b, T> {
     {
         self.disp_builder = bundle
             .build(&mut self.world, self.disp_builder)
-            .map_err(|err| Error::System(err))?;
+            .map_err(|err| Error::Core(err))?;
         Ok(self)
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,8 +5,8 @@ use std::fmt::{Display, Formatter};
 use std::fmt::Result as FmtResult;
 use std::result::Result as StdResult;
 
+use core;
 use config::ConfigError;
-use ecs::error::BoxedErr;
 use renderer;
 
 /// Engine result type.
@@ -21,8 +21,8 @@ pub enum Error {
     // Asset(AssetError),
     /// Configuration error.
     Config(ConfigError),
-    /// System error.
-    System(BoxedErr),
+    /// Core error.
+    Core(core::Error),
 }
 
 impl StdError for Error {
@@ -30,7 +30,7 @@ impl StdError for Error {
         match *self {
             Error::Application => "Application error!",
             Error::Config(_) => "Configuration error!",
-            Error::System(_) => "System error!",
+            Error::Core(_) => "Core error!",
         }
     }
 
@@ -47,19 +47,19 @@ impl Display for Error {
         match *self {
             Error::Application => write!(fmt, "Application initialization failed!"),
             Error::Config(ref e) => write!(fmt, "Configuration loading failed: {}", e),
-            Error::System(ref e) => write!(fmt, "System creation failed: {}", e),
+            Error::Core(ref e) => write!(fmt, "System creation failed: {}", e),
         }
     }
 }
 
-impl From<BoxedErr> for Error {
-    fn from(e: BoxedErr) -> Self {
-        Error::System(e)
+impl From<core::Error> for Error {
+    fn from(e: core::Error) -> Self {
+        Error::Core(e)
     }
 }
 
 impl From<renderer::error::Error> for Error {
     fn from(err: renderer::error::Error) -> Self {
-        Error::System(BoxedErr::new(err))
+        Error::Core(core::Error::with_chain(err, "Renderer error"))
     }
 }


### PR DESCRIPTION
* Introduces error-chain for assets and core crate

## Example output

```
error: Failed to load asset with name "mesh/teapoto.obj"
caused by: Format "WAVEFRONT_OBJ" could not load asset
caused by: Failed to load bytes from source
caused by: Failed to fetch metadata for "/home/thomas/Workspace/amethyst/examples/assets/mesh/teapoto.obj"
caused by: No such file or directory (os error 2)
note: to handle the error, use a `Progress` other than `()`
```