### PR TITLE
Make CI cache builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,6 +42,7 @@ branches:
 # needed.
 cache:
   - .cargo
+  - target
 
 # Since this is not a .NET project, we can flip the build system off.
 build: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,10 @@ sudo: required
 
 # Force third-party crates to persist from previous builds and update only when
 # needed.
-cache: cargo
+cache: 
+  - cargo
+  - directories:
+      - target
 
 # Allow binaries installed from Cargo.
 before_script:


### PR DESCRIPTION
This PR enables Travis and AppVeyor to cache built dependencies so hopefully we can get acceptable CI times.

Apparently AppVeyor needs manual configuration to enable caching in PR, but I don't know if I can turn that on myself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/835)
<!-- Reviewable:end -->
