### PR TITLE
Re-export exposed Font struct for FontAsset

### DIFF
--- a/amethyst_ui/src/format.rs
+++ b/amethyst_ui/src/format.rs
@@ -1,6 +1,6 @@
 use amethyst_assets::{Asset, Error, Handle, ProcessingState, ResultExt, SimpleFormat};
 use amethyst_core::specs::prelude::VecStorage;
-use gfx_glyph::Font;
+pub use gfx_glyph::Font;
 
 /// A loaded set of fonts from a file.
 #[derive(Clone)]

--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -59,7 +59,7 @@ pub use self::font::default::get_default_font;
 pub use self::font::systemfont::{
     default_system_font, get_all_font_handles, list_system_font_families,
 };
-pub use self::format::{FontAsset, FontFormat, FontHandle, OtfFormat, TtfFormat};
+pub use self::format::{Font, FontAsset, FontFormat, FontHandle, OtfFormat, TtfFormat};
 pub use self::image::UiImage;
 pub use self::layout::{Anchor, ScaleMode, Stretch, UiTransformSystem};
 pub use self::pass::DrawUi;


### PR DESCRIPTION
Currently the `Font` is exposed in public API and it would be useful to re-export it for user to manually initialize fonts

Especially considering that amethyst gets it from `gfx_glyph` and not `rusttype` directly

Not sure if you're ok with it?