### PR TITLE
Improve examples on OSX

### DIFF
--- a/amethyst_controls/src/bundles.rs
+++ b/amethyst_controls/src/bundles.rs
@@ -72,7 +72,6 @@ where
             "mouse_focus",
             &["free_rotation"],
         );
-        builder.add(MouseCenterLockSystem, "mouse_lock", &["mouse_focus"]);
         builder.add(CursorHideSystem::new(), "cursor_hide", &["mouse_focus"]);
         Ok(())
     }

--- a/amethyst_controls/src/lib.rs
+++ b/amethyst_controls/src/lib.rs
@@ -2,7 +2,6 @@
 extern crate amethyst_core;
 extern crate amethyst_input;
 extern crate amethyst_renderer;
-#[macro_use]
 extern crate log;
 extern crate winit;
 
@@ -18,4 +17,4 @@ pub use self::bundles::FlyControlBundle;
 pub use self::components::{ArcBallControlTag, FlyControlTag};
 pub use self::resources::WindowFocus;
 pub use self::systems::{ArcBallMovementSystem, FlyMovementSystem, FreeRotationSystem,
-                        MouseCenterLockSystem, MouseFocusUpdateSystem, CursorHideSystem};
+                        MouseFocusUpdateSystem, CursorHideSystem};

--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -3,12 +3,12 @@ use std::marker::PhantomData;
 
 use amethyst_core::cgmath::{Deg, Vector3};
 use amethyst_core::shrev::{EventChannel, ReaderId};
-use amethyst_core::specs::prelude::{Join, Read, ReadExpect, ReadStorage, Resources, System, Write,
+use amethyst_core::specs::prelude::{Join, Read, ReadStorage, Resources, System, Write,
                                     WriteStorage};
 use amethyst_core::timing::Time;
 use amethyst_core::transform::Transform;
 use amethyst_input::InputHandler;
-use amethyst_renderer::{ScreenDimensions, WindowMessages};
+use amethyst_renderer::WindowMessages;
 use winit::{Event, WindowEvent, DeviceEvent};
 
 use components::{ArcBallControlTag, FlyControlTag};
@@ -170,37 +170,6 @@ where
 
         Self::SystemData::setup(res);
         self.event_reader = Some(res.fetch_mut::<EventChannel<Event>>().register_reader());
-    }
-}
-
-/// The system that locks the mouse to the center of the screen. Useful for first person camera.
-pub struct MouseCenterLockSystem;
-
-impl<'a> System<'a> for MouseCenterLockSystem {
-    type SystemData = (
-        ReadExpect<'a, ScreenDimensions>,
-        Write<'a, WindowMessages>,
-        Read<'a, WindowFocus>,
-    );
-
-    fn run(&mut self, (dim, mut msg, focus): Self::SystemData) {
-        use amethyst_renderer::mouse::*;
-        if focus.is_focused {
-            let half_x = dim.width() as i32 / 2;
-            let half_y = dim.height() as i32 / 2;
-            msg.send_command(move |win| {
-                if let Err(err) = win.set_cursor_position(half_x, half_y) {
-                    error!("Unable to set the cursor position! Error: {:?}", err);
-                }
-            });
-        } else {
-            release_cursor(&mut msg);
-        }
-    }
-
-    fn setup(&mut self, res: &mut Resources) {
-        use amethyst_core::specs::prelude::SystemData;
-        Self::SystemData::setup(res);
     }
 }
 

