### PR TITLE
Fix fly_camera demos window focus

### DIFF
--- a/amethyst_controls/Cargo.toml
+++ b/amethyst_controls/Cargo.toml
@@ -20,6 +20,7 @@ amethyst_input = { path = "../amethyst_input", version = "0.2.1" }
 amethyst_renderer = { path = "../amethyst_renderer", version = "0.6.1" }
 winit = "0.12"
 log = "0.4"
+shrev = "0.8"
 
 thread_profiler = { version = "0.1", optional = true }
 

--- a/amethyst_controls/src/bundles.rs
+++ b/amethyst_controls/src/bundles.rs
@@ -67,7 +67,8 @@ where
             "free_rotation",
             &[],
         );
-        builder.add(MouseCenterLockSystem, "mouse_lock", &["free_rotation"]);
+        builder.add(MouseFocusUpdateSystem::new(), "mouse_focus", &["free_rotation"]);
+        builder.add(MouseCenterLockSystem, "mouse_lock", &["mouse_focus"]);
         Ok(())
     }
 }

--- a/amethyst_controls/src/lib.rs
+++ b/amethyst_controls/src/lib.rs
@@ -5,14 +5,18 @@ extern crate amethyst_renderer;
 #[macro_use]
 extern crate log;
 extern crate winit;
+extern crate shrev;
 
+#[macro_use]
 #[cfg(feature = "profiler")]
 extern crate thread_profiler;
 
 mod components;
 mod bundles;
 mod systems;
+mod resources;
 
 pub use self::bundles::FlyControlBundle;
 pub use self::components::FlyControlTag;
-pub use self::systems::{FlyMovementSystem, FreeRotationSystem, MouseCenterLockSystem};
+pub use self::systems::{FlyMovementSystem, FreeRotationSystem, MouseCenterLockSystem, MouseFocusUpdateSystem};
+pub use self::resources::WindowFocus;

--- a/amethyst_controls/src/resources.rs
+++ b/amethyst_controls/src/resources.rs
@@ -1,0 +1,14 @@
+/// Struct which holds information about whether the window is focused.
+/// Written to by MouseFocusUpdateSystem
+#[derive(Default)]
+pub struct WindowFocus {
+    pub is_focused: bool,
+}
+
+impl WindowFocus {
+    pub fn new() -> WindowFocus {
+        WindowFocus {
+            is_focused: true,
+        }
+    }
+}

--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -10,6 +10,10 @@ use std::marker::PhantomData;
 
 use components::FlyControlTag;
 
+use shrev::{EventChannel, ReaderId};
+use winit::{Event, WindowEvent};
+use resources::WindowFocus;
+
 /// The system that manages the fly movement.
 /// Generic parameters are the parameters for the InputHandler.
 pub struct FlyMovementSystem<A, B> {
@@ -103,22 +107,25 @@ where
 {
     type SystemData = (
         Read<'a, InputHandler<A, B>>,
+        Read<'a, WindowFocus>,
         ReadExpect<'a, ScreenDimensions>,
         WriteStorage<'a, Transform>,
         ReadStorage<'a, FlyControlTag>,
     );
 
-    fn run(&mut self, (input, dim, mut transform, tag): Self::SystemData) {
-        // take the same mid-point as the MouseCenterLockSystem
-        let half_x = dim.width() as i32 / 2;
-        let half_y = dim.height() as i32 / 2;
+    fn run(&mut self, (input, focus, dim, mut transform, tag): Self::SystemData) {
+        if focus.is_focused {
+            // take the same mid-point as the MouseCenterLockSystem
+            let half_x = dim.width() as i32 / 2;
+            let half_y = dim.height() as i32 / 2;
 
-        if let Some((posx, posy)) = input.mouse_position() {
-            let offset_x = half_x as f32 - posx as f32;
-            let offset_y = half_y as f32 - posy as f32;
-            for (transform, _) in (&mut transform, &tag).join() {
-                transform.pitch_local(Deg(offset_y * self.sensitivity_y));
-                transform.yaw_global(Deg(offset_x * self.sensitivity_x));
+            if let Some((posx, posy)) = input.mouse_position() {
+                let offset_x = half_x as f32 - posx as f32;
+                let offset_y = half_y as f32 - posy as f32;
+                for (transform, _) in (&mut transform, &tag).join() {
+                    transform.pitch_local(Deg(offset_y * self.sensitivity_y));
+                    transform.yaw_global(Deg(offset_x * self.sensitivity_x));
+                }
             }
         }
     }
@@ -128,16 +135,26 @@ where
 pub struct MouseCenterLockSystem;
 
 impl<'a> System<'a> for MouseCenterLockSystem {
-    type SystemData = (ReadExpect<'a, ScreenDimensions>, Write<'a, WindowMessages>);
+    type SystemData = (
+        ReadExpect<'a, ScreenDimensions>,
+        Write<'a, WindowMessages>, 
+        Write<'a, WindowFocus>
+    );
 
-    fn run(&mut self, (dim, mut msg): Self::SystemData) {
-        let half_x = dim.width() as i32 / 2;
-        let half_y = dim.height() as i32 / 2;
-        msg.send_command(move |win| {
-            if let Err(err) = win.set_cursor_position(half_x, half_y) {
-                error!("Unable to set the cursor position! Error: {:?}", err);
-            }
-        });
+    fn run(&mut self, (dim, mut msg, focus): Self::SystemData) {
+        use amethyst_renderer::mouse::*;
+        if focus.is_focused {
+            let half_x = dim.width() as i32 / 2;
+            let half_y = dim.height() as i32 / 2;
+            msg.send_command(move |win| {
+                if let Err(err) = win.set_cursor_position(half_x, half_y) {
+                    error!("Unable to set the cursor position! Error: {:?}", err);
+                }
+
+            });
+        } else {
+            release_cursor(&mut msg);
+        }
     }
 
     fn setup(&mut self, res: &mut Resources) {
@@ -147,5 +164,45 @@ impl<'a> System<'a> for MouseCenterLockSystem {
         let mut msg = res.fetch_mut::<WindowMessages>();
         grab_cursor(&mut msg);
         set_mouse_cursor_none(&mut msg);
+    }
+}
+
+/// A system which reads Events and saves if a window has lost focus in a WindowFocus resource
+pub struct MouseFocusUpdateSystem {
+    event_reader: Option<ReaderId<Event>>,
+}
+
+impl MouseFocusUpdateSystem {
+    pub fn new() -> MouseFocusUpdateSystem {
+        MouseFocusUpdateSystem { 
+            event_reader: None 
+        }
+    }
+}
+
+impl<'a> System<'a> for MouseFocusUpdateSystem {
+    type SystemData = (
+        Read<'a, EventChannel<Event>>,
+        Write<'a, WindowFocus>,
+    );
+
+    fn run(&mut self, (events, mut focus): Self::SystemData) {
+        for event in events.read(&mut self.event_reader.as_mut().unwrap()) {
+            match event {
+                &Event::WindowEvent { ref event, .. } => match event {
+                    &WindowEvent::Focused(focused) => {
+                        focus.is_focused = focused;
+                    },
+                    _ => (),
+                },
+                _ => (),
+            }
+        }
+    }
+
+    fn setup(&mut self, res: &mut Resources) {
+        use amethyst_core::specs::prelude::SystemData;
+        Self::SystemData::setup(res);
+        self.event_reader = Some(res.fetch_mut::<EventChannel<Event>>().register_reader());
     }
 }


### PR DESCRIPTION
This PR fixes the fly_camera example, which still centers the mouse, even if window focus is lost.

Fixes #635

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/694)
<!-- Reviewable:end -->
