### PR TITLE
Fix link to getting started chapter in book.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ See the [Getting Started][gs] chapter in the book for the full-blown "Hello,
 World!" tutorial. For the sake of brevity, you can generate an empty game
 project with `cargo` and build it. Follow along below:
 
-[gs]: https://www.amethyst.rs/book/master/html/getting_started.html
+[gs]: https://www.amethyst.rs/book/master/book/getting_started.html
 
 ## Building Documentation
 


### PR DESCRIPTION
The link to the getting started chapter in the book is currently returning a 404.  This fixes the link.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/530)
<!-- Reviewable:end -->
