### PR TITLE
Use fresnel function instead of duplicating inline in PBM shader

### DIFF
--- a/amethyst_renderer/src/pass/shaders/fragment/pbm.glsl
+++ b/amethyst_renderer/src/pass/shaders/fragment/pbm.glsl
@@ -160,7 +160,7 @@ void main() {
         float HdotV = max(dot(halfway, view_direction), 0.0);
         float geometry = geometry(NdotV, NdotL, roughness2);
 
-        vec3 fresnel = fresnel_base + (1.0 - fresnel_base) * pow(1.0 - HdotV, 5.0);
+        vec3 fresnel = fresnel(HdotV, fresnel_base);
         vec3 diffuse = vec3(1.0) - fresnel;
         diffuse *= 1.0 - metallic;
 


### PR DESCRIPTION
Saw that this was duplicated instead of using the fresnel function which could cause confusion in the future if the algorithm is changed or whatever else.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/772)
<!-- Reviewable:end -->
