### PR TITLE
[Need Help] Implement translation abstractions

### DIFF
--- a/amethyst_core/src/transform/components/local_transform.rs
+++ b/amethyst_core/src/transform/components/local_transform.rs
@@ -1,10 +1,12 @@
 //! Local transform component.
 
-use cgmath::{Array, Deg, ElementWise, EuclideanSpace, InnerSpace, Matrix3, Matrix4, One, Point3,
-             Quaternion, Rotation, Rotation3, SquareMatrix, Transform as CgTransform, Vector3,
-             Zero};
+use std;
+
+use cgmath::{Angle, Array, Deg, ElementWise, EuclideanSpace, Euler, InnerSpace, Matrix3, Matrix4, One, Point3,
+             Quaternion, Rad, Rotation, Rotation3, SquareMatrix, Transform as CgTransform, Vector3, Zero};
 use orientation::Orientation;
 use specs::{Component, DenseVecStorage, FlaggedStorage};
+use super::super::{Move, Pitch, Roll, Rotate, Scale, Yaw};
 
 /// Local position, rotation, and scale (from parent if it exists).
 ///
@@ -20,18 +22,18 @@ pub struct Transform {
 }
 
 impl Transform {
-    /// Rotate to look at a point in space (without rolling)
-    pub fn look_at(&mut self, orientation: &Orientation, position: Point3<f32>) -> &mut Self {
-        self.rotation = Quaternion::look_at(
-            position - Point3::from_vec(self.translation),
-            orientation.up.into(),
-        ).into();
-        self
+    /// Create a new `LocalTransform`.
+    ///
+    /// If you call `matrix` on this, then you would get an identity matrix.
+    pub fn new() -> Self {
+        Default::default()
     }
+}
 
+impl Transform {
     /// Returns the local object matrix for the transform.
     ///
-    /// Combined with the parent's `GlobalTransform` component it gives
+    /// Combined with the parent's global `Transform` component it gives
     /// the global (or world) matrix for the current entity.
     #[inline]
     pub fn matrix(&self) -> Matrix4<f32> {
@@ -40,120 +42,6 @@ impl Transform {
         let mut matrix: Matrix4<f32> = (&quat * scale).into();
         matrix.w = self.translation.extend(1.0f32);
         matrix
-    }
-
-    /// Move relatively to its current position, but independently from its orientation.
-    /// Ideally, first normalize the direction and then multiply it
-    /// by whatever amount you want to move before passing the vector to this method
-    #[inline]
-    pub fn move_global(&mut self, direction: Vector3<f32>) -> &mut Self {
-        self.translation = self.translation + direction;
-        self
-    }
-
-    /// Move relatively to its current position and orientation.
-    #[inline]
-    pub fn move_local(&mut self, axis: Vector3<f32>, amount: f32) -> &mut Self {
-        if axis.magnitude2() == 0.0 {
-            return self;
-        }
-
-        let delta = Quaternion::from(self.rotation) * axis.normalize() * amount;
-
-        self.translation = self.translation + delta;
-        self
-    }
-
-    /// Move forward relative to current position and orientation.
-    pub fn move_forward(&mut self, orientation: &Orientation, amount: f32) -> &mut Self {
-        self.move_local(orientation.forward.into(), amount)
-    }
-
-    /// Move backward relative to current position and orientation.
-    pub fn move_backward(&mut self, orientation: &Orientation, amount: f32) -> &mut Self {
-        self.move_local((-orientation.forward).into(), amount)
-    }
-
-    /// Move right relative to current position and orientation.
-    pub fn move_right(&mut self, orientation: &Orientation, amount: f32) -> &mut Self {
-        self.move_local(orientation.right.into(), amount)
-    }
-
-    /// Move left relative to current position and orientation.
-    pub fn move_left(&mut self, orientation: &Orientation, amount: f32) -> &mut Self {
-        self.move_local((-orientation.right).into(), amount)
-    }
-
-    /// Move up relative to current position and orientation.
-    pub fn move_up(&mut self, orientation: &Orientation, amount: f32) -> &mut Self {
-        self.move_local(orientation.up.into(), amount)
-    }
-
-    /// Move down relative to current position and orientation.
-    pub fn move_down(&mut self, orientation: &Orientation, amount: f32) -> &mut Self {
-        self.move_local((-orientation.up).into(), amount)
-    }
-
-    /// Pitch relatively to the world.
-    pub fn pitch_global(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self {
-        self.rotate_global(orientation.right.into(), angle)
-    }
-
-    /// Pitch relatively to its own rotation.
-    pub fn pitch_local(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self {
-        self.rotate_local(orientation.right.into(), angle)
-    }
-
-    /// Roll relatively to the world.
-    pub fn roll_global(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self {
-        self.rotate_global(orientation.forward.into(), angle)
-    }
-
-    /// Roll relatively to its own rotation.
-    pub fn roll_local(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self {
-        self.rotate_local(orientation.forward.into(), angle)
-    }
-
-    /// Add a rotation to the current rotation
-    #[inline]
-    pub fn rotate(&mut self, quat: Quaternion<f32>) -> &mut Self {
-        self.rotation = (quat * Quaternion::from(self.rotation)).into();
-        self
-    }
-
-    /// Rotate relatively to the world
-    #[inline]
-    pub fn rotate_global(&mut self, axis: Vector3<f32>, angle: Deg<f32>) -> &mut Self {
-        let axis_normalized = Vector3::from(axis).normalize();
-        let q = Quaternion::from_axis_angle(axis_normalized, angle);
-
-        self.rotate(q)
-    }
-
-    /// Rotate relatively to the current orientation
-    #[inline]
-    pub fn rotate_local(&mut self, axis: Vector3<f32>, angle: Deg<f32>) -> &mut Self {
-        let rel_axis_normalized = Quaternion::from(self.rotation)
-            .rotate_vector(Vector3::from(axis))
-            .normalize();
-        let q = Quaternion::from_axis_angle(rel_axis_normalized, angle);
-
-        self.rotate(q)
-    }
-
-    /// Set the position.
-    pub fn set_position(&mut self, position: Vector3<f32>) -> &mut Self {
-        self.translation = position;
-        self
-    }
-
-    /// Set the rotation using Euler x, y, z.
-    pub fn set_rotation<D: Into<Deg<f32>>>(&mut self, x: D, y: D, z: D) -> &mut Self {
-        let rotation = Quaternion::from_angle_x(x.into()) * Quaternion::from_angle_y(y.into())
-            * Quaternion::from_angle_z(z.into());
-
-        self.rotation = rotation.into();
-        self
     }
 
     /// Calculate the view matrix from the given data.
@@ -165,16 +53,19 @@ impl Transform {
             orientation.up,
         )
     }
+}
 
-    /// Yaw relatively to the world.
-    pub fn yaw_global(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self {
-        self.rotate_global(orientation.up.into(), angle)
+impl Transform {
+    /// Add a rotation to the current rotation
+    #[inline]
+    pub fn rotate(&mut self, quat: Quaternion<f32>) -> &mut Self {
+        self.rotation = (quat * Quaternion::from(self.rotation)).into();
+        self
     }
+}
 
-    /// Yaw relatively to its own rotation.
-    pub fn yaw_local(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self {
-        self.rotate_local(orientation.up.into(), angle)
-    }
+impl Component for Transform {
+    type Storage = FlaggedStorage<Self, DenseVecStorage<Self>>;
 }
 
 impl Default for Transform {
@@ -185,19 +76,6 @@ impl Default for Transform {
             scale: Vector3::from_value(1.),
         }
     }
-}
-
-impl Transform {
-    /// Create a new `Transform`.
-    ///
-    /// If you call `matrix` on this, then you would get an identity matrix.
-    pub fn new() -> Self {
-        Default::default()
-    }
-}
-
-impl Component for Transform {
-    type Storage = FlaggedStorage<Self, DenseVecStorage<Self>>;
 }
 
 impl CgTransform<Point3<f32>> for Transform {
@@ -251,4 +129,376 @@ impl CgTransform<Point3<f32>> for Transform {
             })
         }
     }
+}
+
+impl Move for Transform {
+    /// Move relatively to its current position and orientation.
+    fn move_backward(&mut self, orientation: &Orientation, amount: f32) -> &mut Self {
+        self.move_local(orientation.forward.into(), -amount)
+    }
+
+    /// Move relatively to its current position and orientation.
+    fn move_down(&mut self, orientation: &Orientation, amount: f32) -> &mut Self {
+        self.move_local(orientation.up.into(), -amount)
+    }
+
+    /// Move relatively to its current position and orientation.
+    fn move_forward(&mut self, orientation: &Orientation, amount: f32) -> &mut Self {
+        self.move_local(orientation.forward.into(), amount)
+    }
+
+    /// Move relatively to its current position, but independently from its orientation.
+    /// Ideally, first normalize the direction and then multiply it
+    /// by whatever amount you want to move before passing the vector to this method
+    #[inline]
+    fn move_global(&mut self, direction: Vector3<f32>) -> &mut Self {
+        self.translation = self.translation + direction;
+        self
+    }
+
+    /// Move relatively to its current position and orientation.
+    fn move_left(&mut self, orientation: &Orientation, amount: f32) -> &mut Self {
+        self.move_local(orientation.right.into(), -amount)
+    }
+
+    /// Move relatively to its current position and orientation.
+    #[inline]
+    fn move_local(&mut self, axis: Vector3<f32>, amount: f32) -> &mut Self {
+        let delta = Quaternion::from(self.rotation).conjugate().invert() * axis.normalize() * amount;
+
+        self.translation = self.translation + delta;
+        self
+    }
+
+    /// Move relatively to its current position and orientation.
+    fn move_right(&mut self, orientation: &Orientation, amount: f32) -> &mut Self {
+        self.move_local(orientation.right.into(), amount)
+    }
+
+    /// Move relatively to its current position and orientation.
+    fn move_up(&mut self, orientation: &Orientation, amount: f32) -> &mut Self {
+        self.move_local(orientation.up.into(), amount)
+    }
+
+    /// Get current position
+    fn position(&self) -> Point3<f32> {
+        Point3::from_vec(self.translation)
+    }
+
+    /// Set the position.
+    fn set_position(&mut self, position: Point3<f32>) -> &mut Self {
+        self.translation = position.to_vec();
+        self
+    }
+}
+
+impl Pitch for Transform {
+    /// Pitch relatively to the world.
+    fn pitch_global(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self {
+        self.rotate_global(orientation.right.into(), angle)
+    }
+
+    /// Pitch relatively to its own rotation.
+    fn pitch_local(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self {
+        self.rotate_local(orientation.right.into(), angle)
+    }
+}
+
+impl Roll for Transform {
+    /// Roll relatively to the world.
+    fn roll_global(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self {
+        self.rotate_global(orientation.forward.into(), angle)
+    }
+
+    /// Roll relatively to its own rotation.
+    fn roll_local(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self {
+        self.rotate_local(orientation.forward.into(), angle)
+    }
+}
+
+impl Rotate for Transform {
+    /// Rotate to look at a point in space (without rolling)
+    fn look_at(&mut self, orientation: &Orientation, position: Point3<f32>) -> &mut Self {
+        self.rotation = Quaternion::look_at(
+            position - Point3::from_vec(self.translation),
+            orientation.up.into(),
+        ).into();
+        self
+    }
+
+    /// Rotate whole local translation around a point at center via an axis and an angle
+    fn rotate_around(&mut self, center: Point3<f32>, axis: Vector3<f32>, angle: Deg<f32>) -> &mut Self {
+        self.translation -= center.to_vec();
+        self.rotate(Quaternion::from_axis_angle(axis, angle));
+        self.translation += center.to_vec();
+        self
+    }
+
+    /// Rotate relatively to the world
+    #[inline]
+    fn rotate_global(&mut self, axis: Vector3<f32>, angle: Deg<f32>) -> &mut Self {
+        let axis_normalized = Vector3::from(axis).normalize();
+        let q = Quaternion::from_axis_angle(axis_normalized, angle);
+
+        self.rotate(q)
+    }
+
+    /// Rotate relatively to the current orientation
+    #[inline]
+    fn rotate_local(&mut self, axis: Vector3<f32>, angle: Deg<f32>) -> &mut Self {
+        let rel_axis_normalized = Quaternion::from(self.rotation)
+            .rotate_vector(Vector3::from(axis))
+            .normalize();
+        let q = Quaternion::from_axis_angle(rel_axis_normalized, angle);
+
+        self.rotate(q)
+    }
+
+    /// Get current rotation as x, y, z degree values
+    fn rotation(&self) -> (Deg<f32>, Deg<f32>, Deg<f32>) {
+        let euler = Euler::from(self.rotation);
+
+        (
+            euler.x.into(),
+            euler.y.into(),
+            euler.z.into(),
+        )
+    }
+
+    /// Set the rotation using Euler x, y, z.
+    fn set_rotation<D: Into<Deg<f32>>>(&mut self, x: D, y: D, z: D) -> &mut Self
+        where D: Angle, Rad<<D as Angle>::Unitless>: std::convert::From<D>
+    {
+        self.rotation = Quaternion::from(Euler { x, y, z }).cast().unwrap();
+        self
+    }
+}
+
+impl Scale for Transform {
+    /// Get current scale as x, y, z values
+    fn scale(&self) -> (f32, f32, f32) {
+        (self.scale[0], self.scale[1], self.scale[2])
+    }
+
+    // Set new scale
+    fn set_scale(&mut self, x: f32, y: f32, z: f32) -> &mut Self {
+        self.scale[0] = x;
+        self.scale[1] = y;
+        self.scale[2] = z;
+
+        self
+    }
+}
+
+impl Yaw for Transform {
+    /// Yaw relatively to the world.
+    fn yaw_global(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self {
+        self.rotate_global(orientation.up.into(), angle)
+    }
+
+    /// Yaw relatively to its own rotation.
+    fn yaw_local(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self {
+        self.rotate_local(orientation.up.into(), angle)
+    }
+}
+
+#[test]
+fn position() {
+    // Set and get position
+    let mut trans = Transform::default();
+    let pos = trans
+        .set_position([50., 0., 0.].into())
+        .position()
+    ;
+
+    assert_eq!(pos[0], 50.);
+    assert_eq!(pos[1], 0.);
+    assert_eq!(pos[2], 0.);
+}
+
+#[test]
+fn movement() {
+    // Move local and global produce same, correct results for default
+    let mut trans1 = Transform::default();
+    let mut trans2 = Transform::default();
+
+    let pos1 = trans1
+        .move_global([50., 0., 0.].into())
+        .position()
+    ;
+
+    let pos2 = trans2
+        .move_local([1., 0., 0.].into(), 50.)
+        .position()
+    ;
+
+    assert_eq!(pos1.x, 50.);
+    assert_eq!(pos1.y, 0.);
+    assert_eq!(pos1.z, 0.);
+    assert_eq!(pos2.x, 50.);
+    assert_eq!(pos2.y, 0.);
+    assert_eq!(pos2.z, 0.);
+}
+
+#[test]
+fn simple_rotation() {
+    // Set and get rotation
+    let mut trans = Transform::default();
+    let rot = trans
+        .set_rotation(Deg(10.), Deg(20.), Deg(30.))
+        .rotation()
+    ;
+
+    println!("{:?}", rot);
+    assert_eq!(f32::round((rot.0).0), 10.);
+    assert_eq!(f32::round((rot.1).0), 20.);
+    assert_eq!(f32::round((rot.2).0), 30.);
+
+    // Rotate local and global produce same, correct results for default
+    let mut trans1 = Transform::default();
+    let mut trans2 = Transform::default();
+
+    let rot1 = trans1
+        .rotate_global([1., 0., 0.].into(), Deg(50.))
+        .rotation()
+    ;
+
+    let rot2 = trans2
+        .rotate_local([1., 0., 0.].into(), Deg(50.))
+        .rotation()
+    ;
+
+    assert_eq!(f32::round((rot1.0).0), 50.);
+    assert_eq!(f32::round((rot1.1).0), 0.);
+    assert_eq!(f32::round((rot1.2).0), 0.);
+    assert_eq!(f32::round((rot2.0).0), 50.);
+    assert_eq!(f32::round((rot2.1).0), 0.);
+    assert_eq!(f32::round((rot2.2).0), 0.);
+}
+
+#[test]
+fn multi_rotation() {
+    // Rotate around multiple axes
+    let mut trans = Transform::default();
+    let rot = trans
+        .set_rotation(Deg(10.), Deg(20.), Deg(30.))
+        .rotation()
+    ;
+
+    assert_eq!(f32::round((rot.0).0), 10.);
+    assert_eq!(f32::round((rot.1).0), 20.);
+    assert_eq!(f32::round((rot.2).0), 30.);
+
+    // Rotate additively
+    let mut trans = Transform::default();
+    let rot = trans
+        .rotate_global([1., 0., 0.].into(), Deg(50.))
+        .rotate_global([1., 0., 0.].into(), Deg(50.))
+        .rotation()
+    ;
+
+    assert_eq!(f32::round((rot.0).0), 100.);
+    assert_eq!(f32::round((rot.1).0), 0.);
+    assert_eq!(f32::round((rot.2).0), 0.);
+
+    let mut trans = Transform::default();
+    let rot = trans
+        .rotate_local([1., 0., 0.].into(), Deg(50.))
+        .rotate_local([1., 0., 0.].into(), Deg(50.))
+        .rotation()
+    ;
+
+    assert_eq!(f32::round((rot.0).0), 100.);
+    assert_eq!(f32::round((rot.1).0), 0.);
+    assert_eq!(f32::round((rot.2).0), 0.);
+}
+
+#[test]
+fn scaling() {
+    // Set and get scale
+    let mut trans = Transform::default();
+    let scale = trans
+        .set_scale(10., 20., 30.)
+        .scale()
+    ;
+
+    assert_eq!(scale.0, 10.);
+    assert_eq!(scale.1, 20.);
+    assert_eq!(scale.2, 30.);
+}
+
+#[test]
+fn mov_rot() {
+    let mut trans = Transform::default();
+    let trans = trans
+        .move_global([50., 0., 0.].into())
+        .rotate_global([1., 0., 0.].into(), Deg(50.))
+    ;
+
+    let pos = trans.position();
+    let rot = trans.rotation();
+    let scale = trans.scale();
+
+    assert_eq!(pos.x, 50.);
+    assert_eq!(pos.y, 0.);
+    assert_eq!(pos.z, 0.);
+
+    assert_eq!(scale.0, 1.);
+    assert_eq!(scale.1, 1.);
+    assert_eq!(scale.2, 1.);
+
+    assert_eq!(f32::round((rot.0).0), 50.);
+    assert_eq!(f32::round((rot.1).0), 0.);
+    assert_eq!(f32::round((rot.2).0), 0.);
+}
+
+#[test]
+fn scale_rot() {
+    let mut trans = Transform::default();
+    let trans = trans
+        .rotate_global([1., 0., 0.].into(), Deg(50.))
+        .set_scale(10., 20., 30.)
+    ;
+
+    let pos = trans.position();
+    let rot = trans.rotation();
+    let scale = trans.scale();
+
+    assert_eq!(pos.x, 0.);
+    assert_eq!(pos.y, 0.);
+    assert_eq!(pos.z, 0.);
+
+    assert_eq!(scale.0, 10.);
+    assert_eq!(scale.1, 20.);
+    assert_eq!(scale.2, 30.);
+
+    assert_eq!(f32::round((rot.0).0), 50.);
+    assert_eq!(f32::round((rot.1).0), 0.);
+    assert_eq!(f32::round((rot.2).0), 0.);
+}
+
+#[test]
+fn full_transform() {
+    let mut trans = Transform::default();
+    let trans = trans
+        .move_global([50., 0., 0.].into())
+        .rotate_global([1., 0., 0.].into(), Deg(50.))
+        .set_scale(10., 20., 30.)
+    ;
+
+    let pos = trans.position();
+    let rot = trans.rotation();
+    let scale = trans.scale();
+
+    assert_eq!(pos.x, 50.);
+    assert_eq!(pos.y, 0.);
+    assert_eq!(pos.z, 0.);
+
+    assert_eq!(scale.0, 10.);
+    assert_eq!(scale.1, 20.);
+    assert_eq!(scale.2, 30.);
+
+    assert_eq!(f32::round((rot.0).0), 50.);
+    assert_eq!(f32::round((rot.1).0), 0.);
+    assert_eq!(f32::round((rot.2).0), 0.);
 }

--- a/amethyst_core/src/transform/components/transform.rs
+++ b/amethyst_core/src/transform/components/transform.rs
@@ -2,8 +2,11 @@
 
 use std::borrow::Borrow;
 
-use cgmath::{Matrix4, One};
+use cgmath::{Deg, EuclideanSpace, Euler, InnerSpace, Matrix3, Matrix4, One, Point3, Quaternion,
+             Rotation, Vector3};
+use orientation::Orientation;
 use specs::{Component, DenseVecStorage, FlaggedStorage};
+use super::super::{Move, Pitch, Roll, Rotate, Scale, Yaw};
 
 /// Performs a global transformation on the entity (transform from origin).
 ///
@@ -69,4 +72,444 @@ impl Borrow<[[f32; 4]; 4]> for GlobalTransform {
     fn borrow(&self) -> &[[f32; 4]; 4] {
         self.0.as_ref()
     }
+}
+
+impl Move for GlobalTransform {
+    /// Move relatively to its current position and orientation.
+    fn move_backward(&mut self, orientation: &Orientation, amount: f32) -> &mut Self {
+        self.move_local(orientation.forward.into(), -amount)
+    }
+
+    /// Move relatively to its current position and orientation.
+    fn move_down(&mut self, orientation: &Orientation, amount: f32) -> &mut Self {
+        self.move_local(orientation.up.into(), -amount)
+    }
+
+    /// Move relatively to its current position and orientation.
+    fn move_forward(&mut self, orientation: &Orientation, amount: f32) -> &mut Self {
+        self.move_local(orientation.forward.into(), amount)
+    }
+
+    /// Move relatively to its current position, but independently from its orientation.
+    /// Ideally, first normalize the direction and then multiply it
+    /// by whatever amount you want to move before passing the vector to this method
+    fn move_global(&mut self, direction: Vector3<f32>) -> &mut Self {
+        //self.0 = Matrix4::from_translation(direction) * self.0;
+        let new_pos = self.position().to_vec() + direction;
+        let rot = self.rotation();
+        let scale = self.scale();
+
+        self.0 =
+            Matrix4::from_translation(new_pos) *
+                Matrix4::from_angle_x::<Deg<f32>>(rot.0) *
+                Matrix4::from_angle_y::<Deg<f32>>(rot.1) *
+                Matrix4::from_angle_z::<Deg<f32>>(rot.2) *
+                Matrix4::from_nonuniform_scale(scale.0, scale.1, scale.2)
+        ;
+
+        self
+    }
+
+    /// Move relatively to its current position and orientation.
+    fn move_left(&mut self, orientation: &Orientation, amount: f32) -> &mut Self {
+        self.move_local(orientation.right.into(), -amount)
+    }
+
+    /// Move relatively to its current position and orientation.
+    fn move_local(&mut self, axis: Vector3<f32>, amount: f32) -> &mut Self {
+        let scale = self.scale();
+        let q = Quaternion::from(Matrix3::new(
+            self.0[0][0] / scale.0,
+            self.0[0][1] / scale.0,
+            self.0[0][2] / scale.0,
+
+            self.0[1][0] / scale.1,
+            self.0[1][1] / scale.1,
+            self.0[1][2] / scale.1,
+
+            self.0[2][0] / scale.2,
+            self.0[2][1] / scale.2,
+            self.0[2][2] / scale.2,
+        ));
+        let delta = q.conjugate().invert() * axis.normalize() * amount;
+
+        self.move_global(delta)
+    }
+
+    /// Move relatively to its current position and orientation.
+    fn move_right(&mut self, orientation: &Orientation, amount: f32) -> &mut Self {
+        self.move_local(orientation.right.into(), amount)
+    }
+
+    /// Move relatively to its current position and orientation.
+    fn move_up(&mut self, orientation: &Orientation, amount: f32) -> &mut Self {
+        self.move_local(orientation.up.into(), amount)
+    }
+
+    /// Get current position
+    fn position(&self) -> Point3<f32> {
+        Point3::new(
+            self.0[3][0],
+            self.0[3][1],
+            self.0[3][2],
+        )
+    }
+
+    /// Set the position.
+    fn set_position(&mut self, position: Point3<f32>) -> &mut Self {
+        let pos = self.position();
+
+        self.move_global(Vector3::new(
+            position[0] - pos[0],
+            position[1] - pos[1],
+            position[2] - pos[2],
+        ))
+    }
+}
+
+impl Pitch for GlobalTransform {
+    /// Pitch relatively to the world.
+    fn pitch_global(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self {
+        self.rotate_global(orientation.right.into(), angle)
+    }
+
+    /// Pitch relatively to its own rotation.
+    fn pitch_local(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self {
+        self.rotate_local(orientation.right.into(), angle)
+    }
+}
+
+impl Roll for GlobalTransform {
+    /// Roll relatively to the world.
+    fn roll_global(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self {
+        self.rotate_global(orientation.forward.into(), angle)
+    }
+
+    /// Roll relatively to its own rotation.
+    fn roll_local(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self {
+        self.rotate_local(orientation.forward.into(), angle)
+    }
+}
+
+impl Rotate for GlobalTransform {
+    /// Rotate to look at a point in space (without rolling)
+    fn look_at(&mut self, orientation: &Orientation, position: Point3<f32>) -> &mut Self {
+        self.0 = Matrix4::look_at(self.position(), position, Vector3::from(orientation.up));
+        self
+    }
+
+    /// Rotate whole local translation around a point at center via an axis and an angle
+    fn rotate_around(&mut self, center: Point3<f32>, axis: Vector3<f32>, angle: Deg<f32>) -> &mut Self {
+        self.move_global(-center.to_vec());
+        self.rotate_global(axis, angle);
+        self.move_global(center.to_vec());
+        self
+    }
+
+    /// Rotate relatively to the world
+    #[inline]
+    fn rotate_global(&mut self, axis: Vector3<f32>, angle: Deg<f32>) -> &mut Self {
+        let axis_normalized = Vector3::from(axis).normalize();
+
+        self.0 = Matrix4::from_axis_angle(axis_normalized, angle) * self.0;
+        self
+    }
+
+    /// Rotate relatively to the current orientation
+    #[inline]
+    fn rotate_local(&mut self, axis: Vector3<f32>, angle: Deg<f32>) -> &mut Self {
+        let axis_normalized = Vector3::from(axis).normalize();
+
+        self.0 = self.0 * Matrix4::from_axis_angle(axis_normalized, angle);
+        self
+    }
+
+    /// Get current rotation as x, y, z degree values
+    fn rotation(&self) -> (Deg<f32>, Deg<f32>, Deg<f32>) {
+        let c0 = Vector3::new(
+            self.0[0][0],
+            self.0[1][0],
+            self.0[2][0],
+        ).normalize();
+
+        let c1 = Vector3::new(
+            self.0[0][1],
+            self.0[1][1],
+            self.0[2][1],
+        ).normalize();
+
+        let c2 = Vector3::new(
+            self.0[0][2],
+            self.0[1][2],
+            self.0[2][2],
+        ).normalize();
+
+        let angles = Euler::from(Quaternion::from(Matrix3::new(
+            c0.x, c1.x, c2.x,
+            c0.y, c1.y, c2.y,
+            c0.z, c1.z, c2.z,
+        )));
+
+        (
+            angles.x.into(),
+            angles.y.into(),
+            angles.z.into(),
+        )
+    }
+
+    /// Set the rotation using Euler x, y, z.
+    fn set_rotation<D: Into<Deg<f32>>>(&mut self, x: D, y: D, z: D) -> &mut Self {
+        let scale = self.scale();
+
+        self.0 =
+            Matrix4::from_translation(self.position().to_vec()) *
+                Matrix4::from_angle_x::<Deg<f32>>(x.into()) *
+                Matrix4::from_angle_y::<Deg<f32>>(y.into()) *
+                Matrix4::from_angle_z::<Deg<f32>>(z.into()) *
+                Matrix4::from_nonuniform_scale(scale.0, scale.1, scale.2)
+        ;
+
+        self
+    }
+}
+
+impl Scale for GlobalTransform {
+    /// Get current scale as x, y, z values
+    fn scale(&self) -> (f32, f32, f32) {
+        (
+            Vector3::new(self.0[0][0], self.0[0][1], self.0[0][2]).magnitude(),
+            Vector3::new(self.0[1][0], self.0[1][1], self.0[1][2]).magnitude(),
+            Vector3::new(self.0[2][0], self.0[2][1], self.0[2][2]).magnitude(),
+        )
+    }
+
+    // Set new scale
+    fn set_scale(&mut self, x: f32, y: f32, z: f32) -> &mut Self {
+        let rot = self.rotation();
+
+        self.0 =
+            Matrix4::from_translation(self.position().to_vec()) *
+                Matrix4::from_angle_x::<Deg<f32>>(rot.0) *
+                Matrix4::from_angle_y::<Deg<f32>>(rot.1) *
+                Matrix4::from_angle_z::<Deg<f32>>(rot.2) *
+                Matrix4::from_nonuniform_scale(x, y, z)
+        ;
+
+        self
+    }
+}
+
+impl Yaw for GlobalTransform {
+    /// Yaw relatively to the world.
+    fn yaw_global(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self {
+        self.rotate_global(orientation.up.into(), angle)
+    }
+
+    /// Yaw relatively to its own rotation.
+    fn yaw_local(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self {
+        self.rotate_local(orientation.up.into(), angle)
+    }
+}
+
+#[test]
+fn position() {
+    // Set and get position
+    let mut trans = GlobalTransform::default();
+    let pos = trans
+        .set_position([50., 0., 0.].into())
+        .position()
+    ;
+
+    assert_eq!(pos[0], 50.);
+    assert_eq!(pos[1], 0.);
+    assert_eq!(pos[2], 0.);
+}
+
+#[test]
+fn movement() {
+    // Move local and global produce same, correct results for default
+    let mut trans1 = GlobalTransform::default();
+    let mut trans2 = GlobalTransform::default();
+
+    let pos1 = trans1
+        .move_global([50., 0., 0.].into())
+        .position()
+    ;
+
+    let pos2 = trans2
+        .move_local([1., 0., 0.].into(), 50.)
+        .position()
+    ;
+
+    assert_eq!(pos1.x, 50.);
+    assert_eq!(pos1.y, 0.);
+    assert_eq!(pos1.z, 0.);
+    assert_eq!(pos2.x, 50.);
+    assert_eq!(pos2.y, 0.);
+    assert_eq!(pos2.z, 0.);
+}
+
+#[test]
+fn simple_rotation() {
+    // Set and get rotation
+    let mut trans = GlobalTransform::default();
+    let rot = trans
+        .set_rotation(Deg(50.), Deg(0.), Deg(0.))
+        .rotation()
+    ;
+
+    assert_eq!(f32::round((rot.0).0), 50.);
+    assert_eq!(f32::round((rot.1).0), 0.);
+    assert_eq!(f32::round((rot.2).0), 0.);
+
+    // Rotate local and global produce same, correct results for default
+    let mut trans1 = GlobalTransform::default();
+    let mut trans2 = GlobalTransform::default();
+
+    let rot1 = trans1
+        .rotate_global([1., 0., 0.].into(), Deg(50.))
+        .rotation()
+    ;
+
+    let rot2 = trans2
+        .rotate_local([1., 0., 0.].into(), Deg(50.))
+        .rotation()
+    ;
+
+    assert_eq!(f32::round((rot1.0).0), 50.);
+    assert_eq!(f32::round((rot1.1).0), 0.);
+    assert_eq!(f32::round((rot1.2).0), 0.);
+    assert_eq!(f32::round((rot2.0).0), 50.);
+    assert_eq!(f32::round((rot2.1).0), 0.);
+    assert_eq!(f32::round((rot2.2).0), 0.);
+}
+
+#[test]
+fn multi_rotation() {
+    // Rotate around multiple axes
+    let mut trans = GlobalTransform::default();
+    let rot = trans
+        .set_rotation(Deg(10.), Deg(20.), Deg(30.))
+        .rotation()
+    ;
+
+    assert_eq!(f32::round((rot.0).0), 10.);
+    assert_eq!(f32::round((rot.1).0), 20.);
+    assert_eq!(f32::round((rot.2).0), 30.);
+
+    // Rotate additively
+    let mut trans = GlobalTransform::default();
+    let rot = trans
+        .rotate_global([1., 0., 0.].into(), Deg(50.))
+        .rotate_global([1., 0., 0.].into(), Deg(50.))
+        .rotation()
+    ;
+
+    assert_eq!(f32::round((rot.0).0), 100.);
+    assert_eq!(f32::round((rot.1).0), 0.);
+    assert_eq!(f32::round((rot.2).0), 0.);
+
+    let mut trans = GlobalTransform::default();
+    let rot = trans
+        .rotate_local([1., 0., 0.].into(), Deg(50.))
+        .rotate_local([1., 0., 0.].into(), Deg(50.))
+        .rotation()
+    ;
+
+    assert_eq!(f32::round((rot.0).0), 100.);
+    assert_eq!(f32::round((rot.1).0), 0.);
+    assert_eq!(f32::round((rot.2).0), 0.);
+}
+
+#[test]
+fn scaling() {
+    // Set and get scale
+    let mut trans = GlobalTransform::default();
+    let scale = trans
+        .set_scale(10., 20., 30.)
+        .scale()
+    ;
+
+    assert_eq!(scale.0, 10.);
+    assert_eq!(scale.1, 20.);
+    assert_eq!(scale.2, 30.);
+}
+
+#[test]
+fn mov_rot() {
+    let mut trans = GlobalTransform::default();
+    let trans = trans
+        .move_global([50., 0., 0.].into())
+        .rotate_global([1., 0., 0.].into(), Deg(50.))
+    ;
+
+    let pos = trans.position();
+    let rot = trans.rotation();
+    let scale = trans.scale();
+
+    assert_eq!(pos.x, 50.);
+    assert_eq!(pos.y, 0.);
+    assert_eq!(pos.z, 0.);
+
+    assert_eq!(scale.0, 1.);
+    assert_eq!(scale.1, 1.);
+    assert_eq!(scale.2, 1.);
+
+    assert_eq!(f32::round((rot.0).0), 50.);
+    assert_eq!(f32::round((rot.1).0), 0.);
+    assert_eq!(f32::round((rot.2).0), 0.);
+}
+
+#[test]
+fn scale_rot() {
+    let mut trans = GlobalTransform::default();
+    let trans = trans
+        .rotate_global([1., 0., 0.].into(), Deg(50.))
+        .set_scale(10., 20., 30.)
+    ;
+
+    let pos = trans.position();
+    let rot = trans.rotation();
+    let scale = trans.scale();
+
+    assert_eq!(pos.x, 0.);
+    assert_eq!(pos.y, 0.);
+    assert_eq!(pos.z, 0.);
+
+    assert_eq!(scale.0, 10.);
+    assert_eq!(scale.1, 20.);
+    assert_eq!(scale.2, 30.);
+
+    println!("SR3, is: {:?}", rot);
+    assert_eq!(f32::round((rot.0).0), 50.);
+    assert_eq!(f32::round((rot.1).0), 0.);
+    assert_eq!(f32::round((rot.2).0), 0.);
+}
+
+#[test]
+fn full_transform() {
+    let mut trans = GlobalTransform::default();
+    let trans = trans
+        .rotate_global([1., 0., 0.].into(), Deg(50.))
+        .set_scale(10., 20., 30.)
+        .move_global([50., 100., 50.].into())
+    ;
+
+    let pos = trans.position();
+    let rot = trans.rotation();
+    let scale = trans.scale();
+
+    println!("FT1, is: {:?}", pos);
+    assert_eq!(pos.x, 50.);
+    assert_eq!(pos.y, 100.);
+    assert_eq!(pos.z, 50.);
+
+    assert_eq!(scale.0, 10.);
+    assert_eq!(scale.1, 20.);
+    assert_eq!(scale.2, 30.);
+
+    println!("{:?}", rot);
+    assert_eq!(f32::round((rot.0).0), 50.);
+    assert_eq!(f32::round((rot.1).0), 0.);
+    assert_eq!(f32::round((rot.2).0), 0.);
 }

--- a/amethyst_core/src/transform/mod.rs
+++ b/amethyst_core/src/transform/mod.rs
@@ -3,7 +3,9 @@
 pub use self::bundle::TransformBundle;
 pub use self::components::*;
 pub use self::systems::*;
+pub use self::transformations::*;
 
 pub mod components;
 pub mod systems;
 pub mod bundle;
+pub mod transformations;

--- a/amethyst_core/src/transform/transformations.rs
+++ b/amethyst_core/src/transform/transformations.rs
@@ -1,0 +1,92 @@
+//! Movement Traits
+
+use std;
+
+use cgmath::{Angle, Deg, Point3, Rad, Vector3};
+use orientation::Orientation;
+
+pub trait Move {
+    /// Move relatively to its current position and orientation.
+    fn move_backward(&mut self, orientation: &Orientation, amount: f32) -> &mut Self;
+
+    /// Move relatively to its current position and orientation.
+    fn move_down(&mut self, orientation: &Orientation, amount: f32) -> &mut Self;
+
+    /// Move relatively to its current position and orientation.
+    fn move_forward(&mut self, orientation: &Orientation, amount: f32) -> &mut Self;
+    
+    /// Move relatively to its current position, but independently from its orientation.
+    /// Ideally, first normalize the direction and then multiply it
+    /// by whatever amount you want to move before passing the vector to this method
+    fn move_global(&mut self, direction: Vector3<f32>) -> &mut Self;
+    
+    /// Move relatively to its current position and orientation.
+    fn move_left(&mut self, orientation: &Orientation, amount: f32) -> &mut Self;
+    
+    /// Move relatively to its current position and orientation.
+    fn move_local(&mut self, axis: Vector3<f32>, amount: f32) -> &mut Self;
+    
+    /// Move relatively to its current position and orientation.
+    fn move_right(&mut self, orientation: &Orientation, amount: f32) -> &mut Self;
+    
+    /// Move relatively to its current position and orientation.
+    fn move_up(&mut self, orientation: &Orientation, amount: f32) -> &mut Self;
+    
+    /// Get current position
+    fn position(&self) -> Point3<f32>;
+    
+    /// Set the position.
+    fn set_position(&mut self, position: Point3<f32>) -> &mut Self;
+}
+
+pub trait Pitch {
+    /// Pitch relatively to the world.
+    fn pitch_global(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self;
+    
+    /// Pitch relatively to its own rotation.
+    fn pitch_local(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self;
+}
+
+pub trait Roll {
+    /// Roll relatively to the world.
+    fn roll_global(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self;
+    
+    /// Roll relatively to its own rotation.
+    fn roll_local(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self;
+}
+
+pub trait Rotate {
+    /// Rotate to look at a point in space (without rolling)
+    fn look_at(&mut self, orientation: &Orientation, position: Point3<f32>) -> &mut Self;
+    
+    /// Rotate whole local translation around a point at center via an axis and an angle
+    fn rotate_around(&mut self, center: Point3<f32>, axis: Vector3<f32>, angle: Deg<f32>) -> &mut Self;
+    
+    /// Rotate relatively to the world
+    fn rotate_global(&mut self, axis: Vector3<f32>, angle: Deg<f32>) -> &mut Self;
+    
+    /// Rotate relatively to the current orientation
+    fn rotate_local(&mut self, axis: Vector3<f32>, angle: Deg<f32>) -> &mut Self;
+    
+    /// Get current rotation as x, y, z degree values
+    fn rotation(&self) -> (Deg<f32>, Deg<f32>, Deg<f32>);
+    
+    /// Set the rotation using Euler x, y, z.
+    fn set_rotation<D: Into<Deg<f32>>>(&mut self, x: D, y: D, z: D) -> &mut Self where D: Angle, Rad<<D as Angle>::Unitless>: std::convert::From<D>;
+}
+
+pub trait Scale {
+    /// Get current scale as x, y, z values
+    fn scale(&self) -> (f32, f32, f32);
+
+    // Set new scale
+    fn set_scale(&mut self, x: f32, y: f32, z: f32) -> &mut Self;
+}
+
+pub trait Yaw {
+    /// Yaw relatively to the world.
+    fn yaw_global(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self;
+    
+    /// Yaw relatively to its own rotation.
+    fn yaw_local(&mut self, orientation: &Orientation, angle: Deg<f32>) -> &mut Self;
+}


### PR DESCRIPTION
Abstractions for ease-of-use. They work for the most part. I just have problems getting rotation and scaling to work together on `Transform`. Anyone with knowledge about matrices is welcome to check if they spot my problem. Here is the test result:

```
C:\Users\marco_000\Projects\amethyst\amethyst_core>cargo test
    Finished dev [unoptimized + debuginfo] target(s) in 0.2 secs
    Running C:\Users\marco_000\Projects\amethyst\target\debug\deps\amethyst_core-02dfb836f15570b4.exe


running 30 tests
test timing::tests::elapsed ... ok
test transform::components::local_transform::full_transform ... ok
test transform::components::local_transform::mov_rot ... ok
test transform::components::local_transform::movement ... ok
test transform::components::local_transform::multi_rotation ... ok
test transform::components::local_transform::position ... ok
test transform::components::local_transform::scale_rot ... ok
test transform::components::local_transform::scaling ... ok
test transform::components::local_transform::simple_rotation ... ok
test transform::components::transform::full_transform ... FAILED
test transform::components::transform::mov_rot ... ok
test transform::components::transform::movement ... ok
test transform::components::transform::multi_rotation ... ok
test transform::components::transform::position ... ok
test transform::components::transform::scale_rot ... FAILED
test transform::components::transform::scaling ... ok
test transform::components::transform::simple_rotation ... ok
test transform::systems::tests::basic ... ok
test transform::systems::tests::entity_is_parent ... ok
test transform::systems::tests::into_from ... ok
test transform::systems::tests::is_finite_transform ... ok
test transform::systems::tests::nan_transform ... ok
test transform::systems::tests::parent_after ... ok
test transform::systems::tests::parent_before ... ok
test transform::systems::tests::parent_removed ... ok
test transform::systems::tests::transform_matrix ... ok
test transform::systems::tests::zeroed ... ok
test timing::tests::reset ... ok
test timing::tests::restart ... ok
test timing::tests::stop_start ... ok

failures:

---- transform::components::transform::full_transform stdout ----
        FT1, is: Point3 [50, 100, 50]
(47.35735°, 0°, 0°)
thread 'transform::components::transform::full_transform' panicked at 'assertion failed: `(left == right)`
  left: `47`,
 right: `50`', src\transform\components\transform.rs:512:4
note: Run with `RUST_BACKTRACE=1` for a backtrace.

---- transform::components::transform::scale_rot stdout ----
        SR3, is: (48.6195°, 0°, 0°)
thread 'transform::components::transform::scale_rot' panicked at 'assertion failed: `(left == right)`
  left: `49`,
 right: `50`', src\transform\components\transform.rs:484:4


failures:
    transform::components::transform::full_transform
    transform::components::transform::scale_rot

test result: FAILED. 28 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/596)
<!-- Reviewable:end -->
