### PR TITLE
Fix grammar issue in the book: Its -> It’s

### DIFF
--- a/book/src/concepts/state.md
+++ b/book/src/concepts/state.md
@@ -85,7 +85,7 @@ When calling your `State`'s methods, the engine will pass a `StateData` struct w
 
 ## Code
 
-Yes! Its finally time to get some code in here!
+Yes! It's finally time to get some code in here!
 
 Here will just be a small code snippet that shows the basics of `State`'s usage.
 For more advanced examples, see the following pong tutorial.


### PR DESCRIPTION
I found a(nother) minor grammatical error. Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/853)
<!-- Reviewable:end -->
