### PR TITLE
Remove another unwrap

### DIFF
--- a/amethyst_animation/src/systems/control.rs
+++ b/amethyst_animation/src/systems/control.rs
@@ -440,11 +440,13 @@ where
     if check_termination(control_id, hierarchy, &samplers) {
         // Do termination
         for (_, node_entity) in &hierarchy.nodes {
-            let empty = {
-                let mut sampler = samplers.get_mut(*node_entity).unwrap();
-                sampler.clear(control_id);
-                sampler.is_empty()
-            };
+            let empty = samplers
+                .get_mut(*node_entity)
+                .map(|sampler| {
+                    sampler.clear(control_id);
+                    sampler.is_empty()
+                })
+                .unwrap_or(false);
             if empty {
                 samplers.remove(*node_entity);
             }


### PR DESCRIPTION
This would panic when you abort an animation that doesn't yet have a sampler

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/626)
<!-- Reviewable:end -->
