### PR TITLE
[Fix] Renderable runtime crash

### DIFF
--- a/amethyst_ui/src/bundle.rs
+++ b/amethyst_ui/src/bundle.rs
@@ -14,6 +14,8 @@ use super::*;
 ///
 /// Will register all necessary components and systems needed for UI, along with any resources.
 /// The generic types A and B represent the A and B generic parameter of the InputHandler<A,B>.
+///
+/// Will fail with error 'No resource with the given id' if the InputBundle is not added.
 pub struct UiBundle<A, B> {
     _marker1: PhantomData<A>,
     _marker2: PhantomData<B>,

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -13,6 +13,7 @@ use amethyst::core::frame_limiter::FrameRateLimitStrategy;
 use amethyst::core::timing::Time;
 use amethyst::core::transform::{GlobalTransform, Transform, TransformBundle};
 use amethyst::ecs::{Entity, Fetch, FetchMut, Join, ReadStorage, System, World, WriteStorage};
+use amethyst::input::InputBundle;
 use amethyst::renderer::{AmbientColor, Camera, DirectionalLight, DisplayConfig, DrawShaded,
                          ElementState, Event, KeyboardInput, Light, Material, MaterialDefaults,
                          MeshHandle, ObjFormat, Pipeline, PngFormat, PointLight, PosNormTex,
@@ -395,6 +396,7 @@ fn run() -> Result<(), Error> {
         .with_bundle(HotReloadBundle::default())?
         .with_bundle(FPSCounterBundle::default())?
         .with_bundle(RenderBundle::new(pipeline_builder, Some(display_config)))?
+        .with_bundle(InputBundle::<String, String>::new())?
         .build()?;
     game.run();
     Ok(())


### PR DESCRIPTION
UiBundle depends on InputBundle. I forgot to mention it in the doc, and to add it in the renderable example.

Sorry about that  `~u~`

To merge quickly please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/586)
<!-- Reviewable:end -->
