### PR TITLE
Refactor unwraps for several amethyst crates

### DIFF
--- a/amethyst_animation/src/skinning/systems.rs
+++ b/amethyst_animation/src/skinning/systems.rs
@@ -45,18 +45,16 @@ impl<'a> System<'a> for VertexSkinningSystem {
         self.updated.clear();
 
         global_transforms.populate_modified(
-            &mut self
-                .updated_id
-                .as_mut()
-                .expect("VertexSkinningSystem missing updated_id."),
+            &mut self.updated_id.as_mut().expect(
+                "`VertexSkinningSystem::setup` was not called before `VertexSkinningSystem::run`",
+            ),
             &mut self.updated,
         );
 
         global_transforms.populate_inserted(
-            &mut self
-                .inserted_id
-                .as_mut()
-                .expect("VertexSkinningSystem missing inserted_id."),
+            &mut self.inserted_id.as_mut().expect(
+                "`VertexSkinningSystem::setup` was not called before `VertexSkinningSystem::run`",
+            ),
             &mut self.updated,
         );
 
@@ -110,13 +108,19 @@ impl<'a> System<'a> for VertexSkinningSystem {
             (&self.updated, &global_transforms, &mut matrices).join()
         {
             if let Some(global_inverse) = mesh_global.0.try_inverse() {
-                let skin = skins.get(joint_transform.skin).unwrap();
-                joint_transform.matrices.clear();
-                joint_transform
-                    .matrices
-                    .extend(skin.joint_matrices.iter().map(|joint_matrix| {
-                        Into::<[[f32; 4]; 4]>::into(global_inverse * joint_matrix)
-                    }));
+                if let Some(skin) = skins.get(joint_transform.skin) {
+                    joint_transform.matrices.clear();
+                    joint_transform
+                        .matrices
+                        .extend(skin.joint_matrices.iter().map(|joint_matrix| {
+                            Into::<[[f32; 4]; 4]>::into(global_inverse * joint_matrix)
+                        }));
+                } else {
+                    error!(
+                        "Missing `Skin` Component for join transform entity {:?}",
+                        joint_transform.skin
+                    );
+                }
             }
         }
     }

--- a/amethyst_animation/src/systems/control.rs
+++ b/amethyst_animation/src/systems/control.rs
@@ -161,7 +161,8 @@ where
                     .deferred_animations
                     .iter()
                     .position(|a| a.animation_id == id)
-                    .unwrap();
+                    .expect("Unreachable: Id of current `deferred_start` was taken from previous loop over `deferred_animations`");
+
                 let mut def = control_set.deferred_animations.remove(index);
                 def.control.state = ControlState::Deferred(secs_to_duration(start_dur));
                 def.control.command = AnimationCommand::Start;
@@ -462,12 +463,16 @@ where
 
     // setup sampler tree
     for &(ref node_index, ref channel, ref sampler_handle) in &animation.nodes {
-        let node_entity = &hierarchy.nodes[node_index];
+        let node_entity = hierarchy.nodes.get(node_index).expect(
+            "Unreachable: Existence of all nodes are checked in validation of hierarchy above",
+        );
         let component = rest_states
             .get(*node_entity)
             .map(|r| r.state())
             .or_else(|| targets.get(*node_entity))
-            .unwrap();
+            .expect(
+                "Unreachable: Existence of all nodes are checked in validation of hierarchy above",
+            );
         let sampler_control = SamplerControl::<T> {
             control_id: control.id,
             channel: channel.clone(),

--- a/amethyst_animation/src/util.rs
+++ b/amethyst_animation/src/util.rs
@@ -123,16 +123,13 @@ where
 
     fn dot(&self, other: &Self) -> f32 {
         match (*self, *other) {
-            (Scalar(ref s), Scalar(ref o)) => (*s * *o).to_f32().unwrap(),
-            (Vec2(ref s), Vec2(ref o)) => (s[0] * o[0] + s[1] * o[1]).to_f32().unwrap(),
-            (Vec3(ref s), Vec3(ref o)) => {
-                (s[0] * o[0] + s[1] * o[1] + s[2] * o[2]).to_f32().unwrap()
-            }
-            (Vec4(ref s), Vec4(ref o)) => (s[0] * o[0] + s[1] * o[1] + s[2] * o[2] + s[3] * o[3])
-                .to_f32()
-                .unwrap(),
+            (Scalar(ref s), Scalar(ref o)) => (*s * *o),
+            (Vec2(ref s), Vec2(ref o)) => (s[0] * o[0] + s[1] * o[1]),
+            (Vec3(ref s), Vec3(ref o)) => (s[0] * o[0] + s[1] * o[1] + s[2] * o[2]),
+            (Vec4(ref s), Vec4(ref o)) => (s[0] * o[0] + s[1] * o[1] + s[2] * o[2] + s[3] * o[3]),
             _ => panic!("Interpolation can not be done between primitives of different types"),
-        }
+        }.to_f32()
+        .expect("Unexpected error when converting primitive to f32, possibly under/overflow")
     }
 
     fn magnitude2(&self) -> f32 {
@@ -141,7 +138,9 @@ where
 
     fn magnitude(&self) -> f32 {
         match *self {
-            Scalar(ref s) => s.to_f32().unwrap(),
+            Scalar(ref s) => s.to_f32().expect(
+                "Unexpected error when converting primitive to f32, possibly under/overflow",
+            ),
             Vec2(_) | Vec3(_) | Vec4(_) => self.magnitude2().sqrt(),
         }
     }
@@ -158,5 +157,9 @@ fn mul_f32<T>(s: T, scalar: f32) -> T
 where
     T: Real + ToPrimitive + NumCast,
 {
-    NumCast::from(s.to_f32().unwrap() * scalar).unwrap()
+    NumCast::from(
+        s.to_f32()
+            .expect("Unexpected error when converting primitive to f32, possibly under/overflow")
+            * scalar,
+    ).expect("Unexpected error when converting f32 to primitive, possibly under/overflow")
 }

--- a/amethyst_assets/src/prefab/mod.rs
+++ b/amethyst_assets/src/prefab/mod.rs
@@ -247,9 +247,11 @@ impl<T> Prefab<T> {
     ///
     /// ### Panics
     ///
-    /// If sub asset loading have not been triggered
+    /// If sub asset loading has not been triggered.
     pub fn progress(&self) -> &ProgressCounter {
-        self.counter.as_ref().unwrap()
+        self.counter
+            .as_ref()
+            .expect("Sub asset loading has not been triggered")
     }
 
     /// Trigger sub asset loading for the asset

--- a/amethyst_assets/src/prefab/system.rs
+++ b/amethyst_assets/src/prefab/system.rs
@@ -93,8 +93,12 @@ where
             &**pool,
             strategy,
         );
-        prefab_handles
-            .populate_inserted(self.insert_reader.as_mut().unwrap(), &mut self.to_process);
+        prefab_handles.populate_inserted(
+            self.insert_reader.as_mut().expect(
+                "`PrefabLoaderSystem::setup` was not called before `PrefabLoaderSystem::run`",
+            ),
+            &mut self.to_process,
+        );
         self.finished.clear();
         for (root_entity, handle, _) in (&*entities, &prefab_handles, &self.to_process).join() {
             if let Some(prefab) = prefab_storage.get(handle) {
@@ -112,10 +116,16 @@ where
                                 Parent {
                                     entity: self.entities[parent],
                                 },
-                            ).unwrap();
+                            ).expect("Unable to insert `Parent` for prefab");
                     }
-                    tags.insert(new_entity, PrefabTag::new(prefab.tag.unwrap()))
-                        .unwrap();
+                    tags.insert(
+                        new_entity,
+                        PrefabTag::new(
+                            prefab.tag.expect(
+                                "Unreachable: Every loaded prefab should have a `PrefabTag`",
+                            ),
+                        ),
+                    ).expect("Unable to insert `PrefabTag` for prefab entity");
                 }
                 // create components
                 for (index, entity_data) in prefab.entities.iter().enumerate() {
@@ -125,7 +135,7 @@ where
                                 self.entities[index],
                                 &mut prefab_system_data,
                                 &self.entities,
-                            ).unwrap();
+                            ).expect("Unable to add prefab system data to entity");
                     }
                 }
             }

