### PR TITLE
Default font in prefabs

### DIFF
--- a/amethyst_ui/src/prefab.rs
+++ b/amethyst_ui/src/prefab.rs
@@ -275,12 +275,12 @@ where
         system_data: &mut Self::SystemData,
     ) -> Result<bool, PrefabError> {
         let (_, _, ref mut fonts, _) = system_data;
-        if self.font.is_none() {
-            let (ref loader, _, ref storage) = fonts;
-            self.font = Some(AssetPrefab::Handle(get_default_font(loader, storage)));
-        }
 
-        self.font.as_mut().unwrap().load_sub_assets(progress, fonts)
+        self.font
+            .get_or_insert_with(|| {
+                let (ref loader, _, ref storage) = fonts;
+                AssetPrefab::Handle(get_default_font(loader, storage))
+            }).load_sub_assets(progress, fonts)
     }
 }
 

--- a/amethyst_ui/src/prefab.rs
+++ b/amethyst_ui/src/prefab.rs
@@ -5,7 +5,10 @@ use amethyst_assets::{
     PrefabLoaderSystem, Progress, ProgressCounter, Result as AssetResult, ResultExt, SimpleFormat,
 };
 use amethyst_audio::{AudioFormat, Source as Audio};
-use amethyst_core::specs::prelude::{Entities, Entity, Read, ReadExpect, Write, WriteStorage};
+use amethyst_core::specs::{
+    error::BoxedErr,
+    prelude::{Entities, Entity, Read, ReadExpect, Write, WriteStorage},
+};
 use amethyst_renderer::{HiddenPropagate, Texture, TextureFormat, TextureMetadata, TexturePrefab};
 
 use super::*;
@@ -238,7 +241,7 @@ where
         let font_handle = self
             .font
             .as_ref()
-            .expect("did not load sub assets")
+            .ok_or_else(|| PrefabError::Custom(BoxedErr(Box::from("did not load sub assets"))))?
             .add_to_entity(entity, fonts, &[])?;
         let mut ui_text = UiText::new(font_handle, self.text.clone(), self.color, self.font_size);
         ui_text.password = self.password;

--- a/examples/assets/ui/example.ron
+++ b/examples/assets/ui/example.ron
@@ -176,6 +176,23 @@ Container(
             )
         ),
 
+        Text(
+            transform: (
+                id: "system_font",
+                x: 200.,
+                width: 400.,
+                height: 200.,
+                tab_order: 1,
+                anchor: MiddleLeft,
+            ),
+            text: (
+                text: "System Font",
+                font_size: 30.,
+                color: (0.2, 0.2, 1.0, 1.0),
+                align: MiddleLeft,
+            )
+        ),
+
         // ------ Text Align Start ------
         Text(
             transform: (


### PR DESCRIPTION
Hi,
I would like to be able to use (default) system font from UI prefabs, so I made it optional in `UiTextBuilder` and `UiButtonBuilder` and implemented fallback using `get_default_font`.