### PR TITLE
Bump specs version to 0.12

### DIFF
--- a/amethyst_assets/examples/hl.rs
+++ b/amethyst_assets/examples/hl.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 
 use amethyst_assets::*;
 use amethyst_core::specs::common::Errors;
-use amethyst_core::specs::prelude::{Dispatcher, DispatcherBuilder, Read, ReadExpect, System,
-                                    VecStorage, World, Write};
+use amethyst_core::specs::prelude::{Builder, Dispatcher, DispatcherBuilder, Read, ReadExpect,
+                                    System, VecStorage, World, Write};
 use amethyst_core::Time;
 use rayon::{ThreadPool, ThreadPoolBuilder};
 

--- a/amethyst_assets/src/prefab/mod.rs
+++ b/amethyst_assets/src/prefab/mod.rs
@@ -440,7 +440,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use amethyst_core::specs::{RunNow, World};
+    use amethyst_core::specs::{Builder, RunNow, World};
     use amethyst_core::{GlobalTransform, Time, Transform};
     use rayon::ThreadPoolBuilder;
     use std::sync::Arc;

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -23,8 +23,8 @@ log = "0.4"
 rayon = "1.0.1"
 serde = { version = "1", features = ["serde_derive"] }
 shred = { version = "0.7" }
-specs = { version = "0.11", features = ["common"] }
-specs-hierarchy = { version = "0.1" }
+specs = { version = "0.12", features = ["common"] }
+specs-hierarchy = { version = "0.2" }
 shrev = "1.0"
 
 thread_profiler = { version = "0.1" , optional = true }

