### PR TITLE
Add link to prefab docs

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -21,6 +21,7 @@
     * [Sampler](./animation/sampler.md)
     * [Definition](./animation/definition.md)
 * [Custom `GameData`](./game-data.md)
+* [Prefabs](./prefab.md)
 * [Glossary](./glossary.md)
 * [Appendix A: Config Files](./appendices/a_config_files.md)
     * [Adding an Arena Config](./appendices/a_config_files/arena_config.md)


### PR DESCRIPTION
This was missing from the side menu of https://amethyst.rs, is this all thats to add it?