### PR TITLE
Change the welcoming README.md sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 [gc]: https://gitter.im/orgs/amethyst/rooms
 [di]: https://discord.gg/GnP5Whs
 
-**Warning: The book and the documentation are missing content. Amethyst is undergoing a lot of changes at the moment.**
+**Warning: The engine is still in alpha, and thus it changes very fast. You may find out that some parts of the documentation can be outdated. If you find such an occurrence, feel free to open an issue and it will be fixed in no time.**
 
 ## Goals
 


### PR DESCRIPTION
Our current welcoming sentence is as follows:

> **Warning: The book and the documentation are missing content. Amethyst is undergoing a lot of changes at the moment.**

I feel like this phrasing is excessively frightening. While it is true that the book does not cover all the features of the engine, the API reference is very complete and the examples are plentiful. Also, we do change things a lot but the engine overall is stable *enough*, and we tend to make those changes reasonable.

This is why I suggest to implement @jojolepro's excellent alternative:

> **Warning: The engine is still in alpha, and thus it changes very fast. You may find out that some parts of the documentation can be outdated. If you find such an occurance, feel free to open an issue and it will be fixed.**

It does warn the user that we are changing things, but does it in a more reassuring way that represents more our active approach on the engine.

It would be great to have a lot of feedback on this proposition as this is the first thing someone might see while stumbling upon the engine, so it is of major importance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/806)
<!-- Reviewable:end -->
