### PR TITLE
Update "rodio" dependency to 0.7

### DIFF
--- a/amethyst_audio/Cargo.toml
+++ b/amethyst_audio/Cargo.toml
@@ -21,9 +21,9 @@ travis-ci = { repository = "amethyst/amethyst" }
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.2.0"}
 amethyst_core = { path = "../amethyst_core", version = "0.1.0"}
-cpal = "0.4"
+cpal = "0.8"
 log = "0.4"
-rodio = "= 0.5.2"
+rodio = "0.7"
 
 thread_profiler = { version = "0.1", optional = true }
 

--- a/amethyst_audio/src/bundle.rs
+++ b/amethyst_audio/src/bundle.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 use amethyst_assets::Processor;
 use amethyst_core::bundle::{ECSBundle, Result};
 use amethyst_core::specs::prelude::{DispatcherBuilder, World};
-use cpal::default_endpoint;
+use rodio::default_output_device;
 
 use source::*;
 use systems::DjSystem;
@@ -55,7 +55,7 @@ where
 {
     fn build(self, _: &mut World, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<()> {
         builder.add(Processor::<Source>::new(), "source_processor", &[]);
-        if let Some(_) = default_endpoint() {
+        if let Some(_) = default_output_device() {
             builder.add(DjSystem::new(self.picker), "dj_system", self.dep);
         }
 

--- a/amethyst_audio/src/components/audio_emitter.rs
+++ b/amethyst_audio/src/components/audio_emitter.rs
@@ -1,14 +1,14 @@
 use std::io::Cursor;
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 
 use amethyst_core::specs::prelude::Component;
 use amethyst_core::specs::storage::BTreeStorage;
 use rodio::{Decoder, SpatialSink};
 use smallvec::SmallVec;
 
-use DecoderError;
 use source::Source;
+use DecoderError;
 
 /// An audio source, add this component to anything that emits sound.
 #[derive(Default)]

--- a/amethyst_audio/src/end_signal.rs
+++ b/amethyst_audio/src/end_signal.rs
@@ -50,8 +50,8 @@ where
         self.input.channels()
     }
 
-    fn samples_rate(&self) -> u32 {
-        self.input.samples_rate()
+    fn sample_rate(&self) -> u32 {
+        self.input.sample_rate()
     }
 
     fn total_duration(&self) -> Option<Duration> {

--- a/amethyst_audio/src/lib.rs
+++ b/amethyst_audio/src/lib.rs
@@ -23,13 +23,13 @@ pub mod output;
 use std::error::Error;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
+mod bundle;
+mod components;
 mod end_signal;
 mod formats;
 mod sink;
 mod source;
-mod components;
 mod systems;
-mod bundle;
 
 /// An error occurred while decoding the source.
 #[derive(Debug)]

--- a/amethyst_audio/src/output.rs
+++ b/amethyst_audio/src/output.rs
@@ -4,12 +4,11 @@
 use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::io::Cursor;
 
-
 use cpal::OutputDevices;
-use rodio::{Decoder, Device, Sink, Source as RSource, default_output_device, output_devices};
+use rodio::{default_output_device, output_devices, Decoder, Device, Sink, Source as RSource};
 
-use DecoderError;
 use source::Source;
+use DecoderError;
 
 /// A speaker(s) through which audio can be played.
 ///
@@ -93,10 +92,14 @@ impl Iterator for OutputIterator {
 
 /// Get the default output, returns none if no outputs are available.
 pub fn default_output() -> Option<Output> {
-    Some(Output { device: default_output_device()? })
+    Some(Output {
+        device: default_output_device()?,
+    })
 }
 
 /// Get a list of outputs available to the system.
 pub fn outputs() -> OutputIterator {
-    OutputIterator { input: output_devices() }
+    OutputIterator {
+        input: output_devices(),
+    }
 }

--- a/amethyst_audio/src/output.rs
+++ b/amethyst_audio/src/output.rs
@@ -92,9 +92,7 @@ impl Iterator for OutputIterator {
 
 /// Get the default output, returns none if no outputs are available.
 pub fn default_output() -> Option<Output> {
-    Some(Output {
-        device: default_output_device()?,
-    })
+    default_output_device().map(|re| Output { device: re })
 }
 
 /// Get a list of outputs available to the system.

--- a/amethyst_audio/src/sink.rs
+++ b/amethyst_audio/src/sink.rs
@@ -2,9 +2,9 @@ use std::io::Cursor;
 
 use rodio::{Decoder, Sink};
 
-use DecoderError;
 use output::Output;
 use source::Source;
+use DecoderError;
 
 /// This structure provides a way to programmatically pick and play music.
 pub struct AudioSink {

--- a/amethyst_audio/src/sink.rs
+++ b/amethyst_audio/src/sink.rs
@@ -15,7 +15,7 @@ impl AudioSink {
     /// Creates a new `AudioSink` using the given audio output.
     pub fn new(output: &Output) -> AudioSink {
         AudioSink {
-            sink: Sink::new(&output.endpoint),
+            sink: Sink::new(&output.device),
         }
     }
 

--- a/amethyst_audio/src/systems/audio.rs
+++ b/amethyst_audio/src/systems/audio.rs
@@ -81,7 +81,7 @@ impl<'a> System<'a> for AudioSystem {
                     }
                     while let Some(source) = audio_emitter.sound_queue.pop() {
                         let sink = SpatialSink::new(
-                            &listener.output.endpoint,
+                            &listener.output.device,
                             emitter_position,
                             left_ear_position,
                             right_ear_position,

--- a/amethyst_audio/src/systems/audio.rs
+++ b/amethyst_audio/src/systems/audio.rs
@@ -1,7 +1,7 @@
 use std::iter::Iterator;
 use std::mem::replace;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use amethyst_core::cgmath::Transform;
 use amethyst_core::specs::prelude::{Entities, Entity, Join, Read, ReadStorage, System,


### PR DESCRIPTION
The latest `rodio` version introduces some changes in the API naming conventions. However, the changes are minimal and do not affect any `pub`lic field or struct.