### PR TITLE
Derive Serialize for NetConnection

### DIFF
--- a/amethyst_network/src/connection.rs
+++ b/amethyst_network/src/connection.rs
@@ -9,16 +9,21 @@ use uuid::Uuid;
 // TODO: Think about relationship between NetConnection and NetIdentity.
 
 /// A network connection target data.
+#[derive(Serialize)]
+#[serde(bound = "")]
 pub struct NetConnection<E: 'static> {
     /// The remote socket address of this connection.
     pub target: SocketAddr,
     /// The state of the connection.
     pub state: ConnectionState,
     /// The buffer of events to be sent.
+    #[serde(skip)]
     pub send_buffer: EventChannel<NetEvent<E>>,
     /// The buffer of events that have been received.
+    #[serde(skip)]
     pub receive_buffer: EventChannel<NetEvent<E>>,
     /// Private. Used by `NetSocketSystem` to be able to immediately send events upon receiving a new NetConnection.
+    #[serde(skip)]
     send_reader: ReaderId<NetEvent<E>>,
 }
 


### PR DESCRIPTION
I have derived `Serialize` for `NetConnection` to support debugging it in [amethyst-editor-sync](https://github.com/randomPoison/amethyst-editor-sync).

### Possible future extensions:
Serializing `send_buffer` and `receive_buffer` depends on https://github.com/randomPoison/amethyst-editor/issues/23.

I do not think it would be good idea to serialize `send_reader`, but it might be worth using it to report how many `NetEvent`s are yet to be send, using something like `ExactSizeIterator::len(&send_buffer.read(&mut send_reader))`. That would need https://github.com/randomPoison/amethyst-editor-sync/issues/7