### PR TITLE
[Fix] Reformat and fix Concept/Resource example code

### DIFF
--- a/book/src/concepts/resource.md
+++ b/book/src/concepts/resource.md
@@ -36,12 +36,20 @@ Fetching a resource can be done like this:
 ```rust,no_run,noplaypen
 # extern crate amethyst;
 # use amethyst::ecs::{Resources};
-# struct MyResource;
+# #[derive(Debug, PartialEq)]
+# struct MyResource {
+#   pub game_score: i32,
+# }
 # fn main() {
 #   let mut resources = Resources::new();
+#   let my = MyResource{
+#     game_score: 0,
+#   };
+#   resources.insert(my);
   // try_fetch returns a Option<<Fetch<MyResource>>
   let fetched = resources.try_fetch::<MyResource>()
                        .expect("No MyResource present in Resources");
+  assert_eq!(*fetched, MyResource{ game_score: 0, });
 # }
 ```
 
@@ -63,12 +71,20 @@ If you want to change a resource that is already inside of `Resources`:
 ```rust,no_run,noplaypen
 # extern crate amethyst;
 # use amethyst::ecs::{Resources};
-# struct MyResource;
+# struct MyResource {
+#   pub game_score: i32,
+# }
 # fn main() {
 #   let mut resources = Resources::new();
+#   let my = MyResource{
+#     game_score: 0,
+#   };
+#   resources.insert(my);
   // try_fetch_mut returns a Option<<FetchMut<MyResource>>
   let mut fetched = resources.try_fetch_mut::<MyResource>()
                              .expect("No MyResource present in Resources");
+  assert_eq!(fetched.game_score, 0);
+  fetched.game_score = 10;
 # }
 ```
 

--- a/book/src/concepts/resource.md
+++ b/book/src/concepts/resource.md
@@ -39,7 +39,7 @@ Fetching a resource can be done like this:
 # struct MyResource;
 # fn main() {
 #   let mut resources = Resources::new();
-// Returns a Option<MyResource>
+  // try_fetch returns a Option<<Fetch<MyResource>>
   let fetched = resources.try_fetch::<MyResource>()
                        .expect("No MyResource present in Resources");
 # }
@@ -66,6 +66,7 @@ If you want to change a resource that is already inside of `Resources`:
 # struct MyResource;
 # fn main() {
 #   let mut resources = Resources::new();
+  // try_fetch_mut returns a Option<<FetchMut<MyResource>>
   let mut fetched = resources.try_fetch_mut::<MyResource>()
                              .expect("No MyResource present in Resources");
 # }

--- a/book/src/concepts/resource.md
+++ b/book/src/concepts/resource.md
@@ -47,9 +47,13 @@ Fetching a resource can be done like this:
 #   };
 #   resources.insert(my);
   // try_fetch returns a Option<Fetch<MyResource>>
-  let fetched = resources.try_fetch::<MyResource>()
-                       .expect("No MyResource present in Resources");
-  assert_eq!(*fetched, MyResource{ game_score: 0, });
+  let fetched = resources.try_fetch::<MyResource>();
+  if let Some(fetched_resource) = fetched {
+      //dereference Fetch<MyResource> to access data
+      assert_eq!(*fetched_resource, MyResource{ game_score: 0, });
+  } else {
+      println!("No MyResource present in Resources");
+  }
 # }
 ```
 
@@ -81,11 +85,14 @@ If you want to change a resource that is already inside of `Resources`:
 #   };
 #   resources.insert(my);
   // try_fetch_mut returns a Option<FetchMut<MyResource>>
-  let mut fetched = resources.try_fetch_mut::<MyResource>()
-                             .expect("No MyResource present in Resources");
-  assert_eq!(fetched.game_score, 0);
-  fetched.game_score = 10;
-  assert_eq!(fetched.game_score, 10);
+  let fetched = resources.try_fetch_mut::<MyResource>();
+  if let Some(mut fetched_resource) = fetched {
+    assert_eq!(fetched_resource.game_score, 0);
+    fetched_resource.game_score = 10;
+    assert_eq!(fetched_resource.game_score, 10);
+  } else {
+    println!("No MyResource present in Resources");
+  }
 # }
 ```
 

--- a/book/src/concepts/resource.md
+++ b/book/src/concepts/resource.md
@@ -85,6 +85,7 @@ If you want to change a resource that is already inside of `Resources`:
                              .expect("No MyResource present in Resources");
   assert_eq!(fetched.game_score, 0);
   fetched.game_score = 10;
+  assert_eq!(fetched.game_score, 10);
 # }
 ```
 

--- a/book/src/concepts/resource.md
+++ b/book/src/concepts/resource.md
@@ -46,7 +46,7 @@ Fetching a resource can be done like this:
 #     game_score: 0,
 #   };
 #   resources.insert(my);
-  // try_fetch returns a Option<<Fetch<MyResource>>
+  // try_fetch returns a Option<Fetch<MyResource>>
   let fetched = resources.try_fetch::<MyResource>()
                        .expect("No MyResource present in Resources");
   assert_eq!(*fetched, MyResource{ game_score: 0, });
@@ -80,7 +80,7 @@ If you want to change a resource that is already inside of `Resources`:
 #     game_score: 0,
 #   };
 #   resources.insert(my);
-  // try_fetch_mut returns a Option<<FetchMut<MyResource>>
+  // try_fetch_mut returns a Option<FetchMut<MyResource>>
   let mut fetched = resources.try_fetch_mut::<MyResource>()
                              .expect("No MyResource present in Resources");
   assert_eq!(fetched.game_score, 0);

--- a/book/src/concepts/resource.md
+++ b/book/src/concepts/resource.md
@@ -40,7 +40,8 @@ Fetching a resource can be done like this:
 # fn main() {
 #   let mut resources = Resources::new();
 // Returns a Option<MyResource>
-let fetched = resources.try_fetch::<MyResource>().expect("No MyResource present in Resources");
+  let fetched = resources.try_fetch::<MyResource>()
+                       .expect("No MyResource present in Resources");
 # }
 ```
 
@@ -52,7 +53,8 @@ If you want to get a resource and create it if it doesn't exist:
 # fn main() {
 #   let mut resources = Resources::new();
 #   let my = MyResource;
-// If the resource isn't inside `Resources`, it will insert the instance we created earlier.
+  // If the resource isn't inside `Resources`, 
+  // it will insert the instance we created earlier.
 let fetched = resources.entry::<MyResource>().or_insert_with(|| my);
 # }
 ```
@@ -64,7 +66,8 @@ If you want to change a resource that is already inside of `Resources`:
 # struct MyResource;
 # fn main() {
 #   let mut resources = Resources::new();
-let mut fetched = resources.try_fetch_mut::<MyResource>().expect("No MyResource present in Resources");
+  let mut fetched = resources.try_fetch_mut::<MyResource>()
+                             .expect("No MyResource present in Resources");
 # }
 ```
 


### PR DESCRIPTION
Reformatted example code to meet documentation guideline. 
Fixed a wrong return type in comment.
Made the example code compile.
