### PR TITLE
[Documentation] Add package name for libasound2-dev for Fedora to ease installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ does not aim to be API-compatible with it in any way. Some goals include:
 
 ## Usage
 
-**Linux developers: the libasound2-dev and libx11-xcb-dev packages are required to compile Amethyst.**
+**Linux developers: the libasound2-dev (alsa-lib-devel on Fedora) and libx11-xcb-dev packages are required to compile Amethyst.**
 
 Read the [online book][bk] for a comprehensive tutorial to using Amethyst. There
 is also an online crate-level [API reference][ar].


### PR DESCRIPTION
Add in the name for the required RPM on Fedora to make initial setup for a new user that much easier