### PR TITLE
Ignore PhantomData in Debug for Handles

### DIFF
--- a/amethyst_assets/src/storage.rs
+++ b/amethyst_assets/src/storage.rs
@@ -453,7 +453,7 @@ where
 )]
 pub struct Handle<A: ?Sized> {
     id: Arc<u32>,
-    #[derivative(Debug="ignore")]
+    #[derivative(Debug = "ignore")]
     marker: PhantomData<A>,
 }
 


### PR DESCRIPTION
Hey, I just made this change in the GitHub editor cause it was a small change and I did not want to pull down the whole project. That means that I didn't really test it, so, I don't mind if y'all just close this outright because of that.

Anyways, A lot of `marker: PhantomData` showing up in my logs were kind of annoying, so I felt like this could be useful.

Hoping to dive into Amethyst :)