### PR TITLE
Clean unused glyph brushes

### DIFF
--- a/amethyst_ui/src/pass.rs
+++ b/amethyst_ui/src/pass.rs
@@ -228,7 +228,11 @@ impl Pass for DrawUi {
 
         //Gather unused glyph brushes
         //These that are currently in use will be removed from this set.
-        let mut unused_glyph_brushes = self.glyph_brushes.iter().map(|(id, _)| *id).collect::<HashSet<_>>();
+        let mut unused_glyph_brushes = self
+            .glyph_brushes
+            .iter()
+            .map(|(id, _)| *id)
+            .collect::<HashSet<_>>();
 
         let highest_abs_z = (&ui_transform,)
             .join()
@@ -572,7 +576,6 @@ impl Pass for DrawUi {
         for id in unused_glyph_brushes.drain() {
             self.glyph_brushes.remove(&id);
         }
-
     }
 }
 

--- a/amethyst_ui/src/pass.rs
+++ b/amethyst_ui/src/pass.rs
@@ -241,6 +241,10 @@ impl Pass for DrawUi {
         for &(_z, entity) in &self.cached_draw_order.cache {
             // Do not render hidden entities.
             if hidden.contains(entity) || hidden_prop.contains(entity) {
+                ui_text
+                    .get_mut(entity)
+                    .and_then(|ui_text| ui_text.brush_id)
+                    .map(|brush_id| unused_glyph_brushes.remove(&brush_id));
                 continue;
             }
             let ui_transform = ui_transform


### PR DESCRIPTION
This is a bit naive approach to the problem.

I wonder if we should clean brushes or maybe re-use existing ones? (Though I'm not sure how to do it)

Closes #1102

~**UPD:** There is currently issue with `Hidden` UI elements~