### PR TITLE
UI Event overlap support

### DIFF
--- a/amethyst_ui/src/button.rs
+++ b/amethyst_ui/src/button.rs
@@ -211,8 +211,10 @@ impl<'a> UiButtonBuilder<'a> {
         let mut id = self.name.to_string();
         id.push_str("_btn_txt");
         let text_entity = res.entities.create();
-        res.transform
-            .insert(text_entity, UiTransform::new(id, 0., 0., -1., 0., 0., 10));
+        res.transform.insert(
+            text_entity,
+            UiTransform::new(id, 0., 0., -1., 0., 0., 10).as_transparent(),
+        );
         res.anchored
             .insert(text_entity, Anchored::new(Anchor::Middle));
         res.stretched

--- a/amethyst_ui/src/event.rs
+++ b/amethyst_ui/src/event.rs
@@ -55,8 +55,8 @@ impl Component for MouseReactive {
 /// The generic types A and B represent the A and B generic parameter of the InputHandler<A,B>.
 pub struct UiMouseSystem<A, B> {
     was_down: bool,
-    old_pos: (f32, f32),
     click_started_on: Option<Entity>,
+    last_target: Option<Entity>,
     _marker1: PhantomData<A>,
     _marker2: PhantomData<B>,
 }
@@ -66,8 +66,8 @@ impl<A, B> UiMouseSystem<A, B> {
     pub fn new() -> Self {
         UiMouseSystem {
             was_down: false,
-            old_pos: (0.0, 0.0),
             click_started_on: None,
+            last_target: None,
             _marker1: PhantomData,
             _marker2: PhantomData,
         }
@@ -90,37 +90,42 @@ where
     fn run(&mut self, (entities, transform, react, input, mut events): Self::SystemData) {
         let down = input.mouse_button_is_down(MouseButton::Left);
 
-        // to replace on InputHandler generate OnMouseDown and OnMouseUp events
+        // TODO: To replace on InputHandler generate OnMouseDown and OnMouseUp events
         let click_started = down && !self.was_down;
         let click_stopped = !down && self.was_down;
+
         if let Some((pos_x, pos_y)) = input.mouse_position() {
             let x = pos_x as f32;
             let y = pos_y as f32;
-            for (tr, e, _) in (&transform, &*entities, &react).join() {
-                let is_in_rect = tr.position_inside(x, y);
-                let was_in_rect = tr.position_inside(self.old_pos.0, self.old_pos.1);
 
-                if is_in_rect && !was_in_rect {
-                    events.single_write(UiEvent::new(UiEventType::HoverStart, e));
-                } else if !is_in_rect && was_in_rect {
-                    events.single_write(UiEvent::new(UiEventType::HoverStop, e));
-                }
+            let target = targeted((x, y), (&*entities, &transform).join(), &react);
 
-                if is_in_rect {
-                    if click_started {
-                        events.single_write(UiEvent::new(UiEventType::ClickStart, e));
-                        self.click_started_on = Some(e);
-                    } else if click_stopped {
-                        if let Some(e2) = self.click_started_on {
-                            if e2 == e {
-                                events.single_write(UiEvent::new(UiEventType::Click, e2));
-                            }
+            let is_in_rect = target.is_some();
+            let was_in_rect = self.last_target.is_some();
+
+            if is_in_rect && !was_in_rect {
+                events.single_write(UiEvent::new(UiEventType::HoverStart, target.unwrap()));
+            } else if !is_in_rect && was_in_rect {
+                events.single_write(UiEvent::new(
+                    UiEventType::HoverStop,
+                    self.last_target.unwrap(),
+                ));
+            }
+
+            if let Some(e) = target {
+                if click_started {
+                    events.single_write(UiEvent::new(UiEventType::ClickStart, e));
+                    self.click_started_on = Some(e);
+                } else if click_stopped {
+                    if let Some(e2) = self.click_started_on {
+                        if e2 == e {
+                            events.single_write(UiEvent::new(UiEventType::Click, e2));
                         }
                     }
                 }
             }
 
-            self.old_pos = (x, y);
+            self.last_target = target;
         }
 
         // Could be used for drag and drop
@@ -133,4 +138,31 @@ where
 
         self.was_down = down;
     }
+}
+
+fn targeted<'a, I>(
+    pos: (f32, f32),
+    transforms: I,
+    react: &ReadStorage<MouseReactive>,
+) -> Option<Entity> 
+    where I: Iterator<Item=(Entity, &'a UiTransform)> + 'a,
+{
+    use std::f32::INFINITY;
+
+    let candidate = transforms
+        .filter(|t| t.1.opaque)
+        .filter(|t| t.1.position_inside(pos.0, pos.1))
+        .fold((None, INFINITY), |(lowest_entity, lowest_z), (entity, t)| {
+            if lowest_z < t.global_z {
+                (lowest_entity, lowest_z)
+            } else {
+                (Some(entity), t.global_z)
+            }
+        }).0;
+    if let Some(candidate) = candidate {
+        if react.get(candidate).is_some() {
+            return Some(candidate);
+        }
+    }
+    None
 }

--- a/amethyst_ui/src/event.rs
+++ b/amethyst_ui/src/event.rs
@@ -100,16 +100,16 @@ where
 
             let target = targeted((x, y), (&*entities, &transform).join(), &react);
 
-            let is_in_rect = target.is_some();
-            let was_in_rect = self.last_target.is_some();
-
-            if is_in_rect && !was_in_rect {
-                events.single_write(UiEvent::new(UiEventType::HoverStart, target.unwrap()));
-            } else if !is_in_rect && was_in_rect {
-                events.single_write(UiEvent::new(
-                    UiEventType::HoverStop,
-                    self.last_target.unwrap(),
-                ));
+            if target != self.last_target {
+                if let Some(target) = target {
+                    events.single_write(UiEvent::new(UiEventType::HoverStart, target));
+                }
+                if let Some(last_target) = self.last_target {
+                    events.single_write(UiEvent::new(
+                        UiEventType::HoverStop,
+                        last_target,
+                    ));
+                }
             }
 
             if let Some(e) = target {

--- a/amethyst_ui/src/transform.rs
+++ b/amethyst_ui/src/transform.rs
@@ -35,12 +35,17 @@ pub struct UiTransform {
     pub global_z: f32,
     /// The scale mode indicates if the position is in pixel or is relative (%) (WIP!) to the parent's size.
     pub scale_mode: ScaleMode,
+    /// Indicates if actions on the ui can go through this element.
+    /// If set to false, the element will behaves as if it was transparent and will let events go to
+    /// the next element (for example, the text on a button).
+    pub opaque: bool,
     /// A private field to keep this from being initialized without new.
     pd: PhantomData<u8>,
 }
 
 impl UiTransform {
-    /// Creates a new UiTransform
+    /// Creates a new UiTransform.
+    /// By default, it is considered opaque.
     pub fn new(
         id: String,
         x: f32,
@@ -62,13 +67,21 @@ impl UiTransform {
             global_y: y,
             global_z: z,
             scale_mode: ScaleMode::Pixel,
+            opaque: true,
             pd: PhantomData,
         }
     }
     /// Checks if the input position is in the UiTransform rectangle.
-    pub fn position_inside(&self, x: f32, y: f32) -> bool {
+    /// Uses local coordinates (ignores layouting).
+    pub fn position_inside_local(&self, x: f32, y: f32) -> bool {
         x > self.local_x - self.width / 2.0 && y > self.local_y - self.height / 2.0
             && x < self.local_x + self.width / 2.0 && y < self.local_y + self.height / 2.0
+    }
+
+    /// Checks if the input position is in the UiTransform rectangle.
+    pub fn position_inside(&self, x: f32, y: f32) -> bool {
+        x > self.global_x - self.width / 2.0 && y > self.global_y - self.height / 2.0
+            && x < self.global_x + self.width / 2.0 && y < self.global_y + self.height / 2.0
     }
 
     /// Currently unused. Will be implemented in a future PR.
@@ -76,8 +89,32 @@ impl UiTransform {
         self.scale_mode = ScaleMode::Percent;
         self
     }
+
+    /// Sets the opaque variable to false, allowing ui events to go through this ui element.
+    pub fn as_transparent(mut self) -> Self {
+        self.opaque = false;
+        self
+    }
 }
 
 impl Component for UiTransform {
     type Storage = FlaggedStorage<Self, DenseVecStorage<Self>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn inside_local() {
+        let tr = UiTransform::new("".to_string(), 0.0, 0.0, 0.0, 1.0, 1.0, 0);
+        let pos = (-0.49, 0.20);
+        assert!(tr.position_inside(pos.0, pos.1));
+    }
+
+    #[test]
+    fn inside_global() {
+        let tr = UiTransform::new("".to_string(), 0.0, 0.0, 0.0, 1.0, 1.0, 0);
+        let pos = (-0.49, 0.20);
+        assert!(tr.position_inside(pos.0, pos.1));
+    }
 }

--- a/amethyst_ui/src/transform.rs
+++ b/amethyst_ui/src/transform.rs
@@ -108,7 +108,9 @@ mod tests {
     fn inside_local() {
         let tr = UiTransform::new("".to_string(), 0.0, 0.0, 0.0, 1.0, 1.0, 0);
         let pos = (-0.49, 0.20);
-        assert!(tr.position_inside(pos.0, pos.1));
+        assert!(tr.position_inside_local(pos.0, pos.1));
+        let pos = (-1.49, 1.20);
+        assert!(!tr.position_inside_local(pos.0, pos.1));
     }
 
     #[test]
@@ -116,5 +118,7 @@ mod tests {
         let tr = UiTransform::new("".to_string(), 0.0, 0.0, 0.0, 1.0, 1.0, 0);
         let pos = (-0.49, 0.20);
         assert!(tr.position_inside(pos.0, pos.1));
+        let pos = (-1.49, 1.20);
+        assert!(!tr.position_inside(pos.0, pos.1));
     }
 }


### PR DESCRIPTION
When you have two ui elements where the one under (z axis) is MouseReactive and the one on top is (or is not), the one on top should get the event checks and the one under should be ignored. Obviously, which one is picked depends on where you clicked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/656)
<!-- Reviewable:end -->
