### PR TITLE
Make main functions return Results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,15 @@ rust:
   - beta
   - nightly
 
-# Allow for occasional compiler breakage on nightly Rust.
 matrix:
+  # Allow for occasional compiler breakage on nightly Rust.
   allow_failures:
     - rust: nightly
+  # Check on Rust 1.23.
+  include:
+    - rust: 1.23
+      script:
+        - cargo check --tests
 
 # Build the Bors staging and trying branches, plus PRs to develop, master, and
 # the latest release branch.
@@ -48,7 +53,7 @@ script: |
   # Build and test without profiler
   cargo test --all -v &&
   # Build and test with profiler
-  cargo test --all --features profiler -v 
+  cargo test --all --features profiler -v
 
 # Push notifications to `amethyst/general` and `amethyst/engine` Gitter chats.
 notifications:

--- a/book/src/pong_tutorial/pong_tutorial_01.md
+++ b/book/src/pong_tutorial/pong_tutorial_01.md
@@ -67,11 +67,11 @@ up the `State` and close the application. All other keyboard input is ignored
 for now.
 
 Now that we know we can quit, let's add some code to actually get things 
-started! We'll use a `run()` function, which returns a Result and thus 
+started! We'll use an ordinary `main()` function, but which returns a `Result` and thus 
 allows us to use `?`.
 
 ```rust,ignore
-fn run() -> Result<()> {
+fn main() -> Result<()> {
 
     //We'll put the rest of the code here
 
@@ -79,7 +79,7 @@ fn run() -> Result<()> {
 }
 ```
 
