### PR TITLE
Remove unnecessary log warning

### DIFF
--- a/amethyst_core/src/transform/systems.rs
+++ b/amethyst_core/src/transform/systems.rs
@@ -60,9 +60,10 @@ impl<'a> System<'a> for TransformSystem {
         {
             match *event {
                 HierarchyEvent::Removed(entity) => {
-                    if let Err(err) = entities.delete(entity) {
-                        error!("Failed removing entity {:?}: {}", entity, err);
-                    }
+                    // Sometimes the user may have already deleted the entity.
+                    // This is fine, so we'll ignore any errors this may give
+                    // since it can only fail due to the entity already being dead.
+                    let _ = entities.delete(entity);
                 }
                 HierarchyEvent::Modified(entity) => {
                     self.local_modified.add(entity.id());


### PR DESCRIPTION
Sometimes an entity and its children will be deleted at the same time.  This is fine, so we're going to ignore this rather than printing it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/744)
<!-- Reviewable:end -->
