### PR TITLE
implement common traits for TgaFormat

### DIFF
--- a/amethyst_renderer/src/formats/texture.rs
+++ b/amethyst_renderer/src/formats/texture.rs
@@ -364,6 +364,7 @@ impl SimpleFormat<Texture> for BmpFormat {
 }
 
 /// Allows loading of TGA files.
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct TgaFormat;
 
 impl TgaFormat {

--- a/amethyst_renderer/src/lib.rs
+++ b/amethyst_renderer/src/lib.rs
@@ -42,7 +42,6 @@ extern crate gfx;
 extern crate gfx_core;
 #[macro_use]
 extern crate gfx_macros;
-#[macro_use]
 extern crate glsl_layout;
 extern crate hetseq;
 extern crate hibitset;

--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -16,7 +16,6 @@ extern crate fnv;
 extern crate font_kit;
 extern crate gfx;
 extern crate gfx_glyph;
-#[macro_use]
 extern crate glsl_layout;
 extern crate hibitset;
 #[macro_use]


### PR DESCRIPTION
`Clone` is required for the `Format` trait. I did not find any issues regarding this.