### PR TITLE
Fixed broken links to documentation in manifests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["examples/*", "book/*"]
 keywords = ["game", "engine", "sdk", "amethyst"]
 categories = ["game-engines"]
 
-documentation = "https://www.amethyst.rs/doc/master/amethyst"
+documentation = "https://www.amethyst.rs/doc/master/doc/amethyst"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_animation/Cargo.toml
+++ b/amethyst_animation/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Simon Rönnberg <seamonr@gmail.com>"]
 description = "Animation support for Amethyst"
 keywords = ["game", "engine", "animation", "3d", "amethyst"]
 
-documentation = "https://www.amethyst.rs/doc/master/amethyst_animation/"
+documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_animation/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT/Apache-2.0"
 keywords = ["game", "asset", "resource", "management", "amethyst"]
 categories = ["filesystem"]
 
-documentation = "https://www.amethyst.rs/doc/master/amethyst"
+documentation = "https://www.amethyst.rs/doc/master/doc/amethyst/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_audio/Cargo.toml
+++ b/amethyst_audio/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["examples/*"]
 keywords = ["game", "engine", "audio","amethyst"]
 categories = ["audio"]
 
-documentation = "https://www.amethyst.rs/doc/master/amethyst_audio/"
+documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_audio/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_config/Cargo.toml
+++ b/amethyst_config/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Aceeri <conmcclusk@gmail.com>"]
 description = "Loading from .ron files into Rust structures with defaults to prevent hard errors."
 exclude = ["examples/*"]
 
-documentation = "https://www.amethyst.rs/doc/master/amethyst_config/"
+documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_config/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Simon Rönnberg <seamonr@gmail.com>"]
 description = "Amethyst core"
 
-documentation = "https://www.amethyst.rs/doc/master/amethyst_core/"
+documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_core/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Rhuagh <seamonr@gmail.com>"]
 description = "GLTF asset loading"
 
-documentation = "https://www.amethyst.rs/doc/master/amethyst_gltf/"
+documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_gltf/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_input/Cargo.toml
+++ b/amethyst_input/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.1"
 authors = ["Rhuagh <seamonr@gmail.com>", "Xaeroxe <kieseljake@gmail.com>"]
 description = "Input rebinding "
 
-documentation = "https://www.amethyst.rs/doc/master/amethyst_input/"
+documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_input/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_renderer/Cargo.toml
+++ b/amethyst_renderer/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["examples/*"]
 keywords = ["game", "engine", "renderer", "3d", "amethyst"]
 categories = ["rendering", "rendering::engine"]
 
-documentation = "https://www.amethyst.rs/doc/master/amethyst_renderer/"
+documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_renderer/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -6,7 +6,7 @@ description = "Amethyst UI crate"
 keywords = ["ui", "specs", "ecs", "amethyst"]
 categories = ["game-engines"]
 
-documentation = "https://www.amethyst.rs/doc/develop/doc/amethyst_ui/index.html"
+documentation = "https://www.amethyst.rs/doc/develop/doc/amethyst_ui/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 license = "MIT/Apache-2.0"

--- a/amethyst_utils/Cargo.toml
+++ b/amethyst_utils/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Simon Rönnberg <seamonr@gmail.com>"]
 description = "Amethyst utils"
 
-documentation = "https://www.amethyst.rs/doc/master/amethyst_utils/"
+documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_utils/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 


### PR DESCRIPTION
The amethyst ui  link was just changed for consistency.

The newline at the end of utils was added by rustfmt and matches the rest of the manifests, I can make that a separate commit if need be.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/534)
<!-- Reviewable:end -->
