### PR TITLE
feat: Enable users to control what events get pushed to the states

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ amethyst_audio = { path = "amethyst_audio", version = "0.3.0" }
 amethyst_config = { path = "amethyst_config", version = "0.7.0" }
 amethyst_core = { path = "amethyst_core", version = "0.3.0" }
 amethyst_controls = { path = "amethyst_controls", version = "0.2.0" }
+amethyst_derive = { path = "amethyst_derive", version = "0.1.0" }
 amethyst_network = { path = "amethyst_network", version = "0.1.0" }
 amethyst_locale = { path = "amethyst_locale", version = "0.2.0" }
 amethyst_renderer = { path = "amethyst_renderer", version = "0.8.0" }

--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -106,8 +106,8 @@ impl<'a> System<'a> for ArcBallRotationSystem {
 /// The system that manages the view rotation.
 /// Controlled by the mouse.
 /// Goes into an inactive state if the window is not focused (`WindowFocus` resource).
-/// 
-/// Can be manually disabled by making the mouse visible using the `HideCursor` resource: 
+///
+/// Can be manually disabled by making the mouse visible using the `HideCursor` resource:
 /// `HideCursor.hide = false`
 pub struct FreeRotationSystem<A, B> {
     sensitivity_x: f32,

--- a/amethyst_core/src/event.rs
+++ b/amethyst_core/src/event.rs
@@ -1,0 +1,87 @@
+use specs::{World, SystemData};
+
+/// Read events generically
+pub trait EventReader<'a> {
+    type SystemData: SystemData<'a>;
+    type Event: Clone;
+
+    fn read(&mut self, _: Self::SystemData, _: &mut Vec<Self::Event>);
+
+    fn read_from_world(&mut self, world: &'a World, events: &mut Vec<Self::Event>) {
+        self.read(world.system_data(), events);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use shrev::{EventChannel, ReaderId};
+    use specs::Read;
+
+    use super::*;
+
+    #[derive(Clone)]
+    pub struct TestEvent;
+
+    /// TODO: Create macro for this
+    pub struct TestEventReader {
+        reader: ReaderId<TestEvent>
+    }
+
+    impl<'a> EventReader<'a> for TestEventReader {
+        type SystemData = Read<'a, EventChannel<TestEvent>>;
+        type Event = TestEvent;
+
+        fn read(&mut self, events: Self::SystemData, data: &mut Vec<TestEvent>) {
+            data.extend(events.read(&mut self.reader).cloned());
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct OtherEvent;
+
+    pub struct OtherEventReader {
+        reader: ReaderId<OtherEvent>
+    }
+
+    impl<'a> EventReader<'a> for OtherEventReader {
+        type SystemData = Read<'a, EventChannel<OtherEvent>>;
+        type Event = OtherEvent;
+
+        fn read(&mut self, events: Self::SystemData, data: &mut Vec<OtherEvent>) {
+            data.extend(events.read(&mut self.reader).cloned());
+        }
+    }
+
+    #[derive(Clone)]
+    pub enum AggregateEvent {
+        Test(TestEvent),
+        Other(OtherEvent),
+    }
+
+    impl From<TestEvent> for AggregateEvent {
+        fn from(event: TestEvent) -> Self {
+            AggregateEvent::Test(event.clone())
+        }
+    }
+
+    impl From<OtherEvent> for AggregateEvent {
+        fn from(event: OtherEvent) -> Self {
+            AggregateEvent::Other(event)
+        }
+    }
+
+    pub struct AggregateEventReader {
+        test: ReaderId<TestEvent>,
+        other: ReaderId<OtherEvent>,
+    }
+
+    impl<'a> EventReader<'a> for AggregateEventReader {
+        type SystemData = (<TestEventReader as EventReader<'a>>::SystemData, <OtherEventReader as EventReader<'a>>::SystemData);
+        type Event = AggregateEvent;
+
+        fn read(&mut self, system_data: Self::SystemData, data: &mut Vec<AggregateEvent>) {
+            data.extend(system_data.0.read(&mut self.test).cloned().map(Into::into));
+            data.extend(system_data.1.read(&mut self.other).cloned().map(Into::into));
+        }
+    }
+}

--- a/amethyst_core/src/event.rs
+++ b/amethyst_core/src/event.rs
@@ -3,13 +3,15 @@ use specs::{World, SystemData};
 /// Read events generically
 pub trait EventReader<'a> {
     type SystemData: SystemData<'a>;
-    type Event: Clone;
+    type Event: Clone + Send + Sync + 'static;
 
     fn read(&mut self, _: Self::SystemData, _: &mut Vec<Self::Event>);
 
     fn read_from_world(&mut self, world: &'a World, events: &mut Vec<Self::Event>) {
         self.read(world.system_data(), events);
     }
+
+    fn build(world: &mut World) -> Self;
 }
 
 #[cfg(test)]
@@ -34,6 +36,12 @@ mod tests {
         fn read(&mut self, events: Self::SystemData, data: &mut Vec<TestEvent>) {
             data.extend(events.read(&mut self.reader).cloned());
         }
+
+        fn build(world: &mut World) -> Self {
+            TestEventReader {
+                reader: world.write_resource::<EventChannel<TestEvent>>().register_reader()
+            }
+        }
     }
 
     #[derive(Clone)]
@@ -49,6 +57,12 @@ mod tests {
 
         fn read(&mut self, events: Self::SystemData, data: &mut Vec<OtherEvent>) {
             data.extend(events.read(&mut self.reader).cloned());
+        }
+
+        fn build(world: &mut World) -> Self {
+            OtherEventReader {
+                reader: world.write_resource::<EventChannel<OtherEvent>>().register_reader()
+            }
         }
     }
 
@@ -82,6 +96,13 @@ mod tests {
         fn read(&mut self, system_data: Self::SystemData, data: &mut Vec<AggregateEvent>) {
             data.extend(system_data.0.read(&mut self.test).cloned().map(Into::into));
             data.extend(system_data.1.read(&mut self.other).cloned().map(Into::into));
+        }
+
+        fn build(world: &mut World) -> Self {
+            AggregateEventReader {
+                test: world.write_resource::<EventChannel<TestEvent>>().register_reader(),
+                other: world.write_resource::<EventChannel<OtherEvent>>().register_reader(),
+            }
         }
     }
 }

--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -24,18 +24,18 @@ compile_error!("the cfg flag \"no_threading\" is required when building for emsc
 pub use self::axis::{Axis2, Axis3};
 pub use self::named::{Named, WithNamed};
 pub use bundle::{Error, ErrorKind, Result, SystemBundle};
+pub use event::EventReader;
 pub use orientation::Orientation;
 use std::sync::Arc;
 pub use timing::*;
 pub use transform::*;
-pub use event::EventReader;
 
 mod axis;
 pub mod bundle;
+mod event;
 pub mod frame_limiter;
 mod named;
 mod orientation;
-mod event;
 pub mod timing;
 pub mod transform;
 

--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -28,12 +28,14 @@ pub use orientation::Orientation;
 use std::sync::Arc;
 pub use timing::*;
 pub use transform::*;
+pub use event::EventReader;
 
 mod axis;
 pub mod bundle;
 pub mod frame_limiter;
 mod named;
 mod orientation;
+mod event;
 pub mod timing;
 pub mod transform;
 

--- a/amethyst_derive/Cargo.toml
+++ b/amethyst_derive/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "amethyst_derive"
+version = "0.1.0"
+authors = ["Simon Rönnberg <seamonr@gmail.com>"]
+description = "Amethyst derive"
+
+documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_derive/"
+homepage = "https://www.amethyst.rs/"
+repository = "https://github.com/amethyst/amethyst"
+
+license = "MIT/Apache-2.0"
+
+[badges]
+appveyor = { repository = "amethyst/amethyst" }
+travis-ci = { repository = "amethyst/amethyst" }
+
+[dependencies]
+syn = { version = "0.15", features = ["visit"] }
+quote = "0.6"
+proc-macro2 = "0.4"
+amethyst_core = { path = "../amethyst_core", version = "0.3.0" }
+
+[lib]
+name = "amethyst_derive"
+proc-macro = true

--- a/amethyst_derive/src/lib.rs
+++ b/amethyst_derive/src/lib.rs
@@ -1,0 +1,129 @@
+#![recursion_limit = "256"]
+
+extern crate amethyst_core;
+extern crate proc_macro;
+extern crate proc_macro2;
+#[macro_use]
+extern crate syn;
+#[macro_use]
+extern crate quote;
+
+use proc_macro::TokenStream;
+use syn::{Data, DeriveInput, Ident, Meta, NestedMeta, Type};
+
+#[proc_macro_derive(EventReader, attributes(reader))]
+pub fn event_reader_derive(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let gen = impl_event_reader(&ast);
+    gen.into()
+}
+
+fn impl_event_reader(ast: &DeriveInput) -> proc_macro2::TokenStream {
+    let event_name = &ast.ident;
+
+    let mut reader_name: Option<Ident> = None;
+    for meta in ast
+        .attrs
+        .iter()
+        .filter(|attr| attr.path.segments[0].ident == "reader")
+        .map(|attr| {
+            attr.interpret_meta()
+                .expect("reader attribute incorrectly defined")
+        }) {
+        match meta {
+            Meta::List(l) => {
+                for nested_meta in l.nested.iter() {
+                    match *nested_meta {
+                        NestedMeta::Meta(Meta::Word(ref word)) => {
+                            reader_name = Some(word.clone());
+                        }
+                        _ => panic!("reader attribute does not contain a single name"),
+                    }
+                }
+            }
+            _ => (),
+        };
+    }
+
+    let reader_name = reader_name.expect(&format!(
+        r#"
+#[derive(EventReader)] requested for {}, but #[reader(SomeEventReader)] attribute is missing
+
+Example usage:
+#[derive(EventReader)]
+#[reader(SomeEventReader)]
+pub enum SomeEvent {{
+    One(Event1),
+    Two(Event2),
+}}
+"#,
+        event_name
+    ));
+
+    let tys = collect_field_types(&ast.data);
+    let tys = &tys;
+    let names = collect_variant_names(&ast.data);
+    let names = &names;
+
+    let reads : Vec<_> = (0..tys.len()).map(|n| {
+        let variant = &names[n];
+        quote! {
+            events.extend(data.#n.read(self.#n.as_mut().expect("ReaderId undefined, has setup been run?")).cloned().map(|e| #event_name::#variant(e)));
+        }
+    }).collect();
+    let setups: Vec<_> = (0..tys.len())
+        .map(|n| {
+            let ty = &tys[n];
+            quote! {
+                self.#n = Some(res.fetch_mut::<EventChannel<#ty>>().register_reader());
+            }
+        }).collect();
+    quote! {
+        #[allow(missing_docs)]
+        #[derive(Default)]
+        pub struct #reader_name(
+            #(Option<ReaderId<#tys>>, )*
+        );
+
+        impl<'a> EventReader<'a> for #reader_name {
+            type SystemData = (
+                #(Read<'a, EventChannel<#tys>>),*
+            );
+            type Event = #event_name;
+
+            fn read(&mut self, data: Self::SystemData, events: &mut Vec<#event_name>) {
+                #(#reads)*
+            }
+
+            fn setup(&mut self, res: &mut Resources) {
+                <Self::SystemData as SystemData<'a>>::setup(res);
+                #(#setups)*
+            }
+        }
+    }
+}
+
+fn collect_field_types(ast: &Data) -> Vec<Type> {
+    let variants = match *ast {
+        Data::Enum(ref variants) => &variants.variants,
+        _ => panic!("EventReader derive only support enums"),
+    };
+    variants
+        .iter()
+        .map(|v| {
+            v.fields
+                .iter()
+                .next()
+                .expect("Event enum variant does not contain an inner event type")
+                .ty
+                .clone()
+        }).collect()
+}
+
+fn collect_variant_names(ast: &Data) -> Vec<Ident> {
+    let variants = match *ast {
+        Data::Enum(ref variants) => &variants.variants,
+        _ => panic!("EventReader derive only support enums"),
+    };
+    variants.iter().map(|v| v.ident.clone()).collect()
+}

--- a/amethyst_derive/tests/test.rs
+++ b/amethyst_derive/tests/test.rs
@@ -1,0 +1,21 @@
+#[macro_use]
+extern crate amethyst_derive;
+extern crate amethyst_core;
+use amethyst_core::{
+    shrev::{EventChannel, ReaderId},
+    specs::{Read, Resources, SystemData},
+    EventReader,
+};
+
+#[derive(Clone)]
+pub struct TestEvent1;
+
+#[derive(Clone)]
+pub struct TestEvent2;
+
+#[derive(Clone, EventReader)]
+#[reader(TestEventReader)]
+pub enum TestEvent {
+    One(TestEvent1),
+    Two(TestEvent2),
+}

--- a/amethyst_gltf/src/format/material.rs
+++ b/amethyst_gltf/src/format/material.rs
@@ -68,8 +68,13 @@ pub fn load_material(
     // Can't use map/and_then because of Result returning from the load_texture function
     prefab.normal = match material.normal_texture() {
         Some(normal_texture) => Some(
-            load_texture(&normal_texture.texture(), buffers, source.clone(), name, false)
-                .map(|data| TexturePrefab::Data(data))?,
+            load_texture(
+                &normal_texture.texture(),
+                buffers,
+                source.clone(),
+                name,
+                false,
+            ).map(|data| TexturePrefab::Data(data))?,
         ),
 
         None => None,
@@ -78,8 +83,13 @@ pub fn load_material(
     // Can't use map/and_then because of Result returning from the load_texture function
     prefab.ambient_occlusion = match material.occlusion_texture() {
         Some(occlusion_texture) => Some(
-            load_texture(&occlusion_texture.texture(), buffers, source.clone(), name, false)
-                .map(|data| TexturePrefab::Data(data))?,
+            load_texture(
+                &occlusion_texture.texture(),
+                buffers,
+                source.clone(),
+                name,
+                false,
+            ).map(|data| TexturePrefab::Data(data))?,
         ),
 
         None => None,
@@ -117,10 +127,10 @@ fn deconstruct_image(data: &TextureData, offset: usize, step: usize) -> TextureD
     use gfx::format::SurfaceType;
     match *data {
         TextureData::Image(ref image_data, ref metadata) => {
-            let metadata = metadata
-                .clone()
-                .with_format(SurfaceType::R8)
-                .with_size(image_data.rgba.width() as u16, image_data.rgba.height() as u16);
+            let metadata = metadata.clone().with_format(SurfaceType::R8).with_size(
+                image_data.rgba.width() as u16,
+                image_data.rgba.height() as u16,
+            );
             let image_data = image_data
                 .rgba
                 .clone()

--- a/amethyst_renderer/src/formats/texture.rs
+++ b/amethyst_renderer/src/formats/texture.rs
@@ -436,16 +436,12 @@ pub fn create_texture_asset(
     t.map(|t| ProcessingState::Loaded(t))
 }
 
-fn apply_options<D, T>(
-    tb: TextureBuilder<D, T>,
-    metadata: TextureMetadata,
-) -> TextureBuilder<D, T>
+fn apply_options<D, T>(tb: TextureBuilder<D, T>, metadata: TextureMetadata) -> TextureBuilder<D, T>
 where
     D: AsRef<[T]>,
     T: Pod + Copy,
 {
-    tb
-        .with_sampler(metadata.sampler)
+    tb.with_sampler(metadata.sampler)
         .mip_levels(metadata.mip_levels)
         .dynamic(metadata.dynamic)
         .with_format(metadata.format)

--- a/amethyst_renderer/src/lib.rs
+++ b/amethyst_renderer/src/lib.rs
@@ -120,7 +120,7 @@ pub use sprite::{
 pub use sprite_visibility::{SpriteVisibility, SpriteVisibilitySortingSystem};
 pub use system::RenderSystem;
 pub use tex::{
-    FilterMethod, SamplerInfo, SurfaceType, Texture, TextureBuilder, TextureHandle, WrapMode
+    FilterMethod, SamplerInfo, SurfaceType, Texture, TextureBuilder, TextureHandle, WrapMode,
 };
 pub use transparent::{
     Blend, BlendChannel, BlendValue, ColorMask, Equation, Factor, Transparent, ALPHA, REPLACE,

--- a/amethyst_ui/src/prefab.rs
+++ b/amethyst_ui/src/prefab.rs
@@ -378,12 +378,20 @@ where
             ref mut textures,
             ref mut sounds,
         ) = system_data;
-        let normal_image = self.normal_image.add_to_entity(entity, textures, entity_set)?;
-        let hover_image = self.hover_image.add_to_entity(entity, textures, entity_set)?;
-        let press_image = self.press_image.add_to_entity(entity, textures, entity_set)?;
+        let normal_image = self
+            .normal_image
+            .add_to_entity(entity, textures, entity_set)?;
+        let hover_image = self
+            .hover_image
+            .add_to_entity(entity, textures, entity_set)?;
+        let press_image = self
+            .press_image
+            .add_to_entity(entity, textures, entity_set)?;
         let hover_sound = self.hover_sound.add_to_entity(entity, sounds, entity_set)?;
         let press_sound = self.press_sound.add_to_entity(entity, sounds, entity_set)?;
-        let release_sound = self.release_sound.add_to_entity(entity, sounds, entity_set)?;
+        let release_sound = self
+            .release_sound
+            .add_to_entity(entity, sounds, entity_set)?;
         buttons.insert(
             entity,
             UiButton::new(

--- a/book/src/game-data.md
+++ b/book/src/game-data.md
@@ -103,7 +103,7 @@ our `Application`, but first we should create some `State`s.
 struct Main;
 struct Paused;
 
-impl<'a, 'b> State<CustomGameData<'a, 'b>,()> for Paused {
+impl<'a, 'b> State<CustomGameData<'a, 'b>, StateEvent> for Paused {
     fn on_start(&mut self, data: StateData<CustomGameData>) {
         create_paused_ui(data.world);
     }
@@ -111,8 +111,8 @@ impl<'a, 'b> State<CustomGameData<'a, 'b>,()> for Paused {
     fn handle_event(
         &mut self,
         data: StateData<CustomGameData>,
-        event: StateEvent<()>,
-    ) -> Trans<CustomGameData<'a, 'b>,()> {
+        event: StateEvent>,
+    ) -> Trans<CustomGameData<'a, 'b>, StateEvent> {
         if let StateEvent::Window(event) = &event {
             if is_close_requested(&event) || is_key_down(&event, VirtualKeyCode::Escape) {
                 Trans::Quit
@@ -127,13 +127,13 @@ impl<'a, 'b> State<CustomGameData<'a, 'b>,()> for Paused {
         }
     }
 
-    fn update(&mut self, data: StateData<CustomGameData>) -> Trans<CustomGameData<'a, 'b>,()> {
+    fn update(&mut self, data: StateData<CustomGameData>) -> Trans<CustomGameData<'a, 'b>, StateEvent> {
         data.data.update(&data.world, false); // false to say we should not dispatch running
         Trans::None
     }
 }
 
-impl<'a, 'b> State<CustomGameData<'a, 'b>,()> for Main {
+impl<'a, 'b> State<CustomGameData<'a, 'b>, StateEvent> for Main {
     fn on_start(&mut self, data: StateData<CustomGameData>) {
         initialise(data.world);
     }
@@ -141,8 +141,8 @@ impl<'a, 'b> State<CustomGameData<'a, 'b>,()> for Main {
     fn handle_event(
         &mut self,
         _: StateData<CustomGameData>,
-        event: StateEvent<()>,
-    ) -> Trans<CustomGameData<'a, 'b>,()> {
+        event: StateEvent,
+    ) -> Trans<CustomGameData<'a, 'b>, StateEvent> {
         if let StateEvent::Window(event) = &event {
             if is_close_requested(&event) || is_key_down(&event, VirtualKeyCode::Escape) {
                 Trans::Quit
@@ -156,7 +156,7 @@ impl<'a, 'b> State<CustomGameData<'a, 'b>,()> for Main {
         }
     }
 
-    fn update(&mut self, data: StateData<CustomGameData>) -> Trans<CustomGameData<'a, 'b>> {
+    fn update(&mut self, data: StateData<CustomGameData>) -> Trans<CustomGameData<'a, 'b>, StateEvent> {
         data.data.update(&data.world, true); // true to say we should dispatch running
         Trans::None
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -58,6 +58,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * The z in UiTransformBuilder now defaults to 1 instead of 0, allowing to skip defining the z in the ui prefabs. ([#946])
 * Added comments to ui prefab. ([#946])
 * Summarized all `use amethyst::` statements to allow collapsing in IDE's. ([#974])
+* `Application` now uses `EventReader`s to determine what events to send to the `State`s, more information in the `State` 
+  book chapter ([#996])
 * Breaking: Refactor `TextureMetadata` so filter method and clamping can be configured more easily ([#981])
 * Renamed `PrefabData` functions to be easier to understand ([#1008])
 
@@ -102,6 +104,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#976]: https://github.com/amethyst/amethyst/pull/976
 [#981]: https://github.com/amethyst/amethyst/pull/981
 [#994]: https://github.com/amethyst/amethyst/pull/994
+[#996]: https://github.com/amethyst/amethyst/pull/996
 [#997]: https://github.com/amethyst/amethyst/pull/997
 [#1006]: https://github.com/amethyst/amethyst/pull/1006
 [#1008]: https://github.com/amethyst/amethyst/pull/1008

--- a/examples/animation/main.rs
+++ b/examples/animation/main.rs
@@ -59,7 +59,7 @@ impl<'a, 'b> SimpleState<'a, 'b> for Example {
     fn handle_event(
         &mut self,
         data: StateData<GameData>,
-        event: StateEvent<()>,
+        event: StateEvent,
     ) -> SimpleTrans<'a, 'b> {
         let StateData { world, .. } = data;
         if let StateEvent::Window(event) = &event {

--- a/examples/custom_game_data/main.rs
+++ b/examples/custom_game_data/main.rs
@@ -58,7 +58,7 @@ impl Component for Tag {
     type Storage = NullStorage<Self>;
 }
 
-impl<'a, 'b> State<CustomGameData<'a, 'b>, ()> for Loading {
+impl<'a, 'b> State<CustomGameData<'a, 'b>, StateEvent> for Loading {
     fn on_start(&mut self, data: StateData<CustomGameData>) {
         self.scene = Some(data.world.exec(|loader: PrefabLoader<MyPrefabData>| {
             loader.load("prefab/renderable.ron", RonFormat, (), &mut self.progress)
@@ -82,8 +82,8 @@ impl<'a, 'b> State<CustomGameData<'a, 'b>, ()> for Loading {
     fn handle_event(
         &mut self,
         _: StateData<CustomGameData>,
-        event: StateEvent<()>,
-    ) -> Trans<CustomGameData<'a, 'b>, ()> {
+        event: StateEvent,
+    ) -> Trans<CustomGameData<'a, 'b>, StateEvent> {
         if let StateEvent::Window(event) = event {
             if is_close_requested(&event) || is_key_down(&event, VirtualKeyCode::Escape) {
                 return Trans::Quit;
@@ -92,7 +92,10 @@ impl<'a, 'b> State<CustomGameData<'a, 'b>, ()> for Loading {
         Trans::None
     }
 
-    fn update(&mut self, data: StateData<CustomGameData>) -> Trans<CustomGameData<'a, 'b>, ()> {
+    fn update(
+        &mut self,
+        data: StateData<CustomGameData>,
+    ) -> Trans<CustomGameData<'a, 'b>, StateEvent> {
         data.data.update(&data.world, true);
         match self.progress.complete() {
             Completion::Failed => {
@@ -114,12 +117,12 @@ impl<'a, 'b> State<CustomGameData<'a, 'b>, ()> for Loading {
     }
 }
 
-impl<'a, 'b> State<CustomGameData<'a, 'b>, ()> for Paused {
+impl<'a, 'b> State<CustomGameData<'a, 'b>, StateEvent> for Paused {
     fn handle_event(
         &mut self,
         data: StateData<CustomGameData>,
-        event: StateEvent<()>,
-    ) -> Trans<CustomGameData<'a, 'b>, ()> {
+        event: StateEvent,
+    ) -> Trans<CustomGameData<'a, 'b>, StateEvent> {
         if let StateEvent::Window(event) = &event {
             if is_close_requested(&event) || is_key_down(&event, VirtualKeyCode::Escape) {
                 Trans::Quit
@@ -134,13 +137,16 @@ impl<'a, 'b> State<CustomGameData<'a, 'b>, ()> for Paused {
         }
     }
 
-    fn update(&mut self, data: StateData<CustomGameData>) -> Trans<CustomGameData<'a, 'b>, ()> {
+    fn update(
+        &mut self,
+        data: StateData<CustomGameData>,
+    ) -> Trans<CustomGameData<'a, 'b>, StateEvent> {
         data.data.update(&data.world, false);
         Trans::None
     }
 }
 
-impl<'a, 'b> State<CustomGameData<'a, 'b>, ()> for Main {
+impl<'a, 'b> State<CustomGameData<'a, 'b>, StateEvent> for Main {
     fn on_start(&mut self, data: StateData<CustomGameData>) {
         data.world.create_entity().with(self.scene.clone()).build();
     }
@@ -148,8 +154,8 @@ impl<'a, 'b> State<CustomGameData<'a, 'b>, ()> for Main {
     fn handle_event(
         &mut self,
         data: StateData<CustomGameData>,
-        event: StateEvent<()>,
-    ) -> Trans<CustomGameData<'a, 'b>, ()> {
+        event: StateEvent,
+    ) -> Trans<CustomGameData<'a, 'b>, StateEvent> {
         if let StateEvent::Window(event) = &event {
             if is_close_requested(&event) || is_key_down(&event, VirtualKeyCode::Escape) {
                 Trans::Quit
@@ -169,7 +175,10 @@ impl<'a, 'b> State<CustomGameData<'a, 'b>, ()> for Main {
         }
     }
 
-    fn update(&mut self, data: StateData<CustomGameData>) -> Trans<CustomGameData<'a, 'b>, ()> {
+    fn update(
+        &mut self,
+        data: StateData<CustomGameData>,
+    ) -> Trans<CustomGameData<'a, 'b>, StateEvent> {
         data.data.update(&data.world, true);
         Trans::None
     }

--- a/examples/gltf/main.rs
+++ b/examples/gltf/main.rs
@@ -116,7 +116,7 @@ impl<'a, 'b> SimpleState<'a, 'b> for Example {
     fn handle_event(
         &mut self,
         data: StateData<GameData>,
-        event: StateEvent<()>,
+        event: StateEvent,
     ) -> SimpleTrans<'a, 'b> {
         let StateData { world, .. } = data;
         if let StateEvent::Window(event) = &event {

--- a/examples/net_client/main.rs
+++ b/examples/net_client/main.rs
@@ -31,17 +31,12 @@ fn main() -> Result<()> {
 
 /// Default empty state
 pub struct State1;
-impl<'a, 'b> State<GameData<'a, 'b>, ()> for State1 {
+impl<'a, 'b> SimpleState<'a, 'b> for State1 {
     fn on_start(&mut self, data: StateData<GameData>) {
         data.world
             .create_entity()
             .with(NetConnection::<()>::new("127.0.0.1:3456".parse().unwrap()))
             .build();
-    }
-
-    fn update(&mut self, mut data: StateData<GameData>) -> Trans<GameData<'a, 'b>, ()> {
-        data.data.update(&mut data.world);
-        Trans::None
     }
 }
 

--- a/examples/net_server/main.rs
+++ b/examples/net_server/main.rs
@@ -30,17 +30,12 @@ fn main() -> Result<()> {
 
 /// Default empty state
 pub struct State1;
-impl<'a, 'b> State<GameData<'a, 'b>, ()> for State1 {
+impl<'a, 'b> SimpleState<'a, 'b> for State1 {
     fn on_start(&mut self, data: StateData<GameData>) {
         data.world
             .create_entity()
             .with(NetConnection::<()>::new("127.0.0.1:3455".parse().unwrap()))
             .build();
-    }
-
-    fn update(&mut self, mut data: StateData<GameData>) -> Trans<GameData<'a, 'b>, ()> {
-        data.data.update(&mut data.world);
-        Trans::None
     }
 }
 

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -82,7 +82,7 @@ impl<'a, 'b> SimpleState<'a, 'b> for Example {
     fn handle_event(
         &mut self,
         data: StateData<GameData>,
-        event: StateEvent<()>,
+        event: StateEvent,
     ) -> SimpleTrans<'a, 'b> {
         let w = data.world;
         if let StateEvent::Window(event) = &event {

--- a/examples/sprites_ordered/main.rs
+++ b/examples/sprites_ordered/main.rs
@@ -96,7 +96,7 @@ impl<'a, 'b> SimpleState<'a, 'b> for Example {
     fn handle_event(
         &mut self,
         mut data: StateData<GameData>,
-        event: StateEvent<()>,
+        event: StateEvent,
     ) -> SimpleTrans<'a, 'b> {
         if let StateEvent::Window(event) = &event {
             if is_close_requested(&event) || is_key_down(&event, VirtualKeyCode::Escape) {

--- a/examples/ui/main.rs
+++ b/examples/ui/main.rs
@@ -42,11 +42,7 @@ impl<'a, 'b> SimpleState<'a, 'b> for Example {
         });
     }
 
-    fn handle_event(
-        &mut self,
-        _: StateData<GameData>,
-        event: StateEvent<()>,
-    ) -> SimpleTrans<'a, 'b> {
+    fn handle_event(&mut self, _: StateData<GameData>, event: StateEvent) -> SimpleTrans<'a, 'b> {
         match &event {
             StateEvent::Window(event) => {
                 if is_close_requested(&event) || is_key_down(&event, VirtualKeyCode::Escape) {
@@ -62,7 +58,6 @@ impl<'a, 'b> SimpleState<'a, 'b> for Example {
                 );
                 Trans::None
             }
-            _ => Trans::None,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //!         println!("Starting game!");
 //!     }
 //!
-//!     fn handle_event(&mut self, _: StateData<()>, event: StateEvent<()>) -> EmptyTrans {
+//!     fn handle_event(&mut self, _: StateData<()>, event: StateEvent) -> EmptyTrans {
 //!         if let StateEvent::Window(event) = &event {
 //!             match event {
 //!                  Event::WindowEvent { event, .. } => match event {
@@ -66,6 +66,8 @@ pub extern crate amethyst_audio as audio;
 pub extern crate amethyst_config as config;
 pub extern crate amethyst_controls as controls;
 pub extern crate amethyst_core as core;
+#[macro_use]
+pub extern crate amethyst_derive as derive;
 pub extern crate amethyst_input as input;
 pub extern crate amethyst_locale as locale;
 pub extern crate amethyst_network as network;
@@ -86,7 +88,7 @@ extern crate rustc_version_runtime;
 #[macro_use]
 extern crate serde_derive;
 
-pub use self::app::{Application, CoreApplication, ApplicationBuilder};
+pub use self::app::{Application, ApplicationBuilder, CoreApplication};
 pub use self::error::{Error, Result};
 pub use self::game_data::{DataInit, GameData, GameDataBuilder};
 pub use self::logger::{start_logger, LevelFilter as LogLevelFilter, LoggerConfig, StdoutLog};
@@ -97,6 +99,9 @@ pub use self::state_event::{StateEvent, StateEventReader};
 pub use core::shred;
 pub use core::shrev;
 pub use core::specs as ecs;
+
+#[doc(hidden)]
+pub use derive::*;
 
 pub mod prelude;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ extern crate rustc_version_runtime;
 #[macro_use]
 extern crate serde_derive;
 
-pub use self::app::{Application, ApplicationBuilder};
+pub use self::app::{Application, CoreApplication, ApplicationBuilder};
 pub use self::error::{Error, Result};
 pub use self::game_data::{DataInit, GameData, GameDataBuilder};
 pub use self::logger::{start_logger, LevelFilter as LogLevelFilter, LoggerConfig, StdoutLog};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ pub use self::logger::{start_logger, LevelFilter as LogLevelFilter, LoggerConfig
 pub use self::state::{
     EmptyState, EmptyTrans, SimpleState, SimpleTrans, State, StateData, StateMachine, Trans,
 };
-pub use self::state_event::StateEvent;
+pub use self::state_event::{StateEvent, StateEventReader};
 pub use core::shred;
 pub use core::shrev;
 pub use core::specs as ecs;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,6 @@
 //! Contains common types that can be glob-imported (`*`) for convenience.
 
-pub use app::{Application, ApplicationBuilder};
+pub use app::{Application, ApplicationBuilder, CoreApplication};
 pub use config::Config;
 pub use core::WithNamed;
 pub use ecs::prelude::{Builder, World};

--- a/src/state.rs
+++ b/src/state.rs
@@ -62,11 +62,11 @@ pub enum Trans<T, E> {
 }
 
 /// An empty `Trans`. Made to be used with `EmptyState`.
-pub type EmptyTrans = Trans<(), ()>;
+pub type EmptyTrans = Trans<(), StateEvent<()>>;
 
 /// A simple default `Trans`. Made to be used with `SimpleState`.
 /// By default it contains a `GameData` as its `StateData` and doesn't have a custom event type.
-pub type SimpleTrans<'a, 'b> = Trans<GameData<'a, 'b>, ()>;
+pub type SimpleTrans<'a, 'b> = Trans<GameData<'a, 'b>, StateEvent<()>>;
 
 /// A trait which defines game states that can be used by the state machine.
 pub trait State<T, E: Send + Sync + 'static> {
@@ -83,7 +83,7 @@ pub trait State<T, E: Send + Sync + 'static> {
     fn on_resume(&mut self, _data: StateData<T>) {}
 
     /// Executed on every frame before updating, for use in reacting to events.
-    fn handle_event(&mut self, _data: StateData<T>, _event: StateEvent<E>) -> Trans<T, E> {
+    fn handle_event(&mut self, _data: StateData<T>, _event: E) -> Trans<T, E> {
         Trans::None
     }
 
@@ -162,7 +162,7 @@ pub trait EmptyState {
     fn shadow_update(&mut self, _data: StateData<()>) {}
 }
 
-impl<T: EmptyState> State<(), ()> for T {
+impl<T: EmptyState> State<(), StateEvent<()>> for T {
     /// Executed when the game state begins.
     fn on_start(&mut self, data: StateData<()>) {
         self.on_start(data)
@@ -268,7 +268,7 @@ pub trait SimpleState<'a, 'b> {
     /// as long as this state is on the [StateMachine](struct.StateMachine.html)'s state-stack.
     fn shadow_update(&mut self, _data: StateData<GameData>) {}
 }
-impl<'a, 'b, T: SimpleState<'a, 'b>> State<GameData<'a, 'b>, ()> for T {
+impl<'a, 'b, T: SimpleState<'a, 'b>> State<GameData<'a, 'b>, StateEvent<()>> for T {
     //pub trait SimpleState<'a,'b>: State<GameData<'a,'b>,()> {
 
     /// Executed when the game state begins.
@@ -366,7 +366,7 @@ impl<'a, T, E: Send + Sync + 'static> StateMachine<'a, T, E> {
     }
 
     /// Passes a single event to the active state to handle.
-    pub fn handle_event(&mut self, data: StateData<T>, event: StateEvent<E>) {
+    pub fn handle_event(&mut self, data: StateData<T>, event: E) {
         let StateData { world, data } = data;
         if self.running {
             let trans = match self.state_stack.last_mut() {

--- a/src/state.rs
+++ b/src/state.rs
@@ -46,7 +46,7 @@ where
 
 /// Types of state transitions.
 /// T is the type of shared data between states.
-/// E is the type of custom events handled by StateEvent<E>.
+/// E is the type of events
 pub enum Trans<T, E> {
     /// Continue as normal.
     None,
@@ -62,11 +62,11 @@ pub enum Trans<T, E> {
 }
 
 /// An empty `Trans`. Made to be used with `EmptyState`.
-pub type EmptyTrans = Trans<(), StateEvent<()>>;
+pub type EmptyTrans = Trans<(), StateEvent>;
 
 /// A simple default `Trans`. Made to be used with `SimpleState`.
 /// By default it contains a `GameData` as its `StateData` and doesn't have a custom event type.
-pub type SimpleTrans<'a, 'b> = Trans<GameData<'a, 'b>, StateEvent<()>>;
+pub type SimpleTrans<'a, 'b> = Trans<GameData<'a, 'b>, StateEvent>;
 
 /// A trait which defines game states that can be used by the state machine.
 pub trait State<T, E: Send + Sync + 'static> {
@@ -127,7 +127,7 @@ pub trait EmptyState {
     fn on_resume(&mut self, _data: StateData<()>) {}
 
     /// Executed on every frame before updating, for use in reacting to events.
-    fn handle_event(&mut self, _data: StateData<()>, event: StateEvent<()>) -> EmptyTrans {
+    fn handle_event(&mut self, _data: StateData<()>, event: StateEvent) -> EmptyTrans {
         if let StateEvent::Window(event) = &event {
             if is_close_requested(&event) {
                 Trans::Quit
@@ -162,7 +162,7 @@ pub trait EmptyState {
     fn shadow_update(&mut self, _data: StateData<()>) {}
 }
 
-impl<T: EmptyState> State<(), StateEvent<()>> for T {
+impl<T: EmptyState> State<(), StateEvent> for T {
     /// Executed when the game state begins.
     fn on_start(&mut self, data: StateData<()>) {
         self.on_start(data)
@@ -184,7 +184,7 @@ impl<T: EmptyState> State<(), StateEvent<()>> for T {
     }
 
     /// Executed on every frame before updating, for use in reacting to events.
-    fn handle_event(&mut self, data: StateData<()>, event: StateEvent<()>) -> EmptyTrans {
+    fn handle_event(&mut self, data: StateData<()>, event: StateEvent) -> EmptyTrans {
         self.handle_event(data, event)
     }
 
@@ -233,7 +233,7 @@ pub trait SimpleState<'a, 'b> {
     fn handle_event(
         &mut self,
         _data: StateData<GameData>,
-        event: StateEvent<()>,
+        event: StateEvent,
     ) -> SimpleTrans<'a, 'b> {
         if let StateEvent::Window(event) = &event {
             if is_close_requested(&event) {
@@ -268,7 +268,8 @@ pub trait SimpleState<'a, 'b> {
     /// as long as this state is on the [StateMachine](struct.StateMachine.html)'s state-stack.
     fn shadow_update(&mut self, _data: StateData<GameData>) {}
 }
-impl<'a, 'b, T: SimpleState<'a, 'b>> State<GameData<'a, 'b>, StateEvent<()>> for T {
+
+impl<'a, 'b, T: SimpleState<'a, 'b>> State<GameData<'a, 'b>, StateEvent> for T {
     //pub trait SimpleState<'a,'b>: State<GameData<'a,'b>,()> {
 
     /// Executed when the game state begins.
@@ -295,7 +296,7 @@ impl<'a, 'b, T: SimpleState<'a, 'b>> State<GameData<'a, 'b>, StateEvent<()>> for
     fn handle_event(
         &mut self,
         data: StateData<GameData>,
-        event: StateEvent<()>,
+        event: StateEvent,
     ) -> SimpleTrans<'a, 'b> {
         self.handle_event(data, event)
     }

--- a/src/state_event.rs
+++ b/src/state_event.rs
@@ -1,7 +1,11 @@
 use renderer::Event;
 use ui::UiEvent;
+use core::EventReader;
+use core::shrev::{ReaderId, EventChannel};
+use core::specs::{World, Read};
 
 /// The enum holding the different types of event that can be received in a `State` in the handle_event method.
+#[derive(Clone)]
 pub enum StateEvent<E: Send + Sync + 'static> {
     /// Events sent by the winit window.
     Window(Event),
@@ -10,4 +14,39 @@ pub enum StateEvent<E: Send + Sync + 'static> {
     /// Custom user events.
     /// To receive events from there, you need to write `E` instances into EventChannel<E>
     Custom(E),
+}
+
+pub struct StateEventReader<E: Send + Sync + 'static> {
+    window: ReaderId<Event>,
+    ui: ReaderId<UiEvent>,
+    custom: ReaderId<E>,
+}
+
+impl <E: Send + Sync + 'static> StateEventReader<E> {
+    pub fn new(world: &mut World) -> Self {
+        let window = world
+            .write_resource::<EventChannel<Event>>()
+            .register_reader();
+        let ui = world
+            .write_resource::<EventChannel<UiEvent>>()
+            .register_reader();
+        let custom = world
+            .write_resource::<EventChannel<E>>()
+            .register_reader();
+
+        StateEventReader {
+            window, custom, ui
+        }
+    }
+}
+
+impl<'a, E: Clone + Send + Sync + 'static> EventReader<'a> for StateEventReader<E> {
+    type SystemData = (Read<'a, EventChannel<Event>>, Read<'a, EventChannel<UiEvent>>, Read<'a, EventChannel<E>>);
+    type Event = StateEvent<E>;
+
+    fn read(&mut self, data: Self::SystemData, events: &mut Vec<StateEvent<E>>) {
+        events.extend(data.0.read(&mut self.window).cloned().map(|e| StateEvent::Window(e)));
+        events.extend(data.1.read(&mut self.ui).cloned().map(|e| StateEvent::Ui(e)));
+        events.extend(data.2.read(&mut self.custom).cloned().map(|e| StateEvent::Custom(e)));
+    }
 }

--- a/src/state_event.rs
+++ b/src/state_event.rs
@@ -6,23 +6,19 @@ use core::specs::{World, Read};
 
 /// The enum holding the different types of event that can be received in a `State` in the handle_event method.
 #[derive(Clone)]
-pub enum StateEvent<E: Send + Sync + 'static> {
+pub enum StateEvent {
     /// Events sent by the winit window.
     Window(Event),
     /// Events sent by the ui system.
     Ui(UiEvent),
-    /// Custom user events.
-    /// To receive events from there, you need to write `E` instances into EventChannel<E>
-    Custom(E),
 }
 
-pub struct StateEventReader<E: Send + Sync + 'static> {
+pub struct StateEventReader {
     window: ReaderId<Event>,
     ui: ReaderId<UiEvent>,
-    custom: ReaderId<E>,
 }
 
-impl <E: Send + Sync + 'static> StateEventReader<E> {
+impl StateEventReader {
     pub fn new(world: &mut World) -> Self {
         let window = world
             .write_resource::<EventChannel<Event>>()
@@ -30,23 +26,26 @@ impl <E: Send + Sync + 'static> StateEventReader<E> {
         let ui = world
             .write_resource::<EventChannel<UiEvent>>()
             .register_reader();
-        let custom = world
-            .write_resource::<EventChannel<E>>()
-            .register_reader();
 
         StateEventReader {
-            window, custom, ui
+            window, ui
         }
     }
 }
 
-impl<'a, E: Clone + Send + Sync + 'static> EventReader<'a> for StateEventReader<E> {
-    type SystemData = (Read<'a, EventChannel<Event>>, Read<'a, EventChannel<UiEvent>>, Read<'a, EventChannel<E>>);
-    type Event = StateEvent<E>;
+impl<'a> EventReader<'a> for StateEventReader {
+    type SystemData = (Read<'a, EventChannel<Event>>, Read<'a, EventChannel<UiEvent>>);
+    type Event = StateEvent;
 
-    fn read(&mut self, data: Self::SystemData, events: &mut Vec<StateEvent<E>>) {
+    fn read(&mut self, data: Self::SystemData, events: &mut Vec<StateEvent>) {
         events.extend(data.0.read(&mut self.window).cloned().map(|e| StateEvent::Window(e)));
         events.extend(data.1.read(&mut self.ui).cloned().map(|e| StateEvent::Ui(e)));
-        events.extend(data.2.read(&mut self.custom).cloned().map(|e| StateEvent::Custom(e)));
+    }
+
+    fn build(world: &mut World) -> Self {
+        StateEventReader {
+            window: world.write_resource::<EventChannel<Event>>().register_reader(),
+            ui: world.write_resource::<EventChannel<UiEvent>>().register_reader(),
+        }
     }
 }

--- a/src/state_event.rs
+++ b/src/state_event.rs
@@ -1,51 +1,17 @@
+use core::{
+    shrev::{EventChannel, ReaderId},
+    specs::{Read, Resources, SystemData},
+    EventReader,
+};
 use renderer::Event;
 use ui::UiEvent;
-use core::EventReader;
-use core::shrev::{ReaderId, EventChannel};
-use core::specs::{World, Read};
 
 /// The enum holding the different types of event that can be received in a `State` in the handle_event method.
-#[derive(Clone)]
+#[derive(Clone, EventReader)]
+#[reader(StateEventReader)]
 pub enum StateEvent {
     /// Events sent by the winit window.
     Window(Event),
     /// Events sent by the ui system.
     Ui(UiEvent),
-}
-
-pub struct StateEventReader {
-    window: ReaderId<Event>,
-    ui: ReaderId<UiEvent>,
-}
-
-impl StateEventReader {
-    pub fn new(world: &mut World) -> Self {
-        let window = world
-            .write_resource::<EventChannel<Event>>()
-            .register_reader();
-        let ui = world
-            .write_resource::<EventChannel<UiEvent>>()
-            .register_reader();
-
-        StateEventReader {
-            window, ui
-        }
-    }
-}
-
-impl<'a> EventReader<'a> for StateEventReader {
-    type SystemData = (Read<'a, EventChannel<Event>>, Read<'a, EventChannel<UiEvent>>);
-    type Event = StateEvent;
-
-    fn read(&mut self, data: Self::SystemData, events: &mut Vec<StateEvent>) {
-        events.extend(data.0.read(&mut self.window).cloned().map(|e| StateEvent::Window(e)));
-        events.extend(data.1.read(&mut self.ui).cloned().map(|e| StateEvent::Ui(e)));
-    }
-
-    fn build(world: &mut World) -> Self {
-        StateEventReader {
-            window: world.write_resource::<EventChannel<Event>>().register_reader(),
-            ui: world.write_resource::<EventChannel<UiEvent>>().register_reader(),
-        }
-    }
 }

--- a/travis.sh
+++ b/travis.sh
@@ -1,6 +1,7 @@
 MDBOOK_RELEASE="v0.2.1/mdbook-v0.2.1-x86_64-unknown-linux-gnu.tar.gz"
 
 echo "Build and test without profiler"
+rm -rf target/debug/deps/amethyst* target/debug/deps/libamethyst*
 cargo test --all -v || exit 1
 
 if [ ${TRAVIS_OS_NAME} = "linux" ]


### PR DESCRIPTION
Adds EventReader, which is a trait that abstract event reading. The primary user for this is to make it configurable what events get read by Application and sent to the States. 

Also added a new derive crate, which a derive macro for creating an EventReader for an aggregated event enum. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/996)
<!-- Reviewable:end -->
