### PR TITLE
feat: Add texture animation

### DIFF
--- a/amethyst_animation/src/bundle.rs
+++ b/amethyst_animation/src/bundle.rs
@@ -5,6 +5,7 @@ use amethyst_core::{ECSBundle, Result};
 use amethyst_core::specs::{Component, DispatcherBuilder, World};
 use amethyst_renderer::JointTransforms;
 
+use material::MaterialTextureSet;
 use resources::{Animation, AnimationControlSet, AnimationHierarchy, AnimationSampling,
                 AnimationSet, RestState, Sampler, SamplerControlSet};
 use skinning::{Joint, Skin, VertexSkinningSystem};
@@ -100,6 +101,7 @@ where
             .entry()
             .or_insert_with(AssetStorage::<Sampler<T::Primitive>>::new);
         world.register::<SamplerControlSet<T>>();
+        world.add_resource(MaterialTextureSet::default());
         Ok(builder
             .add(SamplerProcessor::<T::Primitive>::new(), "", &[])
             .add(SamplerInterpolationSystem::<T>::new(), self.name, self.dep))

--- a/amethyst_animation/src/lib.rs
+++ b/amethyst_animation/src/lib.rs
@@ -16,19 +16,21 @@ extern crate thread_profiler;
 
 pub use self::bundle::{AnimationBundle, SamplingBundle, VertexSkinningBundle};
 pub use self::resources::{Animation, AnimationCommand, AnimationControl, AnimationControlSet,
-                          AnimationHierarchy, AnimationSampling, AnimationSet, BlendMethod,
-                          ControlState, EndControl, Sampler, SamplerControl, SamplerControlSet,
-                          StepDirection};
+                          AnimationHierarchy, AnimationSampling, AnimationSet, ApplyData,
+                          BlendMethod, ControlState, EndControl, Sampler, SamplerControl,
+                          SamplerControlSet, StepDirection};
 pub use self::skinning::{Joint, Skin, VertexSkinningSystem};
 pub use self::systems::{AnimationControlSystem, AnimationProcessor, SamplerInterpolationSystem,
                         SamplerProcessor};
 pub use self::transform::TransformChannel;
+pub use self::material::{MaterialPrimitive, MaterialChannel, MaterialTextureSet};
 pub use self::util::{get_animation_set, SamplerPrimitive};
 pub use minterpolate::{InterpolationFunction, InterpolationPrimitive};
 
 mod skinning;
 mod resources;
 mod systems;
+mod material;
 mod transform;
 mod bundle;
 mod util;

--- a/amethyst_animation/src/lib.rs
+++ b/amethyst_animation/src/lib.rs
@@ -15,6 +15,7 @@ extern crate serde;
 extern crate thread_profiler;
 
 pub use self::bundle::{AnimationBundle, SamplingBundle, VertexSkinningBundle};
