### PR TITLE
Lock winit to 0.10.0

### DIFF
--- a/amethyst_input/Cargo.toml
+++ b/amethyst_input/Cargo.toml
@@ -18,7 +18,7 @@ travis-ci = { repository = "amethyst/amethyst" }
 amethyst_core = { path = "../amethyst_core/", version = "0.1.0" }
 amethyst_config = { path = "../amethyst_config/", version = "0.5.0" }
 derivative = "1.0"
-winit = "0.10"
+winit = "= 0.10.0"
 fnv = "1.0"
 serde = { version = "1", features = ["serde_derive"] }
 shrev = "0.8"


### PR DESCRIPTION
0.10.1 broke semver, so we have to lock this to 0.10.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/560)
<!-- Reviewable:end -->
