### PR TITLE
Fix compile errors in pong-tutorial-01 for amethyst 0.8.0

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-01.md
+++ b/book/src/pong-tutorial/pong-tutorial-01.md
@@ -17,11 +17,11 @@ In `src` there's a `main.rs` file. Delete everything, then add these imports:
 ```rust,ignore
 extern crate amethyst;
 
+use amethyst::input::{is_close_requested, is_key_down};
 use amethyst::prelude::*;
+use amethyst::renderer::{DisplayConfig, DrawFlat, Event, Pipeline,
+                         PosTex, RenderBundle, Stage, VirtualKeyCode};
 use amethyst::LoggerConfig;
-use amethyst::renderer::{DisplayConfig, DrawFlat, Event, KeyboardInput,
-                         Pipeline, PosTex, RenderBundle, Stage,
-                         VirtualKeyCode, WindowEvent};
 ```
 
 We'll be learning more about these as we go through this tutorial. The prelude
@@ -41,19 +41,10 @@ just implement two methods:
 ```rust,ignore
 impl<'a, 'b> State<GameData<'a, 'b>> for Pong {
     fn handle_event(&mut self, _: StateData<GameData>, event: Event) -> Trans<GameData<'a, 'b>> {
-      match event {
-          Event::WindowEvent { event, .. } => match event {
-              WindowEvent::KeyboardInput {
-                  input:
-                      KeyboardInput {
-                          virtual_keycode: Some(VirtualKeyCode::Escape),
-                          ..
-                      },
-                  ..
-              } => Trans::Quit,
-              _ => Trans::None,
-          },
-          _ => Trans::None,
+      if is_close_requested(&event) || is_key_down(&event, VirtualKeyCode::Escape) {
+          Trans::Quit
+      } else {
+          Trans::None
       }
     }
 

--- a/book/src/pong-tutorial/pong-tutorial-01.md
+++ b/book/src/pong-tutorial/pong-tutorial-01.md
@@ -18,7 +18,7 @@ In `src` there's a `main.rs` file. Delete everything, then add these imports:
 extern crate amethyst;
 
 use amethyst::prelude::*;
-use amethyst::input::{is_close_requested, is_key_down};
+use amethyst::LoggerConfig;
 use amethyst::renderer::{DisplayConfig, DrawFlat, Event, KeyboardInput,
                          Pipeline, PosTex, RenderBundle, Stage,
                          VirtualKeyCode, WindowEvent};
@@ -41,11 +41,20 @@ just implement two methods:
 ```rust,ignore
 impl<'a, 'b> State<GameData<'a, 'b>> for Pong {
     fn handle_event(&mut self, _: StateData<GameData>, event: Event) -> Trans<GameData<'a, 'b>> {
-        if is_close_requested(&event) || is_key_down(&event, VirtualKeyCode::Escape) {
-            Trans::Quit
-        } else {
-            Trans::None
-        }
+      match event {
+          Event::WindowEvent { event, .. } => match event {
+              WindowEvent::KeyboardInput {
+                  input:
+                      KeyboardInput {
+                          virtual_keycode: Some(VirtualKeyCode::Escape),
+                          ..
+                      },
+                  ..
+              } => Trans::Quit,
+              _ => Trans::None,
+          },
+          _ => Trans::None,
+      }
     }
 
     fn update(&mut self, data: StateData<GameData>) -> Trans<GameData<'a, 'b>> {
@@ -146,8 +155,8 @@ Ok(())
 We've discovered Amethyst's root object: [Application][ap]. It binds the OS
 event loop, state machines, timers and other core components in a central place.
 Here we're creating a new `RenderBundle`, adding the `Pipeline` we created,
-along with our config, and building. There is also a helper function 
-`with_basic_renderer` on `GameDataBuilder` that you can use to create your 
+along with our config, and building. There is also a helper function
+`with_basic_renderer` on `GameDataBuilder` that you can use to create your
 `Pipeline` and `RenderBundle`, that performs most of the actions above. In the
 full `pong` example in the `Amethyst` repository that function is used instead.
 

--- a/book/src/pong-tutorial/pong-tutorial-01.md
+++ b/book/src/pong-tutorial/pong-tutorial-01.md
@@ -21,7 +21,6 @@ use amethyst::input::{is_close_requested, is_key_down};
 use amethyst::prelude::*;
 use amethyst::renderer::{DisplayConfig, DrawFlat, Event, Pipeline,
                          PosTex, RenderBundle, Stage, VirtualKeyCode};
-use amethyst::LoggerConfig;
 ```
 
 We'll be learning more about these as we go through this tutorial. The prelude
@@ -79,8 +78,8 @@ fn main() -> amethyst::Result<()> {
 }
 ```
 
-Inside `main()` we first start the default amethyst logger so we can see
-errors, warnings and debug messages while the program is running.
+Inside `main()` we first start the amethyst logger with a default `LoggerConfig`
+so we can see errors, warnings and debug messages while the program is running.
 
 ```rust,ignore
 amethyst::start_logger(Default::default());

--- a/book/src/pong-tutorial/pong-tutorial-01.md
+++ b/book/src/pong-tutorial/pong-tutorial-01.md
@@ -41,11 +41,11 @@ just implement two methods:
 ```rust,ignore
 impl<'a, 'b> State<GameData<'a, 'b>> for Pong {
     fn handle_event(&mut self, _: StateData<GameData>, event: Event) -> Trans<GameData<'a, 'b>> {
-      if is_close_requested(&event) || is_key_down(&event, VirtualKeyCode::Escape) {
-          Trans::Quit
-      } else {
-          Trans::None
-      }
+        if is_close_requested(&event) || is_key_down(&event, VirtualKeyCode::Escape) {
+            Trans::Quit
+        } else {
+            Trans::None
+        }
     }
 
     fn update(&mut self, data: StateData<GameData>) -> Trans<GameData<'a, 'b>> {


### PR DESCRIPTION
I couldn't find `is_close_requested` or `is_key_down` in the docs anywhere, so I updated the input handling to use the example code in the docs (https://docs.rs/amethyst/0.8.0/amethyst) / `amethyst new` template.

Also I needed to import `LoggerConfig` for the main function.

Side note: The `amethyst new` command created a project with `amethyst 0.7.0` instead of `0.8.0`. Is this expected behavior?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/850)
<!-- Reviewable:end -->
