### PR TITLE
Remove unnecessary mutability in pong example

### DIFF
--- a/examples/pong/systems/move_balls.rs
+++ b/examples/pong/systems/move_balls.rs
@@ -1,6 +1,6 @@
 use amethyst::core::timing::Time;
 use amethyst::core::transform::Transform;
-use amethyst::ecs::prelude::{Join, Read, System, WriteStorage};
+use amethyst::ecs::prelude::{Join, Read, ReadStorage, System, WriteStorage};
 use Ball;
 
 /// This system is responsible for moving all balls according to their speed
@@ -9,14 +9,14 @@ pub struct MoveBallsSystem;
 
 impl<'s> System<'s> for MoveBallsSystem {
     type SystemData = (
-        WriteStorage<'s, Ball>,
+        ReadStorage<'s, Ball>,
         WriteStorage<'s, Transform>,
         Read<'s, Time>,
     );
 
-    fn run(&mut self, (mut balls, mut locals, time): Self::SystemData) {
+    fn run(&mut self, (balls, mut locals, time): Self::SystemData) {
         // Move every ball according to its speed, and the time passed.
-        for (ball, local) in (&mut balls, &mut locals).join() {
+        for (ball, local) in (&balls, &mut locals).join() {
             local.translation[0] += ball.velocity[0] * time.delta_seconds();
             local.translation[1] += ball.velocity[1] * time.delta_seconds();
         }


### PR DESCRIPTION
Moving the balls does not change the ball velocity or radius, so `Ball` doesn't need to be mutable in `MoveBallSystem`.

I was working through the pong example and I couldn't figure out why `Ball` was `WriteStorage` in `MoveBallSystem`. Since I'm new to Rust, I thought it would be a great exercise in learning about this corner of the type system. Well, after learning (a lot!), turns out that it doesn't have to be mutable at all. So I decided to deprive future learners of the same opportunity that I had. :wink:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/803)
<!-- Reviewable:end -->
