### PR TITLE
Add TextureMetadata::srgb_scale for defaults with nearest filter

### DIFF
--- a/amethyst_renderer/src/formats/texture.rs
+++ b/amethyst_renderer/src/formats/texture.rs
@@ -70,6 +70,15 @@ impl TextureMetadata {
         }
     }
 
+    /// Creates texture metadata for `Srgb` texture but without texture filtering. This is usually
+    /// the case for color textures for 2D sprites and pixel art textures.
+    ///
+    /// For the values of all the other fields please refer to the documentation of the respective
+    /// field.
+    pub fn srgb_scale() -> Self {
+        TextureMetadata::srgb().with_filter(FilterMethod::Scale)
+    }
+
     /// Sampler info
     pub fn with_sampler(mut self, info: SamplerInfo) -> Self {
         self.sampler = info;

--- a/amethyst_renderer/src/formats/texture.rs
+++ b/amethyst_renderer/src/formats/texture.rs
@@ -75,6 +75,8 @@ impl TextureMetadata {
     ///
     /// For the values of all the other fields please refer to the documentation of the respective
     /// field.
+    ///
+    /// Wrap mode is set to `WrapMode::Clamp` by default. 
     pub fn srgb_scale() -> Self {
         TextureMetadata::srgb().with_filter(FilterMethod::Scale)
     }

--- a/amethyst_renderer/src/formats/texture.rs
+++ b/amethyst_renderer/src/formats/texture.rs
@@ -76,7 +76,7 @@ impl TextureMetadata {
     /// For the values of all the other fields please refer to the documentation of the respective
     /// field.
     ///
-    /// Wrap mode is set to `WrapMode::Clamp` by default. 
+    /// Wrap mode is set to `WrapMode::Clamp` by default.
     pub fn srgb_scale() -> Self {
         TextureMetadata::srgb().with_filter(FilterMethod::Scale)
     }
@@ -441,16 +441,12 @@ pub fn create_texture_asset(
     t.map(|t| ProcessingState::Loaded(t))
 }
 
-fn apply_options<D, T>(
-    tb: TextureBuilder<D, T>,
-    metadata: TextureMetadata,
-) -> TextureBuilder<D, T>
+fn apply_options<D, T>(tb: TextureBuilder<D, T>, metadata: TextureMetadata) -> TextureBuilder<D, T>
 where
     D: AsRef<[T]>,
     T: Pod + Copy,
 {
-    tb
-        .with_sampler(metadata.sampler)
+    tb.with_sampler(metadata.sampler)
         .mip_levels(metadata.mip_levels)
         .dynamic(metadata.dynamic)
         .with_format(metadata.format)

--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -441,7 +441,7 @@ fn load_sprite_sheet(world: &mut World) -> SpriteSheetHandle {
         loader.load(
             "texture/pong_spritesheet.png",
             PngFormat,
-            TextureMetadata::srgb(),
+            TextureMetadata::srgb_scale(),
             (),
             &texture_storage,
         )
@@ -486,7 +486,7 @@ Heading back to the code, we need to add this snippet after loading the texture.
 #       loader.load(
 #           "texture/pong_spritesheet.png",
 #           PngFormat,
-#           TextureMetadata::srgb(),
+#           TextureMetadata::srgb_scale(),
 #           (),
 #           &texture_storage,
 #       )
@@ -526,7 +526,7 @@ sprite sheet. Behold, texture coordinates!
 #       loader.load(
 #           "texture/pong_spritesheet.png",
 #           PngFormat,
-#           TextureMetadata::srgb(),
+#           TextureMetadata::srgb_scale(),
 #           (),
 #           &texture_storage,
 #       )
@@ -656,7 +656,7 @@ Next we simply add the components to the paddle entities:
 #   sprite_number: 0,
 #   flip_horizontal: true,
 #   flip_vertical: false,
-# }; 
+# };
 // Create a left plank entity.
 world
     .create_entity()

--- a/book/src/sprites/load_the_texture.md
+++ b/book/src/sprites/load_the_texture.md
@@ -53,6 +53,8 @@ There are two things that may surprise you.
 
     You pick the texture ID based on how you want to reference it. For example, you might have an application configuration that says `path/to/spritesheet_0.png` is ID `100`, `path/to/spritesheet_1.png` is ID `101`, so you can use that. Or, you might do something clever like calculate an ID based on the path, and if it's already loaded, then you know you don't have to load it again.
 
+The loaded texture will use linear filter, e.g. screen pixels will be linearly interpolated between the closest image pixels. In layman's terms, if your images have small resolution, sprites will look blury. Use `TextureMetadata::srgb_scale()` instead to avoid such effect. Screen pixel will be taken from nearest pixel of texture in that case.
+
 [doc_asset]: https://www.amethyst.rs/doc/latest/doc/amethyst_assets/trait.Asset.html
 [doc_asset_get]: https://www.amethyst.rs/doc/latest/doc/amethyst_assets/struct.AssetStorage.html#method.get
 [doc_fmt_bmp]: https://www.amethyst.rs/doc/latest/doc/amethyst_renderer/struct.BmpFormat.html

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * Documentation for drawing sprites. ([#971])
 * Added `shadow_update()` and `shadow_fixed_update()` to the `State` trait. ([#1006])
 * Added configurable width for debug lines ([#1016])
+* Added `TextureMetadata::srgb_scale()` for default texture metadata with nearest filter ([#1023])
 
 ### Changed
 * Sprites contain their dimensions and offsets to render them with the right size and desired position. ([#829], [#830])
@@ -108,6 +109,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1006]: https://github.com/amethyst/amethyst/pull/1006
 [#1008]: https://github.com/amethyst/amethyst/pull/1008
 [#1016]: https://github.com/amethyst/amethyst/pull/1016
+[#1023]: https://github.com/amethyst/amethyst/pull/1023
 [winit_017]: https://github.com/tomaka/winit/blob/master/CHANGELOG.md#version-0172-2018-08-19
 [glutin_018]: https://github.com/tomaka/glutin/blob/master/CHANGELOG.md#version-0180-2018-08-03
 

--- a/examples/pong/pong.rs
+++ b/examples/pong/pong.rs
@@ -53,7 +53,7 @@ fn load_sprite_sheet(world: &mut World) -> SpriteSheetHandle {
         loader.load(
             "texture/pong_spritesheet.png",
             PngFormat,
-            TextureMetadata::srgb().with_filter(FilterMethod::Scale),
+            TextureMetadata::srgb_scale(),
             (),
             &texture_storage,
         )

--- a/examples/pong/pong.rs
+++ b/examples/pong/pong.rs
@@ -7,9 +7,8 @@ use amethyst::{
     ecs::prelude::World,
     prelude::*,
     renderer::{
-        Camera, FilterMethod, MaterialTextureSet, PngFormat, Projection, Sprite, SpriteRender,
-        SpriteSheet, SpriteSheetHandle, Texture, TextureCoordinates, TextureMetadata,
-        WindowMessages,
+        Camera, MaterialTextureSet, PngFormat, Projection, Sprite, SpriteRender, SpriteSheet,
+        SpriteSheetHandle, Texture, TextureCoordinates, TextureMetadata, WindowMessages,
     },
     ui::{Anchor, TtfFormat, UiText, UiTransform},
 };
@@ -124,9 +123,11 @@ fn initialise_camera(world: &mut World) {
             ARENA_WIDTH,
             ARENA_HEIGHT,
             0.0,
-        ))).with(GlobalTransform(
+        )))
+        .with(GlobalTransform(
             Matrix4::from_translation(Vector3::new(0.0, 0.0, 1.0)).into(),
-        )).build();
+        ))
+        .build();
 }
 
 /// Hide the cursor, so it's invisible while playing.
@@ -172,7 +173,8 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: SpriteSheetHandle)
             width: PADDLE_WIDTH,
             height: PADDLE_HEIGHT,
             velocity: PADDLE_VELOCITY,
-        }).with(left_transform)
+        })
+        .with(left_transform)
         .build();
 
     // Create right plank entity.
@@ -184,7 +186,8 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: SpriteSheetHandle)
             width: PADDLE_WIDTH,
             height: PADDLE_HEIGHT,
             velocity: PADDLE_VELOCITY,
-        }).with(right_transform)
+        })
+        .with(right_transform)
         .build();
 }
 
@@ -210,7 +213,8 @@ fn initialise_ball(world: &mut World, sprite_sheet_handle: SpriteSheetHandle) {
         .with(Ball {
             radius: BALL_RADIUS,
             velocity: [BALL_VELOCITY_X, BALL_VELOCITY_Y],
-        }).with(local_transform)
+        })
+        .with(local_transform)
         .build();
 }
 
