### PR TITLE
Add rustc version to init output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ amethyst_ui = { path = "amethyst_ui", version = "0.1" }
 amethyst_utils = { path = "amethyst_utils", version = "0.1" }
 derivative = "1.0"
 rayon = "0.8"
+rustc_version = "0.2"
 shred = "0.5"
 shrev = "0.6"
 specs = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ amethyst_ui = { path = "amethyst_ui", version = "0.1" }
 amethyst_utils = { path = "amethyst_utils", version = "0.1" }
 derivative = "1.0"
 rayon = "0.8"
-rustc_version = "0.2"
+rustc_version_runtime = "0.1"
 shred = "0.5"
 shrev = "0.6"
 specs = "0.10"

--- a/src/app.rs
+++ b/src/app.rs
@@ -307,17 +307,16 @@ impl<'a, 'b, T> ApplicationBuilder<'a, 'b, T> {
 
     pub fn new<P: AsRef<Path>>(path: P, initial_state: T) -> Result<Self> {
         use bundle::AppBundle;
-        use rustc_version;
+        use rustc_version_runtime;
 
         println!("Initializing Amethyst...");
         println!("Version: {}", vergen::semver());
         println!("Platform: {}", vergen::target());
         println!("Amethyst git commit: {}", vergen::sha());
-        if let Ok(rustc_meta) = rustc_version::version_meta() {
-            println!("Rustc version: {} {:?}", rustc_meta.semver, rustc_meta.channel);
-            if let Some(hash) = rustc_meta.commit_hash {
-                println!("Rustc git commit: {}", hash);
-            }
+        let rustc_meta = rustc_version_runtime::version_meta();
+        println!("Rustc version: {} {:?}", rustc_meta.semver, rustc_meta.channel);
+        if let Some(hash) = rustc_meta.commit_hash {
+            println!("Rustc git commit: {}", hash);
         }
 
         let mut disp_builder = DispatcherBuilder::new();

--- a/src/app.rs
+++ b/src/app.rs
@@ -307,11 +307,18 @@ impl<'a, 'b, T> ApplicationBuilder<'a, 'b, T> {
 
     pub fn new<P: AsRef<Path>>(path: P, initial_state: T) -> Result<Self> {
         use bundle::AppBundle;
+        use rustc_version;
 
         println!("Initializing Amethyst...");
         println!("Version: {}", vergen::semver());
         println!("Platform: {}", vergen::target());
-        println!("Git commit: {}", vergen::sha());
+        println!("Amethyst git commit: {}", vergen::sha());
+        if let Ok(rustc_meta) = rustc_version::version_meta() {
+            println!("Rustc version: {} {:?}", rustc_meta.semver, rustc_meta.channel);
+            if let Some(hash) = rustc_meta.commit_hash {
+                println!("Rustc git commit: {}", hash);
+            }
+        }
 
         let mut disp_builder = DispatcherBuilder::new();
         let mut world = World::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ pub extern crate winit;
 #[macro_use]
 extern crate derivative;
 extern crate rayon;
+extern crate rustc_version;
 
 pub use self::app::{Application, ApplicationBuilder};
 pub use self::error::{Error, Result};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub extern crate winit;
 #[macro_use]
 extern crate derivative;
 extern crate rayon;
-extern crate rustc_version;
+extern crate rustc_version_runtime;
 
 pub use self::app::{Application, ApplicationBuilder};
 pub use self::error::{Error, Result};


### PR DESCRIPTION
With the memory layout changing in rustc soon it occurred to me that the compiler version and branch used might be critical for debugging issues in the future, so I added rustc version info to the initialization text.  Some example output looks like this:

```
Initializing Amethyst...
Version:
Platform: x86_64-pc-windows-msvc
Amethyst git commit: afa10de66d5b1e6613ed7290aa123639b76fe0fa
Rustc version: 1.21.0 Stable
Rustc git commit: 3b72af97e42989b2fe104d8edbaee123cdf7c58f
```