### PR TITLE
Add a variant to animation::EndControl

### DIFF
--- a/amethyst_animation/src/resources.rs
+++ b/amethyst_animation/src/resources.rs
@@ -194,6 +194,8 @@ pub enum EndControl {
     Loop(Option<u32>),
     /// When duration of sampler/animation is reached, go back to rest state
     Normal,
+    /// When duration of sampler/animation is reached, do nothing: stay at the last sampled state
+    Stay,
 }
 
 /// Control a single active sampler

--- a/amethyst_animation/src/systems/sampling.rs
+++ b/amethyst_animation/src/systems/sampling.rs
@@ -136,12 +136,22 @@ fn process_sampler<T>(
                 output.push((control.blend_weight, control.channel.clone(), control.after));
             }
             if let EndControl::Stay = control.end {
-                let last_output = sampler
-                    .output
+                let last_frame = sampler
+                    .input
                     .last()
                     .cloned()
-                    .unwrap_or(control.after);
-                output.push((control.blend_weight, control.channel.clone(), last_output));
+                    .unwrap_or(0.);
+                
+                output.push((
+                    control.blend_weight,
+                    control.channel.clone(),
+                    sampler.function.interpolate(
+                        last_frame,
+                        &sampler.input,
+                        &sampler.output,
+                        false,
+                    ),
+                ));
             }
         }
         _ => {}

--- a/amethyst_animation/src/systems/sampling.rs
+++ b/amethyst_animation/src/systems/sampling.rs
@@ -135,6 +135,14 @@ fn process_sampler<T>(
             if let EndControl::Normal = control.end {
                 output.push((control.blend_weight, control.channel.clone(), control.after));
             }
+            if let EndControl::Stay = control.end {
+                let last_output = sampler
+                    .output
+                    .last()
+                    .cloned()
+                    .unwrap_or(control.after);
+                output.push((control.blend_weight, control.channel.clone(), last_output));
+            }
         }
         _ => {}
     }


### PR DESCRIPTION
Add a Stay variant to EndControl, which make the property being animated on stay at the last sampled state at the end of the animation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/610)
<!-- Reviewable:end -->
