### PR TITLE
Initial thread_profling setup and basic fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,20 @@ appveyor = { repository = "amethyst/amethyst", branch = "develop" }
 travis-ci = { repository = "amethyst/amethyst", branch = "develop" }
 
 [features]
-profiler = ["thread_profiler/thread_profiler"]
+profiler = [
+    "thread_profiler",
+    "thread_profiler/thread_profiler",
+    "amethyst_assets/profiler",
+    "amethyst_animation/profiler",
+    "amethyst_audio/profiler",
+    "amethyst_config/profiler",
+    "amethyst_core/profiler",
+    "amethyst_controls/profiler",
+    "amethyst_renderer/profiler",
+    "amethyst_input/profiler",
+    "amethyst_ui/profiler",
+    "amethyst_utils/profiler",
+]
 
 [dependencies]
 amethyst_assets = { path = "amethyst_assets", version = "0.2.0" }

--- a/amethyst_animation/Cargo.toml
+++ b/amethyst_animation/Cargo.toml
@@ -29,4 +29,9 @@ serde = { version = "1.0", features = ["derive"] }
 shred = "0.5"
 specs = "0.10"
 
+thread_profiler = { version = "0.1", optional = true }
+
 [dev-dependencies]
+
+[features]
+profiler = [ "thread_profiler/thread_profiler" ]

--- a/amethyst_animation/src/lib.rs
+++ b/amethyst_animation/src/lib.rs
@@ -12,10 +12,15 @@ extern crate serde;
 extern crate shred;
 extern crate specs;
 
+#[macro_use]
+#[cfg(feature = "profiler")]
+extern crate thread_profiler;
+
 pub use self::bundle::{AnimationBundle, SamplingBundle, VertexSkinningBundle};
-pub use self::resources::{Animation, AnimationCommand, AnimationControl, AnimationControlSet, AnimationHierarchy,
-                          AnimationSampling, AnimationSet, BlendMethod, ControlState, EndControl,
-                          Sampler, SamplerControl, SamplerControlSet, StepDirection};
+pub use self::resources::{Animation, AnimationCommand, AnimationControl, AnimationControlSet,
+                          AnimationHierarchy, AnimationSampling, AnimationSet, BlendMethod,
+                          ControlState, EndControl, Sampler, SamplerControl, SamplerControlSet,
+                          StepDirection};
 pub use self::skinning::{Joint, Skin, VertexSkinningSystem};
 pub use self::systems::{AnimationControlSystem, AnimationProcessor, SamplerInterpolationSystem,
                         SamplerProcessor};

