### PR TITLE
Fix wrong resource paths in examples

### DIFF
--- a/examples/appendix_a/main.rs
+++ b/examples/appendix_a/main.rs
@@ -36,11 +36,11 @@ fn main() -> amethyst::Result<()> {
     use pong::Pong;
 
     let display_config_path = format!(
-        "{}/examples/pong/resources/display.ron",
+        "{}/examples/appendix_a/resources/display.ron",
         env!("CARGO_MANIFEST_DIR")
     );
     let key_bindings_path = format!(
-        "{}/examples/pong/resources/input.ron",
+        "{}/examples/appendix_a/resources/input.ron",
         env!("CARGO_MANIFEST_DIR")
     );
 

--- a/examples/custom_game_data/main.rs
+++ b/examples/custom_game_data/main.rs
@@ -165,7 +165,7 @@ fn main() -> Result<(), Error> {
     let resources_directory = format!("{}/examples/assets", env!("CARGO_MANIFEST_DIR"));
 
     let display_config_path = format!(
-        "{}/examples/renderable/resources/display_config.ron",
+        "{}/examples/custom_game_data/resources/display_config.ron",
         env!("CARGO_MANIFEST_DIR")
     );
 


### PR DESCRIPTION
Nitpicky, but still :stuck_out_tongue_winking_eye:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/812)
<!-- Reviewable:end -->
