### PR TITLE
Load node names from glTF files

### DIFF
--- a/amethyst_assets/src/prefab/impls.rs
+++ b/amethyst_assets/src/prefab/impls.rs
@@ -1,5 +1,5 @@
 use amethyst_core::specs::{Entity, WriteStorage};
-use amethyst_core::{GlobalTransform, Transform};
+use amethyst_core::{GlobalTransform, Named, Transform};
 use {PrefabData, PrefabError, ProgressCounter};
 
 impl<'a, T> PrefabData<'a> for Option<T>
@@ -63,6 +63,22 @@ impl<'a> PrefabData<'a> for Transform {
         _: &[Entity],
     ) -> Result<(), PrefabError> {
         storages.1.insert(entity, GlobalTransform::default())?;
+        storages.0.insert(entity, self.clone()).map(|_| ())
+    }
+}
+
+impl<'a> PrefabData<'a> for Named {
+    type SystemData = (
+        WriteStorage<'a, Named>,
+    );
+    type Result = ();
+
+    fn load_prefab(
+        &self,
+        entity: Entity,
+        storages: &mut Self::SystemData,
+        _: &[Entity],
+    ) -> Result<(), PrefabError> {
         storages.0.insert(entity, self.clone()).map(|_| ())
     }
 }

--- a/amethyst_gltf/src/format/mod.rs
+++ b/amethyst_gltf/src/format/mod.rs
@@ -277,6 +277,11 @@ fn load_node(
 ) -> Result<(), GltfError> {
     node_map.insert(node.index(), entity_index);
 
+    // Load node name.
+    if let Some(name) = node.name() {
+        prefab.data_or_default(entity_index).name = Some(Named::new(name.to_string()));
+    }
+
     // Load transformation data, default will be identity
     let (translation, rotation, scale) = node.transform().decomposed();
     let mut local_transform = Transform::default();

--- a/amethyst_gltf/src/lib.rs
+++ b/amethyst_gltf/src/lib.rs
@@ -20,6 +20,7 @@ extern crate thread_profiler;
 
 use animation::{AnimatablePrefab, SkinnablePrefab};
 use assets::{Handle, Prefab, PrefabData, PrefabLoaderSystem, ProgressCounter};
+use core::Named;
 use core::cgmath::{Array, EuclideanSpace, Point3, Vector3};
 use core::specs::error::Error;
 use core::specs::prelude::{Component, DenseVecStorage, Entity, WriteStorage};
@@ -55,6 +56,8 @@ pub struct GltfPrefab {
     pub skinnable: Option<SkinnablePrefab>,
     /// Node extent
     pub extent: Option<GltfNodeExtent>,
+    /// Node name
+    pub name: Option<Named>,
 }
 
 impl GltfPrefab {
@@ -167,6 +170,7 @@ impl<'a> PrefabData<'a> for GltfPrefab {
     type SystemData = (
         <Transform as PrefabData<'a>>::SystemData,
         <MeshData as PrefabData<'a>>::SystemData,
+        <Named as PrefabData<'a>>::SystemData,
         <MaterialPrefab<TextureFormat> as PrefabData<'a>>::SystemData,
         <AnimatablePrefab<usize, Transform> as PrefabData<'a>>::SystemData,
         <SkinnablePrefab as PrefabData<'a>>::SystemData,
@@ -183,6 +187,7 @@ impl<'a> PrefabData<'a> for GltfPrefab {
         let (
             ref mut transforms,
             ref mut meshes,
+            ref mut names,
             ref mut materials,
             ref mut animatables,
             ref mut skinnables,
@@ -193,6 +198,9 @@ impl<'a> PrefabData<'a> for GltfPrefab {
         }
         if let Some(ref mesh) = self.mesh_handle {
             meshes.1.insert(entity, mesh.clone())?;
+        }
+        if let Some(ref name) = self.name {
+            name.load_prefab(entity, names, entities)?;
         }
         if let Some(ref material) = self.material {
             material.load_prefab(entity, materials, entities)?;
@@ -214,7 +222,7 @@ impl<'a> PrefabData<'a> for GltfPrefab {
         progress: &mut ProgressCounter,
         system_data: &mut Self::SystemData,
     ) -> Result<bool, Error> {
-        let (_, ref mut meshes, ref mut materials, ref mut animatables, _, _) = system_data;
+        let (_, ref mut meshes, _, ref mut materials, ref mut animatables, _, _) = system_data;
         let mut ret = false;
         if let Some(ref mesh) = self.mesh {
             self.mesh_handle = Some(meshes.0.load_from_data(

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * State::handle_event can now handle multiple types of events. ([#887])
 * Added Named Component. ([#879])([#896])
 * Support for progressive jpeg loading. ([#877])
+* Load node names for glTF prefabs. ([#905])
 
 ### Changed
 * Sprites contain their dimensions and offsets to render them with the right size and desired position. ([#829], [#830])
@@ -34,6 +35,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#892]: https://github.com/amethyst/amethyst/pull/892
 [#877]: https://github.com/amethyst/amethyst/pull/877
 [#896]: https://github.com/amethyst/amethyst/pull/896
+[#905]: https://github.com/amethyst/amethyst/pull/905
 
 ## [0.8.0] - 2018-08
 ### Added


### PR DESCRIPTION
This PR adds support for loading node names from glTF files. Node names are applied to the corresponding entities in the instantiated hierarchy via the new `Named` component. Only node names are imported; Other items in a glTF file can have names, but this PR makes not attempt to support them.

This PR also implements `PrefabData` for `Named`, which should enable broader support for specifying entity names in prefab.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/905)
<!-- Reviewable:end -->