+pub use self::material::{MaterialChannel, MaterialPrimitive, MaterialTextureSet};
 pub use self::resources::{Animation, AnimationCommand, AnimationControl, AnimationControlSet,
                           AnimationHierarchy, AnimationSampling, AnimationSet, ApplyData,
                           BlendMethod, ControlState, EndControl, Sampler, SamplerControl,
@@ -23,7 +24,6 @@ pub use self::skinning::{Joint, Skin, VertexSkinningSystem};
 pub use self::systems::{AnimationControlSystem, AnimationProcessor, SamplerInterpolationSystem,
                         SamplerProcessor};
 pub use self::transform::TransformChannel;
-pub use self::material::{MaterialPrimitive, MaterialChannel, MaterialTextureSet};
 pub use self::util::{get_animation_set, SamplerPrimitive};
 pub use minterpolate::{InterpolationFunction, InterpolationPrimitive};
 

--- a/amethyst_animation/src/material.rs
+++ b/amethyst_animation/src/material.rs
@@ -1,0 +1,236 @@
+use fnv::FnvHashMap;
+
+use amethyst_assets::Handle;
+use amethyst_core::specs::Fetch;
+use amethyst_renderer::{Material, Texture, TextureOffset};
+use minterpolate::InterpolationPrimitive;
+
+use {AnimationSampling, ApplyData, BlendMethod};
+
+/// Textures used by texture animations
+#[derive(Debug, Default)]
+pub struct MaterialTextureSet {
+    textures: FnvHashMap<usize, Handle<Texture>>,
+    texture_inverse: FnvHashMap<Handle<Texture>, usize>,
+}
+
+impl MaterialTextureSet {
+    pub fn new() -> Self {
+        MaterialTextureSet {
+            textures: FnvHashMap::default(),
+            texture_inverse: FnvHashMap::default(),
+        }
+    }
+
+    pub fn handle(&self, index: usize) -> Option<Handle<Texture>> {
+        self.textures.get(&index).cloned()
+    }
+
+    pub fn index(&self, handle: &Handle<Texture>) -> Option<usize> {
+        self.texture_inverse.get(handle).cloned()
+    }
+
+    pub fn insert(&mut self, index: usize, handle: Handle<Texture>) {
+        self.textures.insert(index, handle.clone());
+        self.texture_inverse.insert(handle, index);
+    }
+
+    pub fn remove(&mut self, index: usize) {
+        if let Some(handle) = self.textures.remove(&index) {
+            self.texture_inverse.remove(&handle);
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.textures.clear();
+        self.texture_inverse.clear();
+    }
+}
+
+/// Sampler primitive for Material animations
+/// Note that material can only ever be animated with `Step`, or a panic will occur.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum MaterialPrimitive {
+    Texture(usize),
+    Offset((f32, f32), (f32, f32)),
+}
+
+impl InterpolationPrimitive for MaterialPrimitive {
+    fn add(&self, _: &Self) -> Self {
+        panic!("Cannot add MaterialPrimitive")
+    }
+
+    fn sub(&self, _: &Self) -> Self {
+        panic!("Cannot sub MaterialPrimitive")
+    }
+
+    fn mul(&self, _: f32) -> Self {
+        panic!("Cannot mul MaterialPrimitive")
+    }
+
+    fn dot(&self, _: &Self) -> f32 {
+        panic!("Cannot dot MaterialPrimitive")
+    }
+
+    fn magnitude2(&self) -> f32 {
+        panic!("Cannot magnitude2 MaterialPrimitive")
+    }
+
+    fn magnitude(&self) -> f32 {
+        panic!("Cannot magnitude MaterialPrimitive")
+    }
+
+    fn normalize(&self) -> Self {
+        panic!("Cannot normalize MaterialPrimitive")
+    }
+}
+
+/// Channels that are animatable on `Material`
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub enum MaterialChannel {
+    AlbedoTexture,
+    AlbedoOffset,
+    EmissionTexture,
+    EmissionOffset,
+    NormalTexture,
+    NormalOffset,
+    MetallicTexture,
+    MetallicOffset,
+    RoughnessTexture,
+    RoughnessOffset,
+    AmbientOcclusionTexture,
+    AmbientOcclusionOffset,
+    CaveatTexture,
+    CaveatOffset,
+}
+
+impl<'a> ApplyData<'a> for Material {
+    type ApplyData = Fetch<'a, MaterialTextureSet>;
+}
+
+fn offset(offset: &TextureOffset) -> MaterialPrimitive {
+    MaterialPrimitive::Offset(offset.u, offset.v)
+}
+
+fn texture_offset(u: (f32, f32), v: (f32, f32)) -> TextureOffset {
+    TextureOffset { u, v }
+}
+
+impl AnimationSampling for Material {
+    type Primitive = MaterialPrimitive;
+    type Channel = MaterialChannel;
+
+    fn apply_sample(
+        &mut self,
+        channel: &Self::Channel,
+        data: &Self::Primitive,
+        extra: &Fetch<MaterialTextureSet>,
+    ) {
+        match (*channel, *data) {
+            (MaterialChannel::AlbedoTexture, MaterialPrimitive::Texture(i)) => {
+                if let Some(handle) = extra.handle(i) {
+                    self.albedo = handle;
+                }
+            }
+            (MaterialChannel::EmissionTexture, MaterialPrimitive::Texture(i)) => {
+                if let Some(handle) = extra.handle(i) {
+                    self.emission = handle;
+                }
+            }
+            (MaterialChannel::NormalTexture, MaterialPrimitive::Texture(i)) => {
+                if let Some(handle) = extra.handle(i) {
+                    self.normal = handle;
+                }
+            }
+            (MaterialChannel::MetallicTexture, MaterialPrimitive::Texture(i)) => {
+                if let Some(handle) = extra.handle(i) {
+                    self.metallic = handle;
+                }
+            }
+            (MaterialChannel::RoughnessTexture, MaterialPrimitive::Texture(i)) => {
+                if let Some(handle) = extra.handle(i) {
+                    self.roughness = handle;
+                }
+            }
+            (MaterialChannel::AmbientOcclusionTexture, MaterialPrimitive::Texture(i)) => {
+                if let Some(handle) = extra.handle(i) {
+                    self.ambient_occlusion = handle;
+                }
+            }
+            (MaterialChannel::CaveatTexture, MaterialPrimitive::Texture(i)) => {
+                if let Some(handle) = extra.handle(i) {
+                    self.caveat = handle;
+                }
+            }
+
+            (MaterialChannel::AlbedoOffset, MaterialPrimitive::Offset(u, v)) => {
+                self.albedo_offset = texture_offset(u, v)
+            }
+            (MaterialChannel::EmissionOffset, MaterialPrimitive::Offset(u, v)) => {
+                self.emission_offset = texture_offset(u, v)
+            }
+            (MaterialChannel::NormalOffset, MaterialPrimitive::Offset(u, v)) => {
+                self.normal_offset = texture_offset(u, v)
+            }
+            (MaterialChannel::MetallicOffset, MaterialPrimitive::Offset(u, v)) => {
+                self.metallic_offset = texture_offset(u, v)
+            }
+            (MaterialChannel::RoughnessOffset, MaterialPrimitive::Offset(u, v)) => {
+                self.roughness_offset = texture_offset(u, v)
+            }
+            (MaterialChannel::AmbientOcclusionOffset, MaterialPrimitive::Offset(u, v)) => {
+                self.ambient_occlusion_offset = texture_offset(u, v)
+            }
+            (MaterialChannel::CaveatOffset, MaterialPrimitive::Offset(u, v)) => {
+                self.caveat_offset = texture_offset(u, v)
+            }
+
+            _ => panic!("Bad combination of data in Material animation"),
+        }
+    }
+
+    fn current_sample(
+        &self,
+        channel: &Self::Channel,
+        extra: &Fetch<MaterialTextureSet>,
+    ) -> Self::Primitive {
+        match *channel {
+            MaterialChannel::AlbedoTexture => {
+                MaterialPrimitive::Texture(extra.index(&self.albedo).unwrap())
+            }
+            MaterialChannel::EmissionTexture => {
+                MaterialPrimitive::Texture(extra.index(&self.emission).unwrap())
+            }
+            MaterialChannel::NormalTexture => {
+                MaterialPrimitive::Texture(extra.index(&self.normal).unwrap())
+            }
+            MaterialChannel::MetallicTexture => {
+                MaterialPrimitive::Texture(extra.index(&self.metallic).unwrap())
+            }
+            MaterialChannel::RoughnessTexture => {
+                MaterialPrimitive::Texture(extra.index(&self.roughness).unwrap())
+            }
+            MaterialChannel::AmbientOcclusionTexture => {
+                MaterialPrimitive::Texture(extra.index(&self.ambient_occlusion).unwrap())
+            }
+            MaterialChannel::CaveatTexture => {
+                MaterialPrimitive::Texture(extra.index(&self.caveat).unwrap())
+            }
+            MaterialChannel::AlbedoOffset => offset(&self.albedo_offset),
+            MaterialChannel::EmissionOffset => offset(&self.emission_offset),
+            MaterialChannel::NormalOffset => offset(&self.normal_offset),
+            MaterialChannel::MetallicOffset => offset(&self.metallic_offset),
+            MaterialChannel::RoughnessOffset => offset(&self.roughness_offset),
+            MaterialChannel::AmbientOcclusionOffset => offset(&self.ambient_occlusion_offset),
+            MaterialChannel::CaveatOffset => offset(&self.caveat_offset),
+        }
+    }
+
+    fn default_primitive(_: &Self::Channel) -> Self::Primitive {
+        panic!("Blending is not applicable to Material animation")
+    }
+
+    fn blend_method(&self, _: &Self::Channel) -> Option<BlendMethod> {
+        None
+    }
+}

--- a/amethyst_animation/src/resources.rs
+++ b/amethyst_animation/src/resources.rs
@@ -4,6 +4,7 @@ use std::marker;
 use std::time::Duration;
 
 use amethyst_assets::{Asset, AssetStorage, Handle, Result};
+use amethyst_core::shred::SystemData;
 use amethyst_core::specs::{Component, DenseVecStorage, Entity, VecStorage, WriteStorage};
 use amethyst_core::timing::{duration_to_secs, secs_to_duration};
 use fnv::FnvHashMap;
@@ -15,18 +16,33 @@ pub enum BlendMethod {
     Linear,
 }
 
+/// Extra data to extract from `World`, for use when applying or fetching a sample
+pub trait ApplyData<'a> {
+    /// The actual data, must implement `SystemData`
+    type ApplyData: SystemData<'a>;
+}
+
 /// Master trait used to define animation sampling on a component
