### PR TITLE
Switch to sip hash for Bindings

### DIFF
--- a/amethyst_input/Cargo.toml
+++ b/amethyst_input/Cargo.toml
@@ -18,7 +18,6 @@ travis-ci = { repository = "amethyst/amethyst" }
 amethyst_core = { path = "../amethyst_core/", version = "0.2.0" }
 amethyst_config = { path = "../amethyst_config/", version = "0.6.0" }
 derivative = "1.0"
-fnv = "1.0"
 serde = { version = "1", features = ["serde_derive"] }
 winit = "0.13.1"
 

--- a/amethyst_input/src/bindings.rs
+++ b/amethyst_input/src/bindings.rs
@@ -1,16 +1,16 @@
 //! Defines binding structure used for saving and loading input settings.
 
 use std::borrow::Borrow;
+use std::collections::HashMap;
 use std::hash::Hash;
 
-use fnv::FnvHashMap as HashMap;
 use smallvec::SmallVec;
 
 use super::{Axis, Button};
 
 /// Used for saving and loading input settings.
 #[derive(Derivative, Serialize, Deserialize, Clone)]
-#[derivative(Default(bound = "AX: Hash + Eq, AC: Hash + Eq"))]
+#[derivative(Default(bound = ""))]
 pub struct Bindings<AX, AC>
 where
     AX: Hash + Eq,

--- a/amethyst_input/src/lib.rs
+++ b/amethyst_input/src/lib.rs
@@ -2,7 +2,6 @@ extern crate amethyst_config;
 extern crate amethyst_core;
 #[macro_use]
 extern crate derivative;
-extern crate fnv;
 #[macro_use]
 extern crate serde;
 extern crate smallvec;

--- a/examples/arc_ball_camera/main.rs
+++ b/examples/arc_ball_camera/main.rs
@@ -7,7 +7,6 @@ use amethyst::config::Config;
 use amethyst::controls::{ArcBallControlTag, ArcBallMovementSystem, FlyControlTag,
                          FreeRotationSystem, MouseCenterLockSystem, MouseFocusUpdateSystem};
 use amethyst::core::cgmath::{Deg, Vector3};
-use amethyst::core::frame_limiter::FrameRateLimitStrategy;
 use amethyst::core::transform::{GlobalTransform, Transform, TransformBundle};
 use amethyst::ecs::prelude::{Entity, World};
 use amethyst::input::InputBundle;

--- a/examples/custom_game_data/main.rs
+++ b/examples/custom_game_data/main.rs
@@ -5,7 +5,6 @@ extern crate rayon;
 
 use amethyst::assets::{Completion, HotReloadBundle, ProgressCounter};
 use amethyst::config::Config;
-use amethyst::core::frame_limiter::FrameRateLimitStrategy;
 use amethyst::core::transform::TransformBundle;
 use amethyst::ecs::prelude::{Component, Entity, Join, World};
 use amethyst::ecs::storage::NullStorage;

--- a/examples/fly_camera/main.rs
+++ b/examples/fly_camera/main.rs
@@ -6,7 +6,6 @@ use amethyst::assets::Loader;
 use amethyst::config::Config;
 use amethyst::controls::{FlyControlBundle, FlyControlTag};
 use amethyst::core::cgmath::{Deg, Vector3};
-use amethyst::core::frame_limiter::FrameRateLimitStrategy;
 use amethyst::core::transform::{GlobalTransform, Transform, TransformBundle};
 use amethyst::ecs::prelude::World;
 use amethyst::input::InputBundle;

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -8,7 +8,6 @@ extern crate amethyst;
 use amethyst::assets::{Completion, HotReloadBundle, Loader, ProgressCounter};
 use amethyst::config::Config;
 use amethyst::core::cgmath::{Array, Deg, Euler, Quaternion, Rad, Rotation, Rotation3, Vector3};
-use amethyst::core::frame_limiter::FrameRateLimitStrategy;
 use amethyst::core::timing::Time;
 use amethyst::core::transform::{GlobalTransform, Transform, TransformBundle};
 use amethyst::ecs::prelude::{Component, Entity, Join, Read, ReadStorage, System, World,


### PR DESCRIPTION
FNV isn't great for large keys, and since we recommend strings by default for this I figure sip hash is probably better.  It's a good compromise between various key sizes.

I also nabbed a few unused imports in the examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/748)
<!-- Reviewable:end -->
