### PR TITLE
Bugfix: Dynamically generated texture buffers have the wrong size

### DIFF
--- a/amethyst_renderer/src/error.rs
+++ b/amethyst_renderer/src/error.rs
@@ -37,6 +37,8 @@ pub enum Error {
     TargetCreation(gfx::CombinedError),
     /// Failed to create a texture resource.
     TextureCreation(gfx::texture::CreationError),
+    /// The given pixel data and metadata do not match.
+    PixelDataMismatch(String),
     /// The window handle associated with the renderer has been destroyed.
     WindowDestroyed,
 }
@@ -54,6 +56,7 @@ impl StdError for Error {
             Error::SpecsError(_) => "Failed to interact with the ECS!",
             Error::TargetCreation(_) => "Failed to create render target!",
             Error::TextureCreation(_) => "Failed to create texture!",
+            Error::PixelDataMismatch(_) => "Pixel data and metadata do not match!",
             Error::WindowDestroyed => "Window has been destroyed!",
         }
     }
@@ -86,6 +89,9 @@ impl Display for Error {
             Error::SpecsError(ref e) => write!(fmt, "Interaction with ECS failed: {}", e),
             Error::TargetCreation(ref e) => write!(fmt, "Target creation failed: {}", e),
             Error::TextureCreation(ref e) => write!(fmt, "Texture creation failed: {}", e),
+            Error::PixelDataMismatch(ref e) => {
+                write!(fmt, "Pixel data and metadata do not match: {}", e)
+            }
             Error::WindowDestroyed => write!(fmt, "Window has been destroyed"),
         }
     }

--- a/amethyst_renderer/src/formats/texture.rs
+++ b/amethyst_renderer/src/formats/texture.rs
@@ -451,11 +451,17 @@ where
     D: AsRef<[T]>,
     T: Pod + Copy,
 {
-    tb.with_sampler(metadata.sampler)
+    let builder = tb
+        .with_sampler(metadata.sampler)
         .mip_levels(metadata.mip_levels)
         .dynamic(metadata.dynamic)
         .with_format(metadata.format)
-        .with_channel_type(metadata.channel)
+        .with_channel_type(metadata.channel);
+    if let Some((x, y)) = metadata.size {
+        builder.with_size(x, y)
+    } else {
+        builder
+    }
 }
 
 fn create_texture_asset_from_image(

--- a/amethyst_renderer/src/tex.rs
+++ b/amethyst_renderer/src/tex.rs
@@ -176,11 +176,19 @@ where
             let (w, h, _, _) = self.info.kind.get_dimensions();
             let w = w as usize;
             let h = h as usize;
+            if w * h * pixel_width != data.len() {
+                let error = format!(
+                    "Texture size mismatch: Expected pixel data vector of length {:?} (actual: {:?})",
+                    w * h * pixel_width,
+                    data.len()
+                );
+                bail!(::error::Error::PixelDataMismatch(error))
+            }
             for y in 0..h {
                 for x in 0..(w * pixel_width) {
                     v_flip_buffer.push(data[x + (h - y - 1) * w * pixel_width]);
                     // Uncomment this if you need to debug this.
-                    //println!("x: {}, y: {}, w: {}, h: {}, pw: {}", x, y, w, h, pixel_width);
+                    // println!("x: {}, y: {}, w: {}, h: {}, pw: {}", x, y, w, h, pixel_width);
                 }
             }
             data = &v_flip_buffer;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ### Fixed
 
+[#1144]: https://github.com/amethyst/amethyst/pull/1144
 [#1000]: https://github.com/amethyst/amethyst/pull/1000
 [#1043]: https://github.com/amethyst/amethyst/pull/1043
 [#1051]: https://github.com/amethyst/amethyst/pull/1051


### PR DESCRIPTION
Hi there!
I've stumbled upon an issue when trying to create a dynamic texture (that is, not loaded from a file). The size of the opengl texture buffer for non-image textures is always 1x1 (that's why defining a texture with only one color works), but custom sizes defined via `TextureMetadata` are 'forgotten'.

I've never done any serious error handling in my other projects, so please have a look at the error that I use to indicate that a texture of invalidate size is created. Also, the code does not `Err` if "too many" pixels are defined... that probably also should result in an error.