### PR TITLE
Loosen up generic type bounds for InputBundle

### DIFF
--- a/amethyst_input/src/bindings.rs
+++ b/amethyst_input/src/bindings.rs
@@ -10,7 +10,7 @@ use super::{Axis, Button};
 
 /// Used for saving and loading input settings.
 #[derive(Derivative, Serialize, Deserialize, Clone)]
-#[derivative(Default(bound = "AX: Hash + Eq, AC: Hash + Eq"))]
+#[derivative(Default(bound = ""))]
 pub struct Bindings<AX, AC>
 where
     AX: Hash + Eq,

--- a/amethyst_input/src/bundle.rs
+++ b/amethyst_input/src/bundle.rs
@@ -27,7 +27,8 @@ use {Bindings, InputSystem};
 ///
 /// No errors returned from this bundle.
 ///
-#[derive(Default)]
+#[derive(Derivative)]
+#[derivative(Default(bound = ""))]
 pub struct InputBundle<AX, AC>
 where
     AX: Hash + Eq,
@@ -38,8 +39,8 @@ where
 
 impl<AX, AC> InputBundle<AX, AC>
 where
-    AX: Hash + Eq + DeserializeOwned + Serialize + Default,
-    AC: Hash + Eq + DeserializeOwned + Serialize + Default,
+    AX: Hash + Eq,
+    AC: Hash + Eq,
 {
     /// Create a new input bundle with no bindings
     pub fn new() -> Self {
@@ -53,7 +54,11 @@ where
     }
 
     /// Load bindings from file
-    pub fn with_bindings_from_file<P: AsRef<Path>>(self, file: P) -> Self {
+    pub fn with_bindings_from_file<P: AsRef<Path>>(self, file: P) -> Self
+    where
+        AX: DeserializeOwned + Serialize,
+        AC: DeserializeOwned + Serialize,
+    {
         self.with_bindings(Bindings::load(file))
     }
 }


### PR DESCRIPTION
This allows input axes and actions to not implement Default, which is particularly useful for enums.
Serialization traits are also not necessary if bindings are never intended to be loaded from file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/808)
<!-- Reviewable:end -->
