### PR TITLE
Remove unwrap in amethyst::animation

### DIFF
--- a/amethyst_animation/src/systems/control.rs
+++ b/amethyst_animation/src/systems/control.rs
@@ -233,11 +233,11 @@ where
             if check_termination(control.id, hierarchy, &samplers) {
                 // Do termination
                 for (_, node_entity) in &hierarchy.nodes {
-                    let empty = {
-                        let mut sampler = samplers.get_mut(*node_entity).unwrap();
-                        sampler.clear(control.id);
-                        sampler.is_empty()
-                    };
+                    let empty = samplers.get_mut(*node_entity)
+                        .map(|sampler| {
+                            sampler.clear(control.id);
+                            sampler.is_empty()})
+                        .unwrap_or(false);
                     if empty {
                         samplers.remove(*node_entity);
                     }


### PR DESCRIPTION
I was getting panics when adding, starting and then aborting an animation all before the animation control has a chance to run. This removes them.

Do tell me if such small pull requests are more annoying than useful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/612)
<!-- Reviewable:end -->
