### PR TITLE
Added basic mouse button support

### DIFF
--- a/amethyst_input/src/lib.rs
+++ b/amethyst_input/src/lib.rs
@@ -22,7 +22,9 @@ pub use self::controller::{ControllerAxis, ControllerButton};
 pub use self::event::InputEvent;
 pub use self::input_handler::InputHandler;
 pub use self::system::InputSystem;
-pub use self::util::{get_key, is_close_requested, is_key_down};
+pub use self::util::{
+    get_key, is_close_requested, is_key_down, is_mouse_button_down, was_mouse_button_released,
+};
 
 #[cfg(feature = "sdl_controller")]
 pub use self::sdl_events_system::SdlEventsSystem;

--- a/amethyst_input/src/util.rs
+++ b/amethyst_input/src/util.rs
@@ -1,4 +1,4 @@
-use winit::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent};
+use winit::{ElementState, Event, KeyboardInput, MouseButton, VirtualKeyCode, WindowEvent};
 
 pub fn get_key(event: &Event) -> Option<(VirtualKeyCode, ElementState)> {
     match *event {
@@ -34,4 +34,40 @@ pub fn is_close_requested(event: &Event) -> bool {
         },
         _ => false,
     }
+}
+
+pub fn get_mouse_button(event: &Event) -> Option<(MouseButton, ElementState)> {
+    match *event {
+        Event::WindowEvent { ref event, .. } => match *event {
+            WindowEvent::MouseInput {
+                ref button, state, ..
+            } => Some((*button, state)),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Returns true if the specified mouse button is down this frame.
+/// Does not know about previous states.
+///
+/// Buttons: Left, Right, Middle, Other(u8)
+pub fn is_mouse_button_down(event: &Event, mouse_button: MouseButton) -> bool {
+    let op = get_mouse_button(event);
+    if let Some((key, state)) = op {
+        return key == mouse_button && state == ElementState::Pressed;
+    }
+    return false;
+}
+
+/// Returns true if the specified mouse button was released this frame.
+/// Does not know about previous states.
+///
+/// Buttons: Left, Right, Middle, Other(u8)
+pub fn was_mouse_button_released(event: &Event, mouse_button: MouseButton) -> bool {
+    let op = get_mouse_button(event);
+    if let Some((key, state)) = op {
+        return key == mouse_button && state == ElementState::Released;
+    }
+    return false;
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ## Unreleased
 ### Added
+* `amethyst::input::utils::{ is_mouse_button_down, was_mouse_button_released}` added for basic mouse support. ([#867])
 ### Changed
 ### Removed
 ### Fixed


### PR DESCRIPTION
A simple rewrite of the existing `is_key_down` and `get_key` to allow for detection of mouse button down and released.

Non-exclusive rights granted to the source code under both the MIT License and the Apache License 2.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/871)
<!-- Reviewable:end -->
