### PR TITLE
Add workaround for Wayland issues

### DIFF
--- a/amethyst_renderer/src/renderer.rs
+++ b/amethyst_renderer/src/renderer.rs
@@ -160,7 +160,9 @@ impl RendererBuilder {
         RendererBuilder {
             config: DisplayConfig::default(),
             events: el,
-            winit_builder: WindowBuilder::new().with_title("Amethyst"),
+            winit_builder: WindowBuilder::new()
+                .with_title("Amethyst")
+                .with_dimensions(LogicalSize::new(600.0, 500.0)),
         }
     }
 

--- a/amethyst_renderer/src/system.rs
+++ b/amethyst_renderer/src/system.rs
@@ -43,6 +43,12 @@ where
     where
         B: PipelineBuild<Pipeline = P>,
     {
+        use std::env;
+
+        // ask winit explicitly to use X11 since Wayland causes several issues
+        // see https://github.com/amethyst/amethyst/issues/890
+        env::set_var("WINIT_UNIX_BACKEND", "x11");
+
         let mut renderer = {
             let mut renderer = Renderer::build();
 


### PR DESCRIPTION
Addresses #890 

This just asks winit to use X11 instead of Wayland.

Known side effect: if no dimensions are specified, the default window size on Wayland will differ from the one on X11