### PR TITLE
Fix for dragging between monitors with different DPIs

### DIFF
--- a/amethyst_renderer/src/renderer.rs
+++ b/amethyst_renderer/src/renderer.rs
@@ -22,6 +22,7 @@ pub struct Renderer {
     events: EventsLoop,
     multisampling: u16,
     cached_size: LogicalSize,
+    cached_hidpi_factor: f64,
 }
 
 impl Renderer {
@@ -78,12 +79,15 @@ impl Renderer {
         use glutin::GlContext;
 
         if let Some(size) = self.window().get_inner_size() {
-            if size != self.cached_size {
+            let hidpi_factor = self.window().get_hidpi_factor();
+
+            if size != self.cached_size || hidpi_factor != self.cached_hidpi_factor {
                 self.cached_size = size.into();
+                self.cached_hidpi_factor = hidpi_factor;
                 #[cfg(feature = "opengl")]
                 self.window.resize(PhysicalSize::from_logical(
                     size,
-                    self.window().get_hidpi_factor(),
+                    hidpi_factor,
                 ));
                 self.resize(pipe, size.into());
             }
@@ -214,6 +218,8 @@ impl RendererBuilder {
             .get_inner_size()
             .expect("Unable to fetch window size, as the window went away!")
             .into();
+        let cached_hidpi_factor = window.get_hidpi_factor();
+
         let encoder = factory.create_command_buffer().into();
         Ok(Renderer {
             device,
@@ -224,6 +230,7 @@ impl RendererBuilder {
             events: self.events,
             multisampling: self.config.multisampling,
             cached_size,
+            cached_hidpi_factor,
         })
     }
 }


### PR DESCRIPTION
If you drag from a monitor with high dpi (Macbook Retina screen in my case) to a lower dpi external monitor the screen doesn't update and you end up seeing the top left quarter of the picture.

I copied the logic around the window size: adding cached_hidpi_factor to the renderer struct and comparing this to the current dpi in the draw method.

Hopefully pretty straightforward change but please let me know your thoughts. I'm new to rust so feel free to critique whatever implementation decisions I've made :)