### PR TITLE
make default logger more configurable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ pub use self::{
     app::{Application, ApplicationBuilder, CoreApplication},
     error::{Error, Result},
     game_data::{DataInit, GameData, GameDataBuilder},
-    logger::{start_logger, LevelFilter as LogLevelFilter, LoggerConfig, StdoutLog},
+    logger::{start_logger, LevelFilter as LogLevelFilter, Logger, LoggerConfig, StdoutLog},
     state::{
         EmptyState, EmptyTrans, SimpleState, SimpleTrans, State, StateData, StateMachine, Trans,
     },

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -39,6 +39,76 @@ impl Default for LoggerConfig {
     }
 }
 
+pub struct Logger {
+    dispatch: fern::Dispatch,
+}
+
+impl Logger {
+    pub fn new() -> Self {
+        let dispatch = fern::Dispatch::new().format(|out, message, record| {
+            out.finish(format_args!(
+                "[{level}][{target}] {message}",
+                level = record.level(),
+                target = record.target(),
+                message = message,
+            ))
+        });
+        Logger { dispatch }
+    }
+
+    pub fn from_config(mut config: LoggerConfig) -> Self {
+        if config.allow_env_override {
+            env_var_override(&mut config);
+        }
+
+        let mut logger = Logger::new();
+        logger.dispatch = logger.dispatch.level(config.level_filter);
+
+        match config.stdout {
+            StdoutLog::Plain => logger.dispatch = logger.dispatch.chain(io::stdout()),
+            StdoutLog::Colored => {
+                logger.dispatch = logger.dispatch.chain(Logger::colored_stdout(
+                    fern::colors::ColoredLevelConfig::new(),
+                ))
+            }
+            StdoutLog::Off => {}
+        }
+
+        if let Some(path) = config.log_file {
+            match fern::log_file(path) {
+                Ok(log_file) => logger.dispatch = logger.dispatch.chain(log_file),
+                Err(_) => eprintln!("Unable to access the log file, as such it will not be used"),
+            }
+        }
+
+        logger
+    }
+
+    pub fn colored_stdout(color_config: fern::colors::ColoredLevelConfig) -> fern::Dispatch {
+        fern::Dispatch::new()
+            .chain(io::stdout())
+            .format(move |out, message, record| {
+                let color = color_config.get_color(&record.level());
+                out.finish(format_args!(
+                    "{color}{message}{color_reset}",
+                    color = format!("\x1B[{}m", color.to_fg_str()),
+                    message = message,
+                    color_reset = "\x1B[0m",
+                ))
+            })
+    }
+
+    pub fn start(self) {
+        self.dispatch.apply().unwrap_or_else(|_| {
+            debug!("Global logger already set, default Amethyst logger will not be used")
+        });
+    }
+
+    pub fn get_dispatch(self) -> fern::Dispatch {
+        self.dispatch
+    }
+}
+
 /// Starts a basic logger outputting to stdout with color on supported platforms, and/or to file.
 ///
 /// If you do not intend on using the logger builtin to Amethyst, it's highly recommended you
@@ -48,29 +118,8 @@ impl Default for LoggerConfig {
 /// * AMETHYST_LOG_STDOUT - determines the output to the terminal
 /// * AMETHYST_LOG_LEVEL_FILTER - sets the log level
 /// * AMETHYST_LOG_FILE_PATH - if set, enables logging to the file at the path
-pub fn start_logger(mut config: LoggerConfig) {
-    if config.allow_env_override {
-        env_var_override(&mut config);
-    }
-
-    let mut dispatch = basic_dispatch(config.level_filter);
-
-    match config.stdout {
-        StdoutLog::Plain => dispatch = dispatch.chain(io::stdout()),
-        StdoutLog::Colored => dispatch = dispatch.chain(colored_stdout()),
-        StdoutLog::Off => {}
-    }
-
-    if let Some(path) = config.log_file {
-        match fern::log_file(path) {
-            Ok(log_file) => dispatch = dispatch.chain(log_file),
-            Err(_) => eprintln!("Unable to access the log file, as such it will not be used"),
-        }
-    }
-
-    dispatch.apply().unwrap_or_else(|_| {
-        debug!("Global logger already set, default Amethyst logger will not be used")
-    });
+pub fn start_logger(config: LoggerConfig) {
+    Logger::from_config(config).start();
 }
 
 fn env_var_override(config: &mut LoggerConfig) {
@@ -90,33 +139,4 @@ fn env_var_override(config: &mut LoggerConfig) {
     if let Ok(path) = env::var("AMETHYST_LOG_FILE_PATH") {
         config.log_file = Some(PathBuf::from(path));
     }
-}
-
-fn basic_dispatch(level_filter: LevelFilter) -> fern::Dispatch {
-    fern::Dispatch::new()
-        .level(level_filter)
-        .format(|out, message, record| {
-            out.finish(format_args!(
-                "[{level}][{target}] {message}",
-                level = record.level(),
-                target = record.target(),
-                message = message,
-            ))
-        })
-}
-
-fn colored_stdout() -> fern::Dispatch {
-    let color_config = fern::colors::ColoredLevelConfig::new();
-
-    fern::Dispatch::new()
-        .chain(io::stdout())
-        .format(move |out, message, record| {
-            let color = color_config.get_color(&record.level());
-            out.finish(format_args!(
-                "{color}{message}{color_reset}",
-                color = format!("\x1B[{}m", color.to_fg_str()),
-                message = message,
-                color_reset = "\x1B[0m",
-            ))
-        })
 }


### PR DESCRIPTION
`fern::dispatch` gets build and can be returned to the user instead
off starting it directly, this allows the user to add extra options to
the logger like `level_for()` before starting the logger.

Example:
```
let logger = amethyst::Logger::from_config(amethyst::LoggerConfig::default());
logger.get_dispatch()
    .level_for("gfx_device_gl", log::LevelFilter::Warn)
    .level_for("gfx_glyph", log::LevelFilter::Error)
    .apply();
```