### PR TITLE
Derive Serialize (and other traits) for more types

### DIFF
--- a/amethyst_controls/src/components.rs
+++ b/amethyst_controls/src/components.rs
@@ -3,7 +3,7 @@ use amethyst_core::specs::prelude::{Component, Entity, HashMapStorage, NullStora
 
 /// Add this to a camera if you want it to be a fly camera.
 /// You need to add the FlyControlBundle or the required systems for it to work.
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct FlyControlTag;
 
 impl Component for FlyControlTag {

--- a/amethyst_controls/src/resources.rs
+++ b/amethyst_controls/src/resources.rs
@@ -1,6 +1,6 @@
 /// Struct which holds information about whether the window is focused.
 /// Written to by MouseFocusUpdateSystem
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct WindowFocus {
     pub is_focused: bool,
 }
@@ -13,6 +13,7 @@ impl WindowFocus {
 
 /// Resource indicating if the mouse should be grabbed and hidden by the CursorHideSystem
 /// when the window is focused.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct HideCursor {
     pub hide: bool,
 }

--- a/amethyst_ui/src/button/mod.rs
+++ b/amethyst_ui/src/button/mod.rs
@@ -8,6 +8,7 @@ use amethyst_core::specs::prelude::{Component, DenseVecStorage};
 
 /// A clickable button, this must be paired with a `UiImage`
 /// and this entity must have a child entity with a `UiText`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct UiButton {
     /// Default text color
     normal_text_color: [f32; 4],

--- a/amethyst_ui/src/transform.rs
+++ b/amethyst_ui/src/transform.rs
@@ -24,7 +24,7 @@ impl<'a> UiFinder<'a> {
 /// The UiTransform represents the transformation of a ui element.
 /// Values are in pixel and the position is calculated from the bottom left of the screen
 /// to the center of the ui element's area.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct UiTransform {
     /// An identifier. Serves no purpose other than to help you distinguish between UI elements.
     pub id: String,

--- a/amethyst_utils/src/removal.rs
+++ b/amethyst_utils/src/removal.rs
@@ -7,7 +7,7 @@ use std::result::Result;
 /// A marker `Component` used to remove entities and clean up your scene.
 /// The generic parameter `I` is the type of id you want to use.
 /// Generally an int or an enum.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Removal<I>
 where
     I: Debug + Clone,


### PR DESCRIPTION
I've derived `Serialize` impls for a number of types in order to support displaying them in the editor via [amethyst-editor-sync](https://github.com/randomPoison/amethyst-editor-sync). I've also derived various other commonly-used traits where appropriate. Please let me know if any of these traits shouldn't be added, or if there are any other traits you think I should go ahead and add as part of this PR 🙂 