### PR TITLE
Refactor UI to be more user friendly

### DIFF
--- a/amethyst_ui/src/bundle.rs
+++ b/amethyst_ui/src/bundle.rs
@@ -39,11 +39,10 @@ where
         builder.add(UiSystem::new(), "ui_system", &["font_processor"]);
         builder.add(ResizeSystem::new(), "ui_resize_system", &[]);
         builder.add(UiMouseSystem::<A, B>::new(), "ui_mouse_system", &[]);
-        builder.add(UiLayoutSystem::new(), "ui_layout", &["ui_system"]);
         builder.add(
             UiParentSystem::default(),
             "ui_parent",
-            &["transform_system", "ui_layout"],
+            &["transform_system"],
         );
         Ok(())
     }

--- a/amethyst_ui/src/bundle.rs
+++ b/amethyst_ui/src/bundle.rs
@@ -40,8 +40,8 @@ where
         builder.add(ResizeSystem::new(), "ui_resize_system", &[]);
         builder.add(UiMouseSystem::<A, B>::new(), "ui_mouse_system", &[]);
         builder.add(
-            UiParentSystem::default(),
-            "ui_parent",
+            UiTransformSystem::default(),
+            "ui_transform",
             &["transform_system"],
         );
         Ok(())

--- a/amethyst_ui/src/button.rs
+++ b/amethyst_ui/src/button.rs
@@ -45,8 +45,8 @@ pub struct UiButtonBuilder {
     width: f32,
     height: f32,
     tab_order: i32,
-    anchor: Option<Anchor>,
-    stretch: Option<Stretch>,
+    anchor: Anchor,
+    stretch: Stretch,
     text: String,
     text_color: [f32; 4],
     font: Option<FontHandle>,
@@ -65,8 +65,8 @@ impl Default for UiButtonBuilder {
             width: DEFAULT_WIDTH,
             height: DEFAULT_HEIGHT,
             tab_order: DEFAULT_TAB_ORDER,
-            anchor: None,
-            stretch: None,
+            anchor: Anchor::TopLeft,
+            stretch: Stretch::NoStretch,
             text: "".to_string(),
             text_color: DEFAULT_TXT_COLOR,
             font: None,
@@ -104,13 +104,13 @@ impl UiButtonBuilder {
 
     /// Add an anchor to the button.
     pub fn with_anchor(mut self, anchor: Anchor) -> Self {
-        self.anchor = Some(anchor);
+        self.anchor = anchor;
         self
     }
 
     /// Stretch the button.
     pub fn with_stretch(mut self, stretch: Stretch) -> Self {
-        self.stretch = Some(stretch);
+        self.stretch = stretch;
         self
     }
 
@@ -189,14 +189,14 @@ impl UiButtonBuilder {
                 image_entity,
                 UiTransform::new(
                     self.name,
-                    self.anchor.unwrap_or(Anchor::TopRight),
+                    self.anchor,
                     self.x,
                     self.y,
                     self.z,
                     self.width,
                     self.height,
                     self.tab_order,
-                ).with_stretching(Stretch::NoStretch),
+                ).with_stretch(self.stretch),
             )
             .unwrap();
         let image_handle = self.image.unwrap_or_else(|| {
@@ -226,9 +226,9 @@ impl UiButtonBuilder {
         res.transform
             .insert(
                 text_entity,
-                UiTransform::new(id, Anchor::Middle, 0., 0., -1., 0., 0., 10)
+                UiTransform::new(id, Anchor::Middle, 0., 0., -0.01, 0., 0., 10)
                     .as_transparent()
-                    .with_stretching(Stretch::XY {
+                    .with_stretch(Stretch::XY {
                         x_margin: 0.,
                         y_margin: 0.,
                     }),

--- a/amethyst_ui/src/button.rs
+++ b/amethyst_ui/src/button.rs
@@ -4,7 +4,7 @@ use super::{Anchor, FontAsset, FontHandle, MouseReactive, Stretch, TtfFormat, Ui
 use amethyst_assets::{AssetStorage, Loader};
 use amethyst_core::specs::prelude::{Entities, Entity, Read, ReadExpect, World, WriteStorage};
 use amethyst_core::Parent;
-use amethyst_renderer::Texture;
+use amethyst_renderer::{Texture, TextureHandle};
 use shred::SystemData;
 
 const DEFAULT_Z: f32 = -1.0;
@@ -15,30 +15,18 @@ const DEFAULT_BKGD_COLOR: [f32; 4] = [0.82, 0.83, 0.83, 1.0];
 const DEFAULT_TXT_COLOR: [f32; 4] = [0.0, 0.0, 0.0, 1.0];
 const DEFAULT_FONT_NAME: &'static str = "font/square.ttf";
 
-/// Container that wraps the resources we need to initialize button defaults
-#[derive(SystemData)]
-pub struct UiButtonResources<'a> {
-    font_asset: Read<'a, AssetStorage<FontAsset>>,
-    loader: ReadExpect<'a, Loader>,
-    texture_asset: Read<'a, AssetStorage<Texture>>,
-}
-
 /// Container for all the resources the builder needs to make a new UiButton.
 #[derive(SystemData)]
-struct UiButtonBuilderResources<'a> {
+pub struct UiButtonBuilderResources<'a> {
+    font_asset: Read<'a, AssetStorage<FontAsset>>,
+    texture_asset: Read<'a, AssetStorage<Texture>>,
+    loader: ReadExpect<'a, Loader>,
     entities: Entities<'a>,
     image: WriteStorage<'a, UiImage>,
     mouse_reactive: WriteStorage<'a, MouseReactive>,
     parent: WriteStorage<'a, Parent>,
     text: WriteStorage<'a, UiText>,
     transform: WriteStorage<'a, UiTransform>,
-}
-
-impl<'a> UiButtonResources<'a> {
-    /// Grab the resources we need from the world.
-    pub fn from_world(world: &'a World) -> Self {
-        Self::fetch(&world.res)
-    }
 }
 
 impl<'a> UiButtonBuilderResources<'a> {
@@ -48,13 +36,45 @@ impl<'a> UiButtonBuilderResources<'a> {
     }
 }
 
-/// Builder for a `UiButton`.
-pub struct UiButtonBuilder<'a> {
-    name: &'a str,
-    image: UiImage,
-    text: UiText,
-    parent: Option<Parent>,
-    transform: Option<UiTransform>,
+/// Convenience structure for building a button
+pub struct UiButtonBuilder {
+    name: String,
+    x: f32,
+    y: f32,
+    z: f32,
+    width: f32,
+    height: f32,
+    tab_order: i32,
+    anchor: Option<Anchor>,
+    stretch: Option<Stretch>,
+    text: String,
+    text_color: [f32; 4],
+    font: Option<FontHandle>,
+    font_size: f32,
+    image: Option<TextureHandle>,
+    parent: Option<Entity>,
+}
+
+impl Default for UiButtonBuilder {
+    fn default() -> Self {
+        UiButtonBuilder {
+            name: "".to_string(),
+            x: 0.,
+            y: 0.,
+            z: DEFAULT_Z,
+            width: DEFAULT_WIDTH,
+            height: DEFAULT_HEIGHT,
+            tab_order: DEFAULT_TAB_ORDER,
+            anchor: None,
+            stretch: None,
+            text: "".to_string(),
+            text_color: DEFAULT_TXT_COLOR,
+            font: None,
+            font_size: 32.,
+            image: None,
+            parent: None,
+        }
+    }
 }
 
 /// A clickable button.
@@ -65,59 +85,32 @@ pub struct UiButton {
     pub image: Entity,
 }
 
-impl<'a> UiButtonBuilder<'a> {
+impl UiButtonBuilder {
     /// Construct a new UiButtonBuilder.
     /// This allows easy use of default values for text and button appearance and allows the user
     /// to easily set other UI-related options.
-    pub fn new<'b, S: ToString>(
-        name: &'a str,
-        text: S,
-        resources: UiButtonResources<'b>,
-    ) -> UiButtonBuilder<'a> {
-        let (text, image) = {
-            let loader = &resources.loader;
-
-            let font = loader.load(
-                DEFAULT_FONT_NAME,
-                TtfFormat,
-                Default::default(),
-                (),
-                &resources.font_asset,
-            );
-            let text = UiText::new(font, text.to_string(), DEFAULT_TXT_COLOR, 32.0);
-            let grey =
-                loader.load_from_data(DEFAULT_BKGD_COLOR.into(), (), &resources.texture_asset);
-            let image = UiImage { texture: grey };
-            (text, image)
-        };
-
-        UiButtonBuilder {
-            name,
-            image,
-            text,
-            parent: None,
-            transform: None,
-        }
+    pub fn new<N: ToString, S: ToString>(name: N, text: S) -> UiButtonBuilder {
+        let mut builder = UiButtonBuilder::default();
+        builder.name = name.to_string();
+        builder.text = text.to_string();
+        builder
     }
 
     /// Add a parent to the button.
-    pub fn with_parent(mut self, parent: Parent) -> Self {
+    pub fn with_parent(mut self, parent: Entity) -> Self {
         self.parent = Some(parent);
         self
     }
 
-    /// Add a UiTransform to the image to offset it within the UI.
-    pub fn with_transform(mut self, transform: UiTransform) -> Self {
-        self.transform = Some(transform);
+    /// Add an anchor to the button.
+    pub fn with_anchor(mut self, anchor: Anchor) -> Self {
+        self.anchor = Some(anchor);
         self
     }
 
-    /// This will completely replace the UiText object representing the button's text.
-    /// Use this if you want to change more than just the characters, but the font size, color,
-    /// etc. as well.
-    /// Use [`with_text`](#with_text) to just change the underlying text.
-    pub fn with_uitext(mut self, text: UiText) -> Self {
-        self.text = text;
+    /// Stretch the button.
+    pub fn with_stretch(mut self, stretch: Stretch) -> Self {
+        self.stretch = Some(stretch);
         self
     }
 
@@ -129,19 +122,19 @@ impl<'a> UiButtonBuilder<'a> {
     where
         S: ToString,
     {
-        self.text.text = text.to_string();
+        self.text = text.to_string();
         self
     }
 
     /// Replace the default UiImage with `image`.
-    pub fn with_image(mut self, image: UiImage) -> Self {
-        self.image = image;
+    pub fn with_image(mut self, image: TextureHandle) -> Self {
+        self.image = Some(image);
         self
     }
 
     /// Use a different font for the button text.
     pub fn with_font(mut self, font: FontHandle) -> Self {
-        self.text.font = font;
+        self.font = Some(font);
         self
     }
 
@@ -151,44 +144,83 @@ impl<'a> UiButtonBuilder<'a> {
     /// See `DEFAULT_Z`, `DEFAULT_WIDTH`, `DEFAULT_HEIGHT`, and `DEFAULT_TAB_ORDER` for
     /// the values that will be provided to the default UiTransform.
     pub fn with_position(mut self, x: f32, y: f32) -> Self {
-        self.transform = if let Some(mut t) = self.transform.take() {
-            t.local_x = x;
-            t.pixel_x = x;
-            t.local_y = y;
-            t.pixel_y = y;
-            Some(t)
-        } else {
-            let mut id = self.name.to_string();
-            id.push_str("_new_transform");
-            Some(UiTransform::new(
-                id,
-                Anchor::TopLeft,
-                x,
-                y,
-                DEFAULT_Z,
-                DEFAULT_WIDTH,
-                DEFAULT_HEIGHT,
-                DEFAULT_TAB_ORDER,
-            ))
-        };
+        self.x = x;
+        self.y = y;
+        self
+    }
+
+    /// Provide a Z position, i.e UI layer
+    pub fn with_layer(mut self, z: f32) -> Self {
+        self.z = z;
+        self
+    }
+
+    /// Set button size
+    pub fn with_size(mut self, width: f32, height: f32) -> Self {
+        self.width = width;
+        self.height = height;
+        self
+    }
+
+    /// Set button tab order
+    pub fn with_tab_order(mut self, tab_order: i32) -> Self {
+        self.tab_order = tab_order;
+        self
+    }
+
+    /// Set font size
+    pub fn with_font_size(mut self, size: f32) -> Self {
+        self.font_size = size;
+        self
+    }
+
+    /// Set text color
+    pub fn with_text_color(mut self, text_color: [f32; 4]) -> Self {
+        self.text_color = text_color;
         self
     }
 
     // unwraps are safe because we create the entities inside
     fn build(mut self, mut res: UiButtonBuilderResources) -> UiButton {
+        let mut id = self.name.clone();
         let image_entity = res.entities.create();
-        res.image.insert(image_entity, self.image).unwrap();
+        res.transform
+            .insert(
+                image_entity,
+                UiTransform::new(
+                    self.name,
+                    self.anchor.unwrap_or(Anchor::TopRight),
+                    self.x,
+                    self.y,
+                    self.z,
+                    self.width,
+                    self.height,
+                    self.tab_order,
+                ).with_stretching(Stretch::NoStretch),
+            )
+            .unwrap();
+        let image_handle = self.image.unwrap_or_else(|| {
+            res.loader
+                .load_from_data(DEFAULT_BKGD_COLOR.into(), (), &res.texture_asset)
+        });
+
+        res.image
+            .insert(
+                image_entity,
+                UiImage {
+                    texture: image_handle,
+                },
+            )
+            .unwrap();
         res.mouse_reactive
             .insert(image_entity, MouseReactive)
             .unwrap();
         if let Some(parent) = self.parent.take() {
-            res.parent.insert(image_entity, parent).unwrap();
-        }
-        if let Some(transform) = self.transform.take() {
-            res.transform.insert(image_entity, transform).unwrap();
+            res.parent
+                .insert(image_entity, Parent { entity: parent })
+                .unwrap();
         }
 
-        let mut id = self.name.to_string();
         id.push_str("_btn_txt");
         let text_entity = res.entities.create();
         res.transform
@@ -202,7 +234,21 @@ impl<'a> UiButtonBuilder<'a> {
                     }),
             )
             .unwrap();
-        res.text.insert(text_entity, self.text).unwrap();
+        let font_handle = self.font.unwrap_or_else(|| {
+            res.loader.load(
+                DEFAULT_FONT_NAME,
+                TtfFormat,
+                Default::default(),
+                (),
+                &res.font_asset,
+            )
+        });
+        res.text
+            .insert(
+                text_entity,
+                UiText::new(font_handle, self.text, self.text_color, self.font_size),
+            )
+            .unwrap();
         res.parent
             .insert(
                 text_entity,

--- a/amethyst_ui/src/event.rs
+++ b/amethyst_ui/src/event.rs
@@ -1,9 +1,9 @@
 use amethyst_core::shrev::EventChannel;
-use amethyst_core::specs::prelude::{Component, Entities, Entity, Join, Read, ReadStorage, System,
-                                    Write};
+use amethyst_core::specs::prelude::{Component, Entities, Entity, Join, Read, ReadExpect,
+                                    ReadStorage, System, Write};
 use amethyst_core::specs::storage::NullStorage;
 use amethyst_input::InputHandler;
-use amethyst_renderer::MouseButton;
+use amethyst_renderer::{MouseButton, ScreenDimensions};
 use std::hash::Hash;
 use std::marker::PhantomData;
 use transform::UiTransform;
@@ -84,10 +84,14 @@ where
         ReadStorage<'a, UiTransform>,
         ReadStorage<'a, MouseReactive>,
         Read<'a, InputHandler<A, B>>,
+        ReadExpect<'a, ScreenDimensions>,
         Write<'a, EventChannel<UiEvent>>,
     );
 
-    fn run(&mut self, (entities, transform, react, input, mut events): Self::SystemData) {
+    fn run(
+        &mut self,
+        (entities, transform, react, input, screen_dimensions, mut events): Self::SystemData,
+    ) {
         let down = input.mouse_button_is_down(MouseButton::Left);
 
         // TODO: To replace on InputHandler generate OnMouseDown and OnMouseUp events
@@ -95,8 +99,8 @@ where
         let click_stopped = !down && self.was_down;
 
         if let Some((pos_x, pos_y)) = input.mouse_position() {
-            let x = pos_x as f32;
-            let y = pos_y as f32;
+            let x = pos_x as f32 - screen_dimensions.width() / 2.;
+            let y = pos_y as f32 - screen_dimensions.height() / 2.;
 
             let target = targeted((x, y), (&*entities, &transform).join(), &react);
 

--- a/amethyst_ui/src/event.rs
+++ b/amethyst_ui/src/event.rs
@@ -13,7 +13,6 @@ use transform::UiTransform;
 #[derive(Debug, Clone)]
 pub enum UiEventType {
     /// When an element is clicked normally.
-    /// Happens when the element both start and stops being clicked.
     Click,
     /// When the element starts being clicked (On left mouse down).
     ClickStart,

--- a/amethyst_ui/src/layout.rs
+++ b/amethyst_ui/src/layout.rs
@@ -1,14 +1,14 @@
 use super::UiTransform;
-use amethyst_core::specs::prelude::{BitSet, Component, Entities, FlaggedStorage, InsertedFlag,
-                                    Join, ModifiedFlag, ReadExpect, ReadStorage, ReaderId,
-                                    Resources, System, VecStorage, WriteStorage};
+use amethyst_core::specs::prelude::{BitSet, Entities, InsertedFlag, Join, ModifiedFlag,
+                                    ReadExpect, ReadStorage, ReaderId, Resources, System,
+                                    WriteStorage};
 use amethyst_core::{HierarchyEvent, Parent, ParentHierarchy};
 use amethyst_renderer::ScreenDimensions;
 
 /// Unused, will be implemented in a future PR.
 /// Indicated if the position and margins should be calculated in pixel or
 /// relative to their parent size.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub enum ScaleMode {
     /// Use directly the pixel value.
     Pixel,
@@ -18,7 +18,7 @@ pub enum ScaleMode {
 
 /// Indicated where the anchor is, relative to the parent (or to the screen, if there is no parent).
 /// Follow a normal english Y,X naming.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub enum Anchor {
     /// Anchors the entity at the top left of the parent.
     TopLeft,
@@ -40,44 +40,12 @@ pub enum Anchor {
     BottomRight,
 }
 
-/// Indicates if a component should be stretched.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub enum Stretch {
-    /// Stretches on the X axis.
-    X,
-    /// Stretches on the Y axis.
-    Y,
-    /// Stretches on both axes.
-    XY,
-}
-
-/// Component indicating that the position of this entity should be relative to the parent's position.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct Anchored {
-    /// The `Anchor`
-    anchor: Anchor,
-    /// Defaults to none.
-    /// While the position value in UiTransform will be changed,
-    /// this keeps track of the offset from the anchor.
-    /// By default, it will automatically be set to the UiTransform position before it gets moved by the layout system.
-    #[serde(skip)]
-    offset: Option<(f32, f32)>,
-}
-
-impl Anchored {
-    /// Creates a new `Anchored` component using the `Anchor` setting.
-    pub fn new(anchor: Anchor) -> Self {
-        Anchored {
-            anchor,
-            offset: None,
-        }
-    }
-
+impl Anchor {
     /// Returns the normalized offset using the `Anchor` setting.
     /// The normalized offset is a [-0.5,0.5] value
     /// indicating the relative offset from the parent's position (centered).
     pub fn norm_offset(&self) -> (f32, f32) {
-        match self.anchor {
+        match self {
             Anchor::TopLeft => (-0.5, -0.5),
             Anchor::TopMiddle => (0.0, -0.5),
             Anchor::TopRight => (0.5, -0.5),
@@ -91,94 +59,28 @@ impl Anchored {
     }
 }
 
-impl Component for Anchored {
-    type Storage = VecStorage<Self>;
-}
-
-/// Component indicating that an entity should be stretched to fit the parent size
-/// on one or multiple axes.
+/// Indicates if a component should be stretched.
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct Stretched {
-    /// The `Stretch` setting.
-    /// Indicates on which axes this entity should be stretched.
-    stretch: Stretch,
-    /// Defaults to 0,0.
-    /// Use .with_margin(x,y) to change.
-    margin: (f32, f32),
-}
-
-impl Stretched {
-    /// Create a new `Stretched` component using the `Stretch` setting.
-    pub fn new(stretch: Stretch, margin_x: f32, margin_y: f32) -> Self {
-        Stretched {
-            stretch,
-            margin: (margin_x, margin_y),
-        }
-    }
-}
-
-impl Component for Stretched {
-    type Storage = FlaggedStorage<Self, VecStorage<Self>>;
-}
-
-/// Used to initialize the `UiTransform` and `Anchored` offsets when using the `Anchored` component.
-pub struct UiLayoutSystem {
-    screen_size: (f32, f32),
-}
-
-impl UiLayoutSystem {
-    /// Creates a new UiLayoutSystem.
-    pub fn new() -> Self {
-        UiLayoutSystem {
-            screen_size: (0.0, 0.0),
-        }
-    }
-}
-
-impl<'a> System<'a> for UiLayoutSystem {
-    type SystemData = (
-        Entities<'a>,
-        WriteStorage<'a, UiTransform>,
-        WriteStorage<'a, Anchored>,
-        ReadStorage<'a, Parent>,
-        ReadExpect<'a, ScreenDimensions>,
-    );
-
-    fn run(&mut self, (entities, mut transform, mut anchor, parent, screen_dim): Self::SystemData) {
-        let cur_size = (screen_dim.width(), screen_dim.height());
-        let offset_override = self.screen_size != cur_size;
-        self.screen_size = cur_size;
-        for (entity, mut tr, mut anchor) in (&*entities, &mut transform, &mut anchor).join() {
-            if anchor.offset.is_none() || (offset_override && anchor.offset.is_some()) {
-                if offset_override && anchor.offset.is_some() {
-                    tr.local_x = anchor.offset.unwrap().0;
-                    tr.local_y = anchor.offset.unwrap().1;
-                }
-
-                anchor.offset = Some((tr.local_x, tr.local_y));
-
-                let norm_offset = anchor.norm_offset();
-
-                // Percent will be implemented in a future PR
-                let user_offset = match tr.scale_mode {
-                    ScaleMode::Pixel => anchor.offset.unwrap(),
-                    ScaleMode::Percent => anchor.offset.unwrap(),
-                };
-
-                let middle = (screen_dim.width() / 2.0, screen_dim.height() / 2.0);
-
-                let new_pos_x = middle.0 + norm_offset.0 * screen_dim.width() + user_offset.0;
-                let new_pos_y = middle.1 + norm_offset.1 * screen_dim.height() + user_offset.1;
-                tr.local_x = new_pos_x;
-                tr.local_y = new_pos_y;
-                if !parent.contains(entity) {
-                    tr.global_x = tr.local_x;
-                    tr.global_y = tr.local_y;
-                    tr.global_z = tr.local_z;
-                }
-            }
-        }
-    }
+pub enum Stretch {
+    /// No stretching occurs
+    NoStretch,
+    /// Stretches on the X axis.
+    X {
+        /// The margin length for the width
+        x_margin: f32,
+    },
+    /// Stretches on the Y axis.
+    Y {
+        /// The margin length for the height
+        y_margin: f32,
+    },
+    /// Stretches on both axes.
+    XY {
+        /// The margin length for the width
+        x_margin: f32,
+        /// The margin length for the height
+        y_margin: f32,
+    },
 }
 
 /// Manages the `Parent` component on entities having `UiTransform`
@@ -186,15 +88,14 @@ impl<'a> System<'a> for UiLayoutSystem {
 /// like `UiTransform` alignment and stretching.
 #[derive(Default)]
 pub struct UiParentSystem {
-    local_modified: BitSet,
+    transform_modified: BitSet,
 
-    inserted_local_id: Option<ReaderId<InsertedFlag>>,
-    modified_local_id: Option<ReaderId<ModifiedFlag>>,
-
-    inserted_stretch_id: Option<ReaderId<InsertedFlag>>,
-    modified_stretch_id: Option<ReaderId<ModifiedFlag>>,
+    inserted_transform_id: Option<ReaderId<InsertedFlag>>,
+    modified_transform_id: Option<ReaderId<ModifiedFlag>>,
 
     parent_events_id: Option<ReaderId<HierarchyEvent>>,
+
+    screen_size: (f32, f32),
 }
 
 impl<'a> System<'a> for UiParentSystem {
@@ -202,34 +103,23 @@ impl<'a> System<'a> for UiParentSystem {
         Entities<'a>,
         WriteStorage<'a, UiTransform>,
         ReadStorage<'a, Parent>,
-        ReadStorage<'a, Anchored>,
-        ReadStorage<'a, Stretched>,
         ReadExpect<'a, ScreenDimensions>,
         ReadExpect<'a, ParentHierarchy>,
     );
     fn run(&mut self, data: Self::SystemData) {
-        let (entities, mut locals, parents, anchors, stretches, screen_dim, hierarchy) = data;
+        let (entities, mut transforms, parents, screen_dim, hierarchy) = data;
         #[cfg(feature = "profiler")]
         profile_scope!("ui_parent_system");
 
-        self.local_modified.clear();
+        self.transform_modified.clear();
 
-        locals.populate_inserted(
-            &mut self.inserted_local_id.as_mut().unwrap(),
-            &mut self.local_modified,
+        transforms.populate_inserted(
+            &mut self.inserted_transform_id.as_mut().unwrap(),
+            &mut self.transform_modified,
         );
-        locals.populate_modified(
-            &mut self.modified_local_id.as_mut().unwrap(),
-            &mut self.local_modified,
-        );
-
-        stretches.populate_inserted(
-            &mut self.inserted_stretch_id.as_mut().unwrap(),
-            &mut self.local_modified,
-        );
-        stretches.populate_modified(
-            &mut self.modified_stretch_id.as_mut().unwrap(),
-            &mut self.local_modified,
+        transforms.populate_modified(
+            &mut self.modified_transform_id.as_mut().unwrap(),
+            &mut self.transform_modified,
         );
 
         for event in hierarchy
@@ -237,104 +127,126 @@ impl<'a> System<'a> for UiParentSystem {
             .read(&mut self.parent_events_id.as_mut().unwrap())
         {
             if let HierarchyEvent::Modified(entity) = *event {
-                self.local_modified.add(entity.id());
+                self.transform_modified.add(entity.id());
             }
         }
+
+        let current_screen_size = (screen_dim.width(), screen_dim.height());
+        let screen_resized = current_screen_size != self.screen_size;
+        self.screen_size = current_screen_size;
+        for (entity, transform, _) in (&*entities, &mut transforms, !&parents).join() {
+            let self_dirty = self.transform_modified.contains(entity.id());
+            if self_dirty || screen_resized {
+                let norm = transform.anchor.norm_offset();
+                transform.pixel_x = screen_dim.width() * norm.0;
+                transform.pixel_y = screen_dim.height() * norm.1;
+                transform.global_z = transform.local_z;
+
+                let new_size = match transform.stretch {
+                    Stretch::NoStretch => (transform.width, transform.height),
+                    Stretch::X { x_margin } => {
+                        (screen_dim.width() - x_margin * 2.0, transform.height)
+                    }
+                    Stretch::Y { y_margin } => {
+                        (transform.width, screen_dim.height() - y_margin * 2.0)
+                    }
+                    Stretch::XY { x_margin, y_margin } => (
+                        screen_dim.width() - x_margin * 2.0,
+                        screen_dim.height() - y_margin * 2.0,
+                    ),
+                };
+                transform.width = new_size.0;
+                transform.height = new_size.1;
+                match transform.scale_mode {
+                    ScaleMode::Pixel => {
+                        transform.pixel_x += transform.local_x;
+                        transform.pixel_y += transform.local_y;
+                        transform.pixel_width = transform.width;
+                        transform.pixel_height = transform.height;
+                    }
+                    ScaleMode::Percent => {
+                        transform.pixel_x += transform.local_x * screen_dim.width();
+                        transform.pixel_y += transform.local_y * screen_dim.height();
+                        transform.pixel_width = transform.width * screen_dim.width();
+                        transform.pixel_height = transform.height * screen_dim.height();
+                    }
+                }
+            }
+        }
+
+        // Populate the modifications we just did.
+        transforms.populate_modified(
+            &mut self.modified_transform_id.as_mut().unwrap(),
+            &mut self.transform_modified,
+        );
 
         // Compute transforms with parents.
         for entity in hierarchy.all() {
-            let self_dirty = self.local_modified.contains(entity.id());
-            let mut combined_transform: Option<(f32, f32, f32)> = None;
-            let mut new_size: Option<(f32, f32)> = None;
+            {
+                let self_dirty = self.transform_modified.contains(entity.id());
+                let parent_entity = parents.get(*entity).unwrap().entity;
+                let parent_transform_copy = transforms.get(parent_entity).unwrap().clone();
+                let mut transform = transforms.get_mut(*entity).unwrap();
+                let parent_dirty = self.transform_modified.contains(parent_entity.id());
+                if parent_dirty || self_dirty || screen_resized {
+                    let norm = transform.anchor.norm_offset();
+                    transform.pixel_x = parent_transform_copy.pixel_width * norm.0;
+                    transform.pixel_y = parent_transform_copy.pixel_height * norm.1;
+                    transform.global_z = transform.local_z;
 
-            match (parents.get(*entity), locals.get(*entity)) {
-                (Some(parent), Some(local)) => {
-                    let parent_dirty = self.local_modified.contains(parent.entity.id());
-                    if parent_dirty || self_dirty {
-                        if let Some(parent_global) = locals.get(parent.entity) {
-                            combined_transform = Some(match anchors.get(*entity) {
-                                Some(anchor) => {
-                                    let norm = anchor.norm_offset();
-                                    (
-                                        parent_global.global_x + parent_global.width * norm.0
-                                            + anchor.offset.unwrap().0,
-                                        parent_global.global_y + parent_global.height * norm.1
-                                            + anchor.offset.unwrap().1,
-                                        parent_global.global_z + local.local_z,
-                                    )
-                                }
-                                None => (
-                                    parent_global.global_x + local.local_x,
-                                    parent_global.global_y + local.local_y,
-                                    parent_global.global_z + local.local_z,
-                                ),
-                            });
-
-                            // Stretching when having a parent
-
-                            if let Some(st) = stretches.get(*entity) {
-                                new_size = Some(match st.stretch {
-                                    Stretch::X => {
-                                        (parent_global.width - st.margin.0 * 2.0, local.height)
-                                    }
-                                    Stretch::Y => {
-                                        (local.width, parent_global.height - st.margin.1 * 2.0)
-                                    }
-                                    Stretch::XY => (
-                                        parent_global.width - st.margin.0 * 2.0,
-                                        parent_global.height - st.margin.1 * 2.0,
-                                    ),
-                                });
-                            }
+                    let new_size = match transform.stretch {
+                        Stretch::NoStretch => (transform.width, transform.height),
+                        Stretch::X { x_margin } => (
+                            parent_transform_copy.pixel_width - x_margin * 2.0,
+                            transform.height,
+                        ),
+                        Stretch::Y { y_margin } => (
+                            transform.width,
+                            parent_transform_copy.pixel_height - y_margin * 2.0,
+                        ),
+                        Stretch::XY { x_margin, y_margin } => (
+                            parent_transform_copy.pixel_width - x_margin * 2.0,
+                            parent_transform_copy.pixel_height - y_margin * 2.0,
+                        ),
+                    };
+                    transform.width = new_size.0;
+                    transform.height = new_size.1;
+                    match transform.scale_mode {
+                        ScaleMode::Pixel => {
+                            transform.pixel_x += transform.local_x;
+                            transform.pixel_y += transform.local_y;
+                            transform.pixel_width = transform.width;
+                            transform.pixel_height = transform.height;
+                        }
+                        ScaleMode::Percent => {
+                            transform.pixel_x +=
+                                transform.local_x * parent_transform_copy.pixel_width;
+                            transform.pixel_y +=
+                                transform.local_y * parent_transform_copy.pixel_height;
+                            transform.pixel_width =
+                                transform.width * parent_transform_copy.pixel_width;
+                            transform.pixel_height =
+                                transform.height * parent_transform_copy.pixel_height;
                         }
                     }
                 }
-                _ => (),
             }
-
-            // Changing the position and size values here because of how borrowing works.
-
-            if let Some(c) = combined_transform {
-                if let Some(local) = locals.get_mut(*entity) {
-                    local.global_x = c.0;
-                    local.global_y = c.1;
-                    local.global_z = c.2;
-                }
-            }
-
-            if let Some(s) = new_size {
-                if let Some(local) = locals.get_mut(*entity) {
-                    local.width = s.0;
-                    local.height = s.1;
-                }
-            }
-        }
-
-        // When you don't have a parent but do have stretch on, resize with screen size.
-        for (entity, mut local, stretch) in (&*entities, &mut locals, &stretches).join() {
-            if !parents.contains(entity) {
-                let new_size = match stretch.stretch {
-                    Stretch::X => (screen_dim.width() - stretch.margin.0 * 2.0, local.height),
-                    Stretch::Y => (local.width, screen_dim.height() - stretch.margin.1 * 2.0),
-                    Stretch::XY => (
-                        screen_dim.width() - stretch.margin.0 * 2.0,
-                        screen_dim.height() - stretch.margin.1 * 2.0,
-                    ),
-                };
-                local.width = new_size.0;
-                local.height = new_size.1;
-            }
+            // Populate the modifications we just did.
+            transforms.populate_modified(
+                &mut self.modified_transform_id.as_mut().unwrap(),
+                &mut self.transform_modified,
+            );
         }
 
         // We need to treat any changes done inside the system as non-modifications, so we read out
         // any events that were generated during the system run
-        locals.populate_inserted(
-            &mut self.inserted_local_id.as_mut().unwrap(),
-            &mut self.local_modified,
+        transforms.populate_inserted(
+            &mut self.inserted_transform_id.as_mut().unwrap(),
+            &mut self.transform_modified,
         );
-        locals.populate_modified(
-            &mut self.modified_local_id.as_mut().unwrap(),
-            &mut self.local_modified,
+        transforms.populate_modified(
+            &mut self.modified_transform_id.as_mut().unwrap(),
+            &mut self.transform_modified,
         );
     }
 
@@ -342,11 +254,8 @@ impl<'a> System<'a> for UiParentSystem {
         use amethyst_core::specs::prelude::SystemData;
         Self::SystemData::setup(res);
         self.parent_events_id = Some(res.fetch_mut::<ParentHierarchy>().track());
-        let mut locals = WriteStorage::<UiTransform>::fetch(res);
-        let mut stretches = WriteStorage::<Stretched>::fetch(res);
-        self.inserted_local_id = Some(locals.track_inserted());
-        self.modified_local_id = Some(locals.track_modified());
-        self.inserted_stretch_id = Some(stretches.track_inserted());
-        self.modified_stretch_id = Some(stretches.track_modified());
+        let mut transforms = WriteStorage::<UiTransform>::fetch(res);
+        self.inserted_transform_id = Some(transforms.track_inserted());
+        self.modified_transform_id = Some(transforms.track_modified());
     }
 }

--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -48,8 +48,7 @@ pub use self::event::{MouseReactive, UiEvent, UiEventType, UiMouseSystem};
 pub use self::focused::UiFocused;
 pub use self::format::{FontAsset, FontFormat, FontHandle, OtfFormat, TtfFormat};
 pub use self::image::UiImage;
-pub use self::layout::{Anchor, Anchored, ScaleMode, Stretch, Stretched, UiLayoutSystem,
-                       UiParentSystem};
+pub use self::layout::{Anchor, ScaleMode, Stretch, UiParentSystem};
 pub use self::pass::DrawUi;
 pub use self::resize::{ResizeSystem, UiResize};
 pub use self::text::{TextEditing, UiSystem, UiText};

--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -43,7 +43,7 @@ mod text;
 mod transform;
 
 pub use self::bundle::UiBundle;
-pub use self::button::{UiButton, UiButtonBuilder, UiButtonResources};
+pub use self::button::{UiButton, UiButtonBuilder, UiButtonBuilderResources};
 pub use self::event::{MouseReactive, UiEvent, UiEventType, UiMouseSystem};
 pub use self::focused::UiFocused;
 pub use self::format::{FontAsset, FontFormat, FontHandle, OtfFormat, TtfFormat};

--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -48,7 +48,7 @@ pub use self::event::{MouseReactive, UiEvent, UiEventType, UiMouseSystem};
 pub use self::focused::UiFocused;
 pub use self::format::{FontAsset, FontFormat, FontHandle, OtfFormat, TtfFormat};
 pub use self::image::UiImage;
-pub use self::layout::{Anchor, ScaleMode, Stretch, UiParentSystem};
+pub use self::layout::{Anchor, ScaleMode, Stretch, UiTransformSystem};
 pub use self::pass::DrawUi;
 pub use self::resize::{ResizeSystem, UiResize};
 pub use self::text::{TextEditing, UiSystem, UiText};

--- a/amethyst_ui/src/resize.rs
+++ b/amethyst_ui/src/resize.rs
@@ -1,28 +1,50 @@
-use amethyst_core::shrev::{EventChannel, ReaderId};
-use amethyst_core::specs::prelude::{Component, DenseVecStorage, Join, Read, Resources, System,
-                                    WriteStorage};
-use winit::{Event, WindowEvent};
+use amethyst_core::shrev::ReaderId;
+use amethyst_core::specs::prelude::{BitSet, Component, FlaggedStorage, InsertedFlag, Join,
+                                    ModifiedFlag, ReadExpect, Resources, System, WriteStorage};
+use amethyst_renderer::ScreenDimensions;
 
 use super::*;
 
 /// Whenever the window is resized the function in this component will be called on this
 /// entity's UiTransform, along with the new width and height of the window.
-pub struct UiResize(pub Box<FnMut(&mut UiTransform, (f32, f32)) + Send + Sync>);
+///
+/// The function in this component is also guaranteed to be called at least once by the
+/// `ResizeSystem` when either the component is attached, or the function is changed.
+pub struct UiResize {
+    /// The core function of this component
+    pub function: Box<FnMut(&mut UiTransform, (f32, f32)) + Send + Sync>,
+}
+
+impl UiResize {
+    /// Creates a new component with the given function.
+    pub fn new<F>(function: F) -> Self
+    where
+        F: FnMut(&mut UiTransform, (f32, f32)) + Send + Sync + 'static,
+    {
+        UiResize {
+            function: Box::new(function),
+        }
+    }
+}
 
 impl Component for UiResize {
-    type Storage = DenseVecStorage<Self>;
+    type Storage = FlaggedStorage<Self>;
 }
 
 /// This system rearranges UI elements whenever the screen is resized using their `UiResize`
 /// component.
+#[derive(Default)]
 pub struct ResizeSystem {
-    event_reader: Option<ReaderId<Event>>,
+    screen_size: (f32, f32),
+    component_modify_reader: Option<ReaderId<ModifiedFlag>>,
+    component_insert_reader: Option<ReaderId<InsertedFlag>>,
+    local_modified: BitSet,
 }
 
 impl ResizeSystem {
     /// Creates a new ResizeSystem that listens with the given reader Id.
     pub fn new() -> ResizeSystem {
-        ResizeSystem { event_reader: None }
+        ResizeSystem::default()
     }
 }
 
@@ -30,26 +52,50 @@ impl<'a> System<'a> for ResizeSystem {
     type SystemData = (
         WriteStorage<'a, UiTransform>,
         WriteStorage<'a, UiResize>,
-        Read<'a, EventChannel<Event>>,
+        ReadExpect<'a, ScreenDimensions>,
     );
 
-    fn run(&mut self, (mut transform, mut resize, events): Self::SystemData) {
-        for event in events.read(&mut self.event_reader.as_mut().unwrap()) {
-            if let &Event::WindowEvent {
-                event: WindowEvent::Resized(width, height),
-                ..
-            } = event
+    fn run(&mut self, (mut transform, mut resize, dimensions): Self::SystemData) {
+        self.local_modified.clear();
+        resize.populate_inserted(
+            self.component_insert_reader.as_mut().unwrap(),
+            &mut self.local_modified,
+        );
+        resize.populate_modified(
+            self.component_modify_reader.as_mut().unwrap(),
+            &mut self.local_modified,
+        );
+        let screen_size = (dimensions.width() as f32, dimensions.height() as f32);
+        if self.screen_size != screen_size {
+            self.screen_size = screen_size;
+            for (transform, resize) in (&mut transform, &mut resize).join() {
+                (resize.function)(transform, screen_size);
+            }
+        } else {
+            for (transform, resize, _) in (&mut transform, &mut resize, &self.local_modified).join()
             {
-                for (transform, resize) in (&mut transform, &mut resize).join() {
-                    (resize.0)(transform, (width as f32, height as f32));
-                }
+                (resize.function)(transform, screen_size);
             }
         }
+
+        // We need to treat any changes done inside the system as non-modifications, so we read out
+        // any events that were generated during the system run
+        resize.populate_inserted(
+            self.component_insert_reader.as_mut().unwrap(),
+            &mut self.local_modified,
+        );
+        resize.populate_modified(
+            self.component_modify_reader.as_mut().unwrap(),
+            &mut self.local_modified,
+        );
     }
 
     fn setup(&mut self, res: &mut Resources) {
         use amethyst_core::specs::prelude::SystemData;
         Self::SystemData::setup(res);
-        self.event_reader = Some(res.fetch_mut::<EventChannel<Event>>().register_reader());
+        self.screen_size = (0.0, 0.0);
+        let mut resize = WriteStorage::<UiResize>::fetch(res);
+        self.component_modify_reader = Some(resize.channels_mut().modify.register_reader());
+        self.component_insert_reader = Some(resize.channels_mut().insert.register_reader());
     }
 }

--- a/amethyst_ui/src/transform.rs
+++ b/amethyst_ui/src/transform.rs
@@ -4,7 +4,6 @@ use std::marker::PhantomData;
 use amethyst_core::specs::prelude::{Component, DenseVecStorage, Entities, Entity, FlaggedStorage,
                                     Join, ReadStorage};
 
-
 /// Utility `SystemData` for finding UI entities based on `UiTransform` id
 #[derive(SystemData)]
 pub struct UiFinder<'a> {

--- a/amethyst_ui/src/transform.rs
+++ b/amethyst_ui/src/transform.rs
@@ -54,11 +54,11 @@ pub struct UiTransform {
     /// as this one exists they are ordered according to Entity creation order.  Shift-tab walks
     /// this ordering backwards.
     pub tab_order: i32,
-    /// Global x position set by the `UiParentSystem`.
+    /// Global x position set by the `UiTransformSystem`.
     pub(crate) pixel_x: f32,
-    /// Global y position set by the `UiParentSystem`.
+    /// Global y position set by the `UiTransformSystem`.
     pub(crate) pixel_y: f32,
-    /// Global z position set by the `UiParentSystem`.
+    /// Global z position set by the `UiTransformSystem`.
     pub(crate) global_z: f32,
     /// Width in pixels, used for rendering.  Duplicate of `width` if `scale_mode == ScaleMode::Pixel`.
     pub(crate) pixel_width: f32,
@@ -134,22 +134,22 @@ impl UiTransform {
     }
 
     /// Adds stretching to this ui element so it can fill its parent.
-    pub fn with_stretching(mut self, stretch: Stretch) -> Self {
+    pub fn with_stretch(mut self, stretch: Stretch) -> Self {
         self.stretch = stretch;
         self
     }
 
-    /// Returns the global x coordinate of this UiTransform as computed by the `UiParentSystem`.
+    /// Returns the global x coordinate of this UiTransform as computed by the `UiTransformSystem`.
     pub fn pixel_x(&self) -> f32 {
         self.pixel_x
     }
 
-    /// Returns the global y coordinate of this UiTransform as computed by the `UiParentSystem`.
+    /// Returns the global y coordinate of this UiTransform as computed by the `UiTransformSystem`.
     pub fn pixel_y(&self) -> f32 {
         self.pixel_y
     }
 
-    /// Returns the global z coordinate of this UiTransform as computed by the `UiParentSystem`.
+    /// Returns the global z order of this UiTransform as computed by the `UiTransformSystem`.
     pub fn global_z(&self) -> f32 {
         self.global_z
     }

--- a/amethyst_ui/src/transform.rs
+++ b/amethyst_ui/src/transform.rs
@@ -1,9 +1,9 @@
+use super::{Anchor, ScaleMode, Stretch};
 use std::marker::PhantomData;
 
 use amethyst_core::specs::prelude::{Component, DenseVecStorage, Entities, Entity, FlaggedStorage,
                                     Join, ReadStorage};
 
-use ScaleMode;
 
 /// Utility `SystemData` for finding UI entities based on `UiTransform` id
 #[derive(SystemData)]
@@ -29,30 +29,42 @@ impl<'a> UiFinder<'a> {
 pub struct UiTransform {
     /// An identifier. Serves no purpose other than to help you distinguish between UI elements.
     pub id: String,
-    /// X coordinate, 0 is the left edge of the screen, while the width of the screen in pixel is the right edge.
+    /// Indicates where the element sits, relative to the parent (or to the screen, if there is no parent)
+    pub anchor: Anchor,
+    /// If a child ui element needs to fill its parent this can be used to stretch it to the appropriate size.
+    pub stretch: Stretch,
+    /// X coordinate, 0 is the left edge of the screen. If scale_mode is set to pixel then the width of the
+    /// screen in pixel is the right edge.  If scale_mode is percent then the right edge is 1.
+    ///
     /// Centered in the middle of the ui element.
     pub local_x: f32,
-    /// Y coordinate, 0 is the top edge of the screen, while the height of the screen in pixel is the bottom edge.
+    /// Y coordinate, 0 is the top edge of the screen. If scale_mode is set to pixel then the height of the
+    /// screen in pixel is the bottom edge.  If scale_mode is percent then the bottom edge is 1.
+    ///
     /// Centered in the middle of the ui element.
     pub local_y: f32,
     /// Z order, entities with a lower Z order will be rendered on top of entities with a higher
     /// Z order.
     pub local_z: f32,
-    /// The width of this UI element in pixel.
+    /// The width of this UI element.
     pub width: f32,
-    /// The height of this UI element in pixel.
+    /// The height of this UI element.
     pub height: f32,
     /// The UI element tab order.  When the player presses tab the UI focus will shift to the
     /// UI element with the next highest tab order, or if another element with the same tab_order
     /// as this one exists they are ordered according to Entity creation order.  Shift-tab walks
     /// this ordering backwards.
     pub tab_order: i32,
-    /// Global x position set by the `UiParentSystem` and `UiLayoutSystem` systems.
-    pub global_x: f32,
-    /// Global y position set by the `UiParentSystem` and `UiLayoutSystem` systems.
-    pub global_y: f32,
-    /// Global z position set by the `UiParentSystem` and `UiLayoutSystem` systems.
-    pub global_z: f32,
+    /// Global x position set by the `UiParentSystem`.
+    pub(crate) pixel_x: f32,
+    /// Global y position set by the `UiParentSystem`.
+    pub(crate) pixel_y: f32,
+    /// Global z position set by the `UiParentSystem`.
+    pub(crate) global_z: f32,
+    /// Width in pixels, used for rendering.  Duplicate of `width` if `scale_mode == ScaleMode::Pixel`.
+    pub(crate) pixel_width: f32,
+    /// Height in pixels, used for rendering.  Duplicate of `height` if `scale_mode == ScaleMode::Pixel`.
+    pub(crate) pixel_height: f32,
     /// The scale mode indicates if the position is in pixel or is relative (%) (WIP!) to the parent's size.
     pub scale_mode: ScaleMode,
     /// Indicates if actions on the ui can go through this element.
@@ -68,6 +80,7 @@ impl UiTransform {
     /// By default, it is considered opaque.
     pub fn new(
         id: String,
+        anchor: Anchor,
         x: f32,
         y: f32,
         z: f32,
@@ -77,15 +90,19 @@ impl UiTransform {
     ) -> UiTransform {
         UiTransform {
             id,
+            anchor,
+            stretch: Stretch::NoStretch,
             local_x: x,
             local_y: y,
             local_z: z,
             width,
             height,
             tab_order,
-            global_x: x,
-            global_y: y,
+            pixel_x: x,
+            pixel_y: y,
             global_z: z,
+            pixel_width: width,
+            pixel_height: height,
             scale_mode: ScaleMode::Pixel,
             opaque: true,
             pd: PhantomData,
@@ -100,11 +117,12 @@ impl UiTransform {
 
     /// Checks if the input position is in the UiTransform rectangle.
     pub fn position_inside(&self, x: f32, y: f32) -> bool {
-        x > self.global_x - self.width / 2.0 && y > self.global_y - self.height / 2.0
-            && x < self.global_x + self.width / 2.0 && y < self.global_y + self.height / 2.0
+        x > self.pixel_x - self.width / 2.0 && y > self.pixel_y - self.height / 2.0
+            && x < self.pixel_x + self.width / 2.0 && y < self.pixel_y + self.height / 2.0
     }
 
-    /// Currently unused. Will be implemented in a future PR.
+    /// Renders this UI element by evaluating transform as a percentage of the parent size,
+    /// rather than rendering it with pixel units.
     pub fn as_percent(mut self) -> Self {
         self.scale_mode = ScaleMode::Percent;
         self
@@ -114,6 +132,27 @@ impl UiTransform {
     pub fn as_transparent(mut self) -> Self {
         self.opaque = false;
         self
+    }
+
+    /// Adds stretching to this ui element so it can fill its parent.
+    pub fn with_stretching(mut self, stretch: Stretch) -> Self {
+        self.stretch = stretch;
+        self
+    }
+
+    /// Returns the global x coordinate of this UiTransform as computed by the `UiParentSystem`.
+    pub fn pixel_x(&self) -> f32 {
+        self.pixel_x
+    }
+
+    /// Returns the global y coordinate of this UiTransform as computed by the `UiParentSystem`.
+    pub fn pixel_y(&self) -> f32 {
+        self.pixel_y
+    }
+
+    /// Returns the global z coordinate of this UiTransform as computed by the `UiParentSystem`.
+    pub fn global_z(&self) -> f32 {
+        self.global_z
     }
 }
 
@@ -126,7 +165,7 @@ mod tests {
     use super::*;
     #[test]
     fn inside_local() {
-        let tr = UiTransform::new("".to_string(), 0.0, 0.0, 0.0, 1.0, 1.0, 0);
+        let tr = UiTransform::new("".to_string(), Anchor::TopLeft, 0.0, 0.0, 0.0, 1.0, 1.0, 0);
         let pos = (-0.49, 0.20);
         assert!(tr.position_inside_local(pos.0, pos.1));
         let pos = (-1.49, 1.20);
@@ -135,7 +174,7 @@ mod tests {
 
     #[test]
     fn inside_global() {
-        let tr = UiTransform::new("".to_string(), 0.0, 0.0, 0.0, 1.0, 1.0, 0);
+        let tr = UiTransform::new("".to_string(), Anchor::TopLeft, 0.0, 0.0, 0.0, 1.0, 1.0, 0);
         let pos = (-0.49, 0.20);
         assert!(tr.position_inside(pos.0, pos.1));
         let pos = (-1.49, 1.20);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ## Unreleased
 ### Added
+* UI `ScaleMode` is now functional, permitting percentage based `UiTransform`s. ([#774])
 * Add serde trait derives to many core components ([#760])
 * Add a generic asset `Format` for `ron` files ([#760])
 * Improve error handling for asset loading ([#773])
@@ -19,6 +20,10 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * Shape mesh generators ([#777])
 
 ### Changed
+* UI systems will now never overwrite your local `UiTransform` values ([#774])
+* Global `UiTransform` values are no longer writable ([#774])
+* `UiResize` refactored to be more user friendly and more helpful ([#774])
+* `Anchored` and `Stretched` components have been folded into `UiTransform` ([#774])
 * Refactored asset loading so `Processor`s can defer storage insertion ([#760])
 * Moved `MaterialTextureSet` to the renderer crate ([#760])
 * Use `fresnel` function in PBR shader ([#772])
@@ -44,9 +49,10 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#766]: https://github.com/amethyst/amethyst/pull/766
 [#767]: https://github.com/amethyst/amethyst/pull/767
 [#770]: https://github.com/amethyst/amethyst/pull/770
+[#771]: https://github.com/amethyst/amethyst/pull/771
 [#772]: https://github.com/amethyst/amethyst/pull/772
 [#773]: https://github.com/amethyst/amethyst/pull/773
-[#771]: https://github.com/amethyst/amethyst/pull/771
+[#774]: https://github.com/amethyst/amethyst/pull/774
 [#777]: https://github.com/amethyst/amethyst/pull/777
 
 ## [0.7.0] - 2018-05

--- a/examples/appendix_a/pong.rs
+++ b/examples/appendix_a/pong.rs
@@ -4,9 +4,9 @@ use amethyst::core::transform::{GlobalTransform, Transform};
 use amethyst::ecs::prelude::World;
 use amethyst::input::{is_close_requested, is_key};
 use amethyst::prelude::*;
-use amethyst::renderer::{Camera, Event, Material, MeshHandle, PosTex, Projection,
-                         ScreenDimensions, VirtualKeyCode, WindowMessages};
-use amethyst::ui::{TtfFormat, UiResize, UiText, UiTransform};
+use amethyst::renderer::{Camera, Event, Material, MeshHandle, PosTex, Projection, VirtualKeyCode,
+                         WindowMessages};
+use amethyst::ui::{Anchor, TtfFormat, UiText, UiTransform};
 use config::{ArenaConfig, BallConfig, PaddlesConfig};
 use systems::ScoreText;
 use {Ball, Paddle, Side};
@@ -208,19 +208,28 @@ fn initialise_score(world: &mut World) {
         (),
         &world.read_resource(),
     );
-    let mut p1_transform = UiTransform::new("P1".to_string(), 0., 0., 1., 55., 50., 0);
-    let p1_size_fn = |transform: &mut UiTransform, (width, _height)| {
-        transform.local_x = (width / 2.) - 100. - transform.width / 2.;
-    };
-    let mut p2_transform = UiTransform::new("P2".to_string(), 0., 0., 1., 55., 50., 0);
-    let p2_size_fn = |transform: &mut UiTransform, (width, _height)| {
-        transform.local_x = (width / 2.) + 100. - transform.width / 2.;
-    };
-    {
-        let dim = world.read_resource::<ScreenDimensions>();
-        p1_size_fn(&mut p1_transform, (dim.width(), dim.height()));
-        p2_size_fn(&mut p2_transform, (dim.width(), dim.height()));
-    }
+    let p1_transform = UiTransform::new(
+        "P1".to_string(),
+        Anchor::TopMiddle,
+        -50.,
+        50.,
+        1.,
+        55.,
+        50.,
+        0,
+    );
+
+    let p2_transform = UiTransform::new(
+        "P2".to_string(),
+        Anchor::TopMiddle,
+        50.,
+        50.,
+        1.,
+        55.,
+        50.,
+        0,
+    );
+
     let p1_score = world
         .create_entity()
         .with(p1_transform)
@@ -230,7 +239,6 @@ fn initialise_score(world: &mut World) {
             [1.0, 1.0, 1.0, 1.0],
             50.,
         ))
-        .with(UiResize(Box::new(p1_size_fn)))
         .build();
     let p2_score = world
         .create_entity()
@@ -241,7 +249,6 @@ fn initialise_score(world: &mut World) {
             [1.0, 1.0, 1.0, 1.0],
             50.,
         ))
-        .with(UiResize(Box::new(p2_size_fn)))
         .build();
     world.add_resource(ScoreText { p1_score, p2_score });
 }

--- a/examples/custom_game_data/ui.rs
+++ b/examples/custom_game_data/ui.rs
@@ -1,12 +1,13 @@
 use super::Tag;
 use amethyst::ecs::prelude::{Entity, World};
-use amethyst::ui::{Anchor, Anchored, FontHandle, UiText, UiTransform};
+use amethyst::ui::{Anchor, FontHandle, UiText, UiTransform};
 
 pub fn create_load_ui(world: &mut World, font: FontHandle) -> Entity {
     let fps_display = world
         .create_entity()
         .with(UiTransform::new(
             "fps".to_string(),
+            Anchor::TopLeft,
             100.,
             25.,
             1.,
@@ -20,13 +21,13 @@ pub fn create_load_ui(world: &mut World, font: FontHandle) -> Entity {
             [1.0, 1.0, 1.0, 1.0],
             25.,
         ))
-        .with(Anchored::new(Anchor::TopLeft))
         .build();
 
     world
         .create_entity()
         .with(UiTransform::new(
             "fps".to_string(),
+            Anchor::Middle,
             0.,
             0.,
             1.,
@@ -40,7 +41,6 @@ pub fn create_load_ui(world: &mut World, font: FontHandle) -> Entity {
             [1.0, 1.0, 1.0, 1.0],
             25.,
         ))
-        .with(Anchored::new(Anchor::Middle))
         .with(Tag)
         .build();
 
@@ -51,7 +51,8 @@ pub fn create_paused_ui(world: &mut World, font: FontHandle) {
     world
         .create_entity()
         .with(UiTransform::new(
-            "fps".to_string(),
+            "pause_text".to_string(),
+            Anchor::Middle,
             0.,
             -50.,
             1.,
@@ -65,7 +66,6 @@ pub fn create_paused_ui(world: &mut World, font: FontHandle) {
             [1.0, 1.0, 1.0, 1.0],
             25.,
         ))
-        .with(Anchored::new(Anchor::Middle))
         .with(Tag)
         .build();
 }

--- a/examples/pong/pong.rs
+++ b/examples/pong/pong.rs
@@ -6,7 +6,7 @@ use amethyst::input::{is_close_requested, is_key};
 use amethyst::prelude::*;
 use amethyst::renderer::{Camera, Event, Material, MeshHandle, PosTex, Projection, VirtualKeyCode,
                          WindowMessages};
-use amethyst::ui::{Anchor, Anchored, TtfFormat, UiText, UiTransform};
+use amethyst::ui::{Anchor, TtfFormat, UiText, UiTransform};
 use systems::ScoreText;
 use {Ball, Paddle, Side};
 use {ARENA_HEIGHT, ARENA_WIDTH};
@@ -153,9 +153,27 @@ fn initialise_score(world: &mut World) {
         (),
         &world.read_resource(),
     );
-    let p1_transform = UiTransform::new("P1".to_string(), -50., 50., 1., 55., 50., 0);
+    let p1_transform = UiTransform::new(
+        "P1".to_string(),
+        Anchor::TopMiddle,
+        -50.,
+        50.,
+        1.,
+        55.,
+        50.,
+        0,
+    );
 
-    let p2_transform = UiTransform::new("P2".to_string(), 50., 50., 1., 55., 50., 0);
+    let p2_transform = UiTransform::new(
+        "P2".to_string(),
+        Anchor::TopMiddle,
+        50.,
+        50.,
+        1.,
+        55.,
+        50.,
+        0,
+    );
 
     let p1_score = world
         .create_entity()
@@ -166,7 +184,6 @@ fn initialise_score(world: &mut World) {
             [1.0, 1.0, 1.0, 1.0],
             50.,
         ))
-        .with(Anchored::new(Anchor::TopMiddle))
         .build();
     let p2_score = world
         .create_entity()
@@ -177,7 +194,6 @@ fn initialise_score(world: &mut World) {
             [1.0, 1.0, 1.0, 1.0],
             50.,
         ))
-        .with(Anchored::new(Anchor::TopMiddle))
         .build();
     world.add_resource(ScoreText { p1_score, p2_score });
 }

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -13,10 +13,10 @@ use amethyst::ecs::prelude::{Component, Entity, Join, Read, ReadStorage, System,
                              WriteExpect, WriteStorage};
 use amethyst::ecs::storage::NullStorage;
 use amethyst::input::{get_key, is_close_requested, is_key, InputBundle};
-use amethyst::renderer::{AmbientColor, Camera, DirectionalLight, DrawShaded, Event, Light,
-                         Material, MaterialDefaults, MeshHandle, ObjFormat, PngFormat, PointLight,
-                         PosNormTex, Projection, Rgba, VirtualKeyCode};
-use amethyst::ui::{Anchor, Anchored, FontHandle, TtfFormat, UiBundle, UiText, UiTransform};
+use amethyst::renderer::{AmbientColor, Camera, DirectionalLight, DrawShaded, Event,
+                         Light, Material, MaterialDefaults, MeshHandle, ObjFormat, Pipeline,
+                         PngFormat, PointLight, PosNormTex, Projection, Rgba, VirtualKeyCode};
+use amethyst::ui::{Anchor, FontHandle, TtfFormat, UiBundle, UiText, UiTransform};
 use amethyst::utils::fps_counter::{FPSCounter, FPSCounterBundle};
 use amethyst::{Application, Error, GameData, GameDataBuilder, State, StateData, Trans};
 
@@ -111,6 +111,7 @@ impl<'a, 'b> State<GameData<'a, 'b>> for Loading {
             .create_entity()
             .with(UiTransform::new(
                 "fps".to_string(),
+                Anchor::TopLeft,
                 100.,
                 25.,
                 1.,
@@ -124,13 +125,13 @@ impl<'a, 'b> State<GameData<'a, 'b>> for Loading {
                 [1.0, 1.0, 1.0, 1.0],
                 25.,
             ))
-            .with(Anchored::new(Anchor::TopLeft))
             .build();
 
         data.world
             .create_entity()
             .with(UiTransform::new(
                 "fps".to_string(),
+                Anchor::Middle,
                 0.,
                 0.,
                 1.,
@@ -144,7 +145,6 @@ impl<'a, 'b> State<GameData<'a, 'b>> for Loading {
                 [1.0, 1.0, 1.0, 1.0],
                 25.,
             ))
-            .with(Anchored::new(Anchor::Middle))
             .with(LoadTag)
             .build();
 

--- a/examples/ui/main.rs
+++ b/examples/ui/main.rs
@@ -6,7 +6,7 @@ extern crate log;
 
 use amethyst::assets::{AssetStorage, Loader};
 use amethyst::core::cgmath::Deg;
-use amethyst::core::transform::{GlobalTransform, Parent, TransformBundle};
+use amethyst::core::transform::{GlobalTransform, TransformBundle};
 use amethyst::core::Time;
 use amethyst::ecs::prelude::{Entity, System, World, Write};
 use amethyst::input::{is_close_requested, is_key, InputBundle};
@@ -15,7 +15,7 @@ use amethyst::renderer::{AmbientColor, Camera, DrawShaded, Light, Mesh, PngForma
                          PosNormTex, Projection, Rgba, Texture, Shape};
 use amethyst::shrev::{EventChannel, ReaderId};
 use amethyst::ui::{Anchor, FontAsset, MouseReactive, Stretch, TextEditing, TtfFormat,
-                   UiBundle, UiButtonBuilder, UiButtonResources, UiEvent, UiFocused, UiImage,
+                   UiBundle, UiButtonBuilder, UiEvent, UiFocused, UiImage,
                    UiText, UiTransform};
 use amethyst::utils::fps_counter::{FPSCounter, FPSCounterBundle};
 use amethyst::winit::{Event, VirtualKeyCode};
@@ -135,43 +135,23 @@ impl<'a, 'b> State<GameData<'a, 'b>> for Example {
             ))
             .build();
 
-        let button_builder = {
-            // Until we can borrow immutably whilst also borrowing mutably, we need to restrict this
-            // lifetime
-            UiButtonBuilder::new("btn", "Button!", UiButtonResources::from_world(&world))
-                .with_uitext(UiText::new(
-                    font.clone(),
-                    "Button!".to_string(),
-                    [0.2, 0.2, 1.0, 1.0],
-                    20.,
-                ))
-                .with_transform(UiTransform::new(
-                    "btn_transform".to_string(),
-                    Anchor::TopMiddle,
-                    0.0,
-                    32.0,
-                    -1.0,
-                    128.0,
-                    64.0,
-                    9,
-                ))
-                .with_image(UiImage {
-                    texture: green.clone(),
-                })
-                .with_parent(Parent {
-                    entity: background.clone(),
-                })
-        };
-        button_builder.build_from_world(world);
-        let simple_builder = {
-            UiButtonBuilder::new(
-                "simple_btn",
-                "Simpler!",
-                UiButtonResources::from_world(&world),
-            ).with_font(font.clone())
-                .with_position(275.0, 50.0)
-        };
-        simple_builder.build_from_world(world);
+        UiButtonBuilder::new("btn_transform", "Button!")
+            .with_font(font.clone())
+            .with_text_color([0.2, 0.2, 1.0, 1.0])
+            .with_font_size(20.)
+            .with_position(0.0, 32.0)
+            .with_layer(-1.)
+            .with_size(128., 64.)
+            .with_tab_order(9)
+            .with_image(green.clone())
+            .with_anchor(Anchor::TopMiddle)
+            .with_parent(background.clone())
+            .build_from_world(world);
+
+        UiButtonBuilder::new("simple_btn", "Simpler!")
+            .with_font(font.clone())
+            .with_position(250.0, 50.0)
+            .build_from_world(world);
 
         let fps = world
             .create_entity()

--- a/examples/ui/main.rs
+++ b/examples/ui/main.rs
@@ -14,9 +14,9 @@ use amethyst::prelude::*;
 use amethyst::renderer::{AmbientColor, Camera, DrawShaded, Light, Mesh, PngFormat, PointLight,
                          PosNormTex, Projection, Rgba, Texture, Shape};
 use amethyst::shrev::{EventChannel, ReaderId};
-use amethyst::ui::{Anchor, Anchored, FontAsset, MouseReactive, Stretch, Stretched, TextEditing,
-                   TtfFormat, UiBundle, UiButtonBuilder, UiButtonResources, UiEvent, UiFocused,
-                   UiImage, UiText, UiTransform};
+use amethyst::ui::{Anchor, FontAsset, MouseReactive, Stretch, TextEditing, TtfFormat,
+                   UiBundle, UiButtonBuilder, UiButtonResources, UiEvent, UiFocused, UiImage,
+                   UiText, UiTransform};
 use amethyst::utils::fps_counter::{FPSCounter, FPSCounterBundle};
 use amethyst::winit::{Event, VirtualKeyCode};
 
@@ -38,7 +38,7 @@ impl<'a, 'b> State<GameData<'a, 'b>> for Example {
         initialise_sphere(world);
         initialise_lights(world);
         initialise_camera(world);
-        let (logo, font, red, green, blue) = {
+        let (logo, font, background_color, green) = {
             let loader = world.read_resource::<Loader>();
 
             let logo = loader.load(
@@ -56,8 +56,8 @@ impl<'a, 'b> State<GameData<'a, 'b>> for Example {
                 (),
                 &world.read_resource::<AssetStorage<FontAsset>>(),
             );
-            let red = loader.load_from_data(
-                [1.0, 0.0, 0.0, 1.0].into(),
+            let background_color = loader.load_from_data(
+                [0.36, 0.10, 0.57, 1.0].into(),
                 (),
                 &world.read_resource::<AssetStorage<Texture>>(),
             );
@@ -66,64 +66,28 @@ impl<'a, 'b> State<GameData<'a, 'b>> for Example {
                 (),
                 &world.read_resource::<AssetStorage<Texture>>(),
             );
-            let blue = loader.load_from_data(
-                [0.0, 0.0, 1.0, 1.0].into(),
-                (),
-                &world.read_resource::<AssetStorage<Texture>>(),
-            );
-            (logo, font, red, green, blue)
+            (logo, font, background_color, green)
         };
 
         let background = world
             .create_entity()
-            .with(UiTransform::new(
-                "background".to_string(),
-                0.0,
-                0.0,
-                0.0,
-                20.0,
-                20.0,
-                0,
-            ))
-            .with(UiImage {
-                texture: red.clone(),
-            })
-            .with(Stretched::new(Stretch::XY, 0.0, 0.0))
-            .with(Anchored::new(Anchor::Middle))
-            .build();
-
-        let top_right = world
-            .create_entity()
             .with(
-                UiTransform::new("top_right".to_string(), -32.0, 32.0, -1.0, 64.0, 64.0, 0)
-                    .as_percent(),
+                UiTransform::new(
+                    "background".to_string(),
+                    Anchor::Middle,
+                    0.0,
+                    0.0,
+                    10.0,
+                    20.0,
+                    20.0,
+                    0,
+                ).with_stretching(Stretch::XY {
+                    x_margin: 0.0,
+                    y_margin: 0.0,
+                }),
             )
             .with(UiImage {
-                texture: green.clone(),
-            })
-            .with(Anchored::new(Anchor::TopRight))
-            .with(Parent {
-                entity: background.clone(),
-            })
-            .build();
-        world
-            .create_entity()
-            .with(UiTransform::new(
-                "middle_top_right".to_string(),
-                0.0,
-                0.0,
-                -2.0,
-                32.0,
-                32.0,
-                0,
-            ))
-            .with(UiImage {
-                texture: blue.clone(),
-            })
-            .with(Anchored::new(Anchor::Middle))
-            .with(Stretched::new(Stretch::X, 2.0, 0.0))
-            .with(Parent {
-                entity: top_right.clone(),
+                texture: background_color.clone(),
             })
             .build();
 
@@ -131,8 +95,9 @@ impl<'a, 'b> State<GameData<'a, 'b>> for Example {
             .create_entity()
             .with(UiTransform::new(
                 "logo".to_string(),
+                Anchor::BottomMiddle,
                 0.,
-                -32.,
+                32.,
                 -3.,
                 64.,
                 64.,
@@ -141,7 +106,6 @@ impl<'a, 'b> State<GameData<'a, 'b>> for Example {
             .with(UiImage {
                 texture: logo.clone(),
             })
-            .with(Anchored::new(Anchor::BottomMiddle))
             .with(MouseReactive)
             .build();
 
@@ -149,6 +113,7 @@ impl<'a, 'b> State<GameData<'a, 'b>> for Example {
             .create_entity()
             .with(UiTransform::new(
                 "hello_world".to_string(),
+                Anchor::Middle,
                 0.,
                 0.,
                 -4.,
@@ -159,10 +124,9 @@ impl<'a, 'b> State<GameData<'a, 'b>> for Example {
             .with(UiText::new(
                 font.clone(),
                 "Hello world!".to_string(),
-                [0.2, 0.2, 1.0, 1.0],
+                [0.5, 0.5, 1.0, 1.0],
                 75.,
             ))
-            .with(Anchored::new(Anchor::Middle))
             .with(TextEditing::new(
                 12,
                 [0.0, 0.0, 0.0, 1.0],
@@ -183,6 +147,7 @@ impl<'a, 'b> State<GameData<'a, 'b>> for Example {
                 ))
                 .with_transform(UiTransform::new(
                     "btn_transform".to_string(),
+                    Anchor::TopMiddle,
                     0.0,
                     32.0,
                     -1.0,
@@ -193,7 +158,6 @@ impl<'a, 'b> State<GameData<'a, 'b>> for Example {
                 .with_image(UiImage {
                     texture: green.clone(),
                 })
-                .with_anchored(Anchored::new(Anchor::TopMiddle))
                 .with_parent(Parent {
                     entity: background.clone(),
                 })
@@ -205,7 +169,7 @@ impl<'a, 'b> State<GameData<'a, 'b>> for Example {
                 "Simpler!",
                 UiButtonResources::from_world(&world),
             ).with_font(font.clone())
-                .with_position(250.0, 50.0)
+                .with_position(275.0, 50.0)
         };
         simple_builder.build_from_world(world);
 
@@ -213,6 +177,7 @@ impl<'a, 'b> State<GameData<'a, 'b>> for Example {
             .create_entity()
             .with(UiTransform::new(
                 "fps".to_string(),
+                Anchor::TopLeft,
                 100.,
                 30.,
                 -3.,
@@ -226,7 +191,6 @@ impl<'a, 'b> State<GameData<'a, 'b>> for Example {
                 [1.0, 1.0, 1.0, 1.0],
                 75.,
             ))
-            .with(Anchored::new(Anchor::TopLeft))
             .build();
         self.fps_display = Some(fps);
         world.write_resource::<UiFocused>().entity = Some(text);
@@ -256,15 +220,6 @@ impl<'a, 'b> State<GameData<'a, 'b>> for Example {
 }
 
 fn main() -> amethyst::Result<()> {
-    println!("Due to some bugs this example currently comes with a seizure warning.");
-    println!("If you have a history of seizures please do not run this.");
-    println!("Would you like to run this? (Y/N)");
-    let mut input = String::new();
-    let _ = ::std::io::stdin().read_line(&mut input);
-    if !input.to_lowercase().starts_with("y") {
-        return Ok(());
-    }
-
     let display_config_path = format!(
         "{}/examples/ui/resources/display.ron",
         env!("CARGO_MANIFEST_DIR")

--- a/examples/ui/main.rs
+++ b/examples/ui/main.rs
@@ -77,11 +77,11 @@ impl<'a, 'b> State<GameData<'a, 'b>> for Example {
                     Anchor::Middle,
                     0.0,
                     0.0,
-                    10.0,
+                    0.0,
                     20.0,
                     20.0,
                     0,
-                ).with_stretching(Stretch::XY {
+                ).with_stretch(Stretch::XY {
                     x_margin: 0.0,
                     y_margin: 0.0,
                 }),
@@ -97,7 +97,7 @@ impl<'a, 'b> State<GameData<'a, 'b>> for Example {
                 "logo".to_string(),
                 Anchor::BottomMiddle,
                 0.,
-                32.,
+                -32.,
                 -3.,
                 64.,
                 64.,
@@ -150,7 +150,7 @@ impl<'a, 'b> State<GameData<'a, 'b>> for Example {
 
         UiButtonBuilder::new("simple_btn", "Simpler!")
             .with_font(font.clone())
-            .with_position(250.0, 50.0)
+            .with_position(275.0, 50.0)
             .build_from_world(world);
 
         let fps = world


### PR DESCRIPTION
`ScaleMode` works now yay 😁 

This PR makes us more courteous towards the `UiTransform` local values.  We never overwrite the local values anymore. and it removes the conflict between modifications to global value and local values by preventing the end user from writing to the global values.  Global values should only be used to prevent re-calculation anyways.

`UiResize` has been refactored to be more user friendly and also more helpful in general.  Now we don't need to execute the internal closure on the transform before attaching it, and neither do we need to box the closure ourselves.

I also folded anchoring and stretching into the `UiTransform` itself.  Behavior without these components was unspecified before.

I updated some colors in the UI example as I didn't like the red, and since I can no longer see screen flickering I removed the seizure warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/774)
<!-- Reviewable:end -->
