### PR TITLE
Derive Serialize/Deserialize for Named

### DIFF
--- a/amethyst_core/src/named.rs
+++ b/amethyst_core/src/named.rs
@@ -79,7 +79,7 @@ use std::borrow::Cow;
 ///     }
 /// }
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Named {
     pub name: Cow<'static, str>,
 }


### PR DESCRIPTION
This makes `Named` consistent with other components that contain simple, serializable data. I specifically need `Named` to be serializable for use in the editor. It seems like we're not bothering to make serde support optional, so seems fine to just derive the impls directly?