### PR TITLE
Provide associated constants for Rgba colors

### DIFF
--- a/amethyst_renderer/src/color.rs
+++ b/amethyst_renderer/src/color.rs
@@ -9,34 +9,47 @@ use glsl_layout::{vec3, vec4};
 pub struct Rgba(pub f32, pub f32, pub f32, pub f32);
 
 impl Rgba {
+    /// Solid black color value.
+    pub const BLACK: Rgba = Rgba(0.0, 0.0, 0.0, 1.0);
+    /// Solid blue color value.
+    pub const BLUE: Rgba = Rgba(0.0, 0.0, 1.0, 1.0);
+    /// Solid green color value.
+    pub const GREEN: Rgba = Rgba(0.0, 1.0, 0.0, 1.0);
+    /// Solid red color value.
+    pub const RED: Rgba = Rgba(1.0, 0.0, 0.0, 1.0);
+    /// Transparent color value.
+    pub const TRANSPARENT: Rgba = Rgba(0.0, 0.0, 0.0, 0.0);
+    /// Solid white color value.
+    pub const WHITE: Rgba = Rgba(1.0, 1.0, 1.0, 1.0);
+
     /// Returns a solid black color value.
     pub fn black() -> Rgba {
-        Rgba(0.0, 0.0, 0.0, 1.0)
+        Rgba::BLACK
     }
 
     /// Returns a solid blue color value.
     pub fn blue() -> Rgba {
-        Rgba(0.0, 0.0, 1.0, 1.0)
+        Rgba::BLUE
     }
 
     /// Returns a solid green color value.
     pub fn green() -> Rgba {
-        Rgba(0.0, 1.0, 0.0, 1.0)
+        Rgba::GREEN
     }
 
     /// Returns a solid red color value.
     pub fn red() -> Rgba {
-        Rgba(1.0, 0.0, 0.0, 1.0)
+        Rgba::RED
     }
 
     /// Returns a transparent color value.
     pub fn transparent() -> Rgba {
-        Rgba(0.0, 0.0, 0.0, 0.0)
+        Rgba::TRANSPARENT
     }
 
     /// Returns a solid white color value.
     pub fn white() -> Rgba {
-        Rgba(1.0, 1.0, 1.0, 1.0)
+        Rgba::WHITE
     }
 }
 


### PR DESCRIPTION
I know I first reached for associated constants rather than functions for these simple predefined colors. (I very much prefer to write `Rgba::BLACK` over something like `[0.0, 0.0, 0.0, 1.0]`; it's much more descriptive.)

These simple constant constructors seem like good fits for associated constants -- is there any reason they aren't provided as such?

Here I define an associated constant on `amethyst_renderer::color::Rgba` for each constant constructor function it has, and redefine the functions in terms of the constants. The functions can be marked `const` on 1.31 as well.

It's basically opinion whether `::BLACK` or `::black()` is preferred. Neither can be imported directly, and have to be referred to through the `Rgba` type. For something small and trivial like `Rgba` though, it seems decently convenient to the user to provide both.

------

A reasoning behind not providing associated constants would be a valid and quickly accepted reason to close the PR; this PR is also effectively doubling as the issue "why aren't there associated constants on `Rgba`?". The implementation is trivial so I thought I'd go ahead and provide it.)