### PR TITLE
Add OSX to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ branches:
     - master
     - /release-.*/
 
-# Test on Linux - OSX builds take in excess of 5 hours to start as of 2017-09-19.
 os:
   - linux
+  - osx
 
 # Install ALSA development libraries before compiling on Linux.
 addons:


### PR DESCRIPTION
Travis seems to have significantly improved their OSX infrastructure, so I'd like to turn this on again.