### PR TITLE
Add documentation to prefab_data_derive

### DIFF
--- a/amethyst_derive/src/lib.rs
+++ b/amethyst_derive/src/lib.rs
@@ -20,6 +20,9 @@ pub fn event_reader_derive(input: TokenStream) -> TokenStream {
     gen.into()
 }
 
+/// Deriving a `Prefab` requires that `amethyst::ecs::Entity` and
+/// `amethyst:assets::{PrefabData, PrefabError, ProgressCounter}` are imported
+/// and visible in the current scope. This is due to how Rust macros work.
 #[proc_macro_derive(PrefabData, attributes(prefab))]
 pub fn prefab_data_derive(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);

--- a/book/src/prefab.md
+++ b/book/src/prefab.md
@@ -205,6 +205,10 @@ Amethyst supplies a derive macro for creating the `PrefabData` implementation fo
 * Single `Component` 
 * Aggregate `PrefabData` structs which contain other `PrefabData` constructs, and optionally simple data `Component`s
 
+In addition, deriving a `Prefab` requires that `amethyst::ecs::Entity` and
+ `amethyst:assets::{PrefabData, PrefabError, ProgressCounter}` are imported
+ and visible in the current scope. This is due to how Rust macros work.
+
 An example of a single `Component` derive:
 
 ```rust,no_run,noplaypen


### PR DESCRIPTION
Adds document describing which imports are needed in order to successfully derive `PrefabData`. Related to #1093.