### PR TITLE
Use Cow<'static, str> in Named

### DIFF
--- a/amethyst_core/src/named.rs
+++ b/amethyst_core/src/named.rs
@@ -1,14 +1,114 @@
 use specs::world::LazyBuilder;
 use specs::{Component, DenseVecStorage, EntityBuilder, WriteStorage};
+use std::borrow::Cow;
 
-/// A component that gives a name to an `Entity`
+/// A component that gives a name to an [`Entity`].
+///
+/// There are two ways you can get a name for an entity:
+///
+/// * Hard-coding the entity name in code, in which case the name would be a [`&'static str`][str].
+/// * Dynamically generating the string or loading it from a data file, in which case the name
+///   would be a `String`.
+///
+/// To support both of these cases smoothly, `Named` stores the name as [`Cow<'static, str>`].
+/// You can pass either a [`&'static str`][str] or a [`String`] to [`Named::new`], and your code
+/// can generally treat the `name` field as a [`&str`][str] without needing to know whether the
+/// name is actually an owned or borrowed string.
+///
+/// [`Entity`]: https://docs.rs/specs/*/specs/struct.Entity.html
+/// [`Cow<'static, str>`]: https://doc.rust-lang.org/std/borrow/enum.Cow.html
+/// [`String`]: https://doc.rust-lang.org/std/string/struct.String.html
+/// [str]: https://doc.rust-lang.org/std/primitive.str.html
+/// [`Named::new`]: #method.new
+///
+/// # Examples
+///
+/// Creating a name from string constant:
+///
+/// ```
+/// # extern crate amethyst;
+/// use amethyst::core::{Named, WithNamed};
+/// use amethyst::ecs::prelude::*;
+///
+/// let mut world = World::new();
+/// world.register::<Named>();
+///
+/// world
+///     .create_entity()
+///     .named("Super Cool Entity")
+///     .build();
+/// ```
+///
+/// Creating a name from a dynamically generated string:
+///
+/// ```
+/// # extern crate amethyst;
+/// use amethyst::core::{Named, WithNamed};
+/// use amethyst::ecs::prelude::*;
+///
+/// let mut world = World::new();
+/// world.register::<Named>();
+///
+/// for entity_num in 0..10 {
+///     world
+///         .create_entity()
+///         .named(format!("Entity Number {}", entity_num))
+///         .build();
+/// }
+/// ```
+///
+/// Accessing a named entity in a system:
+///
+/// ```
+/// # extern crate amethyst;
+/// use amethyst::core::Named;
+/// use amethyst::ecs::prelude::*;
+///
+/// pub struct NameSystem;
+///
+/// impl<'s> System<'s> for NameSystem {
+///     type SystemData = (
+///         Entities<'s>,
+///         ReadStorage<'s, Named>,
+///     );
+///
+///     fn run(&mut self, (entities, names): Self::SystemData) {
+///         for (entity, name) in (&*entities, &names).join() {
+///             println!("Entity {:?} is named {}", entity, name.name);
+///         }
+///     }
+/// }
+/// ```
+#[derive(Debug, Clone)]
 pub struct Named {
-    pub name: &'static str,
+    pub name: Cow<'static, str>,
 }
 
 impl Named {
-    pub fn new(name: &'static str) -> Self {
-        Named { name }
+    /// Constructs a new `Named` from a string.
+    ///
+    /// # Examples
+    ///
+    /// From a string constant:
+    ///
+    /// ```
+    /// # extern crate amethyst;
+    /// use amethyst::core::Named;
+    ///
+    /// let name_component = Named::new("Super Cool Entity");
+    /// ```
+    ///
+    /// From a dynamic string:
+    ///
+    /// ```
+    /// # extern crate amethyst;
+    /// use amethyst::core::Named;
+    ///
+    /// let entity_num = 7;
+    /// let name_component = Named::new(format!("Entity Number {}", entity_num));
+    /// ```
+    pub fn new<S>(name: S) -> Self where S: Into<Cow<'static, str>> {
+        Named { name: name.into() }
     }
 }
 
@@ -22,11 +122,11 @@ where
     Self: Sized,
 {
     /// Adds a name to the entity being built.
-    fn named(self, name: &'static str) -> Self;
+    fn named<S>(self, name: S) -> Self where S: Into<Cow<'static, str>>;
 }
 
 impl<'a> WithNamed for EntityBuilder<'a> {
-    fn named(self, name: &'static str) -> Self {
+    fn named<S>(self, name: S) -> Self where S: Into<Cow<'static, str>> {
         // Unwrap: The only way this can fail is if the entity is invalid and this is used while creating the entity.
         self.world
             .system_data::<(WriteStorage<'a, Named>,)>()
@@ -38,7 +138,7 @@ impl<'a> WithNamed for EntityBuilder<'a> {
 }
 
 impl<'a> WithNamed for LazyBuilder<'a> {
-    fn named(self, name: &'static str) -> Self {
+    fn named<S>(self, name: S) -> Self where S: Into<Cow<'static, str>> {
         self.lazy.insert::<Named>(self.entity, Named::new(name));
         self
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 ### Added
 * `SpriteRender` pass to draw sprites without using `Material` and `Mesh`. ([#829], [#830])
 * Sprite animation uses the `SpriteRenderChannel`. ([#829], [#830])
-* Added Named Component. ([#879])
+* Added Named Component. ([#879])([#896])
 * Support for progressive jpeg loading. ([#877])
 
 ### Changed
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#878]: https://github.com/amethyst/amethyst/pull/878
 [#892]: https://github.com/amethyst/amethyst/pull/892
 [#877]: https://github.com/amethyst/amethyst/pull/877
+[#896]: https://github.com/amethyst/amethyst/pull/896
 
 ## [0.8.0] - 2018-08
 ### Added


### PR DESCRIPTION
Switch `Named` to represent the name using `Cow<'static, str>` instead of `&'static str` so that we can use `Named` for dynamically-generated names and names loaded from data files. The motivator here is that I would like to use `Named` for loading node names from glTF files, but it would have to support storing the names as `String`. Using `Cow<'static, str>` allows us to store `String` names without requiring an allocation if the users simply wants to use a string constant for the name.

I also added more documentation for `Named`, including a bunch of examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/896)
<!-- Reviewable:end -->
