### PR TITLE
Fix MacOS 10.14 nothing rendering until resize

### DIFF
--- a/amethyst_renderer/src/renderer.rs
+++ b/amethyst_renderer/src/renderer.rs
@@ -208,9 +208,9 @@ impl RendererBuilder {
     }
 
     /// Consumes the builder and creates the new `Renderer`.
-    pub fn build(self) -> Result<Renderer> {
+    pub fn build(mut self) -> Result<Renderer> {
         let Backend(device, mut factory, main_target, window) =
-            init_backend(self.winit_builder.clone(), &self.events, &self.config)?;
+            init_backend(self.winit_builder.clone(), &mut self.events, &self.config)?;
 
         let cached_size = window
             .get_inner_size()
@@ -238,7 +238,7 @@ struct Backend(pub Device, pub Factory, pub Target, pub Window);
 
 /// Creates the Direct3D 11 backend.
 #[cfg(all(feature = "d3d11", target_os = "windows"))]
-fn init_backend(wb: WindowBuilder, el: &EventsLoop, config: &DisplayConfig) -> Result<Backend> {
+fn init_backend(wb: WindowBuilder, el: &mut EventsLoop, config: &DisplayConfig) -> Result<Backend> {
     use gfx_window_dxgi as win;
 
     // FIXME: vsync + multisampling from config
@@ -264,7 +264,7 @@ fn init_backend(wb: WindowBuilder, el: &EventsLoop, config: &DisplayConfig) -> R
 }
 
 #[cfg(all(feature = "metal", target_os = "macos"))]
-fn init_backend(wb: WindowBuilder, el: &EventsLoop, config: &DisplayConfig) -> Result<Backend> {
+fn init_backend(wb: WindowBuilder, el: &mut EventsLoop, config: &DisplayConfig) -> Result<Backend> {
     use gfx_window_metal as win;
 
     // FIXME: vsync + multisampling from config
@@ -289,8 +289,8 @@ fn init_backend(wb: WindowBuilder, el: &EventsLoop, config: &DisplayConfig) -> R
 }
 
 /// Creates the OpenGL backend.
-#[cfg(feature = "opengl")]
-fn init_backend(wb: WindowBuilder, el: &EventsLoop, config: &DisplayConfig) -> Result<Backend> {
+#[cfg(all(feature = "opengl", not(target_os = "macos")))]
+fn init_backend(wb: WindowBuilder, el: &mut EventsLoop, config: &DisplayConfig) -> Result<Backend> {
     use gfx_window_glutin as win;
     use glutin;
     #[cfg(target_os = "macos")]
@@ -315,6 +315,45 @@ fn init_backend(wb: WindowBuilder, el: &EventsLoop, config: &DisplayConfig) -> R
         },
         size,
     );
+
+    Ok(Backend(dev, fac, main_target, win))
+}
+
+/// Creates the OpenGL backend.
+#[cfg(all(feature = "opengl", target_os = "macos"))]
+fn init_backend(wb: WindowBuilder, el: &mut EventsLoop, config: &DisplayConfig) -> Result<Backend> {
+    use gfx_window_glutin as win;
+    use glutin::{self, GlContext, GlProfile, GlRequest};
+
+    let ctx = glutin::ContextBuilder::new()
+        .with_multisampling(config.multisampling)
+        .with_vsync(config.vsync)
+        .with_gl_profile(GlProfile::Core)
+        .with_gl(GlRequest::Latest);
+
+    let (win, dev, fac, color, depth) = win::init::<ColorFormat, DepthFormat>(wb, ctx, el);
+    let size = win.get_inner_size().ok_or(Error::WindowDestroyed)?.into();
+    let main_target = Target::new(
+        ColorBuffer {
+            as_input: None,
+            as_output: color,
+        },
+        DepthBuffer {
+            as_input: None,
+            as_output: depth,
+        },
+        size,
+    );
+
+    // FIXME: Resolve #972 and remove this extra resize
+    // On Mac 10.14 we need to resize the window after creation
+    // this is related to this issue amethyst/amethyst#972
+    el.poll_events(|_| {});
+    let (width, height): (u32, u32) = win
+        .get_outer_size()
+        .expect("Window no longer exists")
+        .into();
+    win.resize((width, height).into());
 
     Ok(Backend(dev, fac, main_target, win))
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -76,6 +76,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * Improved compatibility with older drivers ([#1012])
 * `AssetPrefab` loaded files at an incorrect time ([#1020])
 * Removed unreachable code in `TexturePrefab` ([#1020])
+* Fix OpenGL not rendering on window creation due to `glutin` bug ([#972])
 
 [#829]: https://github.com/amethyst/amethyst/issues/829
 [#830]: https://github.com/amethyst/amethyst/pull/830
@@ -105,6 +106,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#965]: https://github.com/amethyst/amethyst/pull/965
 [#969]: https://github.com/amethyst/amethyst/pull/969
 [#971]: https://github.com/amethyst/amethyst/pull/971
+[#972]: https://github.com/amethyst/amethyst/issue/972
 [#974]: https://github.com/amethyst/amethyst/pull/974
 [#976]: https://github.com/amethyst/amethyst/pull/976
 [#981]: https://github.com/amethyst/amethyst/pull/981


### PR DESCRIPTION
This fix adds window resize to happen after window creation on macos
and opengl. This is a work around proposed in #972. This fix should be
temporary until there is a fix upstream. This shouldn't affect users
as the resize happens only after window creation and only then. This
closes #972.