### PR TITLE
Deny unknown fields for BasicScenePrefab

### DIFF
--- a/amethyst_utils/src/scene.rs
+++ b/amethyst_utils/src/scene.rs
@@ -19,15 +19,16 @@ use removal::Removal;
 ///
 /// ### Type parameters:
 ///
-/// `V`: Vertex format to use for generated `Mesh`es, must to be one of:
+/// - `V`: Vertex format to use for generated `Mesh`es, must to be one of:
 ///     * `Vec<PosTex>`
 ///     * `Vec<PosNormTex>`
 ///     * `Vec<PosNormTangTex>`
 ///     * `ComboMeshCreator`
-/// `R`: The type of id used by the Removal component.
+/// - `R`: The type of id used by the Removal component.
 /// - `M`: `Format` to use for loading `Mesh`es from file
 #[derive(Deserialize, Serialize, PrefabData)]
 #[serde(default)]
+#[serde(deny_unknown_fields)]
 pub struct BasicScenePrefab<V, R = (), M = ObjFormat>
 where
     M: Format<Mesh> + Clone,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * Updated `winit` to `0.18` (see [Winit's changelog][winit_018]). ([#1131])
 * Updated `glutin` to `0.19` (see [Glutin's changelog][glutin_019]). ([#1131])
 * Renamed the `DrawSprite` pass to `DrawFlat2D` as it now handles both sprites and images without spritesheets. ([#1153])
+* `BasicScenePrefab` deserialization now returns an error on invalid fields. ([#1164])
 
 ### Removed
 
@@ -66,6 +67,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1129]: https://github.com/amethyst/amethyst/pull/1129
 [#1131]: https://github.com/amethyst/amethyst/pull/1131
 [#1153]: https://github.com/amethyst/amethyst/pull/1153
+[#1164]: https://github.com/amethyst/amethyst/pull/1164
 [winit_018]: https://github.com/tomaka/winit/blob/v0.18.0/CHANGELOG.md#version-0180-2018-11-07
 [glutin_019]: https://github.com/tomaka/glutin/blob/master/CHANGELOG.md#version-0190-2018-11-09
 


### PR DESCRIPTION
This adds `#[serde(deny_unknown_fields)]` to `BasicScenePrefab` so that an invalid field causes an error, instead of being silently ignored. I had trouble figuring out why my custom components aren't being added, so this should help. The message looks like:

```
Some(Message("unknown field `custom_component`, expected one of `graphics`, `transform`, `light`, `camera`, `control_tag`, `removal`"))
```
