### PR TITLE
Revert "Locking khronos_api at 1.0.1 because 1.1.0 is broken"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ amethyst_input = { path = "amethyst_input", version = "0.1" }
 amethyst_ui = { path = "amethyst_ui", version = "0.1" }
 amethyst_utils = { path = "amethyst_utils", version = "0.1" }
 derivative = "1.0"
-khronos_api = "~1.0.1"
 rayon = "0.8"
 shred = "0.5"
 shrev = "0.6"


### PR DESCRIPTION
This reverts commit 58ed3a0f132528bfb92997b411d86a8aecb2fa92.

This isn't necessary as the problem crates have been yanked.