### PR TITLE
Do Not Merge: Experiment using `typename` to derive system names.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,8 @@ fern = { version = "0.5", features = ["colored"] }
 log = "0.4"
 rayon = "1.0.1"
 rustc_version_runtime = "0.1"
+typename = "0.1"
+typename_derive = "0.1"
 winit = "0.15"
 
 thread_profiler = { version = "0.1", optional = true }

--- a/amethyst_animation/Cargo.toml
+++ b/amethyst_animation/Cargo.toml
@@ -26,6 +26,8 @@ itertools = "0.7.6"
 log = "0.4"
 minterpolate = { version = "0.3", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
+typename = "0.1"
+typename_derive = "0.1"
 
 thread_profiler = { version = "0.1", optional = true }
 

--- a/amethyst_animation/src/bundle.rs
+++ b/amethyst_animation/src/bundle.rs
@@ -3,6 +3,7 @@ use std::marker;
 
 use amethyst_core::specs::prelude::{Component, DispatcherBuilder};
 use amethyst_core::{Result, SystemBundle};
+use typename::TypeName;
 
 use resources::AnimationSampling;
 use skinning::VertexSkinningSystem;
@@ -81,7 +82,7 @@ impl<'a, T> SamplingBundle<'a, T> {
 
 impl<'a, 'b, 'c, T> SystemBundle<'a, 'b> for SamplingBundle<'c, T>
 where
-    T: AnimationSampling + Component,
+    T: AnimationSampling + Component + TypeName,
 {
     fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<()> {
         builder.add(SamplerProcessor::<T::Primitive>::new(), "", &[]);
@@ -135,8 +136,8 @@ impl<'a, I, T> AnimationBundle<'a, I, T> {
 
 impl<'a, 'b, 'c, I, T> SystemBundle<'a, 'b> for AnimationBundle<'c, I, T>
 where
-    I: PartialEq + Eq + Hash + Copy + Send + Sync + 'static,
-    T: AnimationSampling + Component + Clone,
+    I: PartialEq + Eq + Hash + Copy + Send + Sync + TypeName + 'static,
+    T: AnimationSampling + Component + Clone + TypeName,
 {
     fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<()> {
         builder.add(AnimationProcessor::<T>::new(), "", &[]);

--- a/amethyst_animation/src/lib.rs
+++ b/amethyst_animation/src/lib.rs
@@ -56,6 +56,9 @@ extern crate log;
 extern crate minterpolate;
 #[macro_use]
 extern crate serde;
+extern crate typename;
+#[macro_use]
+extern crate typename_derive;
 
 #[cfg(feature = "profiler")]
 extern crate thread_profiler;

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -26,6 +26,8 @@ shred = { version = "0.7" }
 specs = { version = "0.12", features = ["common"] }
 specs-hierarchy = { version = "0.2" }
 shrev = "1.0"
+typename = "0.1"
+typename_derive = "0.1"
 
 thread_profiler = { version = "0.1" , optional = true }
 

--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -13,6 +13,9 @@ extern crate rayon;
 #[macro_use]
 extern crate serde;
 extern crate specs_hierarchy;
+extern crate typename;
+#[macro_use]
+extern crate typename_derive;
 
 #[macro_use]
 #[cfg(feature = "profiler")]

--- a/amethyst_core/src/transform/components/local_transform.rs
+++ b/amethyst_core/src/transform/components/local_transform.rs
@@ -13,7 +13,7 @@ use specs::prelude::{Component, DenseVecStorage, FlaggedStorage};
 /// Used for rendering position and orientation.
 ///
 /// The transforms are preformed in this order: scale, then rotation, then translation.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, TypeName)]
 #[serde(default)]
 pub struct Transform {
     /// Quaternion [w (scalar), x, y, z]
@@ -318,7 +318,8 @@ impl CgTransform<Point3<f32>> for Transform {
         Self {
             scale: self.scale.mul_element_wise(other.scale),
             rotation: self.rotation * other.rotation,
-            translation: self.rotation
+            translation: self
+                .rotation
                 .rotate_vector(other.translation.mul_element_wise(self.scale))
                 + self.translation,
         }
@@ -375,7 +376,8 @@ impl CgTransform<Point2<f32>> for Transform {
         Self {
             scale: self.scale.mul_element_wise(other.scale),
             rotation: self.rotation * other.rotation,
-            translation: self.rotation
+            translation: self
+                .rotation
                 .rotate_vector(other.translation.mul_element_wise(self.scale))
                 + self.translation,
         }

--- a/amethyst_core/src/transform/systems.rs
+++ b/amethyst_core/src/transform/systems.rs
@@ -9,6 +9,7 @@ use transform::{GlobalTransform, HierarchyEvent, Parent, ParentHierarchy, Transf
 
 /// Handles updating `GlobalTransform` components based on the `Transform`
 /// component and parents.
+#[derive(TypeName)]
 pub struct TransformSystem {
     local_modified: BitSet,
     global_modified: BitSet,


### PR DESCRIPTION
Seeing what using the `typename` crate to get programmatic system names does. I don't like how it means downstream crates need to depend on `typename` to get to use it (they need to import the trait), and animated types need to `#[derive(TypeName)]` as well.

Issue #824

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/827)
<!-- Reviewable:end -->