--- a/amethyst_animation/src/systems/control.rs
+++ b/amethyst_animation/src/systems/control.rs
@@ -233,10 +233,12 @@ where
             if check_termination(control.id, hierarchy, &samplers) {
                 // Do termination
                 for (_, node_entity) in &hierarchy.nodes {
-                    let empty = samplers.get_mut(*node_entity)
+                    let empty = samplers
+                        .get_mut(*node_entity)
                         .map(|sampler| {
                             sampler.clear(control.id);
-                            sampler.is_empty()})
+                            sampler.is_empty()
+                        })
                         .unwrap_or(false);
                     if empty {
                         samplers.remove(*node_entity);

--- a/amethyst_animation/src/systems/sampling.rs
+++ b/amethyst_animation/src/systems/sampling.rs
@@ -136,12 +136,8 @@ fn process_sampler<T>(
                 output.push((control.blend_weight, control.channel.clone(), control.after));
             }
             if let EndControl::Stay = control.end {
-                let last_frame = sampler
-                    .input
-                    .last()
-                    .cloned()
-                    .unwrap_or(0.);
-                
+                let last_frame = sampler.input.last().cloned().unwrap_or(0.);
+
                 output.push((
                     control.blend_weight,
                     control.channel.clone(),

--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -31,6 +31,11 @@ parking_lot = "0.4.4"
 rayon = "0.8"
 specs = { version = "0.10", features = ["common"] }
 
+thread_profiler = { version = "0.1", optional = true }
+
 [dev-dependencies]
 ron = "0.1.4"
 serde = { version = "1", features = ["serde_derive"] }
+
+[features]
+profiler = [ "thread_profiler/thread_profiler" ]

--- a/amethyst_assets/examples/hl.rs
+++ b/amethyst_assets/examples/hl.rs
@@ -37,6 +37,7 @@ impl App {
         world.add_resource(AssetStorage::<MeshAsset>::new());
         world.add_resource(Loader::new(path, pool.clone()));
         world.add_resource(pool);
+        world.add_resource(Time::default());
 
         App {
             dispatcher,

--- a/amethyst_assets/src/asset.rs
+++ b/amethyst_assets/src/asset.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
 use specs::UnprotectedStorage;
+#[cfg(feature = "profiler")]
+#[macro_use]
+use thread_profiler::{register_thread_with_profiler, write_profile};
 
 use {ErrorKind, Handle, Reload, Result, ResultExt, SingleFile, Source};
 
@@ -104,6 +107,8 @@ where
         options: Self::Options,
         create_reload: bool,
     ) -> Result<FormatValue<A>> {
+        #[cfg(feature = "profiler")]
+        profile_scope!("import_asset");
         if create_reload {
             let (b, m) = source
                 .load_with_metadata(&name)
@@ -111,7 +116,6 @@ where
             let data = T::import(&self, b, options.clone())?;
             let reload = SingleFile::new(self.clone(), m, options, name, source);
             let reload = Some(Box::new(reload) as Box<Reload<A>>);
-
             Ok(FormatValue { data, reload })
         } else {
             let b = source.load(&name).chain_err(|| ErrorKind::Source)?;

--- a/amethyst_assets/src/lib.rs
+++ b/amethyst_assets/src/lib.rs
@@ -23,6 +23,10 @@ extern crate parking_lot;
 extern crate rayon;
 extern crate specs;
 
+#[macro_use]
+#[cfg(feature = "profiler")]
+extern crate thread_profiler;
+
 pub use asset::{Asset, Format, FormatValue, SimpleFormat};
 pub use cache::Cache;
 pub use error::{Error, ErrorKind, Result, ResultExt};
@@ -31,6 +35,9 @@ pub use progress::{Completion, Progress, ProgressCounter, Tracker};
 pub use reload::{HotReloadBundle, HotReloadStrategy, HotReloadSystem, Reload, SingleFile};
 pub use source::{Directory, Source};
 pub use storage::{AssetStorage, Handle, Processor, WeakHandle};
+
+#[cfg(feature = "profiler")]
+use thread_profiler::{register_thread_with_profiler, write_profile};
 
 mod asset;
 mod cache;

--- a/amethyst_assets/src/loader.rs
+++ b/amethyst_assets/src/loader.rs
@@ -144,6 +144,8 @@ impl Loader {
         let hot_reload = self.hot_reload;
 
         let cl = move || {
+            #[cfg(feature = "profiler")]
+            profile_scope!("load_asset_from_worker");
             let data = format
                 .import(name.clone(), source, options, hot_reload)
                 .chain_err(|| ErrorKind::Format(F::NAME));

--- a/amethyst_assets/src/loader.rs
+++ b/amethyst_assets/src/loader.rs
@@ -69,6 +69,8 @@ impl Loader {
         N: Into<String>,
         P: Progress,
     {
+        #[cfg(feature = "profiler")]
+        profile_scope!("initialise_loading_assets");
         self.load_from::<A, F, _, _, _>(name, format, options, "", progress, storage)
     }
 
@@ -104,6 +106,8 @@ impl Loader {
         S: AsRef<str> + Eq + Hash + ?Sized,
         String: Borrow<S>,
     {
+        #[cfg(feature = "profiler")]
+        profile_scope!("load_asset_from");
         use progress::Tracker;
 
         let name = name.into();

--- a/amethyst_assets/src/reload.rs
+++ b/amethyst_assets/src/reload.rs
@@ -251,6 +251,9 @@ where
     }
 
     fn reload(self: Box<Self>) -> Result<FormatValue<A>> {
+        #[cfg(feature = "profiler")]
+        profile_scope!("reload_single_file");
+
         let this: SingleFile<_, _> = *self;
         let SingleFile {
             format,

--- a/amethyst_assets/src/source/dir.rs
+++ b/amethyst_assets/src/source/dir.rs
@@ -35,6 +35,8 @@ impl Directory {
 
 impl Source for Directory {
     fn modified(&self, path: &str) -> Result<u64> {
+        #[cfg(feature = "profiler")]
+        profile_scope!("dir_modified_asset");
         use std::fs::metadata;
 
         let path = self.path(path);
@@ -49,6 +51,8 @@ impl Source for Directory {
     }
 
     fn load(&self, path: &str) -> Result<Vec<u8>> {
+        #[cfg(feature = "profiler")]
+        profile_scope!("dir_load_asset");
         use std::io::Read;
 
         let path = self.path(path);

--- a/amethyst_assets/src/source/mod.rs
+++ b/amethyst_assets/src/source/mod.rs
@@ -21,6 +21,9 @@ pub trait Source: Send + Sync + 'static {
     /// There's a default implementation which just calls both methods,
     /// but you may be able to provide a more optimized version yourself.
     fn load_with_metadata(&self, path: &str) -> Result<(Vec<u8>, u64)> {
+        #[cfg(feature = "profiler")]
+        profile_scope!("source_load_asset_with_metadata");
+
         let m = self.modified(path)?;
         let b = self.load(path)?;
 

--- a/amethyst_assets/src/storage.rs
+++ b/amethyst_assets/src/storage.rs
@@ -7,6 +7,8 @@ use crossbeam::sync::MsQueue;
 use hibitset::BitSet;
 use rayon::ThreadPool;
 use specs::{Component, Fetch, FetchMut, System, UnprotectedStorage, VecStorage};
+#[cfg(feature = "profiler")]
+use thread_profiler::{register_thread_with_profiler, write_profile};
 
 use asset::{Asset, FormatValue};
 use error::{ErrorKind, Result, ResultExt};

--- a/amethyst_audio/Cargo.toml
+++ b/amethyst_audio/Cargo.toml
@@ -27,6 +27,11 @@ rodio = "= 0.5.2"
 shred = "0.5"
 specs = "0.10"
 
+thread_profiler = { version = "0.1", optional = true }
+
 [dependencies.smallvec]
 version = "0.4.2"
 features = ["serde"]
+
+[features]
+profiler = [ "thread_profiler/thread_profiler" ]

--- a/amethyst_audio/src/lib.rs
+++ b/amethyst_audio/src/lib.rs
@@ -9,6 +9,10 @@ extern crate shred;
 extern crate smallvec;
 extern crate specs;
 
+#[macro_use]
+#[cfg(feature = "profiler")]
+extern crate thread_profiler;
+
 pub use self::bundle::AudioBundle;
 pub use self::components::*;
 pub use self::formats::{FlacFormat, OggFormat, WavFormat};

--- a/amethyst_config/Cargo.toml
+++ b/amethyst_config/Cargo.toml
@@ -19,5 +19,10 @@ travis-ci = { repository = "amethyst/amethyst" }
 ron = "0.1"
 serde = "1.0"
 
+thread_profiler = { version = "0.1", optional = true }
+
 [dev-dependencies]
 serde_derive = "1"
+
+[features]
+profiler = [ "thread_profiler/thread_profiler" ]

--- a/amethyst_config/examples/main.rs
+++ b/amethyst_config/examples/main.rs
@@ -8,8 +8,7 @@ use amethyst_config::Config;
 pub struct DisplayConfig {
     pub title: String,
     pub brightness: f64,
-    #[serde(default)]
-    pub fullscreen: bool,
+    #[serde(default)] pub fullscreen: bool,
     pub dimensions: (u16, u16),
     pub min_dimensions: Option<(u16, u16)>,
     pub max_dimensions: Option<(u16, u16)>,

--- a/amethyst_config/src/lib.rs
+++ b/amethyst_config/src/lib.rs
@@ -8,6 +8,10 @@
 extern crate ron;
 extern crate serde;
 
+#[macro_use]
+#[cfg(feature = "profiler")]
+extern crate thread_profiler;
+
 use std::error::Error;
 use std::fmt;
 use std::io;

--- a/amethyst_controls/Cargo.toml
+++ b/amethyst_controls/Cargo.toml
@@ -22,3 +22,8 @@ winit = "0.10"
 specs = "0.10"
 shred = "0.5"
 log = "0.4"
+
+thread_profiler = { version = "0.1", optional = true }
+
+[features]
+profiler = [ "thread_profiler/thread_profiler" ]

--- a/amethyst_controls/src/lib.rs
+++ b/amethyst_controls/src/lib.rs
@@ -8,6 +8,10 @@ extern crate shred;
 extern crate specs;
 extern crate winit;
 
+#[macro_use]
+#[cfg(feature = "profiler")]
+extern crate thread_profiler;
+
 mod components;
 mod bundles;
 mod systems;

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -24,3 +24,8 @@ serde = { version = "1", features = ["serde_derive"] }
 shred = "0.5"
 specs = "0.10"
 quickcheck = "0.4.1"
+
+thread_profiler = { version = "0.1" , optional = true }
+
+[features]
+profiler = [ "thread_profiler/thread_profiler" ]

--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -11,6 +11,10 @@ extern crate serde;
 extern crate shred;
 extern crate specs;
 
+#[macro_use]
+#[cfg(feature = "profiler")]
+extern crate thread_profiler;
+
 //#[cfg(test)]
 //extern crate quickcheck;
 

--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -29,3 +29,8 @@ imagefmt = "4.0"
 itertools = "0.7"
 log = "0.4"
 specs = "0.10"
+
+thread_profiler = { version = "0.1", optional = true }
+
+[features]
+profiler = [ "thread_profiler/thread_profiler" ]

--- a/amethyst_gltf/src/lib.rs
+++ b/amethyst_gltf/src/lib.rs
@@ -14,6 +14,10 @@ extern crate itertools;
 extern crate log;
 extern crate specs;
 
+#[macro_use]
+#[cfg(feature = "profiler")]
+extern crate thread_profiler;
+
 pub use format::GltfSceneFormat;
 pub use systems::GltfSceneLoaderSystem;
 

--- a/amethyst_input/Cargo.toml
+++ b/amethyst_input/Cargo.toml
@@ -24,6 +24,11 @@ serde = { version = "1", features = ["serde_derive"] }
 shrev = "0.8"
 specs = "0.10"
 
+thread_profiler = { version = "0.1", optional = true }
+
 [dependencies.smallvec]
 version = "0.4.2"
 features = ["serde"]
+
+[features]
+profiler = [ "thread_profiler/thread_profiler" ]

--- a/amethyst_input/src/event.rs
+++ b/amethyst_input/src/event.rs
@@ -12,14 +12,12 @@ use winit::{MouseButton, VirtualKeyCode};
 pub enum InputEvent<T> {
     /// A key was pressed down, sent exactly once per key press.
     KeyPressed {
-        #[serde(with = "LocalVirtualKeyCode")]
-        key_code: VirtualKeyCode,
+        #[serde(with = "LocalVirtualKeyCode")] key_code: VirtualKeyCode,
         scancode: u32,
     },
     /// A key was released, sent exactly once per key release.
     KeyReleased {
-        #[serde(with = "LocalVirtualKeyCode")]
-        key_code: VirtualKeyCode,
+        #[serde(with = "LocalVirtualKeyCode")] key_code: VirtualKeyCode,
         scancode: u32,
     },
     /// A unicode character was received by the window.  Good for typing.

--- a/amethyst_input/src/lib.rs
+++ b/amethyst_input/src/lib.rs
@@ -10,6 +10,10 @@ extern crate smallvec;
 extern crate specs;
 extern crate winit;
 
+#[macro_use]
+#[cfg(feature = "profiler")]
+extern crate thread_profiler;
+
 pub use self::axis::Axis;
 pub use self::bindings::Bindings;
 pub use self::bundle::InputBundle;

--- a/amethyst_renderer/Cargo.toml
+++ b/amethyst_renderer/Cargo.toml
@@ -24,6 +24,7 @@ default = ["opengl"]
 #metal = ["gfx_device_metal", "gfx_window_metal"]
 opengl = ["gfx_device_gl", "gfx_window_glutin", "glutin"]
 #vulkan = ["gfx_device_vulkan", "gfx_window_vulkan"]
+profiler = [ "thread_profiler/thread_profiler" ]
 
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.2.0" }
@@ -44,6 +45,8 @@ shred = "0.5"
 shrev = "0.8"
 wavefront_obj = "5.0"
 winit = "0.10"
+
+thread_profiler = { version = "0.1", optional = true }
 
 gfx_device_gl = { version = "0.15", optional = true }
 gfx_window_glutin = { version = "0.20", optional = true }

--- a/amethyst_renderer/src/bundle.rs
+++ b/amethyst_renderer/src/bundle.rs
@@ -54,8 +54,7 @@ where
 }
 
 impl<'a, 'b, 'c, B: PipelineBuild<Pipeline = P>, P: 'b + PolyPipeline> ECSBundle<'a, 'b>
-    for RenderBundle<'c, B, P>
-{
+    for RenderBundle<'c, B, P> {
     fn build(
         self,
         world: &mut World,

--- a/amethyst_renderer/src/formats/texture.rs
+++ b/amethyst_renderer/src/formats/texture.rs
@@ -339,8 +339,8 @@ mod tests {
         match TextureData::from([0.25, 0.50, 0.75]) {
             TextureData::Rgba(color, _) => {
                 assert_eq!(color, [0.25, 0.50, 0.75, 1.0]);
-            },
-            _ => panic!("Expected [f32; 3] to turn into TextureData::Rgba")
+            }
+            _ => panic!("Expected [f32; 3] to turn into TextureData::Rgba"),
         }
     }
 }

--- a/amethyst_renderer/src/lib.rs
+++ b/amethyst_renderer/src/lib.rs
@@ -33,8 +33,13 @@ extern crate shred;
 extern crate shrev;
 extern crate smallvec;
 extern crate specs;
+
 extern crate wavefront_obj;
 extern crate winit;
+
+#[macro_use]
+#[cfg(feature = "profiler")]
+extern crate thread_profiler;
 
 #[cfg(all(feature = "d3d11", target_os = "windows"))]
 extern crate gfx_device_dx11;

--- a/amethyst_renderer/src/system.rs
+++ b/amethyst_renderer/src/system.rs
@@ -26,8 +26,7 @@ use tex::Texture;
 #[derivative(Debug)]
 pub struct RenderSystem<P> {
     pipe: P,
-    #[derivative(Debug = "ignore")]
-    renderer: Renderer,
+    #[derivative(Debug = "ignore")] renderer: Renderer,
     cached_size: (u32, u32),
 }
 

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -28,3 +28,8 @@ specs = "0.10"
 unicode-normalization = "0.1"
 unicode-segmentation = "1.2"
 winit = "0.10"
+
+thread_profiler = { version = "0.1", optional = true }
+
+[features]
+profiler = [ "thread_profiler/thread_profiler" ]

--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -21,6 +21,10 @@ extern crate unicode_normalization;
 extern crate unicode_segmentation;
 extern crate winit;
 
+#[macro_use]
+#[cfg(feature = "profiler")]
+extern crate thread_profiler;
+
 mod bundle;
 mod focused;
 mod format;

--- a/amethyst_utils/Cargo.toml
+++ b/amethyst_utils/Cargo.toml
@@ -22,3 +22,8 @@ winit = "0.10"
 specs = "0.10"
 shred = "0.5"
 log = "0.4"
+
+thread_profiler = { version = "0.1", optional = true }
+
+[features]
+profiler = [ "thread_profiler/thread_profiler" ]

--- a/amethyst_utils/src/lib.rs
+++ b/amethyst_utils/src/lib.rs
@@ -5,5 +5,9 @@ extern crate shred;
 extern crate specs;
 extern crate winit;
 
+#[macro_use]
+#[cfg(feature = "profiler")]
+extern crate thread_profiler;
+
 pub mod fps_counter;
 pub mod circular_buffer;

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -29,8 +29,7 @@ struct DemoState {
     directional_light: bool,
     camera_angle: f32,
     fps_display: Entity,
-    #[allow(dead_code)]
-    pipeline_forward: bool, // TODO
+    #[allow(dead_code)] pipeline_forward: bool, // TODO
 }
 
 struct ExampleSystem;

--- a/src/app.rs
+++ b/src/app.rs
@@ -37,8 +37,7 @@ pub struct Application<'a, 'b> {
     #[derivative(Debug = "ignore")]
     pub world: World,
 
-    #[derivative(Debug = "ignore")]
-    dispatcher: Dispatcher<'a, 'b>,
+    #[derivative(Debug = "ignore")] dispatcher: Dispatcher<'a, 'b>,
     events_reader_id: ReaderId<Event>,
     states: StateMachine<'a>,
     ignore_window_close: bool,

--- a/src/state.rs
+++ b/src/state.rs
@@ -54,8 +54,7 @@ pub trait State {
 #[derivative(Debug)]
 pub struct StateMachine<'a> {
     running: bool,
-    #[derivative(Debug = "ignore")]
-    state_stack: Vec<Box<State + 'a>>,
+    #[derivative(Debug = "ignore")] state_stack: Vec<Box<State + 'a>>,
 }
 
 impl<'a> StateMachine<'a> {


### PR DESCRIPTION
Issue #503 

Adds thread_profiler to all new crates.
If the `profile` feature is enabled in the main crate then it is applied to all sub-crates.
`cargo fmt` made some syntax changes, no feature changes.
Adds a few thread_profiles to the amethyst_assets crate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/617)
<!-- Reviewable:end -->
