### PR TITLE
Offset the animation duration for sprites rendering example.

### DIFF
--- a/examples/sprites/animation.rs
+++ b/examples/sprites/animation.rs
@@ -12,7 +12,7 @@ pub fn grey_bat(sprite_sheet: &SpriteSheet, world: &mut World) -> Handle<Animati
 
     let sprite_offset_sampler = {
         Sampler {
-            input: vec![0., 0.5, 0.7, 0.9, 1.1, 1.3, 1.5, 1.7, 1.9, 2.1, 2.3],
+            input: vec![0., 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4],
             function: InterpolationFunction::Step,
             output: sprite_offsets,
         }
@@ -50,7 +50,7 @@ pub fn brown_bat(sprite_sheet: &SpriteSheet, world: &mut World) -> Handle<Animat
 
     let sprite_offset_sampler = {
         Sampler {
-            input: vec![0., 0.2, 0.4, 0.6, 0.8],
+            input: vec![0., 0.1, 0.2, 0.3, 0.4],
             function: InterpolationFunction::Step,
             output: sprite_offsets,
         }

--- a/examples/sprites/main.rs
+++ b/examples/sprites/main.rs
@@ -136,16 +136,7 @@ impl State for Example {
 
             let animation_id = 0;
 
-            // If you want to start an animation from the beginning, use this:
-            // animation_set.add_animation(
-            //     animation_id,
-            //     &animation,
-            //     EndControl::Loop(None),
-            //     1., // Rate at which the animation plays
-            //     AnimationCommand::Start,
-            // );
-
-            // Otherwise, this offsets the animation:
+            // Offset the animation:
             let animation_control = AnimationControl::new(
                 animation,
                 EndControl::Loop(None),

--- a/examples/sprites/main.rs
+++ b/examples/sprites/main.rs
@@ -16,6 +16,10 @@ mod png_loader;
 mod sprite;
 mod sprite_sheet_loader;
 
+use std::time::Duration;
+
+use amethyst::animation::{get_animation_set, AnimationBundle, AnimationCommand, AnimationControl,
+                          ControlState, EndControl, MaterialTextureSet};
 use amethyst::assets::{AssetStorage, Loader};
 use amethyst::core::cgmath::{Matrix4, Point3, Transform as CgTransform, Vector3};
 use amethyst::core::transform::{GlobalTransform, Transform, TransformBundle};
@@ -26,8 +30,6 @@ use amethyst::renderer::{Camera, ColorMask, DisplayConfig, DrawFlat, Event, Keyb
                          Material, MaterialDefaults, Mesh, Pipeline, PosTex, Projection,
                          RenderBundle, ScreenDimensions, Stage, VirtualKeyCode, WindowEvent, ALPHA};
 use amethyst::ui::{DrawUi, UiBundle};
-use amethyst_animation::{get_animation_set, AnimationBundle, AnimationCommand, EndControl,
-                         MaterialTextureSet};
 
 const BACKGROUND_COLOUR: [f32; 4] = [0.0, 0.0, 0.0, 1.0]; // black
 
@@ -131,14 +133,28 @@ impl State for Example {
             let mut animation_control_set_storage = world.write_storage();
             let animation_set =
                 get_animation_set::<u32, Material>(&mut animation_control_set_storage, entity);
+
             let animation_id = 0;
-            animation_set.add_animation(
-                animation_id,
-                &animation,
+
+            // If you want to start an animation from the beginning, use this:
+            // animation_set.add_animation(
+            //     animation_id,
+            //     &animation,
+            //     EndControl::Loop(None),
+            //     1., // Rate at which the animation plays
+            //     AnimationCommand::Start,
+            // );
+
+            // Otherwise, this offsets the animation:
+            let animation_control = AnimationControl::new(
+                animation,
                 EndControl::Loop(None),
-                1., // Rate at which the animation plays
+                // Offset from beginning
+                ControlState::Deferred(Duration::from_millis(i as u64 * 200)),
                 AnimationCommand::Start,
+                1., // Rate at which the animation plays
             );
+            animation_set.insert(animation_id, animation_control);
 
             // Store the entity
             self.entities.push(entity);
@@ -173,10 +189,7 @@ fn initialise_camera(world: &mut World) -> Entity {
     world
         .create_entity()
         .with(Camera::from(Projection::orthographic(
-            0.0,
-            width,
-            height,
-            0.0,
+            0.0, width, height, 0.0,
         )))
         .with(GlobalTransform(Matrix4::from_translation(
             Vector3::new(0.0, 0.0, 1.0).into(),


### PR DESCRIPTION
This makes the sprite bats start at different points in the animation:

![sprite_render](https://user-images.githubusercontent.com/2993230/39550628-12802fa4-4eb6-11e8-9663-0cd40174ded9.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/693)
<!-- Reviewable:end -->