--- a/amethyst_assets/src/source/dir.rs
+++ b/amethyst_assets/src/source/dir.rs
@@ -42,13 +42,13 @@ impl Source for Directory {
 
         let path = self.path(path);
 
-        Ok(metadata(&path)
+        metadata(&path)
             .chain_err(|| format!("Failed to fetch metadata for {:?}", path))?
             .modified()
             .chain_err(|| "Could not get modification time")?
             .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs())
+            .chain_err(|| "Anomalies with the system clock caused `duration_since` to fail")
+            .map(|d| d.as_secs())
     }
 
     fn load(&self, path: &str) -> Result<Vec<u8>> {

--- a/amethyst_assets/src/storage.rs
+++ b/amethyst_assets/src/storage.rs
@@ -154,7 +154,10 @@ impl<A: Asset> AssetStorage<A> {
         F: FnMut(A::Data) -> Result<ProcessingState<A>>,
     {
         {
-            let requeue = self.requeue.get_mut().unwrap();
+            let requeue = self
+                .requeue
+                .get_mut()
+                .expect("The mutex of `requeue` in `AssetStorage` was poisoned");
             while let Some(processed) = self.processed.try_pop() {
                 let assets = &mut self.assets;
                 let bitset = &mut self.bitset;

--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -150,7 +150,10 @@ where
 
     fn run(&mut self, (events, mut transform, tag, focus, hide): Self::SystemData) {
         let focused = focus.is_focused;
-        for event in events.read(&mut self.event_reader.as_mut().unwrap()) {
+        for event in
+            events.read(&mut self.event_reader.as_mut().expect(
+                "`FreeRotationSystem::setup` was not called before `FreeRotationSystem::run`",
+            )) {
             if focused && hide.hide {
                 if let Event::DeviceEvent { ref event, .. } = *event {
                     if let DeviceEvent::MouseMotion { delta: (x, y) } = *event {
@@ -188,7 +191,9 @@ impl<'a> System<'a> for MouseFocusUpdateSystem {
     type SystemData = (Read<'a, EventChannel<Event>>, Write<'a, WindowFocus>);
 
     fn run(&mut self, (events, mut focus): Self::SystemData) {
-        for event in events.read(&mut self.event_reader.as_mut().unwrap()) {
+        for event in events.read(&mut self.event_reader.as_mut().expect(
+            "`MouseFocusUpdateSystem::setup` was not called before `MouseFocusUpdateSystem::run`",
+        )) {
             if let Event::WindowEvent { ref event, .. } = *event {
                 if let WindowEvent::Focused(focused) = *event {
                     focus.is_focused = focused;

--- a/amethyst_core/src/named.rs
+++ b/amethyst_core/src/named.rs
@@ -136,12 +136,11 @@ impl<'a> WithNamed for EntityBuilder<'a> {
     where
         S: Into<Cow<'static, str>>,
     {
-        // Unwrap: The only way this can fail is if the entity is invalid and this is used while creating the entity.
         self.world
             .system_data::<(WriteStorage<'a, Named>,)>()
             .0
             .insert(self.entity, Named::new(name))
-            .unwrap();
+            .expect("Unreachable: Entities should always be valid when just created");
         self
     }
 }

--- a/amethyst_core/src/transform/systems.rs
+++ b/amethyst_core/src/transform/systems.rs
@@ -61,18 +61,23 @@ impl<'a> System<'a> for TransformSystem {
         self.global_modified.clear();
 
         locals.populate_inserted(
-            self.inserted_local_id.as_mut().unwrap(),
+            self.inserted_local_id
+                .as_mut()
+                .expect("`TransformSystem::setup` was not called before `TransformSystem::run`"),
             &mut self.local_modified,
         );
         locals.populate_modified(
-            self.modified_local_id.as_mut().unwrap(),
+            self.modified_local_id
+                .as_mut()
+                .expect("`TransformSystem::setup` was not called before `TransformSystem::run`"),
             &mut self.local_modified,
         );
 
-        for event in hierarchy
-            .changed()
-            .read(self.parent_events_id.as_mut().unwrap())
-        {
+        for event in hierarchy.changed().read(
+            self.parent_events_id
+                .as_mut()
+                .expect("`TransformSystem::setup` was not called before `TransformSystem::run`"),
+        ) {
             match *event {
                 HierarchyEvent::Removed(entity) => {
                     // Sometimes the user may have already deleted the entity.

--- a/amethyst_gltf/src/format/mod.rs
+++ b/amethyst_gltf/src/format/mod.rs
@@ -190,7 +190,10 @@ fn load_scene(
     name: &str,
     prefab: &mut Prefab<GltfPrefab>,
 ) -> Result<(), GltfError> {
-    let scene = gltf.scenes().nth(scene_index).unwrap();
+    let scene = gltf
+        .scenes()
+        .nth(scene_index)
+        .expect("Tried to load a scene which does not exist");
     let mut node_map = HashMap::new();
     let mut skin_map = HashMap::new();
     let mut bounding_box = GltfNodeExtent::default();
@@ -198,7 +201,10 @@ fn load_scene(
     if scene.nodes().len() == 1 {
         load_node(
             gltf,
-            &scene.nodes().next().unwrap(),
+            &scene
+                .nodes()
+                .next()
+                .expect("Unreachable: Length of nodes in scene is checked to be equal to one"),
             0,
             buffers,
             options,
@@ -237,9 +243,13 @@ fn load_scene(
     // load skins
     for (node_index, skin_info) in skin_map {
         load_skin(
-            &gltf.skins().nth(skin_info.skin_index).unwrap(),
+            &gltf.skins().nth(skin_info.skin_index).expect(
+                "Unreachable: `skin_map` is initialized with indexes from the `Gltf` object",
+            ),
             buffers,
-            *node_map.get(&node_index).unwrap(),
+            *node_map
+                .get(&node_index)
+                .expect("Unreachable: `node_map` should contain all nodes present in `skin_map`"),
             &node_map,
             skin_info.mesh_indices,
             prefab,
@@ -325,7 +335,7 @@ fn load_node(
             // single primitive can be loaded directly onto the node
             let (mesh, material_index, bounds) = graphics.remove(0);
             bounding_box.extend_range(&bounds);
-            let prefab_data = prefab.entity(entity_index).unwrap().data_or_default();
+            let prefab_data = prefab.data_or_default(entity_index);
             prefab_data.mesh = Some(mesh);
             if let Some((material_id, material)) =
                 material_index.and_then(|index| gltf.materials().nth(index).map(|m| (index, m)))
@@ -347,7 +357,7 @@ fn load_node(
             // we need to add each primitive as a child entity to the node
             for (mesh, material_index, bounds) in graphics {
                 let mesh_entity = prefab.add(Some(entity_index), None);
-                let prefab_data = prefab.entity(mesh_entity).unwrap().data_or_default();
+                let prefab_data = prefab.data_or_default(entity_index);
                 prefab_data.transform = Some(Transform::default());
                 prefab_data.mesh = Some(mesh);
                 if let Some((material_id, material)) =

--- a/amethyst_gltf/src/format/skin.rs
+++ b/amethyst_gltf/src/format/skin.rs
@@ -22,8 +22,11 @@ pub fn load_skin(
 ) -> Result<(), GltfError> {
     let joints = skin
         .joints()
-        .map(|j| node_map.get(&j.index()).cloned().unwrap())
-        .collect::<Vec<_>>();
+        .map(|j| {
+            node_map.get(&j.index()).cloned().expect(
+                "Unreachable: `node_map` is initialized with the indexes from the `Gltf` object",
+            )
+        }).collect::<Vec<_>>();
 
     let reader = skin.reader(|buffer| buffers.buffer(&buffer));
 

--- a/amethyst_input/src/sdl_events_system.rs
+++ b/amethyst_input/src/sdl_events_system.rs
@@ -78,7 +78,10 @@ where
     fn run_now(&mut self, res: &'a Resources) {
         let (mut handler, mut output) = SdlEventsData::fetch(res);
 
-        let mut event_pump = self.event_pump.take().unwrap();
+        let mut event_pump = self
+            .event_pump
+            .take()
+            .expect("Unreachable: `event_pump` is always reinserted after `take`");
         for event in event_pump.poll_iter() {
             // handle appropriate events locally
             self.handle_sdl_event(&event, &mut handler, &mut output);

--- a/amethyst_input/src/system.rs
+++ b/amethyst_input/src/system.rs
@@ -61,7 +61,12 @@ where
     );
 
     fn run(&mut self, (input, mut handler, mut output): Self::SystemData) {
-        for event in input.read(&mut self.reader.as_mut().unwrap()) {
+        for event in input.read(
+            &mut self
+                .reader
+                .as_mut()
+                .expect("`InputSystem::setup` was not called before `InputSystem::run`"),
+        ) {
             Self::process_event(event, &mut *handler, &mut *output);
         }
     }

--- a/amethyst_renderer/src/hide_system.rs
+++ b/amethyst_renderer/src/hide_system.rs
@@ -34,19 +34,21 @@ impl<'a> System<'a> for HideHierarchySystem {
 
         self.marked_as_modified.clear();
 
-        hidden.populate_inserted(
-            &mut self.inserted_hidden_id.as_mut().unwrap(),
-            &mut self.marked_as_modified,
+        let self_inserted_hidden_id = &mut self.inserted_hidden_id.as_mut().expect(
+            "`HideHierarchySystem::setup` was not called before `HideHierarchySystem::run`",
         );
-        hidden.populate_removed(
-            &mut self.removed_hidden_id.as_mut().unwrap(),
-            &mut self.marked_as_modified,
+        let self_removed_hidden_id = &mut self.removed_hidden_id.as_mut().expect(
+            "`HideHierarchySystem::setup` was not called before `HideHierarchySystem::run`",
         );
+
+        hidden.populate_inserted(self_inserted_hidden_id, &mut self.marked_as_modified);
+        hidden.populate_removed(self_removed_hidden_id, &mut self.marked_as_modified);
 
         for event in hierarchy
             .changed()
-            .read(&mut self.parent_events_id.as_mut().unwrap())
-        {
+            .read(&mut self.parent_events_id.as_mut().expect(
+                "`HideHierarchySystem::setup` was not called before `HideHierarchySystem::run`",
+            )) {
             match *event {
                 HierarchyEvent::Removed(entity) => {
                     self.marked_as_modified.add(entity.id());
@@ -63,16 +65,13 @@ impl<'a> System<'a> for HideHierarchySystem {
             {
                 let self_dirty = self.marked_as_modified.contains(entity.id());
 
-                let parent_entity = parents.get(*entity).unwrap().entity;
+                let parent_entity = parents.get(*entity).expect("Unreachable: All entities in `ParentHierarchy` should also be in `Parents`").entity;
                 let parent_dirty = self.marked_as_modified.contains(parent_entity.id());
                 if parent_dirty {
                     if hidden.contains(parent_entity) {
                         for child in hierarchy.all_children_iter(parent_entity) {
                             if let Err(e) = hidden.insert(child, HiddenPropagate::default()) {
-                                error!(
-                                    "Failed to automatically add HiddenPropagate, error: {:?}",
-                                    e
-                                );
+                                error!("Failed to automatically add `HiddenPropagate`: {:?}", e);
                             };
                         }
                     } else {
@@ -86,10 +85,7 @@ impl<'a> System<'a> for HideHierarchySystem {
                     if hidden.contains(*entity) {
                         for child in hierarchy.all_children_iter(*entity) {
                             if let Err(e) = hidden.insert(child, HiddenPropagate::default()) {
-                                error!(
-                                    "Failed to automatically add HiddenPropagate, error: {:?}",
-                                    e
-                                );
+                                error!("Failed to automatically add `HiddenPropagate`: {:?}", e);
                             };
                         }
                     } else {
@@ -102,14 +98,8 @@ impl<'a> System<'a> for HideHierarchySystem {
             // Populate the modifications we just did.
             // Happens inside the for-loop, so that the changes are picked up in the next iteration already,
             // instead of on the next `system.run()`
-            hidden.populate_inserted(
-                &mut self.inserted_hidden_id.as_mut().unwrap(),
-                &mut self.marked_as_modified,
-            );
-            hidden.populate_removed(
-                &mut self.removed_hidden_id.as_mut().unwrap(),
-                &mut self.marked_as_modified,
-            );
+            hidden.populate_inserted(self_inserted_hidden_id, &mut self.marked_as_modified);
+            hidden.populate_removed(self_removed_hidden_id, &mut self.marked_as_modified);
         }
     }
 

--- a/amethyst_renderer/src/pass/sprite/interleaved.rs
+++ b/amethyst_renderer/src/pass/sprite/interleaved.rs
@@ -195,9 +195,10 @@ impl SpriteBatch {
         material_texture_set: &MaterialTextureSet,
         tex_storage: &AssetStorage<Texture>,
     ) {
-        if global.is_none() {
-            return;
-        }
+        let global = match global {
+            Some(v) => v,
+            None => return,
+        };
 
         let texture_handle = match sprite_sheet_storage.get(&sprite_render.sprite_sheet) {
             Some(sprite_sheet) => match material_texture_set.handle(sprite_sheet.texture_id) {
@@ -232,7 +233,7 @@ impl SpriteBatch {
         self.sprites.push(SpriteDrawData {
             texture: texture_handle,
             render: sprite_render.clone(),
-            transform: *global.unwrap(),
+            transform: *global,
         });
     }
 
@@ -270,12 +271,16 @@ impl SpriteBatch {
         let num_sprites = self.sprites.len();
 
         for (i, sprite) in self.sprites.iter().enumerate() {
-            // `unwrap` checked when collecting the sprites.
+            // `unwrap`
             let sprite_sheet = sprite_sheet_storage
                 .get(&sprite.render.sprite_sheet)
-                .unwrap();
+                .expect(
+                    "Unreachable: Existence of sprite sheet checked when collecting the sprites",
+                );
 
-            let texture = tex_storage.get(&sprite.texture).unwrap();
+            let texture = tex_storage
+                .get(&sprite.texture)
+                .expect("Unable to get texture of sprite");
 
             // Append sprite to instance data.
             let sprite_data = &sprite_sheet.sprites[sprite.render.sprite_number];
@@ -323,7 +328,7 @@ impl SpriteBatch {
 
                 let vbuf = factory
                     .create_buffer_immutable(&instance_data, buffer::Role::Vertex, Bind::empty())
-                    .unwrap();
+                    .expect("Unable to create immutable buffer for `SpriteBatch`");
 
                 for _ in DrawSprite::attributes() {
                     effect.data.vertex_bufs.push(vbuf.raw().clone());

--- a/amethyst_renderer/src/pipe/target.rs
+++ b/amethyst_renderer/src/pipe/target.rs
@@ -193,6 +193,7 @@ impl TargetBuilder {
             depth_buf,
             size,
         };
+
         Ok((self.name, target))
     }
 }

--- a/amethyst_renderer/src/renderer.rs
+++ b/amethyst_renderer/src/renderer.rs
@@ -120,7 +120,7 @@ impl Renderer {
                 .with_num_color_bufs(value.color_bufs().len())
                 .with_depth_buf(value.depth_buf().is_some())
                 .build(&mut self.factory, new_size)
-                .unwrap();
+                .expect("Unable to create new target when resizing");
             targets.insert(key, target);
         }
         pipe.new_targets(targets);
@@ -241,7 +241,8 @@ fn init_backend(wb: WindowBuilder, el: &mut EventsLoop, config: &DisplayConfig) 
     use gfx_window_dxgi as win;
 
     // FIXME: vsync + multisampling from config
-    let (win, dev, mut fac, color) = win::init::<ColorFormat>(wb, el).unwrap();
+    let (win, dev, mut fac, color) =
+        win::init::<ColorFormat>(wb, el).expect("Unable to initialize window (d3d11 backend)");
     let dev = gfx_device_dx11::Deferred::from(dev);
 
     let size = win.get_inner_size_points().ok_or(Error::WindowDestroyed)?;
@@ -267,7 +268,8 @@ fn init_backend(wb: WindowBuilder, el: &mut EventsLoop, config: &DisplayConfig) 
     use gfx_window_metal as win;
 
     // FIXME: vsync + multisampling from config
-    let (win, dev, mut fac, color) = win::init::<ColorFormat>(wb, el).unwrap();
+    let (win, dev, mut fac, color) =
+        win::init::<ColorFormat>(wb, el).expect("Unable to initialize window (metal backend)");
 
     let size = win.get_inner_size_points().ok_or(Error::WindowDestroyed)?;
     let (w, h) = (size.0 as u16, size.1 as u16);

--- a/amethyst_renderer/src/shape.rs
+++ b/amethyst_renderer/src/shape.rs
@@ -59,9 +59,10 @@ where
         _: &[Entity],
     ) -> Result<(), PrefabError> {
         let (_, ref mut meshes, _) = system_data;
-        meshes
-            .insert(entity, self.handle.as_ref().unwrap().clone())
-            .map(|_| ())
+        let self_handle = self.handle.as_ref().expect(
+            "`ShapePrefab::load_sub_assets` was not called before `ShapePrefab::add_to_entity`",
+        );
+        meshes.insert(entity, self_handle.clone()).map(|_| ())
     }
 
     fn load_sub_assets(

--- a/amethyst_renderer/src/system.rs
+++ b/amethyst_renderer/src/system.rs
@@ -74,7 +74,11 @@ where
 
     /// Create a new render system
     pub fn new(pipe: P, renderer: Renderer) -> Self {
-        let cached_size = renderer.window().get_inner_size().unwrap().into();
+        let cached_size = renderer
+            .window()
+            .get_inner_size()
+            .expect("Window no longer exists")
+            .into();
         Self {
             pipe,
             renderer,

--- a/amethyst_ui/src/button/builder.rs
+++ b/amethyst_ui/src/button/builder.rs
@@ -231,7 +231,6 @@ impl UiButtonBuilder {
 
     /// Build this with the `UiButtonBuilderResources`.
     pub fn build(mut self, mut res: UiButtonBuilderResources) -> Entity {
-        // unwraps are safe because we create the entities inside
         let mut id = self.name.clone();
         let image_entity = res.entities.create();
         res.transform
@@ -247,7 +246,7 @@ impl UiButtonBuilder {
                     self.height,
                     self.tab_order,
                 ).with_stretch(self.stretch),
-            ).unwrap();
+            ).expect("Unreachable: Inserting newly created entity");
         let image_handle = self.image.unwrap_or_else(|| {
             res.loader
                 .load_from_data(DEFAULT_BKGD_COLOR.into(), (), &res.texture_asset)
@@ -259,14 +258,14 @@ impl UiButtonBuilder {
                 UiImage {
                     texture: image_handle.clone(),
                 },
-            ).unwrap();
+            ).expect("Unreachable: Inserting newly created entity");
         res.mouse_reactive
             .insert(image_entity, MouseReactive)
-            .unwrap();
+            .expect("Unreachable: Inserting newly created entity");
         if let Some(parent) = self.parent.take() {
             res.parent
                 .insert(image_entity, Parent { entity: parent })
-                .unwrap();
+                .expect("Unreachable: Inserting newly created entity");
         }
 
         id.push_str("_btn_txt");
@@ -280,7 +279,7 @@ impl UiButtonBuilder {
                         x_margin: 0.,
                         y_margin: 0.,
                     }),
-            ).unwrap();
+            ).expect("Unreachable: Inserting newly created entity");
         let font_handle = self
             .font
             .unwrap_or_else(|| get_default_font(&res.loader, &res.font_asset));
@@ -288,14 +287,14 @@ impl UiButtonBuilder {
             .insert(
                 text_entity,
                 UiText::new(font_handle, self.text, self.text_color, self.font_size),
-            ).unwrap();
+            ).expect("Unreachable: Inserting newly created entity");
         res.parent
             .insert(
                 text_entity,
                 Parent {
                     entity: image_entity,
                 },
-            ).unwrap();
+            ).expect("Unreachable: Inserting newly created entity");
 
         res.button
             .insert(
@@ -305,13 +304,13 @@ impl UiButtonBuilder {
                     hover_text_color: self.hover_text_color,
                     press_text_color: self.press_text_color,
                 },
-            ).unwrap();
+            ).expect("Unreachable: Inserting newly created entity");
         if self.hover_image.is_some() || self.press_image.is_some() {
             res.action_image
                 .insert(
                     image_entity,
                     OnUiActionImage::new(Some(image_handle), self.hover_image, self.press_image),
-                ).unwrap();
+                ).expect("Unreachable: Inserting newly created entity");
         }
 
         if self.hover_sound.is_some() || self.press_sound.is_some() || self.release_sound.is_some()
@@ -320,7 +319,7 @@ impl UiButtonBuilder {
                 .insert(
                     image_entity,
                     OnUiActionSound::new(self.hover_sound, self.press_sound, self.release_sound),
-                ).unwrap();
+                ).expect("Unreachable: Inserting newly created entity");
         }
         image_entity
     }

--- a/amethyst_ui/src/button/system.rs
+++ b/amethyst_ui/src/button/system.rs
@@ -59,7 +59,10 @@ impl<'s> System<'s> for UiButtonSystem {
             hierarchy,
         ): Self::SystemData,
     ) {
-        let event_reader = self.event_reader.as_mut().unwrap();
+        let event_reader = self
+            .event_reader
+            .as_mut()
+            .expect("`UiButtonSystem::setup` was not called before `UiButtonSystem::run`");
 
         for event in events.read(event_reader) {
             let button = button_storage.get(event.target);

--- a/amethyst_ui/src/font/default.rs
+++ b/amethyst_ui/src/font/default.rs
@@ -55,7 +55,7 @@ pub fn get_default_font(loader: &Loader, storage: &AssetStorage<FontAsset>) -> F
     return loader.load_from_data(
         TtfFormat
             .import(include_bytes!("./square.ttf").to_vec(), ())
-            .unwrap(),
+            .expect("Unable to import fallback font './square.ttf'"),
         (),
         storage,
     );

--- a/amethyst_ui/src/prefab.rs
+++ b/amethyst_ui/src/prefab.rs
@@ -711,23 +711,17 @@ fn walk_ui_tree<A, I, F, C>(
         }
 
         UiWidget::Image { transform, image } => {
-            prefab.entity(current_index).unwrap().set_data((
-                Some(transform),
-                Some(image),
-                None,
-                None,
-                custom_data,
-            ));
+            prefab
+                .entity(current_index)
+                .expect("Unreachable: `Prefab` entity should always be set when walking ui tree")
+                .set_data((Some(transform), Some(image), None, None, custom_data));
         }
 
         UiWidget::Text { transform, text } => {
-            prefab.entity(current_index).unwrap().set_data((
-                Some(transform),
-                None,
-                Some(text),
-                None,
-                custom_data,
-            ));
+            prefab
+                .entity(current_index)
+                .expect("Unreachable: `Prefab` entity should always be set when walking ui tree")
+                .set_data((Some(transform), None, Some(text), None, custom_data));
         }
 
         UiWidget::Container {
@@ -735,13 +729,11 @@ fn walk_ui_tree<A, I, F, C>(
             background,
             children,
         } => {
-            prefab.entity(current_index).unwrap().set_data((
-                Some(transform),
-                background,
-                None,
-                None,
-                custom_data,
-            ));
+            prefab
+                .entity(current_index)
+                .expect("Unreachable: `Prefab` entity should always be set when walking ui tree")
+                .set_data((Some(transform), background, None, None, custom_data));
+
             for child_widget in children {
                 let child_index = prefab.add(Some(current_index), None);
                 walk_ui_tree(child_widget, child_index, prefab, Default::default());
@@ -760,15 +752,20 @@ fn walk_ui_tree<A, I, F, C>(
                 text: button.text.clone(),
                 font_size: button.font_size,
             };
-            prefab.entity(current_index).unwrap().set_data((
-                Some(transform),
-                button.normal_image.as_ref().map(|image| UiImageBuilder {
-                    image: image.clone(),
-                }),
-                None,
-                Some(button),
-                custom_data,
-            ));
+
+            prefab
+                .entity(current_index)
+                .expect("Unreachable: `Prefab` entity should always be set when walking ui tree")
+                .set_data((
+                    Some(transform),
+                    button.normal_image.as_ref().map(|image| UiImageBuilder {
+                        image: image.clone(),
+                    }),
+                    None,
+                    Some(button),
+                    custom_data,
+                ));
+
             prefab.add(
                 Some(current_index),
                 Some((
@@ -887,7 +884,9 @@ where
     {
         let entity = self.entities.create();
         let handle = self.loader.load(name, progress);
-        self.handles.insert(entity, handle).unwrap(); // safe because we just created the entity
+        self.handles
+            .insert(entity, handle)
+            .expect("Unreachable: We just created the entity");
         entity
     }
 }

--- a/amethyst_ui/src/text.rs
+++ b/amethyst_ui/src/text.rs
@@ -200,7 +200,10 @@ impl<'a> System<'a> for UiKeyboardSystem {
         }
 
         for &mut (ref mut t, entity) in &mut self.tab_order_cache.cache {
-            *t = transform.get(entity).unwrap().tab_order;
+            *t = transform
+                .get(entity)
+                .expect("Unreachable: Entities are collected from a prepopulated cache")
+                .tab_order;
         }
 
         // Attempt to insert the new entities in sorted position.  Should reduce work during
@@ -260,7 +263,11 @@ impl<'a> System<'a> for UiKeyboardSystem {
                 }
             }
         }
-        for event in events.read(self.reader.as_mut().unwrap()) {
+        for event in events.read(
+            self.reader
+                .as_mut()
+                .expect("`UiKeyboardSystem::setup` was not called before `UiKeyboardSystem::run`"),
+        ) {
             // Process events for the whole UI.
             match *event {
                 Event::WindowEvent {
@@ -575,8 +582,11 @@ impl<'a> System<'a> for UiKeyboardSystem {
                             if ctrl_or_cmd(&modifiers) {
                                 let new_clip = extract_highlighted(focused_edit, focused_text);
                                 if !new_clip.is_empty() {
-                                    let mut ctx: ClipboardContext = ClipboardProvider::new().unwrap();
-                                    ctx.set_contents(new_clip).unwrap();
+                                    if let Err(e) = ClipboardProvider::new().and_then(
+                                        |mut ctx: ClipboardContext| ctx.set_contents(new_clip),
+                                    ) {
+                                        error!("Error occured when cutting to clipboard: {:?}", e);
+                                    }
                                 }
                             }
                         }
@@ -584,29 +594,43 @@ impl<'a> System<'a> for UiKeyboardSystem {
                             if ctrl_or_cmd(&modifiers) {
                                 let new_clip = read_highlighted(focused_edit, focused_text);
                                 if !new_clip.is_empty() {
-                                    let mut ctx: ClipboardContext = ClipboardProvider::new().unwrap();
-                                    ctx.set_contents(new_clip.to_owned()).unwrap();
+                                    if let Err(e) = ClipboardProvider::new().and_then(
+                                        |mut ctx: ClipboardContext| {
+                                            ctx.set_contents(new_clip.to_owned())
+                                        },
+                                    ) {
+                                        error!("Error occured when copying to clipboard: {:?}", e);
+                                    }
                                 }
                             }
                         }
                         VirtualKeyCode::V => {
                             if ctrl_or_cmd(&modifiers) {
                                 delete_highlighted(focused_edit, focused_text);
-                                let mut ctx: ClipboardContext = ClipboardProvider::new().unwrap();
-                                if let Ok(contents) = ctx.get_contents() {
-                                    let index = cursor_byte_index(focused_edit, focused_text);
-                                    let empty_space = focused_edit.max_length
-                                        - focused_text.text.graphemes(true).count();
-                                    let contents = contents.graphemes(true).take(empty_space).fold(
-                                        String::new(),
-                                        |mut init, new| {
-                                            init.push_str(new);
-                                            init
-                                        },
-                                    );
-                                    focused_text.text.insert_str(index, &contents);
-                                    focused_edit.cursor_position +=
-                                        contents.graphemes(true).count() as isize;
+
+                                match ClipboardProvider::new()
+                                    .and_then(|mut ctx: ClipboardContext| ctx.get_contents())
+                                {
+                                    Ok(contents) => {
+                                        let index = cursor_byte_index(focused_edit, focused_text);
+                                        let empty_space =
+                                            focused_edit.max_length
+                                                - focused_text.text.graphemes(true).count();
+                                        let contents = contents
+                                            .graphemes(true)
+                                            .take(empty_space)
+                                            .fold(String::new(), |mut init, new| {
+                                                init.push_str(new);
+                                                init
+                                            });
+                                        focused_text.text.insert_str(index, &contents);
+                                        focused_edit.cursor_position +=
+                                            contents.graphemes(true).count() as isize;
+                                    }
+                                    Err(e) => error!(
+                                        "Error occured when pasting contents of clipboard: {:?}",
+                                        e
+                                    ),
                                 }
                             }
                         }


### PR DESCRIPTION
**This PR contains a small breaking change in the public API of `Transform`**.

Crates where unwraps have been replaced:

- [x] amethyst_animation
- [x] amethyst_assets
- [x] amethyst_audio (already no unwraps)
- [x] amethyst_config (already no unwraps)
- [x] amethyst_controls
- [x] amethyst_core
- [x] amethyst_derive (already no unwraps)
- [x] amethyst_gltf
- [x] amethyst_input
- [x] amethyst_locale (already no unwraps)
- [x] amethyst_network
- [x] amethyst_renderer
- [x] amethyst_ui
- [x] amethyst_utils (already no unwraps)

Each crate will receive its own commit. 

Closes: #908 