### PR TITLE
Small book formatting correction

### DIFF
--- a/book/src/concepts/component.md
+++ b/book/src/concepts/component.md
@@ -2,13 +2,13 @@
 
 ## What is a `Component`?
 
-A component is any struct that can be "attached" to an `Entity` (we will cover entity in the next chapter).
+A component is any struct that can be "attached" to an `Entity` (which we will cover in the next chapter).
 
 ## Usage
 
 The relationship between an entity and a component closely ressembles the relation between a real-life object and its properties.
 
-For example, a bottle of water has a shape, a volume, a color and is made of a material(usually plastic).
+For example, a bottle of water has a shape, a volume, a color and is made of a material (usually plastic).
 
 In this example, the bottle is the entity, and the properties are components.
 

--- a/book/src/concepts/component.md
+++ b/book/src/concepts/component.md
@@ -19,7 +19,7 @@ Creating a component is easy.
 You declare a struct:
 
 ```rust
-pub struct MyComponent{
+pub struct MyComponent {
     some_property: String,
 }
 ```

--- a/book/src/concepts/component.md
+++ b/book/src/concepts/component.md
@@ -18,7 +18,7 @@ Creating a component is easy.
 
 You declare a struct:
 
-```rust
+```rust,ignore
 pub struct MyComponent {
     some_property: String,
 }


### PR DESCRIPTION
Insanely minor.

I also tried to fix the issue where the first example has some extra spacing at the top, but I couldn't figure out why it does. Maybe it's a lack of `,ignore`?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/844)
<!-- Reviewable:end -->
