### PR TITLE
Update Fedora install command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $ sudo apt install libasound2-dev libx11-xcb-dev
 ### Fedora
 
 ```
-$ sudo yum install alsa-lib-devel
+$ sudo dnf install alsa-lib-devel
 ```
 
 ## Building Documentation


### PR DESCRIPTION
DNF has been the standard since Fedora 22 which even that had its end of life about 2 years ago

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/814)
<!-- Reviewable:end -->
