### PR TITLE
Proposal to fix CI breakage on nightly

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,5 +43,4 @@ build: false
 
 # Generate documentation, compile the engine, run tests.
 test_script:
-  - cargo test --all -v
-  - cargo test --all -v --features profiler
+  - cargo run --release ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,11 @@ before_script:
 
 # Generate documentation, compile the engine, run tests.
 script: |
+  cargo run --release ci
   # Build and test without profiler
-  cargo test --all -v &&
+  #cargo test --all -v &&
   # Build and test with profiler
-  cargo test --all --features profiler -v 
+  #cargo test --all --features profiler -v 
 
 # Push notifications to `amethyst/general` and `amethyst/engine` Gitter chats.
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,10 +46,6 @@ before_script:
 # Generate documentation, compile the engine, run tests.
 script: |
   cargo run --release ci
-  # Build and test without profiler
-  #cargo test --all -v &&
-  # Build and test with profiler
-  #cargo test --all --features profiler -v 
 
 # Push notifications to `amethyst/general` and `amethyst/engine` Gitter chats.
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_script:
 
 # Generate documentation, compile the engine, run tests.
 script: |
-  cargo run --release ci
+  cargo build --release --bin ci && ./target/release/ci
 
 # Push notifications to `amethyst/general` and `amethyst/engine` Gitter chats.
 notifications:

--- a/src/bin/ci.rs
+++ b/src/bin/ci.rs
@@ -1,0 +1,16 @@
+//! A small script to run all our CI tests
+//!
+//! We can just invoke this script on any platform, cutting down duplication.
+
+use std::process::exit;
+
+fn run() -> Result<(), String> {
+    Ok(())
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("error running ci script: {}", e);
+        exit(1);
+    }
+}

--- a/src/bin/ci.rs
+++ b/src/bin/ci.rs
@@ -2,9 +2,56 @@
 //!
 //! We can just invoke this script on any platform, cutting down duplication.
 
-use std::process::exit;
+use std::process::{Command, exit};
+use std::fmt::Write;
+
+fn run_test_command<P, A, S>(prog: P, args: A) -> Result<(), String>
+where P: AsRef<str>,
+      A: AsRef<[S]>,
+      S: AsRef<str>
+{
+    let mut cmd = Command::new(prog.as_ref());
+    let args = args.as_ref().iter().map(|a| a.as_ref());
+    cmd.args(args);
+    println!("Running command {:?}", cmd);
+    let output = cmd.output().map_err(|e| format!("io error: {}", e))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let mut err_msg = String::new();
+        writeln!(err_msg, "--- Error ---").unwrap();
+        writeln!(err_msg,
+                 "The command {:?} exited with error code {:?}",
+                 cmd,
+                 output.status.code()).unwrap();
+        writeln!(err_msg, "--- Stdout ---").unwrap();
+        writeln!(err_msg, "{}", String::from_utf8_lossy(&output.stdout)).unwrap();
+        writeln!(err_msg, "--- Stderr ---").unwrap();
+        writeln!(err_msg, "{}", String::from_utf8_lossy(&output.stderr)).unwrap();
+        Err(err_msg)
+    }
+
+}
 
 fn run() -> Result<(), String> {
+    //run_test_command("cargo", &["test", "--all"])?;
+    run_test_command("cargo", ["test", "--features", "profiler"])?;
+    for package in [
+        "amethyst_animation",
+        "amethyst_assets",
+        "amethyst_audio",
+        "amethyst_config",
+        "amethyst_controls",
+        "amethyst_core",
+        "amethyst_gltf",
+        "amethyst_input",
+        "amethyst_renderer",
+        "amethyst_ui",
+        "amethyst_utils",
+    ].iter() {
+        let args = vec!["test", "--features", "profiler", "--package", package.to_owned()];
+        run_test_command("cargo", args)?;
+    }
     Ok(())
 }
 

--- a/src/bin/ci.rs
+++ b/src/bin/ci.rs
@@ -34,7 +34,7 @@ where P: AsRef<str>,
 }
 
 fn run() -> Result<(), String> {
-    //run_test_command("cargo", &["test", "--all"])?;
+    run_test_command("cargo", &["test", "--all"])?;
     run_test_command("cargo", ["test", "--features", "profiler"])?;
     for package in [
         "amethyst_animation",


### PR DESCRIPTION
This patch adds a script in src/bin/ci.rs that runs all the required tests. It's good because it provides a single place to edit how tests are run, as well as making it easier to have custom logic in the testing.

It currently just runs the tests that were being run and dumps the output if it fails (and exits with non-zero exit status).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/682)
<!-- Reviewable:end -->
