### PR TITLE
Improve documentation for ScreenDimensions

### DIFF
--- a/amethyst_renderer/src/bundle.rs
+++ b/amethyst_renderer/src/bundle.rs
@@ -33,7 +33,7 @@ impl<'a, 'b> ECSBundle<'a, 'b> for RenderBundle {
     ) -> Result<DispatcherBuilder<'a, 'b>> {
         world.add_resource(AmbientColor(Rgba::from([0.01; 3])));
         world.add_resource(WindowMessages::new());
-        world.add_resource(ScreenDimensions::new(100, 100));
+        world.add_resource(ScreenDimensions::new(0, 0));
         world.add_resource(AssetStorage::<Mesh>::new());
         world.add_resource(AssetStorage::<Texture>::new());
         world.add_resource(Orientation::default());

--- a/amethyst_renderer/src/resources.rs
+++ b/amethyst_renderer/src/resources.rs
@@ -68,11 +68,17 @@ impl ScreenDimensions {
     }
 
     /// Returns the current width of the window.
+    ///
+    /// This is returned as a float for user convenience, as this is typically used with other
+    /// float values.  This will only ever be a positive integer though.
     pub fn width(&self) -> f32 {
         self.w
     }
 
     /// Returns the current height of the window.
+    ///
+    /// This is returned as a float for user convenience, as this is typically used with other
+    /// float values.  This will only ever be a positive integer though.
     pub fn height(&self) -> f32 {
         self.h
     }
@@ -84,6 +90,10 @@ impl ScreenDimensions {
 
     /// Updates the width and height of the screen and recomputes the aspect
     /// ratio.
+    ///
+    /// Only use this if you need to programmatically set the resolution of your game.
+    /// This resource is updated automatically by the engine when a resize occurs so you don't need
+    /// this unless you want to resize the game window.
     pub fn update(&mut self, w: u32, h: u32) {
         self.w = w as f32;
         self.h = h as f32;

--- a/amethyst_renderer/src/resources.rs
+++ b/amethyst_renderer/src/resources.rs
@@ -70,7 +70,7 @@ impl ScreenDimensions {
     /// Returns the current width of the window.
     ///
     /// This is returned as a float for user convenience, as this is typically used with other
-    /// float values.  This will only ever be a positive integer though.
+    /// float values.  This will only ever be a non-negative integer though.
     pub fn width(&self) -> f32 {
         self.w
     }
@@ -78,7 +78,7 @@ impl ScreenDimensions {
     /// Returns the current height of the window.
     ///
     /// This is returned as a float for user convenience, as this is typically used with other
-    /// float values.  This will only ever be a positive integer though.
+    /// float values.  This will only ever be a non-negative integer though.
     pub fn height(&self) -> f32 {
         self.h
     }


### PR DESCRIPTION
This pull request also additionally makes it more obvious that the first frame screen size is inaccurate.

Fixes https://github.com/amethyst/amethyst/issues/522

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/524)
<!-- Reviewable:end -->

  