### PR TITLE
Bumped dependency versions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ thread_profiler = { version = "0.3", optional = true }
 amethyst_gltf = { path = "amethyst_gltf", version = "0.3.0" }
 env_logger = "0.5.13"
 genmesh = "0.6"
-ron = "0.2"
+ron = "0.4"
 
 [build-dependencies]
 vergen = "2.0"

--- a/amethyst_network/Cargo.toml
+++ b/amethyst_network/Cargo.toml
@@ -19,9 +19,9 @@ nightly = [ "amethyst_core/nightly" ]
 amethyst_core = { path = "../amethyst_core", version = "0.3" }
 serde = { version = "1.0.16", features = ["serde_derive"] }
 shrev = "1.0"
-shred = "0.5"
-bincode = "0.9.2"
+shred = "0.7"
+bincode = "1.0"
 log = "0.4"
-uuid = { version = "0.5.1", features = ["v4","serde"] }
-thread_profiler = { version = "0.1" , optional = true }
+uuid = { version = "0.7.1", features = ["v4","serde"] }
+thread_profiler = { version = "0.3" , optional = true }
 fern = "0.5"

--- a/amethyst_network/src/lib.rs
+++ b/amethyst_network/src/lib.rs
@@ -26,8 +26,8 @@ pub use filter::{FilterConnected, NetFilter};
 pub use net_event::NetEvent;
 pub use network_socket::NetSocketSystem;
 
-use bincode::internal::ErrorKind;
-use bincode::{deserialize, serialize, Infinite};
+use bincode::ErrorKind;
+use bincode::{deserialize, serialize};
 
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -40,7 +40,7 @@ pub fn send_event<T>(event: &NetEvent<T>, target: &SocketAddr, socket: &UdpSocke
 where
     T: Serialize,
 {
-    let ser = serialize(event, Infinite);
+    let ser = serialize(event);
     match ser {
         Ok(s) => {
             let slice = s.as_slice();

--- a/amethyst_renderer/Cargo.toml
+++ b/amethyst_renderer/Cargo.toml
@@ -39,7 +39,7 @@ gfx_core = { version = "0.8", features = ["serialize"] }
 gfx_macros = "0.2"
 glsl-layout = { version = "0.1.1", features = ["cgmath", "gfx"] }
 hibitset = { version = "0.5.1", features = ["parallel"] }
-image = "0.19"
+image = "0.20"
 log = "0.4"
 rayon = "1.0.2"
 serde = { version = "1", features = ["serde_derive"] }

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -17,7 +17,7 @@ amethyst_audio = { path = "../amethyst_audio", version = "0.3.0"}
 amethyst_core = { path = "../amethyst_core", version = "0.3.0" }
 amethyst_renderer = { path = "../amethyst_renderer", version = "0.8.0" }
 amethyst_input = { path = "../amethyst_input", version = "0.4.0" }
-clipboard = "0.4"
+clipboard = "0.5"
 derivative = "1.0"
 fnv = "1"
 gfx = { version = "0.17", features = ["serialize"] }


### PR DESCRIPTION
```
ron             0.2   -> 0.4
shred           0.5   -> 0.7
bincode         0.9   -> 1.0
uuid            0.5.1 -> 0.7.1
thread_profiler 0.1   -> 0.3
image           0.19  -> 0.20
clipboard       0.4   -> 0.5
```

Tried bumping `fluent` from `0.2 -> 0.4`, but `MessageContext -> FluentBundle` is no longer `Send + Sync`, so I kept it as it is.

Hopefully this speeds up compilation times re:building multiple versions of dependencies.