### PR TITLE
Fixed broken logo in doc

### DIFF
--- a/amethyst_config/src/lib.rs
+++ b/amethyst_config/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 
 #![crate_name = "amethyst_config"]
-#![doc(html_logo_url = "http://tinyurl.com/hgsb45k")]
+#![doc(html_logo_url = "https://www.amethyst.rs/assets/amethyst.svg")]
 
 #[macro_use]
 extern crate log;

--- a/amethyst_core/src/transform/components/local_transform.rs
+++ b/amethyst_core/src/transform/components/local_transform.rs
@@ -238,9 +238,9 @@ impl Transform {
     ///
     /// # Arguments
     ///
-    ///  - x - The angle to apply around the x axis. Also known at the pitch.
-    ///  - y - The angle to apply around the y axis. Also known at the yaw.
-    ///  - z - The angle to apply around the z axis. Also known at the roll.
+    ///  - x - The angle to apply around the x axis. Also known as the pitch.
+    ///  - y - The angle to apply around the y axis. Also known as the yaw.
+    ///  - z - The angle to apply around the z axis. Also known as the roll.
     pub fn set_rotation<A>(&mut self, x: A, y: A, z: A) -> &mut Self
     where
         A: Angle<Unitless = f32>,

--- a/amethyst_renderer/src/lib.rs
+++ b/amethyst_renderer/src/lib.rs
@@ -25,7 +25,7 @@
 //! [bk]: https://www.amethyst.rs/book/master/
 
 #![deny(missing_docs)]
-#![doc(html_logo_url = "https://tinyurl.com/jtmm43a")]
+#![doc(html_logo_url = "https://www.amethyst.rs/assets/amethyst.svg")]
 
 extern crate amethyst_assets;
 extern crate amethyst_core;

--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -1,7 +1,7 @@
 //! Provides components and systems to create an in game user interface.
 
 #![warn(missing_docs)]
-#![doc(html_logo_url = "https://tinyurl.com/jtmm43a")]
+#![doc(html_logo_url = "https://www.amethyst.rs/assets/amethyst.svg")]
 
 extern crate amethyst_assets;
 extern crate amethyst_audio;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //! ```
 
 #![warn(missing_docs)]
-#![doc(html_logo_url = "https://tinyurl.com/jtmm43a")]
+#![doc(html_logo_url = "https://www.amethyst.rs/assets/amethyst.svg")]
 
 #[macro_use]
 #[cfg(feature = "profiler")]


### PR DESCRIPTION
The link to the Amethyst logo in the API References is broken. This fixes it.
It also fixes #910 in the process.

I would like to use bors on this one to see if removing AppVeyor did not break anything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/913)
<!-- Reviewable:end -->
