### PR TITLE
Should not enable profiling features on optional crates as it breaks …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ profiler = [
     "thread_profiler",
     "thread_profiler/thread_profiler",
     "amethyst_assets/profiler",
-    "amethyst_animation/profiler",
     "amethyst_audio/profiler",
     "amethyst_config/profiler",
     "amethyst_core/profiler",


### PR DESCRIPTION
…if they are not used #657

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/658)
<!-- Reviewable:end -->
