### PR TITLE
Make point lights use GlobalTransform instead of separate `center`

### DIFF
--- a/amethyst_renderer/src/light.rs
+++ b/amethyst_renderer/src/light.rs
@@ -75,8 +75,6 @@ impl From<DirectionalLight> for Light {
 #[derive(Clone, ConstantBuffer, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default)]
 pub struct PointLight {
-    /// Location of the light source in three dimensional space.
-    pub center: [f32; 3], //TODO: Replace with a cgmath type when gfx version > 0.16
     /// Color of the light in RGBA8 format.
     pub color: Rgba,
     /// Brightness of the light source, in lumens.
@@ -91,7 +89,6 @@ pub struct PointLight {
 impl Default for PointLight {
     fn default() -> Self {
         PointLight {
-            center: [0.0, 0.0, 0.0],
             color: Rgba::default(),
             intensity: 10.0,
             radius: 10.0,

--- a/amethyst_renderer/src/light.rs
+++ b/amethyst_renderer/src/light.rs
@@ -51,7 +51,9 @@ impl From<DirectionalLight> for Light {
     }
 }
 
-/// A point light source.
+/// A point light source. Uses the `Transform` set of components for
+/// positioning, and requires a `GlobalTransform` component to be included 
+/// in rendering.
 ///
 /// Lighting calculations are based off of the Frostbite engine's lighting,
 /// which is explained in detail here in [this presentation][fb]. Below is

--- a/amethyst_renderer/src/pass/pbm/interleaved.rs
+++ b/amethyst_renderer/src/pass/pbm/interleaved.rs
@@ -111,7 +111,7 @@ where
     ) {
         let camera = get_camera(active, &camera, &global);
 
-        set_light_args(effect, encoder, &light, &ambient, camera);
+        set_light_args(effect, encoder, &light, &global, &ambient, camera);
 
         match visibility {
             None => for (mesh, material, global) in (&mesh, &material, &global).join() {

--- a/amethyst_renderer/src/pass/pbm/separate.rs
+++ b/amethyst_renderer/src/pass/pbm/separate.rs
@@ -144,7 +144,7 @@ impl Pass for DrawPbmSeparate {
     ) {
         let camera = get_camera(active, &camera, &global);
 
-        set_light_args(effect, encoder, &light, &ambient, camera);
+        set_light_args(effect, encoder, &light, &global, &ambient, camera);
 
         match visibility {
             None => for (entity, mesh, material, global) in

--- a/amethyst_renderer/src/pass/shaded/interleaved.rs
+++ b/amethyst_renderer/src/pass/shaded/interleaved.rs
@@ -111,7 +111,7 @@ where
     ) {
         let camera = get_camera(active, &camera, &global);
 
-        set_light_args(effect, encoder, &light, &ambient, camera);
+        set_light_args(effect, encoder, &light, &global, &ambient, camera);
 
         match visibility {
             None => for (mesh, material, global) in (&mesh, &material, &global).join() {

--- a/amethyst_renderer/src/pass/shaded/separate.rs
+++ b/amethyst_renderer/src/pass/shaded/separate.rs
@@ -141,7 +141,7 @@ impl Pass for DrawShadedSeparate {
         trace!("Drawing shaded pass");
         let camera = get_camera(active, &camera, &global);
 
-        set_light_args(effect, encoder, &light, &ambient, camera);
+        set_light_args(effect, encoder, &light, &global, &ambient, camera);
 
         match visibility {
             None => for (entity, mesh, material, global) in

--- a/amethyst_renderer/src/pass/shaded_util.rs
+++ b/amethyst_renderer/src/pass/shaded_util.rs
@@ -2,8 +2,6 @@ use std::mem;
 
 use amethyst_core::specs::prelude::{Join, ReadStorage};
 use amethyst_core::GlobalTransform;
-use amethyst_core::cgmath;
-type Vector4 = cgmath::Vector4<f32>;
 
 use glsl_layout::*;
 
@@ -47,7 +45,7 @@ pub(crate) fn set_light_args(
             if let Light::Point(ref light) = *light {
                 Some(
                     PointLightPod {
-                        position: (transform.0 * Vector4::new(0.0, 0.0, 0.0, 1.0)).truncate().into(),
+                        position: transform.0.w.truncate().into(),
                         color: light.color.into(),
                         intensity: light.intensity,
                         pad: 0.0,

--- a/amethyst_renderer/src/pass/shaded_util.rs
+++ b/amethyst_renderer/src/pass/shaded_util.rs
@@ -2,6 +2,8 @@ use std::mem;
 
 use amethyst_core::specs::prelude::{Join, ReadStorage};
 use amethyst_core::GlobalTransform;
+use amethyst_core::cgmath;
+type Vector4 = cgmath::Vector4<f32>;
 
 use glsl_layout::*;
 
@@ -35,16 +37,17 @@ pub(crate) fn set_light_args(
     effect: &mut Effect,
     encoder: &mut Encoder,
     light: &ReadStorage<Light>,
+    global: &ReadStorage<GlobalTransform>,
     ambient: &AmbientColor,
     camera: Option<(&Camera, &GlobalTransform)>,
 ) {
-    let point_lights: Vec<_> = light
+    let point_lights: Vec<_> = (light, global)
         .join()
-        .filter_map(|light| {
+        .filter_map(|(light, transform)| {
             if let Light::Point(ref light) = *light {
                 Some(
                     PointLightPod {
-                        position: light.center.into(),
+                        position: (transform.0 * Vector4::new(0.0, 0.0, 0.0, 1.0)).truncate().into(),
                         color: light.color.into(),
                         intensity: light.intensity,
                         pad: 0.0,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * Update dependencies ([#752], [#751])
 * Formalized and documented support for overriding the global logger ([#776])
 * Refactor GLTF loader to use prefabs ([#784])
+* Point lights use `GlobalTransform` for positioning rather than a separate `center` ([#794])
+* Point lights now require a `GlobalTransform` component to be included in rendering ([#794])
 
 ### Fixed
 * Resizing fixed on OSX ([#767])

--- a/examples/asset_loading/main.rs
+++ b/examples/asset_loading/main.rs
@@ -5,7 +5,7 @@ extern crate amethyst;
 extern crate rayon;
 
 use amethyst::assets::{Loader, Result as AssetResult, SimpleFormat};
-use amethyst::core::cgmath::{Array, Vector3};
+use amethyst::core::cgmath::{Array, Vector3, Matrix4};
 use amethyst::core::transform::{GlobalTransform, Transform, TransformBundle};
 use amethyst::ecs::prelude::World;
 use amethyst::input::{is_close_requested, is_key, InputBundle};

--- a/examples/asset_loading/main.rs
+++ b/examples/asset_loading/main.rs
@@ -141,12 +141,17 @@ fn initialise_camera(world: &mut World) {
 /// Adds lights to the scene.
 fn initialise_lights(world: &mut World) {
     let light: Light = PointLight {
-        center: [5.0, -20.0, 15.0].into(),
         intensity: 100.0,
         radius: 1.0,
         color: Rgba::white(),
         ..Default::default()
     }.into();
 
-    world.create_entity().with(light).build();
+    let transform = Matrix4::from_translation([5.0, -20.0, 15.0].into());
+
+    // Add point light.
+    world.create_entity()
+        .with(light)
+        .with(GlobalTransform(transform.into()))
+        .build();
 }

--- a/examples/assets/prefab/animation.ron
+++ b/examples/assets/prefab/animation.ron
@@ -81,9 +81,11 @@ Prefab (
         (
             data: (
                 (
+                    transform: (
+                        translation: (x: 2.0, y: 2.0, z: -2.0),
+                    ),
                     light: (
                         light: Point((
-                            center: (2.0, 2.0, -2.0),
                             intensity: 3.0,
                             color: (1.0, 1.0, 1.0, 1.0),
                             radius: 5.0,

--- a/examples/assets/prefab/example.ron
+++ b/examples/assets/prefab/example.ron
@@ -20,10 +20,13 @@ Prefab (
             ),
         ),
         (
-            data: (
+            data: ( 
+                transform: Transform (
+                    translation: (x: 5.0, y: -20.0, z: 15.0),
+                    rotation: (s: 0.0, v: (x: 0.0, y: 0.0, z: 0.0),),
+                ),
                 light: (
                     light: Point((
-                        center: (5.0, -20.0, 15.0),
                         intensity: 100.0,
                         color: (1.0, 1.0, 1.0, 1.0),
                         radius: 1.0,

--- a/examples/assets/prefab/monster_scene.ron
+++ b/examples/assets/prefab/monster_scene.ron
@@ -41,9 +41,11 @@ Prefab (
         ),
         (
             data: (
+                transform: Transform (
+                     translation: (x: 6.0, y: 6.0, z: -6.0,),
+                ),
                 light: (
                     light: Point((
-                        center: (6.0, 6.0, -6.0),
                         intensity: 6.0,
                         color: (0.8, 0.0, 0.0, 1.0),
                     )),
@@ -52,9 +54,11 @@ Prefab (
         ),
         (
             data: (
+                transform: Transform (
+                     translation: (x: 0.0, y: 4.0, z: 4.0,),
+                ),
                 light: (
                     light: Point((
-                        center: (0.0, 4.0, 4.0),
                         intensity: 6.0,
                         color: (0.0, 0.3, 0.7, 1.0),
                     )),

--- a/examples/assets/prefab/puffy_scene.ron
+++ b/examples/assets/prefab/puffy_scene.ron
@@ -39,9 +39,12 @@ Prefab (
         ),
         (
             data: (
+                transform: (
+                    translation: (x: 6.0, y: 6.0, z: -6.0),
+                    rotation: (s: 0.0, v: (x: 0.0, y: 1.0, z: 0.0),),
+                ),
                 light: (
                     light: Point((
-                        center: (6.0, 6.0, -6.0),
                         intensity: 6.0,
                         color: (0.8, 0.0, 0.0, 1.0),
                     )),
@@ -50,9 +53,12 @@ Prefab (
         ),
         (
             data: (
+                transform: (
+                    translation: (x: 0.0, y: 4.0, z: 4.0),
+                    rotation: (s: 0.0, v: (x: 0.0, y: 1.0, z: 0.0),),
+                ),
                 light: (
                     light: Point((
-                        center: (0.0, 4.0, 4.0),
                         intensity: 6.0,
                         color: (0.0, 0.3, 0.7, 1.0),
                     )),

--- a/examples/assets/prefab/renderable.ron
+++ b/examples/assets/prefab/renderable.ron
@@ -111,9 +111,11 @@ Prefab (
         ),
         (
             data: (
+                transform: (
+                    translation: (x: 1.0, y: 1.0, z: 0.0),
+                ),
                 light: (
                     light: Point((
-                        center: (1.0, 1.0, 0.0),
                         intensity: 50.0,
                     )),
                 ),

--- a/examples/assets/prefab/sphere.ron
+++ b/examples/assets/prefab/sphere.ron
@@ -14,10 +14,13 @@ Prefab (
         ),
         (
             data: (
+                transform: (
+                    translation: (x: 2.0, y: 2.0, z: -2.0),
+                    rotation: (s: 0.0, v: (x: 0.0, y: 1.0, z: 0.0),),
+                ),
                 light: (
                     ambient_color: (Rgba(0.01, 0.01, 0.01, 1.0)),
                     light: Point((
-                        center: (2.0, 2.0, -2.0),
                         intensity: 3.0,
                         color: (1.0, 1.0, 1.0, 1.0),
                         radius: 5.0,

--- a/examples/custom_game_data/example_system.rs
+++ b/examples/custom_game_data/example_system.rs
@@ -46,16 +46,16 @@ impl<'a> System<'a> for ExampleSystem {
             transform.rotation = (delta_rot * Quaternion::from(transform.rotation)).into();
         }
 
-        for point_light in (&mut lights).join().filter_map(|light| {
+        for (point_light, transform) in (&mut lights, &mut transforms).join().filter_map(|(light, transform)| {
             if let Light::Point(ref mut point_light) = *light {
-                Some(point_light)
+                Some((point_light, transform))
             } else {
                 None
             }
         }) {
-            point_light.center[0] = light_orbit_radius * state.light_angle.cos();
-            point_light.center[1] = light_orbit_radius * state.light_angle.sin();
-            point_light.center[2] = light_z;
+            transform.translation.x = light_orbit_radius * state.light_angle.cos();
+            transform.translation.y = light_orbit_radius * state.light_angle.sin();
+            transform.translation.z = light_z;
 
             point_light.color = state.light_color.into();
         }

--- a/examples/custom_game_data/graphic.rs
+++ b/examples/custom_game_data/graphic.rs
@@ -1,0 +1,198 @@
+use amethyst::assets::{Loader, ProgressCounter};
+use amethyst::core::cgmath::{Array, Deg, Euler, Quaternion, Rotation3, Vector3, Matrix4};
+use amethyst::core::{GlobalTransform, Transform};
+use amethyst::ecs::prelude::World;
+use amethyst::renderer::{AmbientColor, Camera, DirectionalLight, Light, Material,
+                         MaterialDefaults, MeshHandle, ObjFormat, PngFormat, PointLight,
+                         Projection, Rgba};
+use amethyst::ui::{FontHandle, TtfFormat};
+
+#[derive(Clone)]
+pub struct Assets {
+    cube: MeshHandle,
+    cone: MeshHandle,
+    lid: MeshHandle,
+    rectangle: MeshHandle,
+    teapot: MeshHandle,
+    red: Material,
+    white: Material,
+    logo: Material,
+    pub font: FontHandle,
+}
+
+pub fn add_graphics_to_world(world: &mut World) {
+    initialise_camera(world);
+
+    let assets = world.read_resource::<Assets>().clone();
+
+    // Add teapot and lid to scene
+    for mesh in vec![assets.lid.clone(), assets.teapot.clone()] {
+        let mut trans = Transform::default();
+        trans.rotation = Quaternion::from(Euler::new(Deg(90.0), Deg(-90.0), Deg(0.0))).into();
+        trans.translation = Vector3::new(5.0, 5.0, 0.0);
+
+        world
+            .create_entity()
+            .with(mesh)
+            .with(assets.red.clone())
+            .with(trans)
+            .with(GlobalTransform::default())
+            .build();
+    }
+
+    // Add cube to scene
+    let mut trans = Transform::default();
+    trans.translation = Vector3::new(5.0, -5.0, 2.0);
+    trans.scale = [2.0; 3].into();
+
+    world
+        .create_entity()
+        .with(assets.cube.clone())
+        .with(assets.logo.clone())
+        .with(trans)
+        .with(GlobalTransform::default())
+        .build();
+
+    // Add cone to scene
+    let mut trans = Transform::default();
+    trans.translation = Vector3::new(-5.0, 5.0, 0.0);
+    trans.scale = [2.0; 3].into();
+
+    world
+        .create_entity()
+        .with(assets.cone.clone())
+        .with(assets.white.clone())
+        .with(trans)
+        .with(GlobalTransform::default())
+        .build();
+
+    // Add custom cube object to scene
+    let mut trans = Transform::default();
+    trans.translation = Vector3::new(-5.0, -5.0, 1.0);
+    world
+        .create_entity()
+        .with(assets.cube.clone())
+        .with(assets.red.clone())
+        .with(trans)
+        .with(GlobalTransform::default())
+        .build();
+
+    // Create base rectangle as floor
+    let mut trans = Transform::default();
+    trans.scale = Vector3::from_value(10.);
+
+    world
+        .create_entity()
+        .with(assets.rectangle.clone())
+        .with(assets.white.clone())
+        .with(trans)
+        .with(GlobalTransform::default())
+        .build();
+
+    let light: Light = PointLight {
+        color: [1.0, 1.0, 0.0].into(),
+        intensity: 50.0,
+        ..PointLight::default()
+    }.into();
+    
+    // Add lights to scene
+    world.create_entity()
+        .with(light)
+        .with(Transform::default())
+        .with(GlobalTransform::default())
+        .build();
+
+    let light: Light = DirectionalLight {
+        color: [0.2; 4].into(),
+        direction: [-1.0; 3],
+    }.into();
+
+    world.create_entity().with(light).build();
+    world.add_resource(AmbientColor(Rgba::from([0.01; 3])));
+}
+
+fn initialise_camera(world: &mut World) {
+    let mut local = Transform::default();
+    local.translation = Vector3::new(0., -20., 10.);
+    local.rotation = Quaternion::from_angle_x(Deg(75.)).into();
+    world
+        .create_entity()
+        .with(Camera::from(Projection::perspective(1.3, Deg(60.0))))
+        .with(local)
+        .with(GlobalTransform::default())
+        .build();
+}
+
+pub fn load_assets(world: &mut World) -> ProgressCounter {
+    let mut progress = ProgressCounter::default();
+    let assets = {
+        let mesh_storage = world.read_resource();
+        let tex_storage = world.read_resource();
+        let font_storage = world.read_resource();
+        let mat_defaults = world.read_resource::<MaterialDefaults>();
+        let loader = world.read_resource::<Loader>();
+
+        let red = loader.load_from_data([1.0, 0.0, 0.0, 1.0].into(), &mut progress, &tex_storage);
+        let red = Material {
+            albedo: red,
+            ..mat_defaults.0.clone()
+        };
+
+        let white = loader.load_from_data([1.0, 1.0, 1.0, 1.0].into(), &mut progress, &tex_storage);
+        let white = Material {
+            albedo: white,
+            ..mat_defaults.0.clone()
+        };
+
+        let logo = Material {
+            albedo: loader.load(
+                "texture/logo.png",
+                PngFormat,
+                Default::default(),
+                &mut progress,
+                &tex_storage,
+            ),
+            ..mat_defaults.0.clone()
+        };
+
+        let cube = loader.load("mesh/cube.obj", ObjFormat, (), &mut progress, &mesh_storage);
+        let cone = loader.load("mesh/cone.obj", ObjFormat, (), &mut progress, &mesh_storage);
+        let lid = loader.load("mesh/lid.obj", ObjFormat, (), &mut progress, &mesh_storage);
+        let teapot = loader.load(
+            "mesh/teapot.obj",
+            ObjFormat,
+            (),
+            &mut progress,
+            &mesh_storage,
+        );
+        let rectangle = loader.load(
+            "mesh/rectangle.obj",
+            ObjFormat,
+            (),
+            &mut progress,
+            &mesh_storage,
+        );
+        let font = loader.load(
+            "font/square.ttf",
+            TtfFormat,
+            (),
+            &mut progress,
+            &font_storage,
+        );
+
+        Assets {
+            cube,
+            cone,
+            lid,
+            rectangle,
+            teapot,
+            red,
+            white,
+            logo,
+            font,
+        }
+    };
+
+    world.add_resource(assets);
+    progress
+}

--- a/examples/custom_game_data/graphic.rs
+++ b/examples/custom_game_data/graphic.rs
@@ -1,5 +1,5 @@
 use amethyst::assets::{Loader, ProgressCounter};
-use amethyst::core::cgmath::{Array, Deg, Euler, Quaternion, Rotation3, Vector3, Matrix4};
+use amethyst::core::cgmath::{Array, Deg, Euler, Quaternion, Rotation3, Vector3};
 use amethyst::core::{GlobalTransform, Transform};
 use amethyst::ecs::prelude::World;
 use amethyst::renderer::{AmbientColor, Camera, DirectionalLight, Light, Material,

--- a/examples/material/main.rs
+++ b/examples/material/main.rs
@@ -72,22 +72,24 @@ impl<'a, 'b> State<GameData<'a, 'b>> for Example {
 
         println!("Create lights");
         let light1: Light = PointLight {
-            center: [6.0, 6.0, -6.0].into(),
             intensity: 6.0,
             color: [0.8, 0.0, 0.0].into(),
             ..PointLight::default()
         }.into();
 
+        let light1_transform = GlobalTransform(Matrix4::from_translation([6.0, 6.0, -6.0].into()).into());
+
         let light2: Light = PointLight {
-            center: [6.0, -6.0, -6.0].into(),
             intensity: 5.0,
             color: [0.0, 0.3, 0.7].into(),
             ..PointLight::default()
         }.into();
 
-        world.create_entity().with(light1).build();
+        let light2_transform = GlobalTransform(Matrix4::from_translation([6.0, -6.0, -6.0].into()).into());
 
-        world.create_entity().with(light2).build();
+        world.create_entity().with(light1).with(light1_transform).build();
+
+        world.create_entity().with(light2).with(light2_transform).build();
 
         println!("Put camera");
 

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -246,16 +246,16 @@ impl<'a> System<'a> for ExampleSystem {
             transform.rotation = (delta_rot * Quaternion::from(transform.rotation)).into();
         }
 
-        for point_light in (&mut lights).join().filter_map(|light| {
+        for (point_light, transform)  in (&mut lights, &mut transforms).join().filter_map(|(light, transform)| {
             if let Light::Point(ref mut point_light) = *light {
-                Some(point_light)
+                Some((point_light, transform))
             } else {
                 None
             }
         }) {
-            point_light.center[0] = light_orbit_radius * state.light_angle.cos();
-            point_light.center[1] = light_orbit_radius * state.light_angle.sin();
-            point_light.center[2] = light_z;
+            transform.translation.x = light_orbit_radius * state.light_angle.cos();
+            transform.translation.y = light_orbit_radius * state.light_angle.sin();
+            transform.translation.z = light_z;
 
             point_light.color = state.light_color.into();
         }


### PR DESCRIPTION
Fixes #782. ~~Seems to work with the separate_sphere example which I updated, the rest of the examples need to be fixed though, likely.~~ I believe I've updated all the examples to work properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/794)
<!-- Reviewable:end -->
