### PR TITLE
Fix a derp in the new docs

### DIFF
--- a/book/src/concepts/state.md
+++ b/book/src/concepts/state.md
@@ -68,7 +68,7 @@ A `State` contains methods that reflect the most commons of those events:
 * update: This method is called as often as possible by the engine.
 
 
-**IMPORTANT: If you use the update method in your state, you need to manually call `world.dispatch()`. For more information, read the "More" section at the end of the world chapter [here](./world.md#more).**
+**IMPORTANT: In order to have the game working, you NEED to implement the `update` method and have it call `data.data.update(&mut data.world)`. This is an implementation detail and will no longer be necessary in future release 0.9 of Amethyst. For more information, read the "More" section at the end of the world chapter [here](./world.md#more).**
 
 ## Game Data
 

--- a/book/src/concepts/world.md
+++ b/book/src/concepts/world.md
@@ -141,13 +141,8 @@ We will talk about what `SystemData` is in the system chapter.
 
 ## More
 
-Normally, `World` is created and updated automatically by the `State`.
-If you need to manually create it, please refer to the methods in the [specs documentation](https://docs.rs/specs/latest/specs/world/struct.World.html).
-
-If you are implementing the `update` method in your `State`, **YOU NEED TO ADD THE FOLLOWING AT THE END OF THE METHOD**:
-
-```rust,ignore
-   world.maintain();
-```
+Because of an implementation detail, for the world to be updated you need to call `state_data.data.update(&state_data.world)` inside of the state update method.
 If you do not do this, the world will not update and the game will look like it froze.
 If you have a bug where nothing happens at all, this is the first thing you should check!
+
+*NOTE: This will no longer be necessary in future release 0.9 of Amethyst.*


### PR DESCRIPTION
This fixes a derp in the new book doc which is quite unfortunate, I would like to have this be merged as soon as possible as it doesn't to mention a necessary step we forgot.

@Xaeroxe could you please check the english here real quick? if only Joel and I review it, it will probably have some baguette lang into it lol

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/841)
<!-- Reviewable:end -->
