### PR TITLE
Fix up common ReaderId pattern

### DIFF
--- a/amethyst_animation/src/bundle.rs
+++ b/amethyst_animation/src/bundle.rs
@@ -37,11 +37,7 @@ impl<'a> VertexSkinningBundle<'a> {
 
 impl<'a, 'b, 'c> SystemBundle<'a, 'b> for VertexSkinningBundle<'c> {
     fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<()> {
-        builder.add(
-            VertexSkinningSystem::new(),
-            "vertex_skinning_system",
-            self.dep,
-        );
+        builder.add(VertexSkinningSystem, "vertex_skinning_system", self.dep);
         Ok(())
     }
 }

--- a/amethyst_animation/src/skinning/systems.rs
+++ b/amethyst_animation/src/skinning/systems.rs
@@ -23,17 +23,6 @@ pub struct VertexSkinningSystemData {
     updated_id: ReaderId<ComponentEvent>,
 }
 
-impl VertexSkinningSystemData {
-    pub fn populate_updated_skins(&mut self, joints: &ReadStorage<'_, Joint>) {
-        self.updated_skins.clear();
-        for (_, joint) in (&self.updated, joints).join() {
-            for skin in &joint.skins {
-                self.updated_skins.add(skin.id());
-            }
-        }
-    }
-}
-
 impl<'a> System<'a> for VertexSkinningSystem {
     type SystemData = (
         ReadStorage<'a, Joint>,
@@ -59,8 +48,19 @@ impl<'a> System<'a> for VertexSkinningSystem {
                 ComponentEvent::Removed(_id) => {}
             });
 
-        data.populate_updated_skins(&joints);
-
+        {
+            let VertexSkinningSystemData {
+                ref updated,
+                ref mut updated_skins,
+                ..
+            } = *data;
+            updated_skins.clear();
+            for (_, joint) in (updated, &joints).join() {
+                for skin in &joint.skins {
+                    updated_skins.add(skin.id());
+                }
+            }
+        }
         for (_id, skin) in (&data.updated_skins, &mut skins).join() {
             // Compute the joint global_transforms
             skin.joint_matrices.clear();

--- a/amethyst_assets/src/prefab/system.rs
+++ b/amethyst_assets/src/prefab/system.rs
@@ -3,7 +3,7 @@ use std::{marker::PhantomData, ops::Deref};
 use amethyst_core::{
     specs::{
         storage::ComponentEvent, BitSet, Entities, Entity, Join, Read, ReadExpect, ReadStorage,
-        ReaderId, Resources, System, Write, WriteStorage,
+        ReaderId, Resources, System, Write, WriteExpect, WriteStorage,
     },
     ArcThreadPool, Parent, Time,
 };
@@ -17,25 +17,26 @@ use super::{Prefab, PrefabData, PrefabTag};
 /// ### Type parameters:
 ///
 /// - `T`: `PrefabData`
+#[derive(Default)]
 pub struct PrefabLoaderSystem<T> {
+    _m: PhantomData<T>,
+}
+
+/// A resource for `PrefabLoaderSystem`.  Automatically created and managed by `PrefabLoaderSystem`.
+pub struct PrefabLoaderSystemData<T> {
     _m: PhantomData<T>,
     entities: Vec<Entity>,
     finished: Vec<Entity>,
     to_process: BitSet,
-    insert_reader: Option<ReaderId<ComponentEvent>>,
+    insert_reader: ReaderId<ComponentEvent>,
     next_tag: u64,
 }
 
-impl<T> Default for PrefabLoaderSystem<T> {
-    fn default() -> Self {
-        PrefabLoaderSystem {
-            _m: PhantomData,
-            entities: Vec::default(),
-            finished: Vec::default(),
-            to_process: BitSet::default(),
-            insert_reader: None,
-            next_tag: 0,
-        }
+impl<T> PrefabLoaderSystemData<T> {
+    /// This function exists as a workaround for the borrow checker not letting us have multiple
+    /// aliasing.
+    fn borrow_parts(&mut self) -> (&mut Vec<Entity>, &mut Vec<Entity>, &mut BitSet) {
+        (&mut self.entities, &mut self.finished, &mut self.to_process)
     }
 }
 
@@ -52,6 +53,7 @@ where
         Option<Read<'a, HotReloadStrategy>>,
         WriteStorage<'a, Parent>,
         WriteStorage<'a, PrefabTag<T>>,
+        WriteExpect<'a, PrefabLoaderSystemData<T>>,
         T::SystemData,
     );
 
@@ -65,13 +67,14 @@ where
             strategy,
             mut parents,
             mut tags,
+            mut data,
             mut prefab_system_data,
         ) = data;
         let strategy = strategy.as_ref().map(Deref::deref);
         prefab_storage.process(
             |mut d| {
-                d.tag = Some(self.next_tag);
-                self.next_tag += 1;
+                d.tag = Some(data.next_tag);
+                data.next_tag += 1;
                 if !d.loading() {
                     if !d
                         .load_sub_assets(&mut prefab_system_data)
@@ -95,29 +98,29 @@ where
         );
         prefab_handles
             .channel()
-            .read(self.insert_reader.as_mut().expect(
-                "`PrefabLoaderSystem::setup` was not called before `PrefabLoaderSystem::run`",
-            )).for_each(|event| {
+            .read(&mut data.insert_reader)
+            .for_each(|event| {
                 if let ComponentEvent::Inserted(id) = event {
-                    self.to_process.add(*id);
+                    data.to_process.add(*id);
                 }
             });
-        self.finished.clear();
-        for (root_entity, handle, _) in (&*entities, &prefab_handles, &self.to_process).join() {
+        data.finished.clear();
+        let (data_entities, finished, to_process) = data.borrow_parts();
+        for (root_entity, handle, _) in (&*entities, &prefab_handles, &*to_process).join() {
             if let Some(prefab) = prefab_storage.get(handle) {
-                self.finished.push(root_entity);
+                finished.push(root_entity);
                 // create entities
-                self.entities.clear();
-                self.entities.push(root_entity);
+                data_entities.clear();
+                data_entities.push(root_entity);
                 for entity_data in prefab.entities.iter().skip(1) {
                     let new_entity = entities.create();
-                    self.entities.push(new_entity);
+                    data_entities.push(new_entity);
                     if let Some(parent) = entity_data.parent {
                         parents
                             .insert(
                                 new_entity,
                                 Parent {
-                                    entity: self.entities[parent],
+                                    entity: data_entities[parent],
                                 },
                             ).expect("Unable to insert `Parent` for prefab");
                     }
@@ -135,23 +138,31 @@ where
                     if let Some(ref prefab_data) = &entity_data.data {
                         prefab_data
                             .add_to_entity(
-                                self.entities[index],
+                                data_entities[index],
                                 &mut prefab_system_data,
-                                &self.entities,
+                                &data_entities,
                             ).expect("Unable to add prefab system data to entity");
                     }
                 }
             }
         }
 
-        for entity in &self.finished {
-            self.to_process.remove(entity.id());
+        for entity in finished.iter() {
+            to_process.remove(entity.id());
         }
     }
 
     fn setup(&mut self, res: &mut Resources) {
         use amethyst_core::specs::prelude::SystemData;
         Self::SystemData::setup(res);
-        self.insert_reader = Some(WriteStorage::<Handle<Prefab<T>>>::fetch(&res).register_reader());
+        let insert_reader = WriteStorage::<Handle<Prefab<T>>>::fetch(&res).register_reader();
+        res.insert(PrefabLoaderSystemData::<T> {
+            _m: PhantomData,
+            entities: Vec::new(),
+            finished: Vec::new(),
+            to_process: BitSet::new(),
+            insert_reader,
+            next_tag: 0,
+        })
     }
 }

--- a/amethyst_assets/src/prefab/system.rs
+++ b/amethyst_assets/src/prefab/system.rs
@@ -32,14 +32,6 @@ pub struct PrefabLoaderSystemData<T> {
     next_tag: u64,
 }
 
-impl<T> PrefabLoaderSystemData<T> {
-    /// This function exists as a workaround for the borrow checker not letting us have multiple
-    /// aliasing.
-    fn borrow_parts(&mut self) -> (&mut Vec<Entity>, &mut Vec<Entity>, &mut BitSet) {
-        (&mut self.entities, &mut self.finished, &mut self.to_process)
-    }
-}
-
 impl<'a, T> System<'a> for PrefabLoaderSystem<T>
 where
     T: PrefabData<'a> + Send + Sync + 'static,
@@ -105,7 +97,12 @@ where
                 }
             });
         data.finished.clear();
-        let (data_entities, finished, to_process) = data.borrow_parts();
+        let PrefabLoaderSystemData::<T> {
+            entities: ref mut data_entities,
+            ref mut finished,
+            ref mut to_process,
+            ..
+        } = *data;
         for (root_entity, handle, _) in (&*entities, &prefab_handles, &*to_process).join() {
             if let Some(prefab) = prefab_storage.get(handle) {
                 finished.push(root_entity);

--- a/amethyst_controls/src/bundles.rs
+++ b/amethyst_controls/src/bundles.rs
@@ -75,11 +75,7 @@ where
             "free_rotation",
             &[],
         );
-        builder.add(
-            MouseFocusUpdateSystem::new(),
-            "mouse_focus",
-            &["free_rotation"],
-        );
+        builder.add(MouseFocusUpdateSystem, "mouse_focus", &["free_rotation"]);
         builder.add(CursorHideSystem::new(), "cursor_hide", &["mouse_focus"]);
         Ok(())
     }
@@ -128,11 +124,7 @@ where
             "free_rotation",
             &[],
         );
-        builder.add(
-            MouseFocusUpdateSystem::new(),
-            "mouse_focus",
-            &["free_rotation"],
-        );
+        builder.add(MouseFocusUpdateSystem, "mouse_focus", &["free_rotation"]);
         builder.add(CursorHideSystem::new(), "cursor_hide", &["mouse_focus"]);
         Ok(())
     }

--- a/amethyst_core/src/transform/bundle.rs
+++ b/amethyst_core/src/transform/bundle.rs
@@ -47,7 +47,7 @@ impl<'a, 'b, 'c> SystemBundle<'a, 'b> for TransformBundle<'c> {
             self.dep,
         );
         builder.add(
-            TransformSystem::new(),
+            TransformSystem,
             "transform_system",
             &["parent_hierarchy_system"],
         );

--- a/amethyst_core/src/transform/systems.rs
+++ b/amethyst_core/src/transform/systems.rs
@@ -24,14 +24,6 @@ pub struct TransformSystemData {
     scratch: Vec<Entity>,
 }
 
-impl TransformSystemData {
-    /// This function exists as a workaround for the borrow checker not letting us have multiple
-    /// aliasing.
-    fn borrow_parts(&mut self) -> (&BitSet, &mut BitSet) {
-        (&self.local_modified, &mut self.global_modified)
-    }
-}
-
 impl<'a> System<'a> for TransformSystem {
     type SystemData = (
         Entities<'a>,
@@ -85,7 +77,11 @@ impl<'a> System<'a> for TransformSystem {
         }
 
         {
-            let (local_modified, global_modified) = data.borrow_parts();
+            let TransformSystemData {
+                ref local_modified,
+                ref mut global_modified,
+                ..
+            } = *data;
             // Compute transforms without parents.
             for (entity, _, local, global, _) in
                 (&*entities, local_modified, &locals, &mut globals, !&parents).join()

--- a/amethyst_renderer/src/hide_system.rs
+++ b/amethyst_renderer/src/hide_system.rs
@@ -1,6 +1,7 @@
 use amethyst_core::{
     specs::prelude::{
-        BitSet, ComponentEvent, ReadExpect, ReadStorage, ReaderId, Resources, System, WriteStorage,
+        BitSet, ComponentEvent, ReadExpect, ReadStorage, ReaderId, Resources, System, WriteExpect,
+        WriteStorage,
     },
     transform::components::{HierarchyEvent, Parent, ParentHierarchy},
 };
@@ -12,12 +13,14 @@ use crate::HiddenPropagate;
 /// Using this system will result in every child being hidden.
 /// Depends on the resource "ParentHierarchy", which is set up by the [TransformBundle](struct.TransformBundle.html)
 #[derive(Default)]
-pub struct HideHierarchySystem {
+pub struct HideHierarchySystem;
+
+/// A resource for `HideHierarchySystem` which is automatically created and managed by
+/// `HideHierarchySystem`.
+pub struct HideHierarchySystemData {
     marked_as_modified: BitSet,
-
-    hidden_events_id: Option<ReaderId<ComponentEvent>>,
-
-    parent_events_id: Option<ReaderId<HierarchyEvent>>,
+    hidden_events_id: ReaderId<ComponentEvent>,
+    parent_events_id: ReaderId<HierarchyEvent>,
 }
 
 impl<'a> System<'a> for HideHierarchySystem {
@@ -25,41 +28,34 @@ impl<'a> System<'a> for HideHierarchySystem {
         WriteStorage<'a, HiddenPropagate>,
         ReadStorage<'a, Parent>,
         ReadExpect<'a, ParentHierarchy>,
+        WriteExpect<'a, HideHierarchySystemData>,
     );
-    fn run(&mut self, (mut hidden, parents, hierarchy): Self::SystemData) {
+    fn run(&mut self, (mut hidden, parents, hierarchy, mut data): Self::SystemData) {
         #[cfg(feature = "profiler")]
         profile_scope!("hide_hierarchy_system");
 
-        self.marked_as_modified.clear();
+        data.marked_as_modified.clear();
 
         // Borrow multiple parts of self as mutable
-        let self_hidden_events_id = &mut self.hidden_events_id.as_mut().expect(
-            "`HideHierarchySystem::setup` was not called before `HideHierarchySystem::run`",
-        );
-        let self_marked_as_modified = &mut self.marked_as_modified;
 
         hidden
             .channel()
-            .read(self_hidden_events_id)
+            .read(&mut data.hidden_events_id)
             .for_each(|event| match event {
                 ComponentEvent::Inserted(id) | ComponentEvent::Removed(id) => {
-                    self_marked_as_modified.add(*id);
+                    data.marked_as_modified.add(*id);
                 }
                 ComponentEvent::Modified(_id) => {}
             });
 
-        for event in hierarchy
-            .changed()
-            .read(&mut self.parent_events_id.as_mut().expect(
-                "`HideHierarchySystem::setup` was not called before `HideHierarchySystem::run`",
-            )) {
+        for event in hierarchy.changed().read(&mut data.parent_events_id) {
             match *event {
                 HierarchyEvent::Removed(entity) => {
-                    self_marked_as_modified.add(entity.id());
+                    data.marked_as_modified.add(entity.id());
                 }
                 HierarchyEvent::Modified(entity) => {
                     // HierarchyEvent::Modified includes insertion of new components to the storage.
-                    self_marked_as_modified.add(entity.id());
+                    data.marked_as_modified.add(entity.id());
                 }
             }
         }
@@ -67,10 +63,10 @@ impl<'a> System<'a> for HideHierarchySystem {
         // Compute hide status with parents.
         for entity in hierarchy.all() {
             {
-                let self_dirty = self_marked_as_modified.contains(entity.id());
+                let self_dirty = data.marked_as_modified.contains(entity.id());
 
                 let parent_entity = parents.get(*entity).expect("Unreachable: All entities in `ParentHierarchy` should also be in `Parents`").entity;
-                let parent_dirty = self_marked_as_modified.contains(parent_entity.id());
+                let parent_dirty = data.marked_as_modified.contains(parent_entity.id());
                 if parent_dirty {
                     if hidden.contains(parent_entity) {
                         for child in hierarchy.all_children_iter(parent_entity) {
@@ -104,10 +100,10 @@ impl<'a> System<'a> for HideHierarchySystem {
             // instead of on the next `system.run()`
             hidden
                 .channel()
-                .read(self_hidden_events_id)
+                .read(&mut data.hidden_events_id)
                 .for_each(|event| match event {
                     ComponentEvent::Inserted(id) | ComponentEvent::Removed(id) => {
-                        self_marked_as_modified.add(*id);
+                        data.marked_as_modified.add(*id);
                     }
                     ComponentEvent::Modified(_id) => {}
                 });
@@ -118,8 +114,12 @@ impl<'a> System<'a> for HideHierarchySystem {
         use amethyst_core::specs::prelude::SystemData;
         Self::SystemData::setup(res);
         // This fetch_mut panics if `ParentHierarchy` is not set up yet, hence the dependency on "parent_hierarchy_system"
-        self.parent_events_id = Some(res.fetch_mut::<ParentHierarchy>().track());
-        let mut hidden = WriteStorage::<HiddenPropagate>::fetch(res);
-        self.hidden_events_id = Some(hidden.register_reader());
+        let parent_events_id = res.fetch_mut::<ParentHierarchy>().track();
+        let hidden_events_id = WriteStorage::<HiddenPropagate>::fetch(res).register_reader();
+        res.insert(HideHierarchySystemData {
+            marked_as_modified: BitSet::new(),
+            parent_events_id,
+            hidden_events_id,
+        });
     }
 }

--- a/amethyst_ui/src/bundle.rs
+++ b/amethyst_ui/src/bundle.rs
@@ -53,27 +53,15 @@ where
             "font_processor",
             &["ui_loader"],
         );
-        builder.add(
-            UiKeyboardSystem::new(),
-            "ui_keyboard_system",
-            &["font_processor"],
-        );
-        builder.add(ResizeSystem::new(), "ui_resize_system", &[]);
-        builder.add(
-            UiTransformSystem::default(),
-            "ui_transform",
-            &["transform_system"],
-        );
+        builder.add(UiKeyboardSystem, "ui_keyboard_system", &["font_processor"]);
+        builder.add(ResizeSystem, "ui_resize_system", &[]);
+        builder.add(UiTransformSystem, "ui_transform", &["transform_system"]);
         builder.add(
             UiMouseSystem::<A, B>::new(),
             "ui_mouse_system",
             &["ui_transform"],
         );
-        builder.add(
-            UiButtonSystem::new(),
-            "ui_button_system",
-            &["ui_mouse_system"],
-        );
+        builder.add(UiButtonSystem, "ui_button_system", &["ui_mouse_system"]);
         Ok(())
     }
 }


### PR DESCRIPTION
I realized there's a better way to use `ReaderId`s in `System`s than we have been using, so I set out to implement this pattern across the engine.  Functionality should be identical, we just don't need `Option<ReaderId>` any more.