### PR TITLE
[Fix] Ui examples prefab was broken

### DIFF
--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -25,3 +25,4 @@
 * Thomas Schaller
 * White-Oak
 * Xaeroxe (Jacob Kiesel)
+* Telzhaak

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -74,6 +74,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * Now loading default fonts from the system for UiButton ([#964])
 * Fixed single frame animation ([#1015])
 * Improved compatibility with older drivers ([#1012])
+* Forgotten `channel` field on `examples/ui` prefab ([#1024])
 
 [#829]: https://github.com/amethyst/amethyst/issues/829
 [#830]: https://github.com/amethyst/amethyst/pull/830
@@ -114,6 +115,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1012]: https://github.com/amethyst/amethyst/pull/1012
 [#1015]: https://github.com/amethyst/amethyst/pull/1015
 [#1016]: https://github.com/amethyst/amethyst/pull/1016
+[#1024]: https://github.com/amethyst/amethyst/pull/1024
 [winit_017]: https://github.com/tomaka/winit/blob/master/CHANGELOG.md#version-0172-2018-08-19
 [glutin_018]: https://github.com/tomaka/glutin/blob/master/CHANGELOG.md#version-0180-2018-08-03
 

--- a/examples/assets/ui/example.ron
+++ b/examples/assets/ui/example.ron
@@ -8,7 +8,7 @@ Container(
         height: 20.,
     ),
     background: (
-        image: Data(Rgba((0.36, 0.10, 0.57, 1.0), ())),
+        image: Data(Rgba((0.36, 0.10, 0.57, 1.0), (channel: Srgb))),
     ),
     children: [
         // Parenting test
@@ -22,7 +22,7 @@ Container(
                 anchor: TopRight,
             ),
             background: (
-                image: Data(Rgba((0.09, 0.02, 0.25, 1.0), ())),
+                image: Data(Rgba((0.09, 0.02, 0.25, 1.0), (channel: Srgb))),
             ),
             children: [
                 Image(
@@ -34,7 +34,7 @@ Container(
                         stretch: XY( x_margin: 0., y_margin: 10.),
                     ),
                     image: (
-                        image: Data(Rgba((0.18, 0.05, 0.85, 1.0), ())),
+                        image: Data(Rgba((0.18, 0.05, 0.85, 1.0), (channel: Srgb))),
                     )
                 ),
             ]
@@ -52,7 +52,7 @@ Container(
                 mouse_reactive: true,
             ),
             image: (
-                image: File("texture/logo_transparent.png", Png, ()),
+                image: File("texture/logo_transparent.png", Png, (channel: Srgb)),
             )
         ),
 
@@ -68,7 +68,7 @@ Container(
                 anchor: BottomLeft,
             ),
             background: (
-                image: Data(Rgba((0.09, 0.02, 0.25, 1.0), ())),
+                image: Data(Rgba((0.09, 0.02, 0.25, 1.0), (channel: Srgb))),
             ),
             children: [
                 Text(
@@ -110,9 +110,9 @@ Container(
                 font: File("font/square.ttf", Ttf, ()),
                 font_size: 20.,
                 normal_text_color: (0.2, 0.2, 1.0, 1.0),
-                normal_image: Data(Rgba((0., 1., 0., 1.), ())),
-                hover_image: Data(Rgba((0.3, 1., 0.3, 1.), ())),
-                press_image: Data(Rgba((0.15, 1., 0.15, 1.), ())),
+                normal_image: Data(Rgba((0., 1., 0., 1.), (channel: Srgb))),
+                hover_image: Data(Rgba((0.3, 1., 0.3, 1.), (channel: Srgb))),
+                press_image: Data(Rgba((0.15, 1., 0.15, 1.), (channel: Srgb))),
                 hover_sound: File("audio/boop.ogg", Ogg, ()),
                 press_sound: File("audio/confirm.ogg", Ogg, ()),
             )
@@ -135,7 +135,7 @@ Container(
                 font: File("font/square.ttf", Ttf, ()),
                 font_size: 20.,
                 normal_text_color: (0.0, 0.0, 0.0, 1.0),
-                normal_image: Data(Rgba((0.82, 0.83, 0.83, 1.0), ())),
+                normal_image: Data(Rgba((0.82, 0.83, 0.83, 1.0), (channel: Srgb))),
             )
         ),
         Text(


### PR DESCRIPTION
When the TextureMetadata was reworked in #981 , the `Ui` examples prefab `example.ron` had not been given the new `channel` field.