@@ -252,7 +256,8 @@ fn initialise_score(world: &mut World) {
             "0".to_string(),
             [1.0, 1.0, 1.0, 1.0],
             50.,
-        )).build();
+        ))
+        .build();
     let p2_score = world
         .create_entity()
         .with(p2_transform)
@@ -261,6 +266,7 @@ fn initialise_score(world: &mut World) {
             "0".to_string(),
             [1.0, 1.0, 1.0, 1.0],
             50.,
-        )).build();
+        ))
+        .build();
     world.add_resource(ScoreText { p1_score, p2_score });
 }

--- a/examples/pong_tutorial_02/pong.rs
+++ b/examples/pong_tutorial_02/pong.rs
@@ -76,7 +76,7 @@ fn load_sprite_sheet(world: &mut World) -> SpriteSheetHandle {
         loader.load(
             "texture/pong_spritesheet.png",
             PngFormat,
-            TextureMetadata::srgb(),
+            TextureMetadata::srgb_scale(),
             (),
             &texture_storage,
         )

--- a/examples/pong_tutorial_03/pong.rs
+++ b/examples/pong_tutorial_03/pong.rs
@@ -76,7 +76,7 @@ fn load_sprite_sheet(world: &mut World) -> SpriteSheetHandle {
         loader.load(
             "texture/pong_spritesheet.png",
             PngFormat,
-            TextureMetadata::srgb(),
+            TextureMetadata::srgb_scale(),
             (),
             &texture_storage,
         )

--- a/examples/sprites/png_loader.rs
+++ b/examples/sprites/png_loader.rs
@@ -18,7 +18,7 @@ where
     loader.load(
         name,
         PngFormat,
-        TextureMetadata::srgb(),
+        TextureMetadata::srgb_scale(),
         (),
         &world.read_resource::<AssetStorage<Texture>>(),
     )

--- a/examples/sprites_ordered/png_loader.rs
+++ b/examples/sprites_ordered/png_loader.rs
@@ -1,7 +1,7 @@
 use amethyst::{
     assets::{AssetStorage, Loader},
     prelude::*,
-    renderer::{FilterMethod, PngFormat, Texture, TextureHandle, TextureMetadata},
+    renderer::{PngFormat, Texture, TextureHandle, TextureMetadata},
 };
 
 /// Returns a `TextureHandle` to the image.
@@ -18,7 +18,7 @@ where
     loader.load(
         name,
         PngFormat,
-        TextureMetadata::srgb().with_filter(FilterMethod::Scale),
+        TextureMetadata::srgb_scale(),
         (),
         &world.read_resource::<AssetStorage<Texture>>(),
     )


### PR DESCRIPTION
Linear interpolation filter (current new default for `TextureMetadata::srgb()`) plays bad with sprites. 2D setups usually use nearest filter. The PR restores old behavior for sprites examples.

* Added new function `TextureMetadata::srgbScale()`
* Pong tutorial is adjusted to use nearest filter 
* Sprites examples are adjusted to use nearest filter 
* Added note in book when to use srgbScale

How to check:
* Check examples pong_tutorial_*, sprites, sprites_ordered
* Check docs