### PR TITLE
[wip] [ci] Cache dependencies with sccache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,27 +29,12 @@ branches:
   - trying
 
 before_install:
-- |
-  if [ ${TRAVIS_OS_NAME} == "windows" ]
-  then
-    wget --no-check-certificate https://www.libsdl.org/release/SDL2-devel-2.0.8-VC.zip
-    7z x SDL2-devel-2.0.8-VC.zip
-    cp SDL2-2.0.8/lib/x64/*.lib ${HOME}/.rustup/toolchains/${TRAVIS_RUST_VERSION}-x86_64-pc-windows-msvc/lib/rustlib/x86_64-pc-windows-msvc/lib
-    cp SDL2-2.0.8/lib/x64/*.dll .
-    rm SDL2-devel-2.0.8-VC.zip
-  elif [ ${TRAVIS_OS_NAME} == "osx" ]
-  then
-    brew update && brew install sdl2
-  else
-    export MDBOOK_RELEASE="v0.2.1/mdbook-v0.2.1-x86_64-unknown-linux-gnu.tar.gz"
-    curl -L -o mdbook.tar.gz https://github.com/rust-lang-nursery/mdBook/releases/download/${MDBOOK_RELEASE}
-    tar -xvf mdbook.tar.gz -C ./
-    rm mdbook.tar.gz
-  fi
+- ./ci/travis/before_install.sh
 
 before_script:
 - export PATH=$PATH:/home/travis/.cargo/bin
 - export RUSTFLAGS="-D warnings"
+- export RUSTC_WRAPPER="./sccache"
 
 # Generate documentation, compile the engine, run tests.
 script:

--- a/ci/travis/before_install.sh
+++ b/ci/travis/before_install.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+MDBOOK_VERSION="v0.2.1"
+
+SCCACHE_VERSION="0.2.7"
+declare -A SCCACHE_TOOLCHAINS=(
+  [windows]="x86_64-pc-windows-msvc"
+  [osx]="x86_64-apple-darwin"
+  [linux]="x86_64-unknown-linux-musl"
+)
+
+
+install_libsdl2(){
+  case ${TRAVIS_OS_NAME} in
+  windows)
+    wget --no-check-certificate https://www.libsdl.org/release/SDL2-devel-2.0.8-VC.zip
+    7z x SDL2-devel-2.0.8-VC.zip
+    cp SDL2-2.0.8/lib/x64/*.lib ${HOME}/.rustup/toolchains/${TRAVIS_RUST_VERSION}-x86_64-pc-windows-msvc/lib/rustlib/x86_64-pc-windows-msvc/lib
+    cp SDL2-2.0.8/lib/x64/*.dll .
+    rm SDL2-devel-2.0.8-VC.zip
+    ;;
+  osx)
+    brew update && brew install sdl2
+    ;;
+  linux)
+    # This is handled by Travis CI's `apt` addon
+    ;;
+  esac
+}
+
+install_mdbook(){
+  case ${TRAVIS_OS_NAME} in
+  linux)
+    export MDBOOK_RELEASE="${MDBOOK_VERSION}/mdbook-${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+    curl -L -o mdbook.tar.gz https://github.com/rust-lang-nursery/mdBook/releases/download/${MDBOOK_RELEASE}
+    tar -xvf mdbook.tar.gz -C ./
+    rm mdbook.tar.gz
+    ;;
+  esac
+}
+
+install_sccache(){
+  SCCACHE_TOOLCHAIN=${SCCACHE_TOOLCHAIN[$TRAVIS_OS_NAME]}
+  SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-${SCCACHE_TOOLCHAIN}.tar.gz"
+  curl -L -o sccache.tar.gz ${SCCACHE_URL}
+  tar -xvf sccache.tar.gz -C ./ sccache
+  rm sccache.tar.gz
+}
+
+install_libsdl2
+install_mdbook
+install_sccache
+
+set +exuo pipefail


### PR DESCRIPTION
This uses [mozilla/sccache](https://github.com/mozilla/sccache) to cache invocations of rustc when building. It's cache seems to be incredibly lightweight at only 221 MiB, since it [doesn't cache everything]( https://github.com/mozilla/sccache/blob/master/src/compiler/rust.rs#L787) that Cargo does.

On my machine, after a `cargo clean` these were the observed results:

Without `sccache`:
```
cargo build --all
784.94s user 39.99s system 737% cpu 1:51.92 total
```
With `sccache`:
```
RUSTC_WRAPPER=../sccache/target/release/sccache cargo build --all
182.72s user 16.83s system 424% cpu 47.028 total
```

## TODO
- [ ] Actually cache the sccache directory with TravisCI
- [ ] Test against actual Travis CI