### PR TITLE
fix: Log an error if a pass tries to render a mesh with incompatible vertex buffers

### DIFF
--- a/amethyst_renderer/src/pass/util.rs
+++ b/amethyst_renderer/src/pass/util.rs
@@ -59,7 +59,10 @@ pub(crate) fn set_attribute_buffers(
     for attr in attributes.iter() {
         match mesh.buffer(attr) {
             Some(vbuf) => effect.data.vertex_bufs.push(vbuf.clone()),
-            None => return false,
+            None => {
+                error!("Required vertex attribute buffer with format {:?} missing in mesh", attr);
+                return false;
+            }
         }
     }
     true


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/749)
<!-- Reviewable:end -->
