### PR TITLE
Corrected the typo

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-01.md
+++ b/book/src/pong-tutorial/pong-tutorial-01.md
@@ -60,7 +60,7 @@ used to react to events. It returns a `Trans`, which is an enum of state machine
 transitions. In this case, we're watching for the Escape keycode, and the
 `CloseRequested` event from the Window. If we receive it, we'll return
 `Trans::Quit` which will be used to clean up the `State` and close the application.
-All other keyboard input is ignored or now.
+All other keyboard input is ignored for now.
 
 The `update` method is executed after events have happened.  In this instance
 we're just using it to execute our dispatcher.  More on that later.


### PR DESCRIPTION
In https://www.amethyst.rs/book/master/concepts/state.html#creating-a-state, I found a typo.
I think it should use `for` instead of `or`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/856)
<!-- Reviewable:end -->