-pub trait AnimationSampling: Send + Sync + 'static {
+pub trait AnimationSampling: Send + Sync + 'static + for<'b> ApplyData<'b> {
     /// The interpolation primitive
     type Primitive: InterpolationPrimitive + Clone + Copy + Send + Sync + 'static;
     /// The channel type
     type Channel: Debug + Clone + Hash + Eq + Send + Sync + 'static;
 
     /// Apply a sample to a channel
-    fn apply_sample(&mut self, channel: &Self::Channel, data: &Self::Primitive);
+    fn apply_sample<'a>(
+        &mut self,
+        channel: &Self::Channel,
+        data: &Self::Primitive,
+        extra: &<Self as ApplyData<'a>>::ApplyData,
+    );
 
     /// Get the current sample for a channel
-    fn current_sample(&self, channel: &Self::Channel) -> Self::Primitive;
+    fn current_sample<'a>(
+        &self,
+        channel: &Self::Channel,
+        extra: &<Self as ApplyData<'a>>::ApplyData,
+    ) -> Self::Primitive;
 
     /// Get default primitive
     fn default_primitive(channel: &Self::Channel) -> Self::Primitive;

--- a/amethyst_animation/src/systems/sampling.rs
+++ b/amethyst_animation/src/systems/sampling.rs
@@ -7,8 +7,8 @@ use amethyst_core::specs::{Component, Fetch, Join, System, WriteStorage};
 use itertools::Itertools;
 use minterpolate::InterpolationPrimitive;
 
