### PR TITLE
Convert some Arc<rayon::ThreadPool> to amethyst::core::ThreadPool

### DIFF
--- a/book/src/game-data.md
+++ b/book/src/game-data.md
@@ -82,7 +82,7 @@ impl<'a, 'b> CustomGameDataBuilder<'a, 'b> {
 impl<'a, 'b> DataInit<CustomGameData<'a, 'b>> for CustomGameDataBuilder<'a, 'b> {
     fn build(self, world: &mut World) -> CustomGameData<'a, 'b> {
         // Get a handle to the `ThreadPool`.
-        let pool = world.read_resource::<Arc<ThreadPool>>().clone();
+        let pool = world.read_resource::<ThreadPool>().clone();
 
         let mut core_dispatcher = self.core.with_pool(pool.clone()).build();
         let mut running_dispatcher = self.running.with_pool(pool.clone()).build();

--- a/examples/custom_game_data/game_data.rs
+++ b/examples/custom_game_data/game_data.rs
@@ -1,8 +1,6 @@
-use amethyst::core::SystemBundle;
+use amethyst::core::{SystemBundle, ThreadPool};
 use amethyst::ecs::prelude::{Dispatcher, DispatcherBuilder, System, World};
 use amethyst::{DataInit, Error, Result};
-use rayon::ThreadPool;
-use std::sync::Arc;
 
 pub struct CustomGameData<'a, 'b> {
     pub base: Dispatcher<'a, 'b>,
@@ -68,7 +66,7 @@ impl<'a, 'b> CustomGameDataBuilder<'a, 'b> {
 impl<'a, 'b> DataInit<CustomGameData<'a, 'b>> for CustomGameDataBuilder<'a, 'b> {
     fn build(self, world: &mut World) -> CustomGameData<'a, 'b> {
         #[cfg(not(no_threading))]
-        let pool = world.read_resource::<Arc<ThreadPool>>().clone();
+        let pool = world.read_resource::<ThreadPool>().clone();
 
         #[cfg(not(no_threading))]
         let mut base = self.base.with_pool(pool.clone()).build();

--- a/src/game_data.rs
+++ b/src/game_data.rs
@@ -1,10 +1,8 @@
 use core::specs::prelude::{Dispatcher, DispatcherBuilder, System, World};
-use core::SystemBundle;
+use core::{SystemBundle, ThreadPool};
 use error::{Error, Result};
-use rayon::ThreadPool;
 use renderer::pipe::pass::Pass;
 use std::path::Path;
-use std::sync::Arc;
 
 /// Initialise trait for game data
 pub trait DataInit<T> {
@@ -259,7 +257,7 @@ impl<'a, 'b> GameDataBuilder<'a, 'b> {
 impl<'a, 'b> DataInit<GameData<'a, 'b>> for GameDataBuilder<'a, 'b> {
     fn build(self, world: &mut World) -> GameData<'a, 'b> {
         #[cfg(not(no_threading))]
-        let pool = world.read_resource::<Arc<ThreadPool>>().clone();
+        let pool = world.read_resource::<ThreadPool>().clone();
 
         #[cfg(not(no_threading))]
         let mut dispatcher = self.disp_builder.with_pool(pool).build();


### PR DESCRIPTION
#893 

There are some other uses of Arc<ThreadPool> in amethyst_{assets, renderer}, but they look to part of the public API, so I don't know if you'd like to change those.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/921)
<!-- Reviewable:end -->