--- a/amethyst_renderer/src/resources.rs
+++ b/amethyst_renderer/src/resources.rs
@@ -53,16 +53,20 @@ pub struct ScreenDimensions {
     h: f32,
     /// Width divided by height.
     aspect_ratio: f32,
+    /// The ratio between the backing framebuffer resolution and the window size in screen pixels.
+    /// This is typically one for a normal display and two for a retina display.
+    hidpi: f32,
     pub(crate) dirty: bool,
 }
 
 impl ScreenDimensions {
     /// Creates a new screen dimensions object with the given width and height.
-    pub fn new(w: u32, h: u32) -> ScreenDimensions {
+    pub fn new(w: u32, h: u32, hidpi: f32) -> ScreenDimensions {
         ScreenDimensions {
             w: w as f32,
             h: h as f32,
             aspect_ratio: w as f32 / h as f32,
+            hidpi,
             dirty: false,
         }
     }
@@ -86,6 +90,12 @@ impl ScreenDimensions {
     /// Returns the current aspect ratio of the window.
     pub fn aspect_ratio(&self) -> f32 {
         self.aspect_ratio
+    }
+
+    /// Returns the ratio between the backing framebuffer resolution and the window size in screen pixels.
+    /// This is typically one for a normal display and two for a retina display.
+    pub fn hidpi_factor(&self) -> f32 {
+        self.hidpi
     }
 
     /// Updates the width and height of the screen and recomputes the aspect

--- a/amethyst_renderer/src/system.rs
+++ b/amethyst_renderer/src/system.rs
@@ -75,11 +75,6 @@ where
         }
     }
 
-    /// Returns the size in pixels of the window.
-    pub fn window_size(&self) -> Option<(u32, u32)> {
-        self.renderer.window().get_inner_size()
-    }
-
     fn asset_loading(
         &mut self,
         (time, pool, strategy, mut mesh_storage, mut texture_storage): AssetLoadingData,
@@ -177,9 +172,10 @@ where
 
         let mat = create_default_mat(res);
         res.insert(MaterialDefaults(mat));
-        let (width, height) = self.window_size()
+        let (width, height) = self.renderer.window().get_inner_size()
             .expect("Window closed during initialization!");
-        res.insert(ScreenDimensions::new(width, height));
+        let hidpi = self.renderer.window().hidpi_factor();
+        res.insert(ScreenDimensions::new(width, height, hidpi));
     }
 }
 

--- a/examples/arc_ball_camera/main.rs
+++ b/examples/arc_ball_camera/main.rs
@@ -4,8 +4,8 @@ extern crate amethyst;
 
 use amethyst::assets::Loader;
 use amethyst::config::Config;
-use amethyst::controls::{ArcBallControlTag, ArcBallMovementSystem, FlyControlTag,
-                         FreeRotationSystem, MouseCenterLockSystem, MouseFocusUpdateSystem};
+use amethyst::controls::{ArcBallControlTag, ArcBallMovementSystem, CursorHideSystem, 
+                         FlyControlTag, FreeRotationSystem, MouseFocusUpdateSystem};
 use amethyst::core::cgmath::{Deg, Vector3};
 use amethyst::core::transform::{GlobalTransform, Transform, TransformBundle};
 use amethyst::ecs::prelude::{Entity, World};
@@ -135,8 +135,8 @@ fn run() -> Result<(), Error> {
             InputBundle::<String, String>::new().with_bindings_from_file(&key_bindings_path),
         )?
         .with(MouseFocusUpdateSystem::new(), "mouse_focus", &[])
-        .with(MouseCenterLockSystem, "mouse_lock", &["mouse_focus"])
-        // This system will keep the camera focussing the target while conserving the orientation
+        .with(CursorHideSystem::new(), "cursor_hide", &["mouse_focus"])
+        // This system will keep the camera focusing the target while conserving the orientation
         // of the camera and its distance to the target
         .with(ArcBallMovementSystem {}, "arc_ball_movement_system", &[])
         // This system manage the orientation of camera in accord to mouse input


### PR DESCRIPTION
Fixes #754 

The `MouseCenterLockSystem` seems unnecessary at best and harmful at worst now, so I removed it and changed the examples to rely on cursor hiding instead.

Since we're now correctly using raw mouse input instead of cursor movement, this system is no longer helpful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/755)
<!-- Reviewable:end -->
