### PR TITLE
Remove roadmap links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -343,8 +343,6 @@ Then you can hit load button and choose `thread_profile.json` file.
 
 * Amethyst
   * [Amethyst Gitter][gi] - The Amethyst project's public chat room.
-  * [Development Roadmap][dr] - See this wiki page for general ideas on what you
-    can hack on.
 * Design Inspiration
   * [Bitsquid: Behind The Scenes (2013)][bs]
   * [Flexible Rendering for Multiple Platforms (2012)][fr]
@@ -356,8 +354,6 @@ Then you can hit load button and choose `thread_profile.json` file.
   * [Rust By Example][re] - Get acquainted with Rust through a series of small
     code samples.
   * [The Rust Programming Language][rl] - The canonical online book about Rust.
-
-[dr]: https://github.com/amethyst/amethyst/wiki/Roadmap
 
 [bs]: https://www.kth.se/social/upload/5289cb3ff276542440dd668c/bitsquid-behind-the-scenes.pdf
 [fr]: http://twvideo01.ubm-us.net/o1/vault/gdc2012/slides/Programming%20Track/Persson_Tobias_Flexible_Rendering.pdf.pdf

--- a/README.md
+++ b/README.md
@@ -128,12 +128,10 @@ the [MIT License][lm] and the [Apache License 2.0][la].
 
 We are a community project that welcomes contribution from anyone. If you're
 interested in helping out, please read the [CONTRIBUTING.md][cm] file before
-getting started. Don't know what to hack on? Check our [active projects][pr],
-read our [roadmap][rm], or search though [our issue tracker][it].
+getting started. Don't know what to hack on? Check our [active projects][pr], or search though [our issue tracker][it].
 
 [cm]: CONTRIBUTING.md
 [pr]: https://github.com/amethyst/amethyst/projects
-[rm]: https://github.com/amethyst/amethyst/wiki/Roadmap
 [it]: https://github.com/amethyst/amethyst/issues
 
 Unless you explicitly state otherwise, any contribution intentionally submitted


### PR DESCRIPTION
The roadmap doesn't exist.  This PR does not have the intent of saying a roadmap is useless and we'll never have one, but until we have one these links are misleading.

Fixes #498

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/554)
<!-- Reviewable:end -->
