### PR TITLE
Use new_observer_frame in Transform::look_at

### DIFF
--- a/amethyst_core/src/transform/components/local_transform.rs
+++ b/amethyst_core/src/transform/components/local_transform.rs
@@ -42,16 +42,20 @@ impl Transform {
     /// // No rotation by default
     /// assert_eq!(*t.rotation().quaternion(), Quaternion::identity());
     /// // look up with up pointing backwards
-    /// t.look_at(Vector3::new(0.0, 1.0, 0.0), Vector3::new(0.0, 0.0, 1.0));
+    /// t.face_towards(Vector3::new(0.0, 1.0, 0.0), Vector3::new(0.0, 0.0, 1.0));
     /// // our rotation should match the angle from straight ahead to straight up
     /// let rotation = UnitQuaternion::rotation_between(
     ///     &Vector3::new(0.0, 1.0, 0.0),
-    ///     &Vector3::new(0.0, 0.0, -1.0),
+    ///     &Vector3::new(0.0, 0.0, 1.0),
     /// ).unwrap();
     /// assert_eq!(*t.rotation(), rotation);
+    /// // now if we move forwards by 1.0, we'll end up at the point we are facing
+    /// // (modulo some floating point error)
+    /// t.move_forward(1.0);
+    /// assert!((*t.translation() - Vector3::new(0.0, 1.0, 0.0)).magnitude() <= 0.0001);
     /// ```
     #[inline]
-    pub fn look_at(&mut self, target: Vector3<f32>, up: Vector3<f32>) -> &mut Self {
+    pub fn face_towards(&mut self, target: Vector3<f32>, up: Vector3<f32>) -> &mut Self {
         self.iso.rotation =
             UnitQuaternion::new_observer_frame(&(self.iso.translation.vector - target), &up);
         self

--- a/amethyst_core/src/transform/components/local_transform.rs
+++ b/amethyst_core/src/transform/components/local_transform.rs
@@ -53,7 +53,7 @@ impl Transform {
     #[inline]
     pub fn look_at(&mut self, target: Vector3<f32>, up: Vector3<f32>) -> &mut Self {
         self.iso.rotation =
-            UnitQuaternion::look_at_rh(&(target - self.iso.translation.vector), &up);
+            UnitQuaternion::new_observer_frame(&(self.iso.translation.vector - target), &up);
         self
     }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ### Changed
 
+* `Transform::look_at` renamed to `Transform::face_towards` and behavior fixed. ([#1142])
 * `Material` animations now directly use `Handle<Texture>` instead of using indirection. ([#1089])
 * `SpriteRenderPrimitive::SpriteSheet` now takes `Handle<SpriteSheet>` instead of a `u64` ID. ([#1089])
 * `nalgebra` is now the math library used by the engine. ([#1066])


### PR DESCRIPTION
Make the forward vector of and entity to point towards position (See #1134) when using Transform::look_at, as per the documentation. In particular, for a camera:

```rust
camera_transform.look_at(point, world_up);
```

should point the camera towards point, as in Unity's Transform.LookAt example:

https://docs.unity3d.com/ScriptReference/Transform.LookAt.html

I have an example that demonstrates this change here:

https://github.com/JamesAngstrom/look_at

you can switch between my branch and current amethyst master in Cargo.toml and see how the camera  behavior changes.

Before (camera rotates away from the sphere):
![before](https://user-images.githubusercontent.com/44684728/48505476-0d635f00-e83f-11e8-8277-317ed2384076.png)
After (camera points at sphere and rotates around it):
![after](https://user-images.githubusercontent.com/44684728/48505512-22d88900-e83f-11e8-9f24-131771c0cd26.png)

We could also have a separate function that has the new behavior with a different name, as suggested in the issue thread, but I think the above is likely going to be the expected behavior of look_at, and matches other game engines.
