### PR TITLE
Implement configurable line width for debug lines

### DIFF
--- a/amethyst_renderer/src/lib.rs
+++ b/amethyst_renderer/src/lib.rs
@@ -99,7 +99,7 @@ pub use light::{DirectionalLight, Light, LightPrefab, PointLight, SpotLight, Sun
 pub use mesh::{vertex_data, Mesh, MeshBuilder, MeshHandle, VertexBuffer};
 pub use mtl::{Material, MaterialDefaults, MaterialTextureSet, TextureOffset};
 pub use pass::{
-    get_camera, set_vertex_args, DrawDebugLines, DrawFlat, DrawFlatSeparate, DrawPbm,
+    get_camera, set_vertex_args, DrawDebugLines, DebugLinesParams, DrawFlat, DrawFlatSeparate, DrawPbm,
     DrawPbmSeparate, DrawShaded, DrawShadedSeparate, DrawSprite,
 };
 pub use pipe::{

--- a/amethyst_renderer/src/pass/debug_lines/mod.rs
+++ b/amethyst_renderer/src/pass/debug_lines/mod.rs
@@ -1,3 +1,4 @@
+pub use self::interleaved::DebugLinesParams;
 pub use self::interleaved::DrawDebugLines;
 
 mod interleaved;

--- a/amethyst_renderer/src/pass/shaders/geometry/debug_lines.glsl
+++ b/amethyst_renderer/src/pass/shaders/geometry/debug_lines.glsl
@@ -24,27 +24,24 @@ layout (points) in;
 layout (triangle_strip, max_vertices = 4) out;
 
 uniform vec3 camera_position;
-
-// The line width is 1 line width unit, which is one 400th the unit size
-const float WIDTH = 1.0 / 400.0;
-const float HALF_WIDTH = WIDTH / 2.0;
+uniform float line_width;
 
 void EmitLine (int id) {
     vec3 cam_dir = normalize(vertex_in[id].position - camera_position);
     vec3 right = normalize(cross(cam_dir, vertex_in[id].normal));
 
-    vec3 width_vector = right * HALF_WIDTH;
+    vec3 width_vector = right * line_width * 0.5;
 
     vertex.color = vertex_in[id].color;
     vec3 pos = vertex_in[id].position - width_vector;
     gl_Position = proj * view * vec4(pos, 1.0);
     EmitVertex();
-    
+
     vertex.color = vertex_in[id].color;
     pos = vertex_in[id].position + width_vector;
     gl_Position = proj * view * vec4(pos, 1.0);
     EmitVertex();
-    
+
     vertex.color = vertex_in[id].color;
     pos = vertex_in[id].position + vertex_in[id].normal - width_vector;
     gl_Position = proj * view * vec4(pos, 1.0);

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -16,6 +16,7 @@
 * Lukas Schmierer
 * Matthias Schuster
 * msiglreith
+* NCrashed (Anton Gushcha)
 * Nikita Chashchinskii
 * Oflor
 * Robbie Cooper

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -101,6 +101,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#994]: https://github.com/amethyst/amethyst/pull/994
 [#1006]: https://github.com/amethyst/amethyst/pull/1006
 [#1008]: https://github.com/amethyst/amethyst/pull/1008
+[#1016]: https://github.com/amethyst/amethyst/pull/1016
 [winit_017]: https://github.com/tomaka/winit/blob/master/CHANGELOG.md#version-0172-2018-08-19
 [glutin_018]: https://github.com/tomaka/glutin/blob/master/CHANGELOG.md#version-0180-2018-08-03
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * Support for multiline text. ([#965])
 * Support for logging to file, toggle for logging to stdout. ([#976], [#994])
 * Added `shadow_update()` and `shadow_fixed_update()` to the `State` trait. ([#1006])
-
+* Added configurable width for debug lines ([#1016])
 
 
 ### Changed

--- a/examples/debug_lines/main.rs
+++ b/examples/debug_lines/main.rs
@@ -2,16 +2,19 @@
 
 extern crate amethyst;
 
-use amethyst::controls::{FlyControlBundle, FlyControlTag};
-use amethyst::core::cgmath::{Deg, Point3, Vector3};
-use amethyst::core::transform::{GlobalTransform, Transform, TransformBundle};
-use amethyst::core::Time;
-use amethyst::ecs::{Read, System, Write};
-use amethyst::input::InputBundle;
-use amethyst::prelude::*;
-use amethyst::renderer::*;
-
-use amethyst::utils::application_root_dir;
+use amethyst::{
+    controls::{FlyControlBundle, FlyControlTag},
+    core::Time,
+    core::{
+        cgmath::{Deg, Point3, Vector3},
+        transform::{GlobalTransform, Transform, TransformBundle},
+    },
+    ecs::{Read, System, Write},
+    input::InputBundle,
+    prelude::*,
+    renderer::*,
+    utils::application_root_dir,
+};
 
 struct ExampleLinesSystem;
 impl<'s> System<'s> for ExampleLinesSystem {

--- a/examples/debug_lines/main.rs
+++ b/examples/debug_lines/main.rs
@@ -46,6 +46,10 @@ impl<'a, 'b> SimpleState<'a, 'b> for ExampleState {
         // Setup debug lines as a resource
         data.world
             .add_resource(DebugLines::new().with_capacity(100));
+        // Configure width of lines. Optional step
+        data.world.add_resource(DebugLinesParams {
+            line_width: 1.0 / 400.0,
+        });
 
         // Setup debug lines as a component and add lines to render axis&grid
         let mut debug_lines_component = DebugLinesComponent::new().with_capacity(100);

--- a/examples/debug_lines/main.rs
+++ b/examples/debug_lines/main.rs
@@ -2,19 +2,16 @@
 
 extern crate amethyst;
 
-use amethyst::{
-    controls::{FlyControlBundle, FlyControlTag},
-    core::Time,
-    core::{
-        cgmath::{Deg, Point3, Vector3},
-        transform::{GlobalTransform, Transform, TransformBundle},
-    },
-    ecs::{Read, System, Write},
-    input::InputBundle,
-    prelude::*,
-    renderer::*,
-    utils::application_root_dir,
-};
+use amethyst::controls::{FlyControlBundle, FlyControlTag};
+use amethyst::core::cgmath::{Deg, Point3, Vector3};
+use amethyst::core::transform::{GlobalTransform, Transform, TransformBundle};
+use amethyst::core::Time;
+use amethyst::ecs::{Read, System, Write};
+use amethyst::input::InputBundle;
+use amethyst::prelude::*;
+use amethyst::renderer::*;
+
+use amethyst::utils::application_root_dir;
 
 struct ExampleLinesSystem;
 impl<'s> System<'s> for ExampleLinesSystem {
@@ -157,12 +154,14 @@ fn main() -> amethyst::Result<()> {
         Some(String::from("move_x")),
         Some(String::from("move_y")),
         Some(String::from("move_z")),
-    ).with_sensitivity(0.1, 0.1);
+    )
+    .with_sensitivity(0.1, 0.1);
 
     let game_data = GameDataBuilder::default()
         .with_bundle(
             InputBundle::<String, String>::new().with_bindings_from_file(&key_bindings_path)?,
-        )?.with(ExampleLinesSystem, "example_lines_system", &[])
+        )?
+        .with(ExampleLinesSystem, "example_lines_system", &[])
         .with_bundle(fly_control_bundle)?
         .with_bundle(TransformBundle::new().with_dep(&["fly_movement"]))?
         .with_bundle(RenderBundle::new(pipe, Some(config)))?;


### PR DESCRIPTION
Problem: debug lines are too thin for orthographic projection with large top/bottom/left/right ranges (usually used for 2D setups).

Solution:
* Use uniform for line width.
* Pass line width via resource.

Also added the usage of the new feature to example.

How to test:
* Change `DebugLinesParams` in `debug_lines` example and run 
 