### PR TITLE
Cfg controlling mutli-threading to make web build again

### DIFF
--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -15,6 +15,9 @@ extern crate serde;
 #[cfg(feature = "profiler")]
 extern crate thread_profiler;
 
+#[cfg(all(target_os = "emscripten", not(no_threading)))]
+compile_error!("the cfg flag \"no_threading\" is required when building for emscripten");
+
 //#[cfg(test)]
 //extern crate quickcheck;
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -827,6 +827,7 @@ impl<'a, 'b, T> ApplicationBuilder<'a, 'b, T> {
         #[cfg(feature = "profiler")]
         profile_scope!("new");
 
+        #[cfg(not(no_threading))]
         let pool = self.world.read_resource::<Arc<ThreadPool>>().clone();
         let reader_id = self.world
             .write_resource::<EventChannel<Event>>()
@@ -837,7 +838,10 @@ impl<'a, 'b, T> ApplicationBuilder<'a, 'b, T> {
             // config: self.config,
             states: StateMachine::new(self.initial_state),
             events_reader_id: reader_id,
+            #[cfg(not(no_threading))]
             dispatcher: self.disp_builder.with_pool(pool).build(),
+            #[cfg(no_threading)]
+            dispatcher: self.disp_builder.build(),
             ignore_window_close: self.ignore_window_close,
         })
     }


### PR DESCRIPTION
This PR introduces a new rustc cfg `no_threading` in order to make amethyst build again for web browsers.
It is meant to signify amethyst must not take advantage of multi-threading facilities.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/646)
<!-- Reviewable:end -->
