### PR TITLE
Don't log warning if logger already set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ thread_profiler = { version = "0.1", optional = true }
 
 [dev-dependencies]
 amethyst_gltf = { path = "amethyst_gltf", version = "0.2" }
+env_logger = "0.5.10"
 genmesh = "0.5"
 ron = "0.2"
 serde = "1.0"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * Use `fresnel` function in PBR shader ([#772])
 * Remove boilerplate for `run` + `main` in examples ([#764])
 * Update dependencies ([#752], [#751])
+* Formalized and documented support for overriding the global logger ([#776])
 
 ### Fixed
 * Resizing fixed on OSX ([#767])
@@ -48,6 +49,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#773]: https://github.com/amethyst/amethyst/pull/773
 [#771]: https://github.com/amethyst/amethyst/pull/771
 [#777]: https://github.com/amethyst/amethyst/pull/777
+[#776]: https://github.com/amethyst/amethyst/pull/776
 
 ## [0.7.0] - 2018-05
 ### Added

--- a/src/app.rs
+++ b/src/app.rs
@@ -326,7 +326,7 @@ impl<S> ApplicationBuilder<S> {
             .level(LevelFilter::Debug)
             .chain(io::stdout())
             .apply()
-            .unwrap_or_else(|e| warn!("Application tried to override existing logger: {}", e));
+            .unwrap_or_else(|_| debug!("Global logger already set, default amethyst logger will not be used"));
 
         info!("Initializing Amethyst...");
         info!("Version: {}", env!("CARGO_PKG_VERSION"));

--- a/src/app.rs
+++ b/src/app.rs
@@ -31,6 +31,69 @@ use vergen;
 /// Since Application functions as the root of the game, Amethyst does not need
 /// to use any global variables. Within this object is everything that your
 /// game needs to run.
+///
+/// # Logging
+///
+/// Amethyst performs logging internally using the [log] crate. By default, `Application` will
+/// initialize a global logger that simply sends logs to the console. You can take advantage of
+/// this and use the logging macros in `log` once you've created your `Application` instance:
+///
+/// ```
+/// extern crate amethyst;
+/// #[macro_use]
+/// extern crate log;
+///
+/// use amethyst::prelude::*;
+/// use amethyst::core::transform::{Parent, Transform};
+/// use amethyst::ecs::prelude::System;
+///
+/// struct NullState;
+/// impl State<()> for NullState {}
+///
+/// fn main() -> amethyst::Result<()> {
+///     // Build the application instance to initialize the default logger.
+///     let mut game = Application::build("assets/", NullState)?
+///         .build(())?;
+///
+///     // Now logging can be performed as normal.
+///     info!("Using the default logger provided by amethyst");
+///     warn!("Uh-oh, something went wrong!");
+///
+///     Ok(())
+/// }
+/// ```
+///
+/// You can also setup your own logging system. Simply intialize any global logger that supports
+/// [log], and it will be used instead of the default logger:
+///
+/// ```
+/// extern crate amethyst;
+/// #[macro_use]
+/// extern crate log;
+/// extern crate env_logger;
+///
+/// use amethyst::prelude::*;
+/// use amethyst::core::transform::{Parent, Transform};
+/// use amethyst::ecs::prelude::System;
+///
+/// struct NullState;
+/// impl State<()> for NullState {}
+///
+/// fn main() -> amethyst::Result<()> {
+///     // Initialize your custom logger (using env_logger in this case) before creating the
+///     // `Application` instance.
+///     env_logger::init();
+///
+///     // The default logger will be automatically disabled and any logging amethyst does
+///     // will go through your custom logger.
+///     let mut game = Application::build("assets/", NullState)?
+///         .build(())?;
+///
+///     Ok(())
+/// }
+/// ```
+///
+/// [log]: https://crates.io/crates/log
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct Application<'a, T> {


### PR DESCRIPTION
Currently, amethyst logs a warning if the user already registered a global logger before calling `ApplicationBuilder::new`. In practice, this isn't really an issue that the user needs to be warned about, it just means that the user chose to setup a different logging library than the one that amethyst provides by default. As such, this PR removes the warning so as not to confuse/worry users, while still allowing them to setup their own logging system if they so choose. I have put in a message at a lower verbosity so that there's still some record that the default logger was overridden.

I had originally [discussed in gitter](https://gitter.im/amethyst/engine?at=5b183d4be26c847ac8c1ec36) adding an option for not setting up the default logger at all, but it occurs to me that there's no need to explicitly disable the default logger, since the log crate already has a mechanism for safely rejecting redundant loggers. Automatically disabling the default logger if the user sets up their own is probably the cleanest, most ergonomic API amethyst could provide.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/776)
<!-- Reviewable:end -->
