### PR TITLE
fix: Rest state for animation needs to be controllable. 

### DIFF
--- a/amethyst_animation/src/bundle.rs
+++ b/amethyst_animation/src/bundle.rs
@@ -6,7 +6,7 @@ use amethyst_renderer::JointTransforms;
 use specs::{Component, DispatcherBuilder, World};
 
 use resources::{Animation, AnimationControlSet, AnimationHierarchy, AnimationSampling,
-                AnimationSet, Sampler, SamplerControlSet};
+                AnimationSet, RestState, Sampler, SamplerControlSet};
 use skinning::{Joint, Skin, VertexSkinningSystem};
 use systems::{AnimationControlSystem, AnimationProcessor, SamplerInterpolationSystem,
               SamplerProcessor};
@@ -152,7 +152,7 @@ impl<'a, I, T> AnimationBundle<'a, I, T> {
 impl<'a, 'b, 'c, I, T> ECSBundle<'a, 'b> for AnimationBundle<'c, I, T>
 where
     I: PartialEq + Copy + Send + Sync + 'static,
-    T: AnimationSampling + Component,
+    T: AnimationSampling + Component + Clone,
 {
     fn build(
         self,
@@ -162,6 +162,7 @@ where
         world.add_resource(AssetStorage::<Animation<T>>::new());
         world.register::<AnimationControlSet<I, T>>();
         world.register::<AnimationHierarchy<T>>();
+        world.register::<RestState<T>>();
         world.register::<AnimationSet<T>>();
         builder = builder.add(AnimationProcessor::<T>::new(), "", &[]).add(
             AnimationControlSystem::<I, T>::new(),

--- a/amethyst_animation/src/lib.rs
+++ b/amethyst_animation/src/lib.rs
@@ -13,9 +13,10 @@ extern crate shred;
 extern crate specs;
 
 pub use self::bundle::{AnimationBundle, SamplingBundle, VertexSkinningBundle};
-pub use self::resources::{Animation, AnimationCommand, AnimationControl, AnimationControlSet, AnimationHierarchy,
-                          AnimationSampling, AnimationSet, BlendMethod, ControlState, EndControl,
-                          Sampler, SamplerControl, SamplerControlSet, StepDirection};
+pub use self::resources::{Animation, AnimationCommand, AnimationControl, AnimationControlSet,
+                          AnimationHierarchy, AnimationSampling, AnimationSet, BlendMethod,
+                          ControlState, EndControl, Sampler, SamplerControl, SamplerControlSet,
+                          StepDirection};
 pub use self::skinning::{Joint, Skin, VertexSkinningSystem};
 pub use self::systems::{AnimationControlSystem, AnimationProcessor, SamplerInterpolationSystem,
                         SamplerProcessor};

--- a/amethyst_animation/src/systems/control.rs
+++ b/amethyst_animation/src/systems/control.rs
@@ -6,8 +6,8 @@ use minterpolate::InterpolationPrimitive;
 use specs::{Component, Entities, Entity, Fetch, Join, ReadStorage, System, WriteStorage};
 
 use resources::{Animation, AnimationCommand, AnimationControl, AnimationControlSet,
-                AnimationHierarchy, AnimationSampling, ControlState, Sampler, SamplerControl,
-                SamplerControlSet, StepDirection};
+                AnimationHierarchy, AnimationSampling, ControlState, RestState, Sampler,
+                SamplerControl, SamplerControlSet, StepDirection};
 
 /// System for setting up animations, should run before `SamplerInterpolationSystem`.
 ///
@@ -38,7 +38,7 @@ impl<I, T> AnimationControlSystem<I, T> {
 impl<'a, I, T> System<'a> for AnimationControlSystem<I, T>
 where
     I: PartialEq + Copy + Send + Sync + 'static,
-    T: AnimationSampling + Component,
+    T: AnimationSampling + Component + Clone,
 {
     type SystemData = (
         Entities<'a>,
@@ -48,6 +48,7 @@ where
         WriteStorage<'a, SamplerControlSet<T>>,
         ReadStorage<'a, AnimationHierarchy<T>>,
         ReadStorage<'a, T>,
+        WriteStorage<'a, RestState<T>>,
     );
 
     fn run(&mut self, data: Self::SystemData) {
@@ -59,6 +60,7 @@ where
             mut samplers,
             hierarchies,
             transforms,
+            mut rest_states,
         ) = data;
         let mut remove_sets = Vec::default();
         for (entity, control_set) in (&*entities, &mut controls).join() {
@@ -74,6 +76,7 @@ where
                             hierarchies.get(entity),
                             &*sampler_storage,
                             &mut samplers,
+                            &mut rest_states,
                             &transforms,
                             &mut remove,
                             &mut self.next_id,
@@ -148,12 +151,13 @@ fn process_animation_control<T>(
     hierarchy: Option<&AnimationHierarchy<T>>,
     sampler_storage: &AssetStorage<Sampler<T::Primitive>>,
     samplers: &mut WriteStorage<SamplerControlSet<T>>,
+    rest_states: &mut WriteStorage<RestState<T>>,
     targets: &ReadStorage<T>,
     remove: &mut bool,
     next_id: &mut u64,
 ) -> Option<ControlState>
 where
-    T: AnimationSampling + Component,
+    T: AnimationSampling + Component + Clone,
 {
     // Checking hierarchy
     let h_fallback = AnimationHierarchy::new_single(animation.nodes[0].0, *entity);
@@ -192,6 +196,7 @@ where
                 control,
                 hierarchy,
                 samplers,
+                rest_states,
                 targets,
             ) {
                 Some(ControlState::Running(Duration::from_secs(0)))
@@ -275,10 +280,11 @@ fn start_animation<T>(
     control: &AnimationControl<T>,
     hierarchy: &AnimationHierarchy<T>,
     samplers: &mut WriteStorage<SamplerControlSet<T>>,
+    rest_states: &mut WriteStorage<RestState<T>>,
     targets: &ReadStorage<T>, // for rest state
 ) -> bool
 where
-    T: AnimationSampling + Component,
+    T: AnimationSampling + Component + Clone,
 {
     // check that hierarchy is valid, and all samplers exist
     if animation
@@ -291,10 +297,16 @@ where
         return false;
     }
 
+    hierarchy.rest_state(|entity| targets.get(entity).cloned(), rest_states);
+
     // setup sampler tree
     for &(ref node_index, ref channel, ref sampler_handle) in &animation.nodes {
         let node_entity = hierarchy.nodes.get(node_index).unwrap();
-        let component = targets.get(*node_entity).unwrap();
+        let component = rest_states
+            .get(*node_entity)
+            .map(|r| r.state())
+            .or_else(|| targets.get(*node_entity))
+            .unwrap();
         let sampler_control = SamplerControl::<T> {
             control_id: control.id,
             channel: channel.clone(),

--- a/amethyst_renderer/src/formats/texture.rs
+++ b/amethyst_renderer/src/formats/texture.rs
@@ -339,8 +339,8 @@ mod tests {
         match TextureData::from([0.25, 0.50, 0.75]) {
             TextureData::Rgba(color, _) => {
                 assert_eq!(color, [0.25, 0.50, 0.75, 1.0]);
-            },
-            _ => panic!("Expected [f32; 3] to turn into TextureData::Rgba")
+            }
+            _ => panic!("Expected [f32; 3] to turn into TextureData::Rgba"),
         }
     }
 }


### PR DESCRIPTION
Will now be set to the state of the base component on the first animation, unless it has already been set.

The previous solution caused the end state to become incorrect for staggered animatinos.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/611)
<!-- Reviewable:end -->
