### PR TITLE
Increase Travis cache timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ sudo: required
 # Force third-party crates to persist from previous builds and update only when
 # needed.
 cache: 
+  - timeout: 1080
   - cargo
   - directories:
       - target

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ sudo: required
 # Force third-party crates to persist from previous builds and update only when
 # needed.
 cache: 
-  - timeout: 1080
+  - timeout: 2160
   - cargo
   - directories:
       - target


### PR DESCRIPTION
The output target directory for Amethyst is pretty heavy, and therefore caching it takes time. This creates issues with how Travis times out if the caching process takes too much time.

This PR increases the caching timeout to an hopefully high enough time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/838)
<!-- Reviewable:end -->
