### PR TITLE
Standardize vsync across examples

### DIFF
--- a/examples/arc_ball_camera/main.rs
+++ b/examples/arc_ball_camera/main.rs
@@ -148,7 +148,6 @@ fn run() -> Result<(), Error> {
         )
         .with_bundle(RenderBundle::new(pipeline_builder, Some(display_config)))?;
     let mut game = Application::build(resources_directory, ExampleState)?
-        .with_frame_limit(FrameRateLimitStrategy::Unlimited, 0)
         .build(game_data)?;
     game.run();
     Ok(())

--- a/examples/arc_ball_camera/resources/display_config.ron
+++ b/examples/arc_ball_camera/resources/display_config.ron
@@ -3,5 +3,5 @@
   multisampling: 0,
   title: "Arc Ball Camera Example",
   visibility: true,
-  vsync: false,
+  vsync: true,
 )

--- a/examples/custom_game_data/main.rs
+++ b/examples/custom_game_data/main.rs
@@ -189,7 +189,6 @@ fn run() -> Result<(), Error> {
         .with_base_bundle(InputBundle::<String, String>::new())?;
 
     let mut game = Application::build(resources_directory, Loading::default())?
-        .with_frame_limit(FrameRateLimitStrategy::Unlimited, 0)
         .build(game_data)?;
     game.run();
 

--- a/examples/custom_game_data/resources/display_config.ron
+++ b/examples/custom_game_data/resources/display_config.ron
@@ -3,5 +3,5 @@
   multisampling: 0,
   title: "Custom GameData Example",
   visibility: true,
-  vsync: false,
+  vsync: true,
 )

--- a/examples/fly_camera/main.rs
+++ b/examples/fly_camera/main.rs
@@ -133,7 +133,6 @@ fn run() -> Result<(), Error> {
         )?
         .with_bundle(RenderBundle::new(pipeline_builder, Some(display_config)))?;
     let mut game = Application::build(resources_directory, ExampleState)?
-        .with_frame_limit(FrameRateLimitStrategy::Unlimited, 0)
         .build(game_data)?;
     game.run();
     Ok(())

--- a/examples/fly_camera/resources/display_config.ron
+++ b/examples/fly_camera/resources/display_config.ron
@@ -3,5 +3,5 @@
   multisampling: 0,
   title: "Fly Camera Example",
   visibility: true,
-  vsync: false,
+  vsync: true,
 )

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -508,7 +508,6 @@ fn run() -> Result<(), Error> {
         .with_bundle(RenderBundle::new(pipeline_builder, Some(display_config)))?
         .with_bundle(InputBundle::<String, String>::new())?;
     let mut game = Application::build(resources_directory, Loading::default())?
-        .with_frame_limit(FrameRateLimitStrategy::Unlimited, 0)
         .build(game_data)?;
     game.run();
     Ok(())

--- a/examples/sphere/resources/display_config.ron
+++ b/examples/sphere/resources/display_config.ron
@@ -6,5 +6,5 @@
   multisampling: 0,
   title: "Sphere example",
   visibility: true,
-  vsync: false,
+  vsync: true,
 )

--- a/examples/sphere_multisample/resources/display_config.ron
+++ b/examples/sphere_multisample/resources/display_config.ron
@@ -6,5 +6,5 @@
   multisampling: 8,
   title: "Sphere example with multisampling",
   visibility: true,
-  vsync: false,
+  vsync: true,
 )


### PR DESCRIPTION
vsync should be true for all examples, excluding renderable.  This PR makes that true.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/746)
<!-- Reviewable:end -->
