### PR TITLE
TGA image support

### DIFF
--- a/amethyst_renderer/src/lib.rs
+++ b/amethyst_renderer/src/lib.rs
@@ -89,7 +89,7 @@ pub use config::DisplayConfig;
 pub use formats::{
     build_mesh_with_combo, create_mesh_asset, create_texture_asset, BmpFormat, ComboMeshCreator,
     GraphicsPrefab, ImageData, JpgFormat, MaterialPrefab, MeshCreator, MeshData, ObjFormat,
-    PngFormat, TextureData, TextureFormat, TextureMetadata, TexturePrefab,
+    PngFormat, TextureData, TextureFormat, TextureMetadata, TexturePrefab, TgaFormat,
 };
 pub use input::{ElementState, Event, KeyboardInput, MouseButton, VirtualKeyCode, WindowEvent};
 pub use light::{DirectionalLight, Light, LightPrefab, PointLight, SpotLight, SunLight};

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * Support for progressive jpeg loading. ([#877])
 * New `application_root_dir()` function in `amethyst_utils`. ([#831])
 * Load node names for glTF prefabs. ([#905])
+* Support for loading TGA images. ([#934])
 
 ### Changed
 * Sprites contain their dimensions and offsets to render them with the right size and desired position. ([#829], [#830])
@@ -55,6 +56,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#915]: https://github.com/amethyst/amethyst/pull/915
 [#868]: https://github.com/amethyst/amethyst/pull/868
 [#929]: https://github.com/amethyst/amethyst/pull/929
+[#934]: https://github.com/amethyst/amethyst/pull/934
 [winit_017]: https://github.com/tomaka/winit/blob/master/CHANGELOG.md#version-0172-2018-08-19
 [glutin_018]: https://github.com/tomaka/glutin/blob/master/CHANGELOG.md#version-0180-2018-08-03
 


### PR DESCRIPTION
This adds support in amethyst_renderer for TGA images. It also fixes an implementation detail where we were calling `image::load_from_memory`, which guesses the image format, even though we always know exactly what format we want. (In fact, `image::load_from_memory` doesn't work on TGA files, so that's two birds with one stone.)