### PR TITLE
Expose the length of `MaterialTextureSet`.

### DIFF
--- a/amethyst_animation/src/material.rs
+++ b/amethyst_animation/src/material.rs
@@ -41,6 +41,10 @@ impl MaterialTextureSet {
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.textures.len()
+    }
+
     pub fn clear(&mut self) {
         self.textures.clear();
         self.texture_inverse.clear();


### PR DESCRIPTION
Allows consumers to query how many textures are in the set.

Maybe I should ask this first: is it a good idea to query the length, and then add textures just by incrementing the index?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/696)
<!-- Reviewable:end -->
