### PR TITLE
Make Travis test the book

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,13 +50,7 @@ before_script:
   - export PATH=$PATH:/home/travis/.cargo/bin
 
 # Generate documentation, compile the engine, run tests.
-script: |
-  # Build and test without profiler
-  cargo test --all -v &&
-  # Build and test with profiler
-  cargo test --all --features profiler -v &&
-  # Build and test with sdl_controller
-  cargo test --all --features sdl_controller -v
+script: bash travis.sh
 
 # Push notifications to `amethyst/general` and `amethyst/engine` Gitter chats.
 notifications:

--- a/book/src/concepts/system.md
+++ b/book/src/concepts/system.md
@@ -267,8 +267,38 @@ This is rather complicated trait to implement, fortunately Amethyst provides a d
 
 Please note that tuples of structs implementing `SystemData` are themselves `SystemData`. This is very useful when you need to request multiple `SystemData` at once quickly.
 
-```rust,ignore
-# // This one remains ignore because for some reason mdbook can't find the SystemData derive macro
+```rust,no_run,noplaypen
+# extern crate amethyst;
+# extern crate shred;
+# #[macro_use] extern crate shred_derive;
+# 
+# use amethyst::ecs::{ReadStorage, WriteStorage, SystemData, Component, VecStorage, System, Join};
+#
+# struct FooComponent {
+#   stuff: f32,
+# }
+# impl Component for FooComponent {
+#   type Storage = VecStorage<FooComponent>;
+# }
+# 
+# struct BarComponent {
+#   stuff: f32,
+# }
+# impl Component for BarComponent {
+#   type Storage = VecStorage<BarComponent>;
+# }
+# 
+# #[derive(SystemData)]
+# struct BazSystemData<'a> {
+#  field: ReadStorage<'a, FooComponent>,
+# }
+# 
+# impl<'a> BazSystemData<'a> {
+#   fn should_process(&self) -> bool {
+#       true
+#   }
+# }
+#
 #[derive(SystemData)]
 struct MySystemData<'a> {
     foo: ReadStorage<'a, FooComponent>,
@@ -281,9 +311,9 @@ struct MyFirstSystem;
 impl<'a> System<'a> for MyFirstSystem {
     type SystemData = MySystemData<'a>;
 
-    fn run(&mut self, data: Self::SystemData) {
+    fn run(&mut self, mut data: Self::SystemData) {
         if data.baz.should_process() {
-            for (foo, mut bar) in (&data.foo, &mut data.bar) {
+            for (foo, mut bar) in (&data.foo, &mut data.bar).join() {
                 bar.stuff += foo.stuff;
             } 
         }

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,21 @@
+MDBOOK_RELEASE="v0.2.1/mdbook-v0.2.1-x86_64-unknown-linux-gnu.tar.gz"
+
+echo "Build and test without profiler"
+cargo test --all -v || exit 1
+
+if [ ${TRAVIS_OS_NAME} = "linux" ]
+then
+    echo "Install mdbook"
+    curl -L -o mdbook.tar.gz https://github.com/rust-lang-nursery/mdBook/releases/download/${MDBOOK_RELEASE}
+    tar -xvf mdbook.tar.gz -C ./
+    rm mdbook.tar.gz
+
+    echo "Build all the examples in the book"
+    ./mdbook test book -L target/debug/deps || exit 2
+fi
+
+echo "Build and test with profiler"
+cargo test --all --features profiler -v || exit 3
+
+echo "Build and test with sdl_controller"
+cargo test --all --features sdl_controller -v || exit 4


### PR DESCRIPTION
This PR makes Travis build all the examples in the book as part of the typical testing process.
This is very fast and will make us avoid the documentation nonsense we had on 0.8 release.