### PR TITLE
Improve ergonomics of the Named component

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -5,6 +5,7 @@ use assets::{Loader, Source};
 use core::frame_limiter::{FrameLimiter, FrameRateLimitConfig, FrameRateLimitStrategy};
 use core::shrev::{EventChannel, ReaderId};
 use core::timing::{Stopwatch, Time};
+use core::Named;
 use ecs::common::Errors;
 use ecs::prelude::{Component, World};
 use error::{Error, Result};
@@ -440,6 +441,8 @@ impl<S, E: Send + Sync + 'static> ApplicationBuilder<S, E> {
         world.add_resource(FrameLimiter::default());
         world.add_resource(Stopwatch::default());
         world.add_resource(Time::default());
+
+        world.register::<Named>();
 
         Ok(ApplicationBuilder {
             initial_state,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,3 +6,4 @@ pub use ecs::prelude::{Builder, World};
 pub use game_data::{DataInit, GameData, GameDataBuilder};
 pub use state::{EmptyState, EmptyTrans, SimpleState, SimpleTrans, State, StateData, Trans};
 pub use state_event::StateEvent;
+pub use core::WithNamed;


### PR DESCRIPTION
Adds the `Named` component to `prelude` and as a default registered component.

I'm unsure about the "registered by default" part but it's honestly the best I can think of right now. The reasoning behind it is that a lot of the time you'll use the named component, maybe even without thinking of it, without having a system that actually consumes it. That's great for forward thinking, but then you also have to manually register `Named` when building the application and remember to remove that once you do add a system which requires a `Named` storage.