-Inside run() we first define a path for our display_config.ron file and load it.
+Inside `main()` we first define a path for our display_config.ron file and load it.
 
 ```rust,ignore
 let path = "./resources/display_config.ron";
@@ -144,18 +144,6 @@ along with our config, and building.
 Then we call `.run()` on `game` which begins the gameloop. The game will 
 continue to run until our `State` returns `Trans::Quit`, or when all states have 
 been popped off the state machine's stack.
-
-Now all that's left is to write a `main()` function to call our `run()` 
-function:
-
-```rust,ignore
-fn main() {
-    if let Err(e) = run() {
-        println!("Error occurred during game execution: {}", e);
-        ::std::process::exit(1);
-    }
-}
-```
 
 Success! Now we should be able to compile and run this code and get a window. 
 It should look something like this:

--- a/examples/animation/main.rs
+++ b/examples/animation/main.rs
@@ -3,19 +3,23 @@
 extern crate amethyst;
 extern crate genmesh;
 
-use amethyst::animation::{get_animation_set, Animation, AnimationBundle, AnimationCommand,
-                          AnimationSet, DeferStartRelation, EndControl, InterpolationFunction,
-                          Sampler, SamplerPrimitive, StepDirection, TransformChannel};
+use amethyst::animation::{
+    get_animation_set, Animation, AnimationBundle, AnimationCommand, AnimationSet,
+    DeferStartRelation, EndControl, InterpolationFunction, Sampler, SamplerPrimitive,
+    StepDirection, TransformChannel,
+};
 use amethyst::assets::{AssetStorage, Handle, Loader};
-use amethyst::core::{GlobalTransform, Parent, Transform, TransformBundle};
 use amethyst::core::cgmath::Deg;
+use amethyst::core::{GlobalTransform, Parent, Transform, TransformBundle};
 use amethyst::ecs::prelude::{Entity, World};
 use amethyst::prelude::*;
-use amethyst::renderer::{AmbientColor, Camera, DisplayConfig, DrawShaded, ElementState, Event,
-                         KeyboardInput, Light, Mesh, Pipeline, PointLight, PosNormTex, Projection,
-                         RenderBundle, Rgba, Stage, VirtualKeyCode, WindowEvent};
-use genmesh::{MapToVertices, Triangulate, Vertices};
+use amethyst::renderer::{
+    AmbientColor, Camera, DisplayConfig, DrawShaded, ElementState, Event, KeyboardInput, Light,
+    Mesh, Pipeline, PointLight, PosNormTex, Projection, RenderBundle, Rgba, Stage, VirtualKeyCode,
+    WindowEvent,
+};
 use genmesh::generators::SphereUV;
+use genmesh::{MapToVertices, Triangulate, Vertices};
 
 // blue
 const SPHERE_COLOUR: [f32; 4] = [0.0, 0.0, 1.0, 1.0];
@@ -183,7 +187,7 @@ impl State for Example {
     }
 }
 
-fn run() -> Result<(), amethyst::Error> {
+fn main() -> amethyst::Result<()> {
     let display_config_path = format!(
         "{}/examples/animation/resources/display_config.ron",
         env!("CARGO_MANIFEST_DIR")
@@ -209,13 +213,6 @@ fn run() -> Result<(), amethyst::Error> {
         .build()?;
     game.run();
     Ok(())
-}
-
-fn main() {
-    if let Err(e) = run() {
-        println!("Failed to execute example: {}", e);
-        ::std::process::exit(1);
-    }
 }
 
 fn gen_sphere(u: usize, v: usize) -> Vec<PosNormTex> {

--- a/examples/appendix_a/main.rs
+++ b/examples/appendix_a/main.rs
@@ -4,15 +4,14 @@ extern crate amethyst;
 #[macro_use]
 extern crate serde_derive;
 
+mod audio;
+mod bundle;
+mod config;
 mod pong;
 mod systems;
-mod bundle;
-mod audio;
-mod config;
 
 use std::time::Duration;
 
-use amethyst::Result;
 use amethyst::audio::AudioBundle;
 use amethyst::core::frame_limiter::FrameRateLimitStrategy;
 use amethyst::core::transform::TransformBundle;
@@ -21,6 +20,7 @@ use amethyst::input::InputBundle;
 use amethyst::prelude::*;
 use amethyst::renderer::{DisplayConfig, DrawFlat, Pipeline, PosTex, RenderBundle, Stage};
 use amethyst::ui::{DrawUi, UiBundle};
+use amethyst::Result;
 
 use audio::Music;
 use bundle::PongBundle;
@@ -33,14 +33,7 @@ const AUDIO_MUSIC: &'static [&'static str] = &[
 const AUDIO_BOUNCE: &'static str = "audio/bounce.ogg";
 const AUDIO_SCORE: &'static str = "audio/score.ogg";
 
-fn main() {
-    if let Err(e) = run() {
-        println!("Failed to execute example: {}", e);
-        ::std::process::exit(1);
-    }
-}
-
-fn run() -> Result<()> {
+fn main() -> Result<()> {
     use pong::Pong;
 
     let display_config_path = format!(

--- a/examples/asset_loading/main.rs
+++ b/examples/asset_loading/main.rs
@@ -4,16 +4,18 @@
 extern crate amethyst;
 extern crate rayon;
 
-use amethyst::{Application, Error, State, Trans};
 use amethyst::assets::{Loader, Result as AssetResult, SimpleFormat};
 use amethyst::config::Config;
 use amethyst::core::cgmath::{Array, Vector3};
 use amethyst::core::transform::{GlobalTransform, Transform, TransformBundle};
 use amethyst::ecs::prelude::World;
 use amethyst::input::InputBundle;
-use amethyst::renderer::{Camera, DisplayConfig, DrawShaded, Event, KeyboardInput, Light, Material,
-                         MaterialDefaults, Mesh, MeshData, Pipeline, PointLight, PosNormTex,
-                         Projection, RenderBundle, Rgba, Stage, VirtualKeyCode, WindowEvent};
+use amethyst::renderer::{
+    Camera, DisplayConfig, DrawShaded, Event, KeyboardInput, Light, Material, MaterialDefaults,
+    Mesh, MeshData, Pipeline, PointLight, PosNormTex, Projection, RenderBundle, Rgba, Stage,
+    VirtualKeyCode, WindowEvent,
+};
+use amethyst::{Application, Result, State, Trans};
 
 #[derive(Clone)]
 struct Custom;
@@ -119,16 +121,7 @@ impl State for AssetsExample {
     }
 }
 
-fn main() {
-    if let Err(error) = run() {
-        eprintln!("Could not run the example!");
-        eprintln!("{}", error);
-        ::std::process::exit(1);
-    }
-}
-
-/// Wrapper around the main, so we can return errors easily.
-fn run() -> Result<(), Error> {
+fn main() -> Result<()> {
     // Add our meshes directory to the asset loader.
     let resources_directory = format!("{}/examples/assets", env!("CARGO_MANIFEST_DIR"));
 

--- a/examples/fly_camera/main.rs
+++ b/examples/fly_camera/main.rs
@@ -2,7 +2,6 @@
 
 extern crate amethyst;
 
-use amethyst::{Application, Error, State, Trans};
 use amethyst::assets::Loader;
 use amethyst::config::Config;
 use amethyst::controls::{FlyControlBundle, FlyControlTag};
@@ -11,10 +10,12 @@ use amethyst::core::frame_limiter::FrameRateLimitStrategy;
 use amethyst::core::transform::{GlobalTransform, Transform, TransformBundle};
 use amethyst::ecs::prelude::World;
 use amethyst::input::InputBundle;
-use amethyst::renderer::{AmbientColor, Camera, DisplayConfig, DrawShaded, ElementState, Event,
-                         KeyboardInput, Material, MaterialDefaults, MeshHandle, ObjFormat,
-                         Pipeline, PosNormTex, Projection, RenderBundle, Rgba, Stage,
-                         VirtualKeyCode, WindowEvent};
+use amethyst::renderer::{
+    AmbientColor, Camera, DisplayConfig, DrawShaded, ElementState, Event, KeyboardInput, Material,
+    MaterialDefaults, MeshHandle, ObjFormat, Pipeline, PosNormTex, Projection, RenderBundle, Rgba,
+    Stage, VirtualKeyCode, WindowEvent,
+};
+use amethyst::{Application, Result, State, Trans};
 
 struct ExampleState;
 
@@ -83,16 +84,7 @@ fn load_assets(world: &World) -> Assets {
     Assets { cube, red }
 }
 
-fn main() {
-    if let Err(error) = run() {
-        eprintln!("Could not run the example!");
-        eprintln!("{}", error);
-        ::std::process::exit(1);
-    }
-}
-
-/// Wrapper around the main, so we can return errors easily.
-fn run() -> Result<(), Error> {
+fn main() -> Result<()> {
     let resources_directory = format!("{}/examples/assets", env!("CARGO_MANIFEST_DIR"));
 
     let display_config_path = format!(

--- a/examples/gltf/main.rs
+++ b/examples/gltf/main.rs
@@ -12,8 +12,10 @@ use amethyst::core::transform::{GlobalTransform, Transform, TransformBundle};
 use amethyst::ecs::prelude::Entity;
 use amethyst::prelude::*;
 use amethyst::renderer::*;
-use amethyst_animation::{get_animation_set, AnimationBundle, AnimationCommand, AnimationSet,
-                         EndControl, VertexSkinningBundle};
+use amethyst_animation::{
+    get_animation_set, AnimationBundle, AnimationCommand, AnimationSet, EndControl,
+    VertexSkinningBundle,
+};
 use amethyst_gltf::{GltfSceneAsset, GltfSceneFormat, GltfSceneLoaderSystem, GltfSceneOptions};
 
 struct Example;
@@ -141,7 +143,7 @@ impl State for Example {
     }
 }
 
-fn run() -> Result<(), amethyst::Error> {
+fn main() -> amethyst::Result<()> {
     let path = format!(
         "{}/examples/gltf/resources/display_config.ron",
         env!("CARGO_MANIFEST_DIR")
@@ -179,13 +181,6 @@ fn run() -> Result<(), amethyst::Error> {
         .build()?;
     game.run();
     Ok(())
-}
-
-fn main() {
-    if let Err(e) = run() {
-        error!("Failed to execute example: {}", e);
-        ::std::process::exit(1);
-    }
 }
 
 fn load_gltf_mesh(

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -21,7 +21,8 @@ impl State for Example {
     }
 }
 
-fn main() {
-    let mut game = Application::new("./", Example).expect("Fatal error");
+fn main() -> amethyst::Result<()> {
+    let mut game = Application::new("./", Example)?;
     game.run();
+    Ok(())
 }

--- a/examples/material/main.rs
+++ b/examples/material/main.rs
@@ -8,8 +8,8 @@ use amethyst::core::cgmath::{Deg, Matrix4, Vector3};
 use amethyst::core::transform::GlobalTransform;
 use amethyst::prelude::*;
 use amethyst::renderer::*;
-use genmesh::{MapToVertices, Triangulate, Vertices};
 use genmesh::generators::SphereUV;
+use genmesh::{MapToVertices, Triangulate, Vertices};
 
 struct Example;
 
@@ -117,7 +117,7 @@ impl State for Example {
     }
 }
 
-fn run() -> Result<(), amethyst::Error> {
+fn main() -> amethyst::Result<()> {
     let path = format!(
         "{}/examples/material/resources/display_config.ron",
         env!("CARGO_MANIFEST_DIR")
@@ -136,13 +136,6 @@ fn run() -> Result<(), amethyst::Error> {
         .build()?;
     game.run();
     Ok(())
-}
-
-fn main() {
-    if let Err(e) = run() {
-        println!("Failed to execute example: {}", e);
-        ::std::process::exit(1);
-    }
 }
 
 fn gen_sphere(u: usize, v: usize) -> Vec<PosNormTangTex> {

--- a/examples/pong/main.rs
+++ b/examples/pong/main.rs
@@ -2,14 +2,13 @@
 
 extern crate amethyst;
 
+mod audio;
+mod bundle;
 mod pong;
 mod systems;
-mod bundle;
-mod audio;
 
 use std::time::Duration;
 
-use amethyst::Result;
 use amethyst::audio::AudioBundle;
 use amethyst::core::frame_limiter::FrameRateLimitStrategy;
 use amethyst::core::transform::TransformBundle;
@@ -18,6 +17,7 @@ use amethyst::input::InputBundle;
 use amethyst::prelude::*;
 use amethyst::renderer::{DisplayConfig, DrawFlat, Pipeline, PosTex, RenderBundle, Stage};
 use amethyst::ui::{DrawUi, UiBundle};
+use amethyst::Result;
 
 use audio::Music;
 use bundle::PongBundle;
@@ -41,14 +41,7 @@ const AUDIO_MUSIC: &'static [&'static str] = &[
 const AUDIO_BOUNCE: &'static str = "audio/bounce.ogg";
 const AUDIO_SCORE: &'static str = "audio/score.ogg";
 
-fn main() {
-    if let Err(e) = run() {
-        println!("Failed to execute example: {}", e);
-        ::std::process::exit(1);
-    }
-}
-
-fn run() -> Result<()> {
+fn main() -> Result<()> {
     use pong::Pong;
 
     let display_config_path = format!(

--- a/examples/pong_tutorial_01/main.rs
+++ b/examples/pong_tutorial_01/main.rs
@@ -1,9 +1,11 @@
 extern crate amethyst;
 
-use amethyst::Result;
 use amethyst::prelude::*;
-use amethyst::renderer::{DisplayConfig, DrawFlat, Event, KeyboardInput, Pipeline, PosTex,
-                         RenderBundle, Stage, VirtualKeyCode, WindowEvent};
+use amethyst::renderer::{
+    DisplayConfig, DrawFlat, Event, KeyboardInput, Pipeline, PosTex, RenderBundle, Stage,
+    VirtualKeyCode, WindowEvent,
+};
+use amethyst::Result;
 
 struct Pong;
 
@@ -26,7 +28,7 @@ impl State for Pong {
     }
 }
 
-fn run() -> Result<()> {
+fn main() -> Result<()> {
     let path = format!(
         "{}/examples/pong_tutorial_01/resources/display_config.ron",
         env!("CARGO_MANIFEST_DIR")
@@ -44,11 +46,4 @@ fn run() -> Result<()> {
         .build()?;
     game.run();
     Ok(())
-}
-
-fn main() {
-    if let Err(e) = run() {
-        println!("Error occurred during game execution: {}", e);
-        ::std::process::exit(1);
-    }
 }

--- a/examples/pong_tutorial_02/main.rs
+++ b/examples/pong_tutorial_02/main.rs
@@ -2,12 +2,12 @@ extern crate amethyst;
 
 mod pong;
 
-use amethyst::Result;
 use amethyst::core::transform::TransformBundle;
 use amethyst::prelude::*;
 use amethyst::renderer::{DisplayConfig, DrawFlat, Pipeline, PosTex, RenderBundle, Stage};
+use amethyst::Result;
 
-fn run() -> Result<()> {
+fn main() -> Result<()> {
     use pong::Pong;
 
     let path = format!(
@@ -29,11 +29,4 @@ fn run() -> Result<()> {
         .build()?;
     game.run();
     Ok(())
-}
-
-fn main() {
-    if let Err(e) = run() {
-        println!("Error occurred during game execution: {}", e);
-        ::std::process::exit(1);
-    }
 }

--- a/examples/pong_tutorial_03/main.rs
+++ b/examples/pong_tutorial_03/main.rs
@@ -3,13 +3,13 @@ extern crate amethyst;
 mod pong;
 mod systems;
 
-use amethyst::Result;
 use amethyst::core::transform::TransformBundle;
 use amethyst::input::InputBundle;
 use amethyst::prelude::*;
 use amethyst::renderer::{DisplayConfig, DrawFlat, Pipeline, PosTex, RenderBundle, Stage};
+use amethyst::Result;
 
-fn run() -> Result<()> {
+fn main() -> Result<()> {
     use pong::Pong;
 
     let path = format!(
@@ -40,11 +40,4 @@ fn run() -> Result<()> {
         .build()?;
     game.run();
     Ok(())
-}
-
-fn main() {
-    if let Err(e) = run() {
-        println!("Error occurred during game execution: {}", e);
-        ::std::process::exit(1);
-    }
 }

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -5,22 +5,24 @@
 
 extern crate amethyst;
 
-use amethyst::{Application, Error, State, Trans};
 use amethyst::assets::{HotReloadBundle, Loader};
 use amethyst::config::Config;
 use amethyst::core::cgmath::{Array, Deg, Euler, Quaternion, Rad, Rotation, Rotation3, Vector3};
 use amethyst::core::frame_limiter::FrameRateLimitStrategy;
 use amethyst::core::timing::Time;
 use amethyst::core::transform::{GlobalTransform, Transform, TransformBundle};
-use amethyst::ecs::prelude::{Entity, Join, Read, ReadStorage, System, World, WriteExpect,
-                             WriteStorage};
+use amethyst::ecs::prelude::{
+    Entity, Join, Read, ReadStorage, System, World, WriteExpect, WriteStorage,
+};
 use amethyst::input::InputBundle;
-use amethyst::renderer::{AmbientColor, Camera, DirectionalLight, DisplayConfig, DrawShaded,
-                         ElementState, Event, KeyboardInput, Light, Material, MaterialDefaults,
-                         MeshHandle, ObjFormat, Pipeline, PngFormat, PointLight, PosNormTex,
-                         Projection, RenderBundle, Rgba, Stage, VirtualKeyCode, WindowEvent};
+use amethyst::renderer::{
+    AmbientColor, Camera, DirectionalLight, DisplayConfig, DrawShaded, ElementState, Event,
+    KeyboardInput, Light, Material, MaterialDefaults, MeshHandle, ObjFormat, Pipeline, PngFormat,
+    PointLight, PosNormTex, Projection, RenderBundle, Rgba, Stage, VirtualKeyCode, WindowEvent,
+};
 use amethyst::ui::{DrawUi, FontHandle, TtfFormat, UiBundle, UiText, UiTransform};
 use amethyst::utils::fps_counter::{FPSCounter, FPSCounterBundle};
+use amethyst::{Application, State, Trans};
 
 struct DemoState {
     light_angle: f32,
@@ -365,16 +367,7 @@ fn load_assets(world: &World) -> Assets {
     }
 }
 
-fn main() {
-    if let Err(error) = run() {
-        eprintln!("Could not run the example!");
-        eprintln!("{}", error);
-        ::std::process::exit(1);
-    }
-}
-
-/// Wrapper around the main, so we can return errors easily.
-fn run() -> Result<(), Error> {
+fn main() -> amethyst::Result<()> {
     // Add our meshes directory to the asset loader.
     let resources_directory = format!("{}/examples/assets", env!("CARGO_MANIFEST_DIR"));
 

--- a/examples/separate_sphere/main.rs
+++ b/examples/separate_sphere/main.rs
@@ -9,8 +9,8 @@ use amethyst::core::transform::GlobalTransform;
 use amethyst::ecs::prelude::World;
 use amethyst::prelude::*;
 use amethyst::renderer::*;
-use genmesh::{MapToVertices, Triangulate, Vertices};
 use genmesh::generators::SphereUV;
+use genmesh::{MapToVertices, Triangulate, Vertices};
 
 const SPHERE_COLOUR: [f32; 4] = [0.0, 0.0, 1.0, 1.0]; // blue
 const AMBIENT_LIGHT_COLOUR: Rgba = Rgba(0.01, 0.01, 0.01, 1.0); // near-black
@@ -49,7 +49,7 @@ impl State for Example {
     }
 }
 
-fn run() -> Result<(), amethyst::Error> {
+fn main() -> amethyst::Result<()> {
     let display_config_path = format!(
         "{}/examples/separate_sphere/resources/display.ron",
         env!("CARGO_MANIFEST_DIR")
@@ -70,13 +70,6 @@ fn run() -> Result<(), amethyst::Error> {
         .build()?;
     game.run();
     Ok(())
-}
-
-fn main() {
-    if let Err(e) = run() {
-        println!("Failed to execute example: {}", e);
-        ::std::process::exit(1);
-    }
 }
 
 fn gen_sphere(u: usize, v: usize) -> ComboMeshCreator {

--- a/examples/sphere/main.rs
+++ b/examples/sphere/main.rs
@@ -8,11 +8,12 @@ use amethyst::core::cgmath::Deg;
 use amethyst::core::transform::GlobalTransform;
 use amethyst::ecs::prelude::World;
 use amethyst::prelude::*;
-use amethyst::renderer::{AmbientColor, Camera, DisplayConfig, DrawShaded, Event, KeyboardInput,
-                         Light, Mesh, Pipeline, PointLight, PosNormTex, Projection, RenderBundle,
-                         Rgba, Stage, VirtualKeyCode, WindowEvent};
-use genmesh::{MapToVertices, Triangulate, Vertices};
+use amethyst::renderer::{
+    AmbientColor, Camera, DisplayConfig, DrawShaded, Event, KeyboardInput, Light, Mesh, Pipeline,
+    PointLight, PosNormTex, Projection, RenderBundle, Rgba, Stage, VirtualKeyCode, WindowEvent,
+};
 use genmesh::generators::SphereUV;
+use genmesh::{MapToVertices, Triangulate, Vertices};
 
 const SPHERE_COLOUR: [f32; 4] = [0.0, 0.0, 1.0, 1.0]; // blue
 const AMBIENT_LIGHT_COLOUR: Rgba = Rgba(0.01, 0.01, 0.01, 1.0); // near-black
@@ -50,7 +51,7 @@ impl State for Example {
     }
 }
 
-fn run() -> Result<(), amethyst::Error> {
+fn main() -> amethyst::Result<()> {
     let display_config_path = format!(
         "{}/examples/sphere/resources/display_config.ron",
         env!("CARGO_MANIFEST_DIR")
@@ -71,13 +72,6 @@ fn run() -> Result<(), amethyst::Error> {
         .build()?;
     game.run();
     Ok(())
-}
-
-fn main() {
-    if let Err(e) = run() {
-        println!("Failed to execute example: {}", e);
-        ::std::process::exit(1);
-    }
 }
 
 fn gen_sphere(u: usize, v: usize) -> Vec<PosNormTex> {

--- a/examples/sphere_multisample/main.rs
+++ b/examples/sphere_multisample/main.rs
@@ -50,7 +50,7 @@ impl State for Example {
     }
 }
 
-fn run() -> Result<(), amethyst::Error> {
+fn main() -> amethyst::Result<()> {
     let display_config_path = format!(
         "{}/examples/sphere/resources/display_config.ron",
         env!("CARGO_MANIFEST_DIR")
@@ -71,13 +71,6 @@ fn run() -> Result<(), amethyst::Error> {
         .build()?;
     game.run();
     Ok(())
-}
-
-fn main() {
-    if let Err(e) = run() {
-        println!("Failed to execute example: {}", e);
-        ::std::process::exit(1);
-    }
 }
 
 fn gen_sphere(u: usize, v: usize) -> Vec<PosNormTex> {

--- a/examples/sprites/main.rs
+++ b/examples/sprites/main.rs
@@ -18,17 +18,21 @@ mod sprite_sheet_loader;
 
 use std::time::Duration;
 
-use amethyst::animation::{get_animation_set, AnimationBundle, AnimationCommand, AnimationControl,
-                          ControlState, EndControl, MaterialTextureSet};
+use amethyst::animation::{
+    get_animation_set, AnimationBundle, AnimationCommand, AnimationControl, ControlState,
+    EndControl, MaterialTextureSet,
+};
 use amethyst::assets::{AssetStorage, Loader};
 use amethyst::core::cgmath::{Matrix4, Point3, Transform as CgTransform, Vector3};
 use amethyst::core::transform::{GlobalTransform, Transform, TransformBundle};
 use amethyst::ecs::prelude::Entity;
 use amethyst::input::InputBundle;
 use amethyst::prelude::*;
-use amethyst::renderer::{Camera, ColorMask, DisplayConfig, DrawFlat, Event, KeyboardInput,
-                         Material, MaterialDefaults, Mesh, Pipeline, PosTex, Projection,
-                         RenderBundle, ScreenDimensions, Stage, VirtualKeyCode, WindowEvent, ALPHA};
+use amethyst::renderer::{
+    Camera, ColorMask, DisplayConfig, DrawFlat, Event, KeyboardInput, Material, MaterialDefaults,
+    Mesh, Pipeline, PosTex, Projection, RenderBundle, ScreenDimensions, Stage, VirtualKeyCode,
+    WindowEvent, ALPHA,
+};
 use amethyst::ui::{DrawUi, UiBundle};
 
 const BACKGROUND_COLOUR: [f32; 4] = [0.0, 0.0, 0.0, 1.0]; // black
@@ -180,10 +184,7 @@ fn initialise_camera(world: &mut World) -> Entity {
     world
         .create_entity()
         .with(Camera::from(Projection::orthographic(
-            0.0,
-            width,
-            height,
-            0.0,
+            0.0, width, height, 0.0,
         )))
         .with(GlobalTransform(Matrix4::from_translation(
             Vector3::new(0.0, 0.0, 1.0).into(),
@@ -191,7 +192,7 @@ fn initialise_camera(world: &mut World) -> Entity {
         .build()
 }
 
-fn run() -> Result<(), amethyst::Error> {
+fn main() -> amethyst::Result<()> {
     let path = format!(
         "{}/examples/sprites/resources/display_config.ron",
         env!("CARGO_MANIFEST_DIR")
@@ -229,13 +230,6 @@ fn run() -> Result<(), amethyst::Error> {
     game.run();
 
     Ok(())
-}
-
-fn main() {
-    if let Err(e) = run() {
-        error!("Failed to execute example: {}", e);
-        ::std::process::exit(1);
-    }
 }
 
 /// Returns a set of vertices that make up a rectangular mesh of the given size.

--- a/examples/ui/main.rs
+++ b/examples/ui/main.rs
@@ -6,23 +6,25 @@ extern crate genmesh;
 extern crate log;
 
 use amethyst::assets::{AssetStorage, Loader};
-use amethyst::core::Time;
 use amethyst::core::cgmath::Deg;
 use amethyst::core::transform::{GlobalTransform, Parent, TransformBundle};
+use amethyst::core::Time;
 use amethyst::ecs::prelude::{Entity, System, World, Write};
 use amethyst::input::InputBundle;
 use amethyst::prelude::*;
-use amethyst::renderer::{AmbientColor, Camera, DisplayConfig, DrawShaded, Light, Mesh, Pipeline,
-                         PngFormat, PointLight, PosNormTex, Projection, RenderBundle, Rgba, Stage,
-                         Texture};
+use amethyst::renderer::{
+    AmbientColor, Camera, DisplayConfig, DrawShaded, Light, Mesh, Pipeline, PngFormat, PointLight,
+    PosNormTex, Projection, RenderBundle, Rgba, Stage, Texture,
+};
 use amethyst::shrev::{EventChannel, ReaderId};
-use amethyst::ui::{Anchor, Anchored, DrawUi, FontAsset, MouseReactive, Stretch, Stretched,
-                   TextEditing, TtfFormat, UiBundle, UiButtonBuilder, UiButtonResources, UiEvent,
-                   UiFocused, UiImage, UiText, UiTransform};
+use amethyst::ui::{
+    Anchor, Anchored, DrawUi, FontAsset, MouseReactive, Stretch, Stretched, TextEditing, TtfFormat,
+    UiBundle, UiButtonBuilder, UiButtonResources, UiEvent, UiFocused, UiImage, UiText, UiTransform,
+};
 use amethyst::utils::fps_counter::{FPSCounter, FPSCounterBundle};
 use amethyst::winit::{Event, KeyboardInput, VirtualKeyCode, WindowEvent};
-use genmesh::{MapToVertices, Triangulate, Vertices};
 use genmesh::generators::SphereUV;
+use genmesh::{MapToVertices, Triangulate, Vertices};
 
 const SPHERE_COLOUR: [f32; 4] = [0.0, 0.0, 1.0, 1.0]; // blue
 const AMBIENT_LIGHT_COLOUR: Rgba = Rgba(0.01, 0.01, 0.01, 1.0); // near-black
@@ -266,46 +268,41 @@ impl State for Example {
     }
 }
 
-fn run() -> Result<(), amethyst::Error> {
-    let display_config_path = format!(
-        "{}/examples/ui/resources/display.ron",
-        env!("CARGO_MANIFEST_DIR")
-    );
-
-    let resources = format!("{}/examples/assets", env!("CARGO_MANIFEST_DIR"));
-    let config = DisplayConfig::load(&display_config_path);
-    let pipe = {
-        Pipeline::build().with_stage(
-            Stage::with_backbuffer()
-                .clear_target(BACKGROUND_COLOUR, 1.0)
-                .with_pass(DrawShaded::<PosNormTex>::new())
-                .with_pass(DrawUi::new()),
-        )
-    };
-    let mut game = Application::build(resources, Example { fps_display: None })?
-        .with_bundle(TransformBundle::new())?
-        .with_bundle(UiBundle::<String, String>::new())?
-        .with(UiEventHandlerSystem::new(), "ui_event_handler", &[])
-        .with_bundle(FPSCounterBundle::default())?
-        .with_bundle(InputBundle::<String, String>::new())?
-        .with_bundle(RenderBundle::new(pipe, Some(config)))?
-        .build()?;
-    game.run();
-    Ok(())
-}
-
-fn main() {
+fn main() -> amethyst::Result<()> {
     println!("Due to some bugs this example currently comes with a seizure warning.");
     println!("If you have a history of seizures please do not run this.");
     println!("Would you like to run this? (Y/N)");
     let mut input = String::new();
     let _ = ::std::io::stdin().read_line(&mut input);
+    
     if input.to_lowercase().starts_with("y") {
-        if let Err(e) = run() {
-            println!("Failed to execute example: {}", e);
-            ::std::process::exit(1);
-        }
+        let display_config_path = format!(
+            "{}/examples/ui/resources/display.ron",
+            env!("CARGO_MANIFEST_DIR")
+        );
+
+        let resources = format!("{}/examples/assets", env!("CARGO_MANIFEST_DIR"));
+        let config = DisplayConfig::load(&display_config_path);
+        let pipe = {
+            Pipeline::build().with_stage(
+                Stage::with_backbuffer()
+                    .clear_target(BACKGROUND_COLOUR, 1.0)
+                    .with_pass(DrawShaded::<PosNormTex>::new())
+                    .with_pass(DrawUi::new()),
+            )
+        };
+        let mut game = Application::build(resources, Example { fps_display: None })?
+            .with_bundle(TransformBundle::new())?
+            .with_bundle(UiBundle::<String, String>::new())?
+            .with(UiEventHandlerSystem::new(), "ui_event_handler", &[])
+            .with_bundle(FPSCounterBundle::default())?
+            .with_bundle(InputBundle::<String, String>::new())?
+            .with_bundle(RenderBundle::new(pipe, Some(config)))?
+            .build()?;
+        game.run();
     }
+
+    Ok(())
 }
 
 fn gen_sphere(u: usize, v: usize) -> Vec<PosNormTex> {

--- a/examples/window/main.rs
+++ b/examples/window/main.rs
@@ -27,7 +27,7 @@ impl State for Example {
     }
 }
 
-fn run() -> Result<(), amethyst::Error> {
+fn main() -> amethyst::Result<()> {
     let path = format!(
         "{}/examples/window/resources/display_config.ron",
         env!("CARGO_MANIFEST_DIR")
@@ -48,11 +48,4 @@ fn run() -> Result<(), amethyst::Error> {
     game.run();
 
     Ok(())
-}
-
-fn main() {
-    if let Err(e) = run() {
-        println!("Failed to execute example: {}", e);
-        ::std::process::exit(1);
-    }
 }


### PR DESCRIPTION
Rust 1.26 supports returning Results from `main()`. Good time to get rid of `run()` functions!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/712)
<!-- Reviewable:end -->
