### PR TITLE
Use derivative default better

### DIFF
--- a/amethyst_input/src/input_handler.rs
+++ b/amethyst_input/src/input_handler.rs
@@ -17,7 +17,7 @@ use super::event::InputEvent::*;
 /// For example, if a key is pressed on the keyboard, this struct will record
 /// that the key is pressed until it is released again.
 #[derive(Derivative)]
-#[derivative(Default(bound = "AX: Hash + Eq, AC: Hash + Eq"))]
+#[derivative(Default(bound = ""))]
 pub struct InputHandler<AX, AC>
 where
     AX: Hash + Eq,


### PR DESCRIPTION
The redundancy of these bounds in the docs was bothering me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/702)
<!-- Reviewable:end -->
