### PR TITLE
Simplify event channel reader example

### DIFF
--- a/book/src/concepts/event-channel.md
+++ b/book/src/concepts/event-channel.md
@@ -87,7 +87,7 @@ struct ReceiverSystem {
 ```
 and you also need to get read access:
 ```rust,ignore
-    type SystemData = (Read<'a, EventChannel<MyEvent>>,);
+    type SystemData = Read<'a, EventChannel<MyEvent>>;
 ```
 
 Then, in the `System`'s setup method:


### PR DESCRIPTION
Just uses `Read` directly instead of in a tuple.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/834)
<!-- Reviewable:end -->