--- a/amethyst_core/src/transform/systems.rs
+++ b/amethyst_core/src/transform/systems.rs
@@ -128,7 +128,7 @@ impl<'a> System<'a> for TransformSystem {
 mod tests {
     use cgmath::{Decomposed, Matrix4, One, Quaternion, Vector3, Zero};
     use shred::RunNow;
-    use specs::prelude::World;
+    use specs::prelude::{Builder, World};
     use specs_hierarchy::{Hierarchy, HierarchySystem};
     use transform::{GlobalTransform, Parent, Transform, TransformSystem};
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,7 +39,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * Moved `MaterialTextureSet` to the renderer crate ([#760])
 * Use `fresnel` function in PBR shader ([#772])
 * Remove boilerplate for `run` + `main` in examples ([#764])
-* Update dependencies ([#752], [#751])
+* Update dependencies ([#752], [#751], [#817])
 * Formalized and documented support for overriding the global logger ([#776])
 * Refactor GLTF loader to use prefabs ([#784])
 * Point lights use `GlobalTransform` for positioning rather than a separate `center` ([#794])
@@ -86,6 +86,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#811]: https://github.com/amethyst/amethyst/pull/811
 [#816]: https://github.com/amethyst/amethyst/pull/816
 [#815]: https://github.com/amethyst/amethyst/pull/815
+[#817]: https://github.com/amethyst/amethyst/pull/817
 
 ## [0.7.0] - 2018-05
 ### Added

--- a/examples/animation/main.rs
+++ b/examples/animation/main.rs
@@ -8,7 +8,7 @@ use amethyst::animation::{get_animation_set, AnimationBundle, AnimationCommand, 
                           AnimationSetPrefab, DeferStartRelation, EndControl, StepDirection};
 use amethyst::assets::{PrefabLoader, PrefabLoaderSystem, RonFormat};
 use amethyst::core::{Transform, TransformBundle};
-use amethyst::ecs::prelude::{Entity, World};
+use amethyst::ecs::prelude::Entity;
 use amethyst::input::{get_key, is_close_requested, is_key};
 use amethyst::prelude::*;
 use amethyst::renderer::{DrawShaded, Event, PosNormTex, VirtualKeyCode};

--- a/examples/arc_ball_camera/main.rs
+++ b/examples/arc_ball_camera/main.rs
@@ -6,9 +6,10 @@ use amethyst::assets::{PrefabLoader, PrefabLoaderSystem, RonFormat};
 use amethyst::controls::ArcBallControlBundle;
 use amethyst::core::transform::TransformBundle;
 use amethyst::input::{is_close_requested, is_key, InputBundle};
+use amethyst::prelude::*;
 use amethyst::renderer::{DrawShaded, Event, PosNormTex, VirtualKeyCode};
 use amethyst::utils::scene::BasicScenePrefab;
-use amethyst::{Application, Error, GameData, GameDataBuilder, State, StateData, Trans};
+use amethyst::Error;
 
 type MyPrefabData = BasicScenePrefab<Vec<PosNormTex>>;
 

--- a/examples/asset_loading/main.rs
+++ b/examples/asset_loading/main.rs
@@ -7,11 +7,11 @@ extern crate rayon;
 use amethyst::assets::{Loader, Result as AssetResult, SimpleFormat};
 use amethyst::core::cgmath::{Array, Vector3, Matrix4};
 use amethyst::core::transform::{GlobalTransform, Transform, TransformBundle};
-use amethyst::ecs::prelude::World;
 use amethyst::input::{is_close_requested, is_key, InputBundle};
+use amethyst::prelude::*;
 use amethyst::renderer::{Camera, DrawShaded, Event, Light, Material, MaterialDefaults, Mesh,
                          MeshData, PointLight, PosNormTex, Projection, Rgba, VirtualKeyCode};
-use amethyst::{Application, Error, GameData, GameDataBuilder, State, StateData, Trans};
+use amethyst::Error;
 
 #[derive(Clone)]
 struct Custom;

--- a/examples/custom_game_data/main.rs
+++ b/examples/custom_game_data/main.rs
@@ -10,12 +10,13 @@ use amethyst::core::transform::TransformBundle;
 use amethyst::ecs::prelude::{Component, Entity};
 use amethyst::ecs::storage::NullStorage;
 use amethyst::input::{is_close_requested, is_key, InputBundle};
+use amethyst::prelude::*;
 use amethyst::renderer::{DisplayConfig, DrawShaded, Event, Pipeline, PosNormTex, RenderBundle,
                          Stage, VirtualKeyCode};
 use amethyst::ui::{DrawUi, UiBundle, UiCreator, UiLoader, UiPrefab};
 use amethyst::utils::fps_counter::FPSCounterBundle;
 use amethyst::utils::scene::BasicScenePrefab;
-use amethyst::{Application, Error, State, StateData, Trans};
+use amethyst::Error;
 
 use example_system::ExampleSystem;
 use game_data::{CustomGameData, CustomGameDataBuilder};

--- a/examples/fly_camera/main.rs
+++ b/examples/fly_camera/main.rs
@@ -6,9 +6,10 @@ use amethyst::assets::{PrefabLoader, PrefabLoaderSystem, RonFormat};
 use amethyst::controls::FlyControlBundle;
 use amethyst::core::transform::TransformBundle;
 use amethyst::input::{is_close_requested, is_key, InputBundle};
+use amethyst::prelude::*;
 use amethyst::renderer::{DrawShaded, Event, PosNormTex, VirtualKeyCode};
 use amethyst::utils::scene::BasicScenePrefab;
-use amethyst::{Application, Error, GameData, GameDataBuilder, State, StateData, Trans};
+use amethyst::Error;
 
 type MyPrefabData = BasicScenePrefab<Vec<PosNormTex>>;
 

--- a/examples/prefab/main.rs
+++ b/examples/prefab/main.rs
@@ -6,9 +6,10 @@ extern crate rayon;
 use amethyst::assets::{PrefabLoader, PrefabLoaderSystem, RonFormat};
 use amethyst::core::TransformBundle;
 use amethyst::input::{is_close_requested, is_key};
+use amethyst::prelude::*;
 use amethyst::renderer::{DrawShaded, Event, PosNormTex, VirtualKeyCode};
 use amethyst::utils::scene::BasicScenePrefab;
-use amethyst::{Application, Error, GameData, GameDataBuilder, State, StateData, Trans};
+use amethyst::Error;
 
 type MyPrefabData = BasicScenePrefab<Vec<PosNormTex>>;
 

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -12,12 +12,13 @@ use amethyst::core::timing::Time;
 use amethyst::core::transform::{Transform, TransformBundle};
 use amethyst::ecs::prelude::{Entity, Join, Read, ReadStorage, System, Write, WriteStorage};
 use amethyst::input::{get_key, is_close_requested, is_key, InputBundle};
+use amethyst::prelude::*;
 use amethyst::renderer::{AmbientColor, Camera, DrawShaded, Event, Light, PosNormTex,
                          VirtualKeyCode};
 use amethyst::ui::{UiBundle, UiCreator, UiFinder, UiText};
 use amethyst::utils::fps_counter::{FPSCounter, FPSCounterBundle};
 use amethyst::utils::scene::BasicScenePrefab;
-use amethyst::{Application, Error, GameData, GameDataBuilder, State, StateData, Trans};
+use amethyst::Error;
 
 type MyPrefabData = BasicScenePrefab<Vec<PosNormTex>>;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,7 +2,7 @@
 
 pub use app::{Application, ApplicationBuilder};
 pub use config::Config;
-pub use ecs::prelude::World;
+pub use ecs::prelude::{Builder, World};
 pub use game_data::{DataInit, GameData, GameDataBuilder};
 //pub use renderer::input::*;
 


### PR DESCRIPTION
Bumps specs dependency version to 0.12.

Specs now requires the `Builder` trait to be in scope to create entities via the regular builder. I added the import to the prelude since it is almost always required (and can be confusing otherwise since its an invisible trait requirement).

~~Blocked on [specs-hierarchy#5](https://github.com/rustgd/specs-hierarchy/pull/5).~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/817)
<!-- Reviewable:end -->
