### PR TITLE
Fixed regression in sprite positioning.

### DIFF
--- a/amethyst_renderer/src/pass/shaders/vertex/sprite.glsl
+++ b/amethyst_renderer/src/pass/shaders/vertex/sprite.glsl
@@ -38,7 +38,7 @@ void main() {
     float tex_u = positions[gl_VertexID][0];
     float tex_v = positions[gl_VertexID][1];
 
-    vec2 uv = pos + (tex_u - 1.0f) * dir_x + (tex_v - 1.0f) * dir_y;
+    vec2 uv = pos + tex_u * dir_x + tex_v * dir_y;
     tex_uv = texture_coords(vec2(tex_u, tex_v), u_offset, v_offset);
 
     vec4 vertex = vec4(uv, depth, 1.0);

--- a/amethyst_renderer/src/pass/sprite/interleaved.rs
+++ b/amethyst_renderer/src/pass/sprite/interleaved.rs
@@ -281,8 +281,12 @@ impl SpriteBatch {
 
             let dir_x = transform.x * sprite_data.width;
             let dir_y = transform.y * sprite_data.height;
-            let pos =
-                transform * Vector4::new(sprite_data.offsets[0], sprite_data.offsets[1], 0.0, 1.0);
+            let pos = transform * Vector4::new(
+                -sprite_data.offsets[0],
+                -sprite_data.offsets[1],
+                0.0,
+                1.0
+            );
 
             instance_data.extend(&[
                 dir_x.x, dir_x.y, dir_y.x, dir_y.y, pos.x, pos.y, uv_left, uv_right, uv_bottom,

--- a/amethyst_renderer/src/pass/sprite/interleaved.rs
+++ b/amethyst_renderer/src/pass/sprite/interleaved.rs
@@ -281,6 +281,12 @@ impl SpriteBatch {
 
             let dir_x = transform.x * sprite_data.width;
             let dir_y = transform.y * sprite_data.height;
+
+            // The offsets are negated to shift the sprite left and down relative to the entity, in
+            // regards to pivot points. This is the convention adopted in:
+            //
+            // * libgdx: <https://gamedev.stackexchange.com/q/22553>
+            // * godot: <https://godotengine.org/qa/9784>
             let pos = transform * Vector4::new(
                 -sprite_data.offsets[0],
                 -sprite_data.offsets[1],

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 ### Fixed
 * Material ids in GLTF loader caused multiple GLTF files to get incorrect materials applied ([#915])
 * Fix render gamma for most textures. ([#868])
+* Fixed regression in sprite positioning after batching. ([#929])
 
 [#829]: https://github.com/amethyst/amethyst/issues/829
 [#830]: https://github.com/amethyst/amethyst/pull/830
@@ -48,6 +49,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#904]: https://github.com/amethyst/amethyst/pull/904
 [#915]: https://github.com/amethyst/amethyst/pull/915
 [#868]: https://github.com/amethyst/amethyst/pull/868
+[#929]: https://github.com/amethyst/amethyst/pull/929
 
 ## [0.8.0] - 2018-08
 ### Added


### PR DESCRIPTION
cc: @msiglreith

The recent sprite batching change included regressions that we didn't notice before:

* sprite render position was shifted left by sprite_w, and down by sprite_h
* offsets were added instead of subtracted

This PR reverts the behaviour to what it was previously.
No changelog entry since it's a bug that's fixed before the feature was released.

Issue #829, #894