### PR TITLE
Sprite batching

### DIFF
--- a/amethyst_renderer/src/pass/shaders/fragment/pbm.glsl
+++ b/amethyst_renderer/src/pass/shaders/fragment/pbm.glsl
@@ -173,6 +173,6 @@ void main() {
 
     vec3 ambient = ambient_color * albedo * ambient_occlusion;
     vec3 color = ambient + lighted + emission;
-   
+
     out_color = vec4(color, alpha);
 }

--- a/amethyst_renderer/src/pass/shaders/vertex/sprite.glsl
+++ b/amethyst_renderer/src/pass/shaders/vertex/sprite.glsl
@@ -5,15 +5,15 @@ layout (std140) uniform ViewArgs {
     mat4 view;
 };
 
-//
-in vec2 size;
-// Pixel offsets for the sprite. Used to shift the sprite left and down.
-in vec2 offsets;
+// Quad transform.
+in vec2 dir_x;
+in vec2 dir_y;
+in vec2 pos;
 
+// Texture quad.
 in vec2 u_offset;
 in vec2 v_offset;
 
-out vec2 uv;
 out vec2 tex_uv;
 
 const vec2 positions[6] = vec2[](
@@ -28,25 +28,18 @@ const vec2 positions[6] = vec2[](
     vec2(0.0, 0.0)  // Left bottom
 );
 
-// coord = 0.0 to 1.0 texture coordinate
-float texture_coord(float coord, vec2 offset) {
-    return offset.x + coord * (offset.y - offset.x);
-}
-
 // coords = 0.0 to 1.0 texture coordinates
 vec2 texture_coords(vec2 coords, vec2 u, vec2 v) {
-    return vec2(texture_coord(coords.x, u), texture_coord(coords.y, v));
+    return vec2(mix(u.x, u.y, coords.x), mix(v.x, v.y, coords.y));
 }
 
 void main() {
     float tex_u = positions[gl_VertexID][0];
     float tex_v = positions[gl_VertexID][1];
 
-    float u = (tex_u - 1.0f) * size[0] + offsets[0];
-    float v = (tex_v - 1.0f) * size[1] + offsets[1];
-
+    vec2 uv = pos + (tex_u - 1.0f) * dir_x + (tex_v - 1.0f) * dir_y;
     tex_uv = texture_coords(vec2(tex_u, tex_v), u_offset, v_offset);
 
-    vec4 vertex = vec4(u, v, 0.0, 1.0);
+    vec4 vertex = vec4(uv, 0.0, 1.0);
     gl_Position = proj * view * vertex;
 }

--- a/amethyst_renderer/src/pass/shaders/vertex/sprite.glsl
+++ b/amethyst_renderer/src/pass/shaders/vertex/sprite.glsl
@@ -1,31 +1,21 @@
 #version 150 core
 
-layout (std140) uniform VertexArgs {
-    uniform mat4 proj;
-    uniform mat4 view;
-    uniform mat4 model;
+layout (std140) uniform ViewArgs {
+    mat4 proj;
+    mat4 view;
 };
 
-layout (std140) uniform SpriteArgs {
-    // Sprite width and height.
-    uniform vec2 sprite_dimensions;
-    // Pixel offsets for the sprite. Used to shift the sprite left and down.
-    uniform vec2 offsets;
-    // Whether to flip the sprite horizontally
-    uniform bool flip_horizontal;
-    // Whether to flip the sprite vertically
-    uniform bool flip_vertical;
-};
+//
+in vec2 size;
+// Pixel offsets for the sprite. Used to shift the sprite left and down.
+in vec2 offsets;
 
-layout (std140) uniform AlbedoOffset {
-    vec2 u_offset;
-    vec2 v_offset;
-} albedo_offset;
+in vec2 u_offset;
+in vec2 v_offset;
 
 out vec2 uv;
 out vec2 tex_uv;
 
-// Position coordinates for two triangles that form a quad.
 const vec2 positions[6] = vec2[](
     // First triangle
     vec2(0.0, 0.0), // Left bottom
@@ -36,18 +26,6 @@ const vec2 positions[6] = vec2[](
     vec2(1.0, 1.0), // Right top
     vec2(0.0, 1.0), // Left top
     vec2(0.0, 0.0)  // Left bottom
-);
-
-const vec2 positions_flip[6] = vec2[](
-    // First triangle
-    vec2(1.0, 1.0), // Left bottom
-    vec2(0.0, 1.0), // Right bottom
-    vec2(0.0, 0.0), // Right top
-
-    // Second triangle
-    vec2(0.0, 0.0), // Right top
-    vec2(1.0, 0.0), // Left top
-    vec2(1.0, 1.0)  // Left bottom
 );
 
 // coord = 0.0 to 1.0 texture coordinate
@@ -61,64 +39,14 @@ vec2 texture_coords(vec2 coords, vec2 u, vec2 v) {
 }
 
 void main() {
-    // The vertex position needs to be adjusted by the offset.
-    //
-    // In the following diagram, the sprite (delimited by the `[]` brackets) has width=6 and
-    // offsets[0]: 2.
-    //
-    // ```
-    // P: the pixel where the sprite starts to be drawn (E - offsets[0]).
-    // Q: the first pixel where the sprite is out of bounds (E - offsets[0] + sprite_w + 1).
-    // E: the position of the entity, which is the center line where the sprite should be flipped.
-    //
-    // |------------|
-    // |   [ E >]   |    P = E - offsets[0]
-    // |------------|      = 5 - 2
-    //     P ^   Q         = 3
-    //  0123456789AB
-    //                   Q = E - offsets[0] + sprite_w + 1
-    //                     = 5 - 2 + 6 + 1
-    //                     = 9
-    // ```
-    //
-    // When flipped horizontally, the entity's center should remain on E, and the vertices mirrored
-    // around it.
-    //
-    // ```
-    // |------------|
-    // |  [< E ]    |    P = E + offsets[0]
-    // |------------|      = 5 + 2
-    //   Q   ^ P           = 7
-    //  0123456789AB
-    //                   Q = E + offsets[0] - sprite_w
-    //                     = 5 + 2 - 6
-    //                     = 1
-    // ```
+    float tex_u = positions[gl_VertexID][0];
+    float tex_v = positions[gl_VertexID][1];
 
-    float u;
-    float v;
-    float tex_u;
-    float tex_v;
+    float u = (tex_u - 1.0f) * size[0] + offsets[0];
+    float v = (tex_v - 1.0f) * size[1] + offsets[1];
 
-    if (flip_horizontal) {
-        tex_u = positions_flip[gl_VertexID][0];
-        u = positions[gl_VertexID][0] * sprite_dimensions[0] + offsets[0] - sprite_dimensions[0];
-    } else {
-        tex_u = positions[gl_VertexID][0];
-        u = tex_u * sprite_dimensions[0] - offsets[0];
-    }
+    tex_uv = texture_coords(vec2(tex_u, tex_v), u_offset, v_offset);
 
-    if (flip_vertical) {
-        tex_v = positions_flip[gl_VertexID][1];
-        v = positions[gl_VertexID][1] * sprite_dimensions[1] + offsets[1] - sprite_dimensions[1];
-    } else {
-        tex_v = positions[gl_VertexID][1];
-        v = tex_v * sprite_dimensions[1] - offsets[1];
-    }
-
-    uv = vec2(u, v);
-    tex_uv = texture_coords(vec2(tex_u, tex_v), albedo_offset.u_offset, albedo_offset.v_offset);
-
-    vec4 vertex = vec4(uv, 0.0, 1.0);
-    gl_Position = proj * view * model * vertex;
+    vec4 vertex = vec4(u, v, 0.0, 1.0);
+    gl_Position = proj * view * vertex;
 }

--- a/amethyst_renderer/src/pass/sprite/interleaved.rs
+++ b/amethyst_renderer/src/pass/sprite/interleaved.rs
@@ -4,29 +4,30 @@ use amethyst_assets::{AssetStorage, Handle};
 use amethyst_core::cgmath::Vector4;
 use amethyst_core::specs::prelude::{Join, Read, ReadStorage};
 use amethyst_core::transform::GlobalTransform;
+
 use gfx_core::state::{Blend, ColorMask};
 use glsl_layout::Uniform;
 
 use super::*;
 use cam::{ActiveCamera, Camera};
 use error::Result;
+use gfx::pso::buffer::ElemStride;
 use mtl::MaterialTextureSet;
-use pass::util::{
-    add_texture, get_camera, set_sprite_args, set_view_args, setup_textures, SpriteArgs,
-    TextureOffsetPod, ViewArgs,
-};
+use pass::util::{add_texture, get_camera, set_view_args, setup_textures, ViewArgs};
 use pipe::pass::{Pass, PassData};
 use pipe::{DepthMode, Effect, NewEffect};
 use sprite::{SpriteRender, SpriteSheet};
 use sprite_visibility::SpriteVisibility;
 use tex::Texture;
 use types::{Encoder, Factory, Slice};
+use vertex::{Attributes, Query, VertexFormat};
 
 /// Draws sprites on a 2D quad.
-#[derive(Derivative, Clone, Debug, PartialEq)]
+#[derive(Derivative, Clone, Debug)]
 #[derivative(Default(bound = "Self: Pass"))]
 pub struct DrawSprite {
     transparency: Option<(ColorMask, Blend, Option<DepthMode>)>,
+    batch: SpriteBatch,
 }
 
 impl DrawSprite
@@ -48,6 +49,10 @@ where
         self.transparency = Some((mask, blend, depth));
         self
     }
+
+    fn attributes() -> Attributes<'static> {
+        <SpriteInstance as Query<(DirX, DirY, Pos, OffsetU, OffsetV)>>::QUERIED_ATTRIBUTES
+    }
 }
 
 impl<'a> PassData<'a> for DrawSprite {
@@ -65,8 +70,6 @@ impl<'a> PassData<'a> for DrawSprite {
 
 impl Pass for DrawSprite {
     fn compile(&mut self, effect: NewEffect) -> Result<Effect> {
-        use gfx::format::{ChannelType, Format, SurfaceType};
-        use gfx::pso::buffer::Element;
         use std::mem;
 
         let mut builder = effect.simple(VERT_SRC, FRAG_SRC);
@@ -76,40 +79,7 @@ impl Pass for DrawSprite {
                 mem::size_of::<<ViewArgs as Uniform>::Std140>(),
                 1,
             )
-            .with_raw_vertex_buffer(
-                &[
-                    (
-                        "size",
-                        Element {
-                            offset: 0,
-                            format: Format(SurfaceType::R32_G32, ChannelType::Float),
-                        },
-                    ),
-                    (
-                        "offsets",
-                        Element {
-                            offset: 8,
-                            format: Format(SurfaceType::R32_G32, ChannelType::Float),
-                        },
-                    ),
-                    (
-                        "u_offset",
-                        Element {
-                            offset: 16,
-                            format: Format(SurfaceType::R32_G32, ChannelType::Float),
-                        },
-                    ),
-                    (
-                        "v_offset",
-                        Element {
-                            offset: 24,
-                            format: Format(SurfaceType::R32_G32, ChannelType::Float),
-                        },
-                    ),
-                ],
-                32,
-                1,
-            );
+            .with_raw_vertex_buffer(Self::attributes(), SpriteInstance::size() as ElemStride, 1);
         setup_textures(&mut builder, &TEXTURES);
         match self.transparency {
             Some((mask, blend, depth)) => builder.with_blended_output("color", mask, blend, depth),
@@ -136,47 +106,49 @@ impl Pass for DrawSprite {
     ) {
         let camera = get_camera(active, &camera, &global);
 
-        let mut batch = SpriteBatch::new();
         match visibility {
             None => {
                 for (sprite_render, global) in (&sprite_render, &global).join() {
-                    batch.add_sprite(
+                    self.batch.add_sprite(
                         sprite_render,
                         Some(global),
                         &sprite_sheet_storage,
                         &material_texture_set,
+                        &tex_storage,
                     );
                 }
-                batch.sort();
+                self.batch.sort();
             }
             Some(ref visibility) => {
                 for (sprite_render, global, _) in
                     (&sprite_render, &global, &visibility.visible_unordered).join()
                 {
-                    batch.add_sprite(
+                    self.batch.add_sprite(
                         sprite_render,
                         Some(global),
                         &sprite_sheet_storage,
                         &material_texture_set,
+                        &tex_storage,
                     );
                 }
 
                 // We are free to optimize the order of the opaque sprites.
-                batch.sort();
+                self.batch.sort();
 
                 for entity in &visibility.visible_ordered {
                     if let Some(sprite_render) = sprite_render.get(*entity) {
-                        batch.add_sprite(
+                        self.batch.add_sprite(
                             sprite_render,
                             global.get(*entity),
                             &sprite_sheet_storage,
                             &material_texture_set,
+                            &tex_storage,
                         );
                     }
                 }
             }
         }
-        batch.encode(
+        self.batch.encode(
             encoder,
             &mut factory,
             effect,
@@ -184,58 +156,67 @@ impl Pass for DrawSprite {
             &sprite_sheet_storage,
             &tex_storage,
         );
+        self.batch.reset();
     }
 }
 
+#[derive(Clone, Debug)]
 struct SpriteDrawData {
     texture: Handle<Texture>,
     render: SpriteRender,
     transform: GlobalTransform,
 }
 
+#[derive(Clone, Default, Debug)]
 struct SpriteBatch {
     sprites: Vec<SpriteDrawData>,
 }
 
 impl SpriteBatch {
-    pub fn new() -> Self {
-        SpriteBatch {
-            sprites: Vec::new(),
-        }
-    }
-
     pub fn add_sprite(
         &mut self,
         sprite_render: &SpriteRender,
         global: Option<&GlobalTransform>,
         sprite_sheet_storage: &AssetStorage<SpriteSheet>,
         material_texture_set: &MaterialTextureSet,
+        tex_storage: &AssetStorage<Texture>,
     ) {
         if global.is_none() {
             return;
         }
 
-        let sprite_sheet = sprite_sheet_storage.get(&sprite_render.sprite_sheet);
-        if sprite_sheet.is_none() {
-            warn!(
-                "Sprite sheet not loaded for sprite_render: `{:?}`.",
-                sprite_render
-            );
-            return;
-        }
-        let sprite_sheet = sprite_sheet.unwrap();
+        let texture_handle = match sprite_sheet_storage.get(&sprite_render.sprite_sheet) {
+            Some(sprite_sheet) => match material_texture_set.handle(sprite_sheet.texture_id) {
+                Some(texture_handle) => {
+                    if tex_storage.get(&texture_handle).is_none() {
+                        warn!(
+                            "Texture not loaded for texture id: `{}`.",
+                            sprite_sheet.texture_id
+                        );
+                        return;
+                    }
 
-        let texture_handle = material_texture_set.handle(sprite_sheet.texture_id);
-        if texture_handle.is_none() {
-            warn!(
-                "Texture handle not found for texture id: `{}`.",
-                sprite_sheet.texture_id
-            );
-            return;
-        }
+                    texture_handle
+                }
+                None => {
+                    warn!(
+                        "Texture handle not found for texture id: `{}`.",
+                        sprite_sheet.texture_id
+                    );
+                    return;
+                }
+            },
+            None => {
+                warn!(
+                    "Sprite sheet not loaded for sprite_render: `{:?}`.",
+                    sprite_render
+                );
+                return;
+            }
+        };
 
         self.sprites.push(SpriteDrawData {
-            texture: texture_handle.unwrap(),
+            texture: texture_handle,
             render: sprite_render.clone(),
             transform: global.unwrap().clone(),
         });
@@ -268,27 +249,19 @@ impl SpriteBatch {
         // Sprite vertex shader
         set_view_args(effect, encoder, camera);
 
-        for sprite in &self.sprites {
-            let sprite_sheet = sprite_sheet_storage.get(&sprite.render.sprite_sheet);
-            if sprite_sheet.is_none() {
-                warn!(
-                    "Sprite sheet not loaded for sprite_render: `{:?}`.",
-                    sprite.render
-                );
-                return;
-            }
-            let sprite_sheet = sprite_sheet.unwrap();
+        let mut instance_data = Vec::<f32>::new();
+        let mut num_instances = 0;
+        let num_sprites = self.sprites.len();
 
-            let texture = tex_storage.get(&sprite.texture);
-            if texture.is_none() {
-                warn!(
-                    "Texture not loaded for texture id: `{}`.",
-                    sprite_sheet.texture_id
-                );
-                return;
-            }
-            add_texture(effect, texture.unwrap());
+        for (i, sprite) in self.sprites.iter().enumerate() {
+            // `unwrap` checked when collecting the sprites.
+            let sprite_sheet = sprite_sheet_storage
+                .get(&sprite.render.sprite_sheet)
+                .unwrap();
 
+            let texture = tex_storage.get(&sprite.texture).unwrap();
+
+            // Append sprite to instance data.
             let sprite_data = &sprite_sheet.sprites[sprite.render.sprite_number];
 
             let tex_coords = &sprite_data.tex_coords;
@@ -305,36 +278,55 @@ impl SpriteBatch {
 
             let transform = &sprite.transform.0;
 
-            let size = transform * Vector4::new(sprite_data.width, sprite_data.height, 0.0, 0.0);
-            let offset =
+            let dir_x = transform.x * sprite_data.width;
+            let dir_y = transform.y * sprite_data.height;
+            let pos =
                 transform * Vector4::new(sprite_data.offsets[0], sprite_data.offsets[1], 0.0, 1.0);
 
-            let vbuf = factory
-                .create_buffer_immutable(
-                    &[
-                        size.x, size.y, offset.x, offset.y, uv_left, uv_right, uv_bottom, uv_top,
-                    ],
-                    buffer::Role::Vertex,
-                    Bind::empty(),
-                )
-                .unwrap();
+            instance_data.extend(&[
+                dir_x.x, dir_x.y, dir_y.x, dir_y.y, pos.x, pos.y, uv_left, uv_right, uv_bottom,
+                uv_top,
+            ]);
+            num_instances += 1;
 
-            effect.data.vertex_bufs.push(vbuf.raw().clone());
-            effect.data.vertex_bufs.push(vbuf.raw().clone());
-            effect.data.vertex_bufs.push(vbuf.raw().clone());
-            effect.data.vertex_bufs.push(vbuf.raw().clone());
+            // Need to flush outstanding draw calls due to state switch (texture).
+            //
+            // 1. We are at the last sprite and want to submit all pending work.
+            // 2. The next sprite will use a different texture triggering a flush.
+            let need_flush =
+                i >= num_sprites - 1 || self.sprites[i + 1].texture.id() != sprite.texture.id();
 
-            effect.draw(
-                &Slice {
-                    start: 0,
-                    end: 6,
-                    base_vertex: 0,
-                    instances: None,
-                    buffer: Default::default(),
-                },
-                encoder,
-            );
-            effect.clear();
+            if need_flush {
+                add_texture(effect, texture);
+
+                let vbuf = factory
+                    .create_buffer_immutable(&instance_data, buffer::Role::Vertex, Bind::empty())
+                    .unwrap();
+
+                for _ in DrawSprite::attributes() {
+                    effect.data.vertex_bufs.push(vbuf.raw().clone());
+                }
+
+                effect.draw(
+                    &Slice {
+                        start: 0,
+                        end: 6,
+                        base_vertex: 0,
+                        instances: Some((num_instances, 0)),
+                        buffer: Default::default(),
+                    },
+                    encoder,
+                );
+
+                effect.clear();
+
+                num_instances = 0;
+                instance_data.clear();
+            }
         }
+    }
+
+    pub fn reset(&mut self) {
+        self.sprites.clear();
     }
 }

--- a/amethyst_renderer/src/pass/sprite/interleaved.rs
+++ b/amethyst_renderer/src/pass/sprite/interleaved.rs
@@ -1,6 +1,7 @@
 //! Flat forward drawing pass that mimics a blit.
 
-use amethyst_assets::AssetStorage;
+use amethyst_assets::{AssetStorage, Handle};
+use amethyst_core::cgmath::Vector4;
 use amethyst_core::specs::prelude::{Join, Read, ReadStorage};
 use amethyst_core::transform::GlobalTransform;
 use gfx_core::state::{Blend, ColorMask};
@@ -10,13 +11,16 @@ use super::*;
 use cam::{ActiveCamera, Camera};
 use error::Result;
 use mtl::MaterialTextureSet;
-use pass::util::{draw_sprite, get_camera, setup_textures, SpriteArgs, VertexArgs};
+use pass::util::{
+    add_texture, get_camera, set_sprite_args, set_view_args, setup_textures, SpriteArgs,
+    TextureOffsetPod, ViewArgs,
+};
 use pipe::pass::{Pass, PassData};
 use pipe::{DepthMode, Effect, NewEffect};
 use sprite::{SpriteRender, SpriteSheet};
 use sprite_visibility::SpriteVisibility;
 use tex::Texture;
-use types::{Encoder, Factory};
+use types::{Encoder, Factory, Slice};
 
 /// Draws sprites on a 2D quad.
 #[derive(Derivative, Clone, Debug, PartialEq)]
@@ -61,17 +65,49 @@ impl<'a> PassData<'a> for DrawSprite {
 
 impl Pass for DrawSprite {
     fn compile(&mut self, effect: NewEffect) -> Result<Effect> {
+        use gfx::format::{ChannelType, Format, SurfaceType};
+        use gfx::pso::buffer::Element;
         use std::mem;
+
         let mut builder = effect.simple(VERT_SRC, FRAG_SRC);
         builder
             .with_raw_constant_buffer(
-                "VertexArgs",
-                mem::size_of::<<VertexArgs as Uniform>::Std140>(),
+                "ViewArgs",
+                mem::size_of::<<ViewArgs as Uniform>::Std140>(),
                 1,
             )
-            .with_raw_constant_buffer(
-                "SpriteArgs",
-                mem::size_of::<<SpriteArgs as Uniform>::Std140>(),
+            .with_raw_vertex_buffer(
+                &[
+                    (
+                        "size",
+                        Element {
+                            offset: 0,
+                            format: Format(SurfaceType::R32_G32, ChannelType::Float),
+                        },
+                    ),
+                    (
+                        "offsets",
+                        Element {
+                            offset: 8,
+                            format: Format(SurfaceType::R32_G32, ChannelType::Float),
+                        },
+                    ),
+                    (
+                        "u_offset",
+                        Element {
+                            offset: 16,
+                            format: Format(SurfaceType::R32_G32, ChannelType::Float),
+                        },
+                    ),
+                    (
+                        "v_offset",
+                        Element {
+                            offset: 24,
+                            format: Format(SurfaceType::R32_G32, ChannelType::Float),
+                        },
+                    ),
+                ],
+                32,
                 1,
             );
         setup_textures(&mut builder, &TEXTURES);
@@ -86,7 +122,7 @@ impl Pass for DrawSprite {
         &'a mut self,
         encoder: &mut Encoder,
         effect: &mut Effect,
-        _factory: Factory,
+        mut factory: Factory,
         (
             active,
             camera,
@@ -100,50 +136,205 @@ impl Pass for DrawSprite {
     ) {
         let camera = get_camera(active, &camera, &global);
 
+        let mut batch = SpriteBatch::new();
         match visibility {
-            None => for (sprite_render, global) in (&sprite_render, &global).join() {
-                draw_sprite(
-                    encoder,
-                    effect,
-                    sprite_render,
-                    &sprite_sheet_storage,
-                    &tex_storage,
-                    &material_texture_set,
-                    camera,
-                    Some(global),
-                );
-            },
+            None => {
+                for (sprite_render, global) in (&sprite_render, &global).join() {
+                    batch.add_sprite(
+                        sprite_render,
+                        Some(global),
+                        &sprite_sheet_storage,
+                        &material_texture_set,
+                    );
+                }
+                batch.sort();
+            }
             Some(ref visibility) => {
                 for (sprite_render, global, _) in
                     (&sprite_render, &global, &visibility.visible_unordered).join()
                 {
-                    draw_sprite(
-                        encoder,
-                        effect,
+                    batch.add_sprite(
                         sprite_render,
-                        &sprite_sheet_storage,
-                        &tex_storage,
-                        &material_texture_set,
-                        camera,
                         Some(global),
+                        &sprite_sheet_storage,
+                        &material_texture_set,
                     );
                 }
 
+                // We are free to optimize the order of the opaque sprites.
+                batch.sort();
+
                 for entity in &visibility.visible_ordered {
                     if let Some(sprite_render) = sprite_render.get(*entity) {
-                        draw_sprite(
-                            encoder,
-                            effect,
+                        batch.add_sprite(
                             sprite_render,
-                            &sprite_sheet_storage,
-                            &tex_storage,
-                            &material_texture_set,
-                            camera,
                             global.get(*entity),
+                            &sprite_sheet_storage,
+                            &material_texture_set,
                         );
                     }
                 }
             }
+        }
+        batch.encode(
+            encoder,
+            &mut factory,
+            effect,
+            camera,
+            &sprite_sheet_storage,
+            &tex_storage,
+        );
+    }
+}
+
+struct SpriteDrawData {
+    texture: Handle<Texture>,
+    render: SpriteRender,
+    transform: GlobalTransform,
+}
+
+struct SpriteBatch {
+    sprites: Vec<SpriteDrawData>,
+}
+
+impl SpriteBatch {
+    pub fn new() -> Self {
+        SpriteBatch {
+            sprites: Vec::new(),
+        }
+    }
+
+    pub fn add_sprite(
+        &mut self,
+        sprite_render: &SpriteRender,
+        global: Option<&GlobalTransform>,
+        sprite_sheet_storage: &AssetStorage<SpriteSheet>,
+        material_texture_set: &MaterialTextureSet,
+    ) {
+        if global.is_none() {
+            return;
+        }
+
+        let sprite_sheet = sprite_sheet_storage.get(&sprite_render.sprite_sheet);
+        if sprite_sheet.is_none() {
+            warn!(
+                "Sprite sheet not loaded for sprite_render: `{:?}`.",
+                sprite_render
+            );
+            return;
+        }
+        let sprite_sheet = sprite_sheet.unwrap();
+
+        let texture_handle = material_texture_set.handle(sprite_sheet.texture_id);
+        if texture_handle.is_none() {
+            warn!(
+                "Texture handle not found for texture id: `{}`.",
+                sprite_sheet.texture_id
+            );
+            return;
+        }
+
+        self.sprites.push(SpriteDrawData {
+            texture: texture_handle.unwrap(),
+            render: sprite_render.clone(),
+            transform: global.unwrap().clone(),
+        });
+    }
+
+    /// Optimize the sprite order to generating more coherent batches.
+    pub fn sort(&mut self) {
+        // Only takes the texture into account for now.
+        self.sprites
+            .sort_by(|a, b| a.texture.id().cmp(&b.texture.id()));
+    }
+
+    pub fn encode(
+        &self,
+        encoder: &mut Encoder,
+        factory: &mut Factory,
+        effect: &mut Effect,
+        camera: Option<(&Camera, &GlobalTransform)>,
+        sprite_sheet_storage: &AssetStorage<SpriteSheet>,
+        tex_storage: &AssetStorage<Texture>,
+    ) {
+        use gfx::buffer;
+        use gfx::memory::{Bind, Typed};
+        use gfx::Factory;
+
+        if self.sprites.is_empty() {
+            return;
+        }
+
+        // Sprite vertex shader
+        set_view_args(effect, encoder, camera);
+
+        for sprite in &self.sprites {
+            let sprite_sheet = sprite_sheet_storage.get(&sprite.render.sprite_sheet);
+            if sprite_sheet.is_none() {
+                warn!(
+                    "Sprite sheet not loaded for sprite_render: `{:?}`.",
+                    sprite.render
+                );
+                return;
+            }
+            let sprite_sheet = sprite_sheet.unwrap();
+
+            let texture = tex_storage.get(&sprite.texture);
+            if texture.is_none() {
+                warn!(
+                    "Texture not loaded for texture id: `{}`.",
+                    sprite_sheet.texture_id
+                );
+                return;
+            }
+            add_texture(effect, texture.unwrap());
+
+            let sprite_data = &sprite_sheet.sprites[sprite.render.sprite_number];
+
+            let tex_coords = &sprite_data.tex_coords;
+            let (uv_left, uv_right) = if sprite.render.flip_horizontal {
+                (tex_coords.right, tex_coords.left)
+            } else {
+                (tex_coords.left, tex_coords.right)
+            };
+            let (uv_bottom, uv_top) = if sprite.render.flip_vertical {
+                (tex_coords.top, tex_coords.bottom)
+            } else {
+                (tex_coords.bottom, tex_coords.top)
+            };
+
+            let transform = &sprite.transform.0;
+
+            let size = transform * Vector4::new(sprite_data.width, sprite_data.height, 0.0, 0.0);
+            let offset =
+                transform * Vector4::new(sprite_data.offsets[0], sprite_data.offsets[1], 0.0, 1.0);
+
+            let vbuf = factory
+                .create_buffer_immutable(
+                    &[
+                        size.x, size.y, offset.x, offset.y, uv_left, uv_right, uv_bottom, uv_top,
+                    ],
+                    buffer::Role::Vertex,
+                    Bind::empty(),
+                )
+                .unwrap();
+
+            effect.data.vertex_bufs.push(vbuf.raw().clone());
+            effect.data.vertex_bufs.push(vbuf.raw().clone());
+            effect.data.vertex_bufs.push(vbuf.raw().clone());
+            effect.data.vertex_bufs.push(vbuf.raw().clone());
+
+            effect.draw(
+                &Slice {
+                    start: 0,
+                    end: 6,
+                    base_vertex: 0,
+                    instances: None,
+                    buffer: Default::default(),
+                },
+                encoder,
+            );
+            effect.clear();
         }
     }
 }

--- a/amethyst_renderer/src/pass/sprite/mod.rs
+++ b/amethyst_renderer/src/pass/sprite/mod.rs
@@ -4,7 +4,114 @@ mod interleaved;
 
 use pass::util::TextureType;
 
+use gfx::format::{ChannelType, Format, SurfaceType};
+use gfx::pso::buffer::Element;
+use gfx::traits::Pod;
+use vertex::{Attribute, AttributeFormat, Attributes, VertexFormat, With};
+
 static VERT_SRC: &[u8] = include_bytes!("../shaders/vertex/sprite.glsl");
 static FRAG_SRC: &[u8] = include_bytes!("../shaders/fragment/sprite.glsl");
 
 static TEXTURES: [TextureType; 1] = [TextureType::Albedo];
+
+#[derive(Clone, Debug)]
+enum DirX {}
+impl Attribute for DirX {
+    const NAME: &'static str = "dir_x";
+    const FORMAT: Format = Format(SurfaceType::R32_G32, ChannelType::Float);
+    const SIZE: u32 = 8;
+    type Repr = [f32; 2];
+}
+
+#[derive(Clone, Debug)]
+enum DirY {}
+impl Attribute for DirY {
+    const NAME: &'static str = "dir_y";
+    const FORMAT: Format = Format(SurfaceType::R32_G32, ChannelType::Float);
+    const SIZE: u32 = 8;
+    type Repr = [f32; 2];
+}
+
+#[derive(Clone, Debug)]
+enum Pos {}
+impl Attribute for Pos {
+    const NAME: &'static str = "pos";
+    const FORMAT: Format = Format(SurfaceType::R32_G32, ChannelType::Float);
+    const SIZE: u32 = 8;
+    type Repr = [f32; 2];
+}
+
+#[derive(Clone, Debug)]
+enum OffsetU {}
+impl Attribute for OffsetU {
+    const NAME: &'static str = "u_offset";
+    const FORMAT: Format = Format(SurfaceType::R32_G32, ChannelType::Float);
+    const SIZE: u32 = 8;
+    type Repr = [f32; 2];
+}
+
+#[derive(Clone, Debug)]
+enum OffsetV {}
+impl Attribute for OffsetV {
+    const NAME: &'static str = "v_offset";
+    const FORMAT: Format = Format(SurfaceType::R32_G32, ChannelType::Float);
+    const SIZE: u32 = 8;
+    type Repr = [f32; 2];
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+struct SpriteInstance {
+    pub dir_x: [f32; 2],
+    pub dir_y: [f32; 2],
+    pub pos: [f32; 2],
+    pub u_offset: [f32; 2],
+    pub v_offset: [f32; 2],
+}
+
+unsafe impl Pod for SpriteInstance {}
+
+impl VertexFormat for SpriteInstance {
+    const ATTRIBUTES: Attributes<'static> = &[
+        (DirX::NAME, <Self as With<DirX>>::FORMAT),
+        (DirY::NAME, <Self as With<DirY>>::FORMAT),
+        (Pos::NAME, <Self as With<Pos>>::FORMAT),
+        (OffsetU::NAME, <Self as With<OffsetU>>::FORMAT),
+        (OffsetV::NAME, <Self as With<OffsetV>>::FORMAT),
+    ];
+}
+
+impl With<DirX> for SpriteInstance {
+    const FORMAT: AttributeFormat = Element {
+        offset: 0,
+        format: DirX::FORMAT,
+    };
+}
+
+impl With<DirY> for SpriteInstance {
+    const FORMAT: AttributeFormat = Element {
+        offset: DirX::SIZE,
+        format: DirY::FORMAT,
+    };
+}
+
+impl With<Pos> for SpriteInstance {
+    const FORMAT: AttributeFormat = Element {
+        offset: DirX::SIZE + DirY::SIZE,
+        format: Pos::FORMAT,
+    };
+}
+
+impl With<OffsetU> for SpriteInstance {
+    const FORMAT: AttributeFormat = Element {
+        offset: DirX::SIZE + DirY::SIZE + Pos::SIZE,
+        format: OffsetU::FORMAT,
+    };
+}
+
+impl With<OffsetV> for SpriteInstance {
+    const FORMAT: AttributeFormat = Element {
+        offset: DirX::SIZE + DirY::SIZE + Pos::SIZE + OffsetU::SIZE,
+        format: OffsetV::FORMAT,
+    };
+}

--- a/amethyst_renderer/src/pass/util.rs
+++ b/amethyst_renderer/src/pass/util.rs
@@ -1,19 +1,18 @@
 use std::mem;
 
 use amethyst_assets::AssetStorage;
-use amethyst_core::cgmath::{Matrix4, One, SquareMatrix, Vector4};
+use amethyst_core::cgmath::{Matrix4, One, SquareMatrix};
 use amethyst_core::specs::prelude::{Join, Read, ReadStorage};
 use amethyst_core::GlobalTransform;
 use cam::{ActiveCamera, Camera};
 use glsl_layout::*;
 use mesh::Mesh;
-use mtl::{Material, MaterialDefaults, MaterialTextureSet, TextureOffset};
+use mtl::{Material, MaterialDefaults, TextureOffset};
 use pass::set_skinning_buffers;
 use pipe::{Effect, EffectBuilder};
 use skinning::JointTransforms;
-use sprite::{Sprite, SpriteRender, SpriteSheet};
 use tex::Texture;
-use types::{Encoder, Slice};
+use types::Encoder;
 use vertex::Attributes;
 
 pub(crate) enum TextureType {
@@ -39,15 +38,6 @@ pub(crate) struct VertexArgs {
     proj: mat4,
     view: mat4,
     model: mat4,
-}
-
-#[repr(C, align(16))]
-#[derive(Clone, Copy, Debug, Uniform)]
-pub(crate) struct SpriteArgs {
-    pub half_diag: vec2,
-    pub offsets: vec2,
-    pub flip_horizontal: boolean,
-    pub flip_vertical: boolean,
 }
 
 #[repr(C, align(16))]
@@ -284,26 +274,6 @@ pub fn set_view_args(
     effect.update_constant_buffer("ViewArgs", &view_args.std140(), encoder);
 }
 
-pub(crate) fn set_sprite_args(
-    effect: &mut Effect,
-    encoder: &mut Encoder,
-    transform: &GlobalTransform,
-    sprite: &Sprite,
-    sprite_render: &SpriteRender,
-) {
-    use amethyst_core::cgmath::Matrix;
-
-    let half_dir = transform.0 * Vector4::new(sprite.width, sprite.height, 0.0, 0.0);
-    let offset = transform.0 * Vector4::new(sprite.offsets[0], sprite.offsets[1], 0.0, 1.0);
-    let geometry_args = SpriteArgs {
-        half_diag: [half_dir.x, half_dir.y].into(),
-        offsets: [offset.x, offset.y].into(),
-        flip_horizontal: sprite_render.flip_horizontal.into(),
-        flip_vertical: sprite_render.flip_vertical.into(),
-    };
-    effect.update_constant_buffer("SpriteArgs", &geometry_args.std140(), encoder);
-}
-
 pub(crate) fn draw_mesh(
     encoder: &mut Encoder,
     effect: &mut Effect,
@@ -351,80 +321,6 @@ pub(crate) fn draw_mesh(
     );
 
     effect.draw(mesh.slice(), encoder);
-    effect.clear();
-}
-
-pub(crate) fn draw_sprite(
-    encoder: &mut Encoder,
-    effect: &mut Effect,
-    sprite_render: &SpriteRender,
-    sprite_sheet_storage: &AssetStorage<SpriteSheet>,
-    tex_storage: &AssetStorage<Texture>,
-    material_texture_set: &MaterialTextureSet,
-    camera: Option<(&Camera, &GlobalTransform)>,
-    global: Option<&GlobalTransform>,
-) {
-    if global.is_none() {
-        return;
-    }
-
-    let sprite_sheet = sprite_sheet_storage.get(&sprite_render.sprite_sheet);
-    if sprite_sheet.is_none() {
-        warn!(
-            "Sprite sheet not loaded for sprite_render: `{:?}`.",
-            sprite_render
-        );
-        return;
-    }
-    let sprite_sheet = sprite_sheet.unwrap();
-
-    let texture_handle = material_texture_set.handle(sprite_sheet.texture_id);
-    if texture_handle.is_none() {
-        warn!(
-            "Texture handle not found for texture id: `{}`.",
-            sprite_sheet.texture_id
-        );
-        return;
-    }
-
-    let texture = tex_storage.get(&texture_handle.unwrap());
-    if texture.is_none() {
-        warn!(
-            "Texture not loaded for texture id: `{}`.",
-            sprite_sheet.texture_id
-        );
-        return;
-    }
-
-    let sprite = &sprite_sheet.sprites[sprite_render.sprite_number];
-
-    // Sprite vertex shader
-    set_view_args(effect, encoder, camera);
-    set_sprite_args(effect, encoder, global.unwrap(), sprite, sprite_render);
-
-    add_texture(effect, texture.unwrap());
-
-    // Set texture coordinates
-    let tex_coords = &sprite.tex_coords;
-    effect.update_constant_buffer(
-        "AlbedoOffset",
-        &TextureOffsetPod {
-            u_offset: [tex_coords.left, tex_coords.right].into(),
-            v_offset: [tex_coords.bottom, tex_coords.top].into(),
-        }.std140(),
-        encoder,
-    );
-
-    effect.draw(
-        &Slice {
-            start: 0,
-            end: 6,
-            base_vertex: 0,
-            instances: None,
-            buffer: Default::default(),
-        },
-        encoder,
-    );
     effect.clear();
 }
 

--- a/amethyst_renderer/src/pass/util.rs
+++ b/amethyst_renderer/src/pass/util.rs
@@ -1,7 +1,7 @@
 use std::mem;
 
 use amethyst_assets::AssetStorage;
-use amethyst_core::cgmath::{Matrix4, One, SquareMatrix};
+use amethyst_core::cgmath::{Matrix4, One, SquareMatrix, Vector4};
 use amethyst_core::specs::prelude::{Join, Read, ReadStorage};
 use amethyst_core::GlobalTransform;
 use cam::{ActiveCamera, Camera};
@@ -28,6 +28,13 @@ pub(crate) enum TextureType {
 
 #[repr(C, align(16))]
 #[derive(Clone, Copy, Debug, Uniform)]
+pub(crate) struct ViewArgs {
+    proj: mat4,
+    view: mat4,
+}
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, Uniform)]
 pub(crate) struct VertexArgs {
     proj: mat4,
     view: mat4,
@@ -37,17 +44,17 @@ pub(crate) struct VertexArgs {
 #[repr(C, align(16))]
 #[derive(Clone, Copy, Debug, Uniform)]
 pub(crate) struct SpriteArgs {
-    sprite_dimensions: vec2,
-    offsets: vec2,
-    flip_horizontal: boolean,
-    flip_vertical: boolean,
+    pub half_diag: vec2,
+    pub offsets: vec2,
+    pub flip_horizontal: boolean,
+    pub flip_vertical: boolean,
 }
 
 #[repr(C, align(16))]
 #[derive(Clone, Copy, Debug, Uniform)]
 pub(crate) struct TextureOffsetPod {
-    u_offset: vec2,
-    v_offset: vec2,
+    pub u_offset: vec2,
+    pub v_offset: vec2,
 }
 
 impl TextureOffsetPod {
@@ -259,15 +266,38 @@ pub fn set_vertex_args(
     effect.update_constant_buffer("VertexArgs", &vertex_args.std140(), encoder);
 }
 
+pub fn set_view_args(
+    effect: &mut Effect,
+    encoder: &mut Encoder,
+    camera: Option<(&Camera, &GlobalTransform)>,
+) {
+    let view_args = camera
+        .as_ref()
+        .map(|&(ref cam, ref transform)| ViewArgs {
+            proj: cam.proj.into(),
+            view: transform.0.invert().unwrap().into(),
+        })
+        .unwrap_or_else(|| ViewArgs {
+            proj: Matrix4::one().into(),
+            view: Matrix4::one().into(),
+        });
+    effect.update_constant_buffer("ViewArgs", &view_args.std140(), encoder);
+}
+
 pub(crate) fn set_sprite_args(
     effect: &mut Effect,
     encoder: &mut Encoder,
+    transform: &GlobalTransform,
     sprite: &Sprite,
     sprite_render: &SpriteRender,
 ) {
+    use amethyst_core::cgmath::Matrix;
+
+    let half_dir = transform.0 * Vector4::new(sprite.width, sprite.height, 0.0, 0.0);
+    let offset = transform.0 * Vector4::new(sprite.offsets[0], sprite.offsets[1], 0.0, 1.0);
     let geometry_args = SpriteArgs {
-        sprite_dimensions: [sprite.width, sprite.height].into(),
-        offsets: sprite.offsets.into(),
+        half_diag: [half_dir.x, half_dir.y].into(),
+        offsets: [offset.x, offset.y].into(),
         flip_horizontal: sprite_render.flip_horizontal.into(),
         flip_vertical: sprite_render.flip_vertical.into(),
     };
@@ -369,8 +399,8 @@ pub(crate) fn draw_sprite(
     let sprite = &sprite_sheet.sprites[sprite_render.sprite_number];
 
     // Sprite vertex shader
-    set_vertex_args(effect, encoder, camera, global.unwrap());
-    set_sprite_args(effect, encoder, sprite, sprite_render);
+    set_view_args(effect, encoder, camera);
+    set_sprite_args(effect, encoder, global.unwrap(), sprite, sprite_render);
 
     add_texture(effect, texture.unwrap());
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * Simplified creating states with SimpleState and EmptyState. ([#887])
 * Updated ProgressCounter to show loading errors. ([#892])
 * Replaced the `imagefmt` crate with `image`. ([#877])
+* Optimize Sprite rendering via batching. ([#902])
+
 ### Removed
 
 ### Fixed
@@ -35,6 +37,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#892]: https://github.com/amethyst/amethyst/pull/892
 [#877]: https://github.com/amethyst/amethyst/pull/877
 [#896]: https://github.com/amethyst/amethyst/pull/896
+[#902]: https://github.com/amethyst/amethyst/pull/902
 [#905]: https://github.com/amethyst/amethyst/pull/905
 
 ## [0.8.0] - 2018-08


### PR DESCRIPTION
Refactor the current sprite drawing to batch consecutive draws into one instanced draw call.

The drawing part is split into two parts: Collecting (+ Sorting) and Encoding.
* Collection: Cache all sprites which are supposed to be display in the current frame. Further sorting with respect to the ordering constraints allows to move together sprites with the same texture reference.
* Encoding: Iterate over the sprite cache to find largest possible batch without state changes.
Sprite information is stored in an instance buffer.

With the move towards the approach outlined above, also a few changes to the shader are integrated (saves ~3ms):
* Use vertex buffers (instancing) with orphaning instead of updating constant buffers 
* Moved quite a bit of logic from shader to the CPU, minimizing the required data sent.

Overall went down from 22ms to 7ms (framelimiter) for the `2d_isometry` sample.

cc https://github.com/amethyst/amethyst/issues/894

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/902)
<!-- Reviewable:end -->
