### PR TITLE
Add missing reexport in logger

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * New vertices() method on MeshCreator trait. ([#946])
 * Support for text alignment (align left, center, right). ([#965])
 * Support for multiline text. ([#965])
+* Support for logging to file, toggle for logging to stdout. ([#976], [#994])
 
 
 
@@ -92,6 +93,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#964]: https://github.com/amethyst/amethyst/pull/964
 [#965]: https://github.com/amethyst/amethyst/pull/965
 [#969]: https://github.com/amethyst/amethyst/pull/969
+[#976]: https://github.com/amethyst/amethyst/pull/976
+[#994]: https://github.com/amethyst/amethyst/pull/994
 [winit_017]: https://github.com/tomaka/winit/blob/master/CHANGELOG.md#version-0172-2018-08-19
 [glutin_018]: https://github.com/tomaka/glutin/blob/master/CHANGELOG.md#version-0180-2018-08-03
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ extern crate serde_derive;
 pub use self::app::{Application, ApplicationBuilder};
 pub use self::error::{Error, Result};
 pub use self::game_data::{DataInit, GameData, GameDataBuilder};
-pub use self::logger::{start_logger, LevelFilter as LogLevelFilter, LoggerConfig};
+pub use self::logger::{start_logger, LevelFilter as LogLevelFilter, LoggerConfig, Stdout};
 pub use self::state::{
     EmptyState, EmptyTrans, SimpleState, SimpleTrans, State, StateData, StateMachine, Trans,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ extern crate serde_derive;
 pub use self::app::{Application, ApplicationBuilder};
 pub use self::error::{Error, Result};
 pub use self::game_data::{DataInit, GameData, GameDataBuilder};
-pub use self::logger::{start_logger, LevelFilter as LogLevelFilter, LoggerConfig, Stdout};
+pub use self::logger::{start_logger, LevelFilter as LogLevelFilter, LoggerConfig, StdoutLog};
 pub use self::state::{
     EmptyState, EmptyTrans, SimpleState, SimpleTrans, State, StateData, StateMachine, Trans,
 };

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -5,7 +5,7 @@ use std::{env, io, path::PathBuf, str::FromStr};
 
 /// An enum that contains options for logging to the terminal.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
-pub enum Stdout {
+pub enum StdoutLog {
     /// Disables logging to the terminal.
     Off,
     /// Enables logging to the terminal without colored output.
@@ -18,7 +18,7 @@ pub enum Stdout {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct LoggerConfig {
     /// Determines whether to log to the terminal or not.
-    pub stdout: Stdout,
+    pub stdout: StdoutLog,
     /// Sets the overarching level filter for the logger.
     pub level_filter: LevelFilter,
     /// If set, enables logging to file at the given path.
@@ -30,7 +30,7 @@ pub struct LoggerConfig {
 impl Default for LoggerConfig {
     fn default() -> LoggerConfig {
         LoggerConfig {
-            stdout: Stdout::Colored,
+            stdout: StdoutLog::Colored,
             level_filter: LevelFilter::Debug,
             log_file: None,
             allow_env_override: true,
@@ -55,9 +55,9 @@ pub fn start_logger(mut config: LoggerConfig) {
     let mut dispatch = basic_dispatch(config.level_filter);
 
     match config.stdout {
-        Stdout::Plain => dispatch = dispatch.chain(io::stdout()),
-        Stdout::Colored => dispatch = dispatch.chain(colored_stdout()),
-        Stdout::Off => {}
+        StdoutLog::Plain => dispatch = dispatch.chain(io::stdout()),
+        StdoutLog::Colored => dispatch = dispatch.chain(colored_stdout()),
+        StdoutLog::Off => {}
     }
 
     if let Some(path) = config.log_file {
@@ -75,9 +75,9 @@ pub fn start_logger(mut config: LoggerConfig) {
 fn env_var_override(config: &mut LoggerConfig) {
     if let Ok(var) = env::var("AMETHYST_LOG_STDOUT") {
         match var.to_lowercase().as_ref() {
-            "off" => config.stdout = Stdout::Off,
-            "plain" => config.stdout = Stdout::Plain,
-            "colored" => config.stdout = Stdout::Colored,
+            "off" => config.stdout = StdoutLog::Off,
+            "plain" => config.stdout = StdoutLog::Plain,
+            "colored" => config.stdout = StdoutLog::Colored,
             _ => {}
         }
     }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -3,10 +3,14 @@ pub use log::LevelFilter;
 use fern;
 use std::{env, io, path::PathBuf, str::FromStr};
 
+/// An enum that contains options for logging to the terminal.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub enum Stdout {
+    /// Disables logging to the terminal.
     Off,
+    /// Enables logging to the terminal without colored output.
     Plain,
+    /// Enables logging to the terminal with colored output on supported platforms.
     Colored,
 }
 


### PR DESCRIPTION
Followup to #976. I tested the new functionality on the internal examples, so I didn't catch the missing visibility; sorry about that. Took this chance to also update the docs.