### PR TITLE
SpotLight support for PBM pass

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,5 +191,9 @@ path = "examples/prefab/main.rs"
 name = "debug_lines"
 path = "examples/debug_lines/main.rs"
 
+[[example]]
+name = "spotlights"
+path = "examples/spotlights/main.rs"
+
 [workspace]
 members = ["amethyst_gltf", "tests/amethyst_test"]

--- a/amethyst_renderer/src/light.rs
+++ b/amethyst_renderer/src/light.rs
@@ -112,16 +112,14 @@ impl From<PointLight> for Light {
 pub struct SpotLight {
     /// Opening angle of the light cone in degrees.
     pub angle: f32, //TODO: Replace with a cgmath type when gfx version > 0.16
-    /// Location of the light source in three dimensional space.
-    pub center: [f32; 3], //TODO: Replace with a cgmath type when gfx version > 0.16
     /// Color of the light in RGBA8 format.
     pub color: Rgba,
     /// Direction that the light is pointing.
     pub direction: [f32; 3], //TODO: Replace with a cgmath type when gfx version > 0.16
     /// Brightness of the light source, in lumens.
     pub intensity: f32,
-    /// Maximum radius of the point light's affected area.
-    pub radius: f32,
+    /// Range/length of the light source.
+    pub range: f32,
     /// Smoothness of the light-to-dark transition from the center to the
     /// radius.
     pub smoothness: f32,
@@ -131,11 +129,10 @@ impl Default for SpotLight {
     fn default() -> Self {
         SpotLight {
             angle: 60.0,
-            center: [0.0, 1.0, 0.0],
             color: Rgba::default(),
             direction: [0.0, -1.0, 0.0],
             intensity: 10.0,
-            radius: 10.0,
+            range: 10.0,
             smoothness: 4.0,
         }
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * combinations of buttons triggering actions ([#1043])
 * `UiPrefab` field `hidden: bool` to hide entities ([#1051])
 * `PrefabData` can now be derived for many situations, see the book for more information ([#1035])
+* Support for DirectionalLight and SpotLight in PBM pass. ([#1074], [#1081])
 
 ### Changed
 
@@ -26,6 +27,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1043]: https://github.com/amethyst/amethyst/pull/1043
 [#1051]: https://github.com/amethyst/amethyst/pull/1051
 [#1035]: https://github.com/amethyst/amethyst/pull/1035
+[#1074]: https://github.com/amethyst/amethyst/pull/1074
+[#1081]: https://github.com/amethyst/amethyst/pull/1081
 
 ## [0.9.0] - 2018-10
 ### Added

--- a/examples/assets/prefab/spotlights_scene.ron
+++ b/examples/assets/prefab/spotlights_scene.ron
@@ -1,0 +1,109 @@
+#![enable(implicit_some)]
+
+Prefab (
+    entities: [
+        (
+            data: (
+                graphics: (
+                    mesh: Shape((shape: Plane(None),)),
+                    material: (
+                        albedo: Data(Rgba((1.0, 1.0, 1.0, 1.0,), (channel: Srgb),)),
+                    ),
+                ),
+                transform: (
+                    rotation: (s: 0.0, v: (x: 0.0, y: 1.0, z: 0.0),),
+                    scale: (x: 4.0, y: 2.0, z: 1.0),
+                ),
+            ),
+        ),
+        (
+            data: (
+                light: (
+                    ambient_color: (Rgba(0.01, 0.01, 0.01, 1.0)),
+                ),
+            ),
+        ),
+        (
+            data: (
+                light: (
+                    light: Spot((
+                        intensity: 3.0,
+                        color: (1.5, 0.0, 0.0, 1.0),
+                        angle: 50.0,
+                        range: 4.0,
+                        smoothness: 0.0,
+                        direction: (0.0, 0.0, 1.0),
+                    )),
+                ),
+                transform: (
+                    translation: (x: 3.0, y: 0.0, z: -2.0),
+                ),
+            ),
+        ),
+        (
+            data: (
+                light: (
+                    light: Spot((
+                        intensity: 3.0,
+                        color: (0.0, 1.0, 0.0, 1.0),
+                        angle: 30.0,
+                        range: 4.0,
+                        smoothness: 0.0,
+                        direction: (0.0, 0.0, 1.0),
+                    )),
+                ),
+                transform: (
+                    translation: (x: 1.25, y: 0.0, z: -2.0),
+                ),
+            ),
+        ),
+        (
+            data: (
+                light: (
+                    light: Spot((
+                        intensity: 3.0,
+                        color: (0.0, 0.0, 1.0, 1.0),
+                        angle: 30.0,
+                        range: 4.0,
+                        smoothness: 0.0,
+                        direction: (0.0, 0.0, 1.0),
+                    )),
+                ),
+                transform: (
+                    translation: (x: -1.25, y: 0.0, z: -2.0),
+                ),
+            ),
+        ),
+        (
+            data: (
+                light: (
+                    light: Spot((
+                        intensity: 2.0,
+                        color: (1.0, 1.0, 0.0, 1.0),
+                        angle: 15.0,
+                        range: 10.0,
+                        smoothness: 0.8,
+                        direction: (1.0, -0.4, 0.4),
+                    )),
+                ),
+                transform: (
+                    translation: (x: -5.0, y: 2, z: -1.5),
+                ),
+            ),
+        ),
+        (
+            data: (
+                transform: (
+                    translation: (x: 0.0, y: 0.0, z: -4.0),
+                    rotation: (s: 0.0, v: (x: 0.0, y: 1.0, z: 0.0),),
+                ),
+                camera: Perspective((
+                    fovy: Rad (1.0471975512),
+                    aspect: 1.3,
+                    near: 0.1,
+                    far: 2000.0,
+                )),
+            ),
+        ),
+    ],
+)

--- a/examples/spotlights/main.rs
+++ b/examples/spotlights/main.rs
@@ -1,0 +1,43 @@
+extern crate amethyst;
+
+use amethyst::{
+    assets::{PrefabLoader, PrefabLoaderSystem, RonFormat},
+    core::transform::TransformBundle,
+    prelude::*,
+    renderer::{DrawPbm, PosNormTangTex},
+    utils::{application_root_dir, scene::BasicScenePrefab},
+};
+
+type MyPrefabData = BasicScenePrefab<Vec<PosNormTangTex>>;
+
+struct Example;
+
+impl<'a, 'b> SimpleState<'a, 'b> for Example {
+    fn on_start(&mut self, data: StateData<GameData>) {
+        let handle = data.world.exec(|loader: PrefabLoader<MyPrefabData>| {
+            loader.load("prefab/spotlights_scene.ron", RonFormat, (), ())
+        });
+        data.world.create_entity().with(handle).build();
+    }
+}
+
+fn main() -> amethyst::Result<()> {
+    amethyst::start_logger(Default::default());
+
+    let app_root = application_root_dir();
+
+    let display_config_path = format!(
+        "{}/examples/spotlights/resources/display_config.ron",
+        app_root
+    );
+
+    let resources = format!("{}/examples/assets/", app_root);
+
+    let game_data = GameDataBuilder::default()
+        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[])
+        .with_bundle(TransformBundle::new())?
+        .with_basic_renderer(display_config_path, DrawPbm::<PosNormTangTex>::new(), false)?;
+    let mut game = Application::new(resources, Example, game_data)?;
+    game.run();
+    Ok(())
+}

--- a/examples/spotlights/resources/display_config.ron
+++ b/examples/spotlights/resources/display_config.ron
@@ -1,0 +1,10 @@
+(
+  dimensions: None,
+  max_dimensions: None,
+  min_dimensions: None,
+  fullscreen: false,
+  multisampling: 0,
+  title: "Spotlights example",
+  visibility: true,
+  vsync: true,
+)


### PR DESCRIPTION
See #855.

This PR adds support for `SpotLight`s in the PBM render pass as well as adding a new example to showcase the lights.

While doing so I encountered that that the `SpotLight` type had obsolete & less-suitable fields and I changed them.

This PR depends on the refactor done in #1074

Here a screenshot of the new example:
![screenshot_2018-10-28_15-20-15](https://user-images.githubusercontent.com/5209613/47617278-b7b05800-dac5-11e8-9a55-f523ef51a330.png)
