### PR TITLE
Sprite build_mesh_and_material is now public

### DIFF
--- a/amethyst_renderer/src/sprite.rs
+++ b/amethyst_renderer/src/sprite.rs
@@ -85,7 +85,7 @@ pub struct SpriteRenderData<'a> {
 }
 
 impl<'a> SpriteRenderData<'a> {
-    fn build_mesh_and_material(
+    pub fn build_mesh_and_material(
         &mut self,
         sprite: &Sprite,
         texture: TextureHandle,

--- a/amethyst_renderer/src/sprite.rs
+++ b/amethyst_renderer/src/sprite.rs
@@ -85,6 +85,10 @@ pub struct SpriteRenderData<'a> {
 }
 
 impl<'a> SpriteRenderData<'a> {
+    
+    /// Creates a MeshHandle and Material from the sprite and texture data.
+    /// Useful if you plan on re-using the same sprite a lot and don't want to
+    /// load the assets each time.
     pub fn build_mesh_and_material(
         &mut self,
         sprite: &Sprite,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * Point lights now require a `GlobalTransform` component to be included in rendering ([#794])
 * `amethyst_input::input_handler::{keys_that_are_down, mouse_buttons_that_are_down, scan_codes_that_are_down, buttons_that_are_down}` now all return `impl Iterator` instead of concrete wrapper types ([#816])
 * Renamed is_key to is_key_down and fixed example to react when the key is pressed instead of released. ([#822])
+* SpriteRenderData now allows to retrieve the MeshHandle and Material before inserting them into an entity. ([#825])
 
 ### Removed
 * Remove `amethyst_input::{KeyCodes, ScanCodes, MouseButtons, Buttons}` in favor of `impl trait` ([#816])
@@ -93,6 +94,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#817]: https://github.com/amethyst/amethyst/pull/817
 [#818]: https://github.com/amethyst/amethyst/pull/818
 [#822]: https://github.com/amethyst/amethyst/pull/822
+[#825]: https://github.com/amethyst/amethyst/pull/825
 
 ## [0.7.0] - 2018-05
 ### Added


### PR DESCRIPTION
Useful to implement external caching, as well as to just re-use the mesh in general.

Side note: I like it when everything (that is safe to be) is public, as it allows way more fine-grained control over what happens.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/825)
<!-- Reviewable:end -->
