### PR TITLE
fix: Disable backface culling for the sprite pass

### DIFF
--- a/amethyst_renderer/src/pass/sprite/interleaved.rs
+++ b/amethyst_renderer/src/pass/sprite/interleaved.rs
@@ -74,6 +74,7 @@ impl Pass for DrawSprite {
 
         let mut builder = effect.simple(VERT_SRC, FRAG_SRC);
         builder
+            .without_back_face_culling()
             .with_raw_constant_buffer(
                 "ViewArgs",
                 mem::size_of::<<ViewArgs as Uniform>::Std140>(),

--- a/amethyst_renderer/src/pipe/effect/mod.rs
+++ b/amethyst_renderer/src/pipe/effect/mod.rs
@@ -11,7 +11,7 @@ use gfx::preset::depth::{LESS_EQUAL_TEST, LESS_EQUAL_WRITE};
 use gfx::pso::buffer::{ElemStride, InstanceRate};
 use gfx::shade::core::UniformValue;
 use gfx::shade::{ProgramError, ToUniform};
-use gfx::state::{Blend, ColorMask, Comparison, Depth, MultiSample, Rasterizer, Stencil};
+use gfx::state::{Blend, ColorMask, Comparison, Depth, MultiSample, Rasterizer, Stencil, CullFace};
 use gfx::traits::Pod;
 use gfx::{Primitive, ShaderSet};
 use glsl_layout::Std140;
@@ -198,6 +198,12 @@ impl<'a> EffectBuilder<'a> {
             prog: src,
             const_bufs: Vec::new(),
         }
+    }
+
+    /// Disable back face culling
+    pub fn without_back_face_culling(&mut self) -> &mut Self {
+        self.rast.cull_face = CullFace::Nothing;
+        self
     }
 
     /// Adds a global constant to this `Effect`.


### PR DESCRIPTION
Might fix (probably) #909.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/925)
<!-- Reviewable:end -->
