### PR TITLE
Refractor unwraps for amethyst_animation

### DIFF
--- a/amethyst_animation/src/systems/control.rs
+++ b/amethyst_animation/src/systems/control.rs
@@ -158,7 +158,8 @@ where
                     .deferred_animations
                     .iter()
                     .position(|a| a.animation_id == id)
-                    .unwrap();
+                    .expect("Unreachable: Id of current 'deferred_start' was taken from previous loop over 'deferred_animations'");
+
                 let mut def = control_set.deferred_animations.remove(index);
                 def.control.state = ControlState::Deferred(secs_to_duration(start_dur));
                 def.control.command = AnimationCommand::Start;
@@ -459,12 +460,16 @@ where
 
     // setup sampler tree
     for &(ref node_index, ref channel, ref sampler_handle) in &animation.nodes {
-        let node_entity = hierarchy.nodes.get(node_index).unwrap();
+        let node_entity = hierarchy.nodes.get(node_index).expect(
+            "Unreachable: Existence of all nodes are checked in validation of hierarchy above",
+        );
         let component = rest_states
             .get(*node_entity)
             .map(|r| r.state())
             .or_else(|| targets.get(*node_entity))
-            .unwrap();
+            .expect(
+                "Unreachable: Existence of all nodes are checked in validation of hierarchy above",
+            );
         let sampler_control = SamplerControl::<T> {
             control_id: control.id,
             channel: channel.clone(),

--- a/amethyst_animation/src/util.rs
+++ b/amethyst_animation/src/util.rs
@@ -121,16 +121,13 @@ where
     fn dot(&self, other: &Self) -> f32 {
         use self::SamplerPrimitive::*;
         match (*self, *other) {
-            (Scalar(ref s), Scalar(ref o)) => (*s * *o).to_f32().unwrap(),
-            (Vec2(ref s), Vec2(ref o)) => (s[0] * o[0] + s[1] * o[1]).to_f32().unwrap(),
-            (Vec3(ref s), Vec3(ref o)) => {
-                (s[0] * o[0] + s[1] * o[1] + s[2] * o[2]).to_f32().unwrap()
-            }
-            (Vec4(ref s), Vec4(ref o)) => (s[0] * o[0] + s[1] * o[1] + s[2] * o[2] + s[3] * o[3])
-                .to_f32()
-                .unwrap(),
+            (Scalar(ref s), Scalar(ref o)) => (*s * *o),
+            (Vec2(ref s), Vec2(ref o)) => (s[0] * o[0] + s[1] * o[1]),
+            (Vec3(ref s), Vec3(ref o)) => (s[0] * o[0] + s[1] * o[1] + s[2] * o[2]),
+            (Vec4(ref s), Vec4(ref o)) => (s[0] * o[0] + s[1] * o[1] + s[2] * o[2] + s[3] * o[3]),
             _ => panic!("Interpolation can not be done between primitives of different types"),
-        }
+        }.to_f32()
+        .expect("Unexpected error when converting primitive to f32, possibly under/overflow")
     }
 
     fn magnitude2(&self) -> f32 {
@@ -140,7 +137,9 @@ where
     fn magnitude(&self) -> f32 {
         use self::SamplerPrimitive::*;
         match *self {
-            Scalar(ref s) => s.to_f32().unwrap(),
+            Scalar(ref s) => s.to_f32().expect(
+                "Unexpected error when converting primitive to f32, possibly under/overflow",
+            ),
             Vec2(_) | Vec3(_) | Vec4(_) => self.magnitude2().sqrt(),
         }
     }
@@ -158,5 +157,9 @@ fn mul_f32<T>(s: T, scalar: f32) -> T
 where
     T: BaseNum,
 {
-    NumCast::from(s.to_f32().unwrap() * scalar).unwrap()
+    NumCast::from(
+        s.to_f32()
+            .expect("Unexpected error when converting primitive to f32, possibly under/overflow")
+            * scalar,
+    ).expect("Unexpected error when converting f32 to primitive, possibly under/overflow")
 }


### PR DESCRIPTION
All unwraps in amethyst_animation have been replaced by expect ol. + rephrased previous expects. There was a unwrap that I was uncertain on how to handle; look below for a comment.

Related to: #908