### PR TITLE
Refactor Z order evaluation to use text cache more effectively

### DIFF
--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -22,6 +22,7 @@ fnv = "1"
 gfx = { version = "0.17", features = ["serialize"] }
 gfx_glyph = "0.9.0"
 hibitset = "0.3"
+log = "0.4"
 rusttype = "0.4"
 shred = "0.5"
 shred-derive = "0.3"

--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -14,6 +14,8 @@ extern crate fnv;
 extern crate gfx;
 extern crate gfx_glyph;
 extern crate hibitset;
+#[macro_use]
+extern crate log;
 extern crate rusttype;
 extern crate shred;
 #[macro_use]

--- a/amethyst_ui/src/shaders/vertex.glsl
+++ b/amethyst_ui/src/shaders/vertex.glsl
@@ -5,7 +5,7 @@
 // std140 is a cross platform layout.
 layout (std140) uniform VertexArgs {
     uniform vec4 proj_vec;
-    uniform vec2 coord;
+    uniform vec4 coord;
     uniform vec2 dimension;
 };
 
@@ -20,7 +20,7 @@ out VertexData {
 void main() {
     vertex.position = vec4(position, 1);
     vertex.position *= vec4(dimension, 1, 1);
-    vertex.position += vec4(coord, 0, 0);
+    vertex.position += coord;
     vertex.position *= proj_vec;
     vertex.position += vec4(-1, 1, 0, 0);
     vertex.tex_coord = tex_coord;


### PR DESCRIPTION
This PR changes UI rendering to use OpenGL depth evaluation instead of the order of operations for drawing.

This has a few benefits
- Sorting the entities is no longer necessary
- Text cache from gfx_glyph is much more efficient because we can batch the draw calls for text now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/661)
<!-- Reviewable:end -->