-use resources::{AnimationSampling, BlendMethod, ControlState, EndControl, Sampler, SamplerControl,
-                SamplerControlSet};
+use resources::{AnimationSampling, ApplyData, BlendMethod, ControlState, EndControl, Sampler,
+                SamplerControl, SamplerControlSet};
 
 /// System for interpolating active samplers.
 ///
@@ -53,9 +53,10 @@ where
         Fetch<'a, AssetStorage<Sampler<T::Primitive>>>,
         WriteStorage<'a, SamplerControlSet<T>>,
         WriteStorage<'a, T>,
+        <T as ApplyData<'a>>::ApplyData,
     );
 
-    fn run(&mut self, (time, samplers, mut control_sets, mut comps): Self::SystemData) {
+    fn run(&mut self, (time, samplers, mut control_sets, mut comps, apply_data): Self::SystemData) {
         for (control_set, comp) in (&mut control_sets, &mut comps).join() {
             self.inner.clear();
             for control in control_set.samplers.iter_mut() {
@@ -76,13 +77,13 @@ where
                                 .map(|p| p.2)
                                 .last()
                             {
-                                comp.apply_sample(channel, &p);
+                                comp.apply_sample(channel, &p, &apply_data);
                             }
                         }
 
                         Some(BlendMethod::Linear) => {
                             if let Some(p) = linear_blend::<T>(channel, &self.inner) {
-                                comp.apply_sample(channel, &p);
+                                comp.apply_sample(channel, &p, &apply_data);
                             }
                         }
                     }

--- a/amethyst_animation/src/transform.rs
+++ b/amethyst_animation/src/transform.rs
@@ -1,7 +1,7 @@
 use amethyst_core::Transform;
 use amethyst_core::cgmath::{InnerSpace, Quaternion, Vector3};
 
-use resources::{AnimationSampling, BlendMethod};
+use resources::{AnimationSampling, ApplyData, BlendMethod};
 use util::SamplerPrimitive;
 
 /// Channels that can be animated on `Transform`
@@ -12,11 +12,15 @@ pub enum TransformChannel {
     Scale,
 }
 
-impl AnimationSampling for Transform {
-    type Channel = TransformChannel;
-    type Primitive = SamplerPrimitive<f32>;
+impl<'a> ApplyData<'a> for Transform {
+    type ApplyData = ();
+}
 
-    fn apply_sample(&mut self, channel: &Self::Channel, data: &SamplerPrimitive<f32>) {
+impl AnimationSampling for Transform {
+    type Primitive = SamplerPrimitive<f32>;
+    type Channel = TransformChannel;
+
+    fn apply_sample(&mut self, channel: &Self::Channel, data: &SamplerPrimitive<f32>, _: &()) {
         use self::TransformChannel::*;
         use util::SamplerPrimitive::*;
         match (channel, *data) {
@@ -27,7 +31,7 @@ impl AnimationSampling for Transform {
         }
     }
 
-    fn current_sample(&self, channel: &Self::Channel) -> SamplerPrimitive<f32> {
+    fn current_sample(&self, channel: &Self::Channel, _: &()) -> SamplerPrimitive<f32> {
         use self::TransformChannel::*;
         match channel {
             &Translation => SamplerPrimitive::Vec3(self.translation.into()),

--- a/amethyst_renderer/src/bundle.rs
+++ b/amethyst_renderer/src/bundle.rs
@@ -1,7 +1,7 @@
 //! ECS rendering bundle
 
 use {AmbientColor, Camera, Light, Material, MaterialDefaults, Mesh, Rgba, ScreenDimensions,
-     Texture, WindowMessages};
+     Texture, TextureOffset, WindowMessages};
 use amethyst_assets::{AssetStorage, Handle, Loader};
 use amethyst_core::bundle::{ECSBundle, Result, ResultExt};
 use amethyst_core::orientation::Orientation;
@@ -120,11 +120,18 @@ fn create_default_mat(world: &World) -> Material {
 
     Material {
         albedo,
+        albedo_offset: TextureOffset::default(),
         emission,
+        emission_offset: TextureOffset::default(),
         normal,
+        normal_offset: TextureOffset::default(),
         metallic,
+        metallic_offset: TextureOffset::default(),
         roughness,
+        roughness_offset: TextureOffset::default(),
         ambient_occlusion,
+        ambient_occlusion_offset: TextureOffset::default(),
         caveat,
+        caveat_offset: TextureOffset::default(),
     }
 }

--- a/amethyst_renderer/src/lib.rs
+++ b/amethyst_renderer/src/lib.rs
@@ -70,7 +70,7 @@ pub use formats::{build_mesh_with_combo, create_mesh_asset, create_texture_asset
 pub use input::{ElementState, Event, KeyboardInput, MouseButton, VirtualKeyCode, WindowEvent};
 pub use light::{DirectionalLight, Light, PointLight, SpotLight, SunLight};
 pub use mesh::{vertex_data, Mesh, MeshBuilder, MeshHandle, VertexBuffer};
-pub use mtl::{Material, MaterialDefaults};
+pub use mtl::{Material, MaterialDefaults, TextureOffset};
 pub use pass::{DrawFlat, DrawFlatSeparate, DrawPbm, DrawPbmSeparate, DrawShaded,
                DrawShadedSeparate};
 pub use pipe::{ColorBuffer, Data, DepthBuffer, DepthMode, Effect, EffectBuilder, Init, Meta,

--- a/amethyst_renderer/src/mtl/mod.rs
+++ b/amethyst_renderer/src/mtl/mod.rs
@@ -4,23 +4,55 @@ use amethyst_core::specs::{Component, DenseVecStorage};
 
 use tex::TextureHandle;
 
+/// Material reference this part of the texture
+#[derive(Debug, Clone, PartialEq)]
+pub struct TextureOffset {
+    /// Start and end offset for U coordinate
+    pub u: (f32, f32),
+    /// Start and end offset for V coordinate
+    pub v: (f32, f32),
+}
+
+impl Default for TextureOffset {
+    fn default() -> Self {
+        TextureOffset {
+            u: (0., 1.),
+            v: (0., 1.),
+        }
+    }
+}
+
 /// Material struct.
-#[derive(Clone, Eq, Hash, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct Material {
     /// Diffuse map.
     pub albedo: TextureHandle,
+    /// Diffuse texture offset
+    pub albedo_offset: TextureOffset,
     /// Emission map.
     pub emission: TextureHandle,
+    /// Emission texture offset
+    pub emission_offset: TextureOffset,
     /// Normal map.
     pub normal: TextureHandle,
+    /// Normal texture offset
+    pub normal_offset: TextureOffset,
     /// Metallic map.
     pub metallic: TextureHandle,
+    /// Metallic texture offset
+    pub metallic_offset: TextureOffset,
     /// Roughness map.
     pub roughness: TextureHandle,
+    /// Roughness texture offset
+    pub roughness_offset: TextureOffset,
     /// Ambient occlusion map.
     pub ambient_occlusion: TextureHandle,
+    /// Ambient occlusion texture offset
+    pub ambient_occlusion_offset: TextureOffset,
     /// Caveat map.
     pub caveat: TextureHandle,
+    /// Caveat texture offset
+    pub caveat_offset: TextureOffset,
 }
 
 impl Component for Material {

--- a/amethyst_renderer/src/pass/flat/interleaved.rs
+++ b/amethyst_renderer/src/pass/flat/interleaved.rs
@@ -13,7 +13,7 @@ use cam::{ActiveCamera, Camera};
 use error::Result;
 use mesh::{Mesh, MeshHandle};
 use mtl::{Material, MaterialDefaults};
-use pass::util::{draw_mesh, get_camera, VertexArgs};
+use pass::util::{draw_mesh, get_camera, setup_textures, VertexArgs};
 use pipe::{DepthMode, Effect, NewEffect};
 use pipe::pass::{Pass, PassData};
 use tex::Texture;
@@ -78,8 +78,8 @@ where
         let mut builder = effect.simple(VERT_SRC, FRAG_SRC);
         builder
             .with_raw_constant_buffer("VertexArgs", mem::size_of::<VertexArgs>(), 1)
-            .with_raw_vertex_buffer(V::QUERIED_ATTRIBUTES, V::size() as ElemStride, 0)
-            .with_texture("albedo");
+            .with_raw_vertex_buffer(V::QUERIED_ATTRIBUTES, V::size() as ElemStride, 0);
+        setup_textures(&mut builder, &TEXTURES);
         match self.transparency {
             Some((mask, blend, depth)) => builder.with_blended_output("color", mask, blend, depth),
             None => builder.with_output("color", Some(DepthMode::LessEqualWrite)),

--- a/amethyst_renderer/src/pass/flat/separate.rs
+++ b/amethyst_renderer/src/pass/flat/separate.rs
@@ -12,7 +12,7 @@ use error::Result;
 use mesh::{Mesh, MeshHandle};
 use mtl::{Material, MaterialDefaults};
 use pass::skinning::{create_skinning_effect, setup_skinning_buffers};
-use pass::util::{draw_mesh, get_camera, VertexArgs};
+use pass::util::{draw_mesh, get_camera, setup_textures, VertexArgs};
 use pipe::{DepthMode, Effect, NewEffect};
 use pipe::pass::{Pass, PassData};
 use skinning::JointTransforms;
@@ -99,9 +99,8 @@ impl Pass for DrawFlatSeparate {
         if self.skinning {
             setup_skinning_buffers(&mut builder);
         }
-        builder
-            .with_raw_constant_buffer("VertexArgs", mem::size_of::<VertexArgs>(), 1)
-            .with_texture("albedo");
+        builder.with_raw_constant_buffer("VertexArgs", mem::size_of::<VertexArgs>(), 1);
+        setup_textures(&mut builder, &TEXTURES);
         match self.transparency {
             Some((mask, blend, depth)) => builder.with_blended_output("color", mask, blend, depth),
             None => builder.with_output("color", Some(DepthMode::LessEqualWrite)),

--- a/amethyst_renderer/src/pass/shaded_util.rs
+++ b/amethyst_renderer/src/pass/shaded_util.rs
@@ -5,7 +5,7 @@ use amethyst_core::specs::{Join, ReadStorage};
 use gfx::traits::Pod;
 
 use cam::Camera;
-use light::{DirectionalLight, Light, PointLight};
+use light::Light;
 use pipe::{Effect, EffectBuilder};
 use resources::AmbientColor;
 use types::Encoder;
@@ -101,8 +101,12 @@ pub(crate) fn set_light_args(
 pub(crate) fn setup_light_buffers(builder: &mut EffectBuilder) {
     builder
         .with_raw_constant_buffer("FragmentArgs", mem::size_of::<FragmentArgs>(), 1)
-        .with_raw_constant_buffer("PointLights", mem::size_of::<PointLight>(), 128)
-        .with_raw_constant_buffer("DirectionalLights", mem::size_of::<DirectionalLight>(), 16)
+        .with_raw_constant_buffer("PointLights", mem::size_of::<PointLightPod>(), 128)
+        .with_raw_constant_buffer(
+            "DirectionalLights",
+            mem::size_of::<DirectionalLightPod>(),
+            16,
+        )
         .with_raw_global("ambient_color")
         .with_raw_global("camera_position");
 }

--- a/amethyst_renderer/src/pass/shaders/fragment/flat.glsl
+++ b/amethyst_renderer/src/pass/shaders/fragment/flat.glsl
@@ -4,6 +4,11 @@
 
 uniform sampler2D albedo;
 
+layout (std140) uniform AlbedoOffset {
+    vec2 u_offset;
+    vec2 v_offset;
+} albedo_offset;
+
 in VertexData {
     vec4 position;
     vec3 normal;
@@ -13,6 +18,14 @@ in VertexData {
 
 out vec4 color;
 
+float tex_coord(float coord, vec2 offset) {
+    return offset.x + coord * (offset.y - offset.x);
+}
+
+vec2 tex_coords(vec2 coord, vec2 u, vec2 v) {
+    return vec2(tex_coord(coord.x, u), tex_coord(coord.y, v));
+}
+
 void main() {
-    color = texture(albedo, vertex.tex_coord);
+    color = texture(albedo, tex_coords(vertex.tex_coord, albedo_offset.u_offset, albedo_offset.v_offset));
 }

--- a/amethyst_renderer/src/pass/shaders/fragment/pbm.glsl
+++ b/amethyst_renderer/src/pass/shaders/fragment/pbm.glsl
@@ -40,6 +40,41 @@ uniform sampler2D roughness;
 uniform sampler2D ambient_occlusion;
 uniform sampler2D caveat;
 
+layout (std140) uniform AlbedoOffset {
+    vec2 u_offset;
+    vec2 v_offset;
+} albedo_offset;
+
+layout (std140) uniform EmissionOffset {
+    vec2 u_offset;
+    vec2 v_offset;
+} emission_offset;
+
+layout (std140) uniform NormalOffset {
+    vec2 u_offset;
+    vec2 v_offset;
+} normal_offset;
+
+layout (std140) uniform MetallicOffset {
+    vec2 u_offset;
+    vec2 v_offset;
+} metallic_offset;
+
+layout (std140) uniform RoughnessOffset {
+    vec2 u_offset;
+    vec2 v_offset;
+} roughness_offset;
+
+layout (std140) uniform AmbientOcclusionOffset {
+    vec2 u_offset;
+    vec2 v_offset;
+} ambient_occlusion_offset;
+
+layout (std140) uniform CaveatOffset {
+    vec2 u_offset;
+    vec2 v_offset;
+} caveat_offset;
+
 in VertexData {
     vec4 position;
     vec3 normal;
@@ -50,6 +85,14 @@ in VertexData {
 out vec4 out_color;
 
 const float PI = 3.14159265359;
+
+float tex_coord(float coord, vec2 offset) {
+    return offset.x + coord * (offset.y - offset.x);
+}
+
+vec2 tex_coords(vec2 coord, vec2 u, vec2 v) {
+    return vec2(tex_coord(coord.x, u), tex_coord(coord.y, v));
+}
 
 float normal_distribution(vec3 N, vec3 H, float a) {
     float a2 = a * a;
@@ -77,13 +120,13 @@ vec3 fresnel(float HdotV, vec3 fresnel_base) {
 }
 
 void main() {
-    vec3 albedo             = texture(albedo, vertex.tex_coord).rgb;
-    vec3 emission           = texture(emission, vertex.tex_coord).rgb;
-    vec3 normal             = texture(normal, vertex.tex_coord).rgb;
-    float metallic          = texture(metallic, vertex.tex_coord).r;
-    float roughness         = texture(roughness, vertex.tex_coord).r;
-    float ambient_occlusion = texture(ambient_occlusion, vertex.tex_coord).r;
-    float caveat            = texture(caveat, vertex.tex_coord).r; // TODO: Use caveat
+    vec3 albedo             = texture(albedo, tex_coords(vertex.tex_coord, albedo_offset.u_offset, albedo_offset.v_offset)).rgb;
+    vec3 emission           = texture(emission, tex_coords(vertex.tex_coord, emission_offset.u_offset, emission_offset.v_offset)).rgb;
+    vec3 normal             = texture(normal, tex_coords(vertex.tex_coord, normal_offset.u_offset, normal_offset.v_offset)).rgb;
+    float metallic          = texture(metallic, tex_coords(vertex.tex_coord, metallic_offset.u_offset, metallic_offset.v_offset)).r;
+    float roughness         = texture(roughness, tex_coords(vertex.tex_coord, roughness_offset.u_offset, roughness_offset.v_offset)).r;
+    float ambient_occlusion = texture(ambient_occlusion, tex_coords(vertex.tex_coord, ambient_occlusion_offset.u_offset, ambient_occlusion_offset.v_offset)).r;
+    float caveat            = texture(caveat, tex_coords(vertex.tex_coord, caveat_offset.u_offset, caveat_offset.v_offset)).r; // TODO: Use caveat
 
     // normal conversion
     normal = normal * 2 - 1;

--- a/amethyst_renderer/src/pass/shaders/fragment/shaded.glsl
+++ b/amethyst_renderer/src/pass/shaders/fragment/shaded.glsl
@@ -35,6 +35,16 @@ uniform vec3 camera_position;
 uniform sampler2D albedo;
 uniform sampler2D emission;
 
+layout (std140) uniform AlbedoOffset {
+    vec2 u_offset;
+    vec2 v_offset;
+} albedo_offset;
+
+layout (std140) uniform EmissionOffset {
+    vec2 u_offset;
+    vec2 v_offset;
+} emission_offset;
+
 in VertexData {
     vec4 position;
     vec3 normal;
@@ -44,9 +54,17 @@ in VertexData {
 
 out vec4 out_color;
 
+float tex_coord(float coord, vec2 offset) {
+    return offset.x + coord * (offset.y - offset.x);
+}
+
+vec2 tex_coords(vec2 coord, vec2 u, vec2 v) {
+    return vec2(tex_coord(coord.x, u), tex_coord(coord.y, v));
+}
+
 void main() {
-    vec4 color = texture(albedo, vertex.tex_coord);
-    vec4 ecolor = texture(emission, vertex.tex_coord);
+    vec4 color = texture(albedo, tex_coords(vertex.tex_coord, albedo_offset.u_offset, albedo_offset.v_offset));
+    vec4 ecolor = texture(emission, tex_coords(vertex.tex_coord, emission_offset.u_offset, emission_offset.v_offset));
     vec4 lighting = vec4(0.0);
     vec4 normal = vec4(normalize(vertex.normal), 0.0);
     for (int i = 0; i < point_light_count; i++) {

--- a/amethyst_renderer/src/pass/util.rs
+++ b/amethyst_renderer/src/pass/util.rs
@@ -7,7 +7,7 @@ use amethyst_core::specs::{Fetch, Join, ReadStorage};
 
 use cam::{ActiveCamera, Camera};
 use mesh::Mesh;
-use mtl::{Material, MaterialDefaults};
+use mtl::{Material, MaterialDefaults, TextureOffset};
 use pass::set_skinning_buffers;
 use pipe::{Effect, EffectBuilder};
 use skinning::JointTransforms;
@@ -31,6 +31,22 @@ pub(crate) struct VertexArgs {
     proj: [[f32; 4]; 4],
     view: [[f32; 4]; 4],
     model: [[f32; 4]; 4],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct TextureOffsetPod {
+    u_offset: [f32; 2],
+    v_offset: [f32; 2],
+}
+
+impl TextureOffsetPod {
+    pub(crate) fn from_offset(offset: &TextureOffset) -> Self {
+        TextureOffsetPod {
+            u_offset: [offset.u.0, offset.u.1],
+            v_offset: [offset.v.0, offset.v.1],
+        }
+    }
 }
 
 pub(crate) fn set_attribute_buffers(
@@ -65,10 +81,12 @@ pub(crate) fn setup_textures(builder: &mut EffectBuilder, types: &[TextureType])
             Caveat => builder.with_texture("caveat"),
         };
     }
+    setup_texture_offsets(builder, types);
 }
 
 pub(crate) fn add_textures(
     effect: &mut Effect,
+    encoder: &mut Encoder,
     storage: &AssetStorage<Texture>,
     material: &Material,
     default: &Material,
@@ -100,6 +118,98 @@ pub(crate) fn add_textures(
                 .or_else(|| storage.get(&default.caveat)),
         };
         add_texture(effect, texture.unwrap());
+    }
+    set_texture_offsets(effect, encoder, material, types);
+}
+
+pub(crate) fn setup_texture_offsets(builder: &mut EffectBuilder, types: &[TextureType]) {
+    use self::TextureType::*;
+    for ty in types {
+        match *ty {
+            Albedo => builder.with_raw_constant_buffer(
+                "AlbedoOffset",
+                mem::size_of::<TextureOffsetPod>(),
+                1,
+            ),
+            Emission => builder.with_raw_constant_buffer(
+                "EmissionOffset",
+                mem::size_of::<TextureOffsetPod>(),
+                1,
+            ),
+            Normal => builder.with_raw_constant_buffer(
+                "NormalOffset",
+                mem::size_of::<TextureOffsetPod>(),
+                1,
+            ),
+            Metallic => builder.with_raw_constant_buffer(
+                "MetallicOffset",
+                mem::size_of::<TextureOffsetPod>(),
+                1,
+            ),
+            Roughness => builder.with_raw_constant_buffer(
+                "RoughnessOffset",
+                mem::size_of::<TextureOffsetPod>(),
+                1,
+            ),
+            AmbientOcclusion => builder.with_raw_constant_buffer(
+                "AmbientOcclusionOffset",
+                mem::size_of::<TextureOffsetPod>(),
+                1,
+            ),
+            Caveat => builder.with_raw_constant_buffer(
+                "CaveatOffset",
+                mem::size_of::<TextureOffsetPod>(),
+                1,
+            ),
+        };
+    }
+}
+
+pub(crate) fn set_texture_offsets(
+    effect: &mut Effect,
+    encoder: &mut Encoder,
+    material: &Material,
+    types: &[TextureType],
+) {
+    use self::TextureType::*;
+    for ty in types {
+        match *ty {
+            Albedo => effect.update_constant_buffer(
+                "AlbedoOffset",
+                &TextureOffsetPod::from_offset(&material.albedo_offset),
+                encoder,
+            ),
+            Emission => effect.update_constant_buffer(
+                "EmissionOffset",
+                &TextureOffsetPod::from_offset(&material.emission_offset),
+                encoder,
+            ),
+            Normal => effect.update_constant_buffer(
+                "NormalOffset",
+                &TextureOffsetPod::from_offset(&material.normal_offset),
+                encoder,
+            ),
+            Metallic => effect.update_constant_buffer(
+                "MetallicOffset",
+                &TextureOffsetPod::from_offset(&material.metallic_offset),
+                encoder,
+            ),
+            Roughness => effect.update_constant_buffer(
+                "RoughnessOffset",
+                &TextureOffsetPod::from_offset(&material.roughness_offset),
+                encoder,
+            ),
+            AmbientOcclusion => effect.update_constant_buffer(
+                "AmbientOcclusionOffset",
+                &TextureOffsetPod::from_offset(&material.ambient_occlusion_offset),
+                encoder,
+            ),
+            Caveat => effect.update_constant_buffer(
+                "CaveatOffset",
+                &TextureOffsetPod::from_offset(&material.caveat_offset),
+                encoder,
+            ),
+        };
     }
 }
 
@@ -167,6 +277,7 @@ pub(crate) fn draw_mesh(
 
     add_textures(
         effect,
+        encoder,
         &tex_storage,
         material.unwrap(),
         &material_defaults.0,


### PR DESCRIPTION
Supports swapping textures (using indexing into a `MaterialTextureSet` resource) and modifying offset into a texture.
The PR also adds support for targeting parts of a texture, using a `Material` defined offset.

Material only support the `Step` interpolation function, all other functions will result in a panic (except possibly a user supplied function).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/641)
<!-- Reviewable:end -->
