### PR TITLE
GameDataBuilder: reverse dependencies, API improvements

### DIFF
--- a/amethyst_assets/src/reload.rs
+++ b/amethyst_assets/src/reload.rs
@@ -4,8 +4,8 @@ use std::{sync::Arc, time::Instant};
 
 use amethyst_core as core;
 use amethyst_core::{
-    specs::prelude::{DispatcherBuilder, Read, Resources, System, Write},
-    SystemBundle, Time,
+    specs::prelude::{Read, Resources, System, Write},
+    SimpleDispatcherBuilder, SystemBundle, Time,
 };
 
 use crate::{Asset, Format, FormatValue, Loader, Result, Source};
@@ -24,8 +24,11 @@ impl HotReloadBundle {
     }
 }
 
-impl<'a, 'b> SystemBundle<'a, 'b> for HotReloadBundle {
-    fn build(self, dispatcher: &mut DispatcherBuilder<'a, 'b>) -> core::Result<()> {
+impl<'a, 'b, 'c, D> SystemBundle<'a, 'b, 'c, D> for HotReloadBundle
+where
+    D: SimpleDispatcherBuilder<'a, 'b, 'c>,
+{
+    fn build(self, dispatcher: &mut D) -> core::Result<()> {
         dispatcher.add(HotReloadSystem::new(self.strategy), "hot_reload", &[]);
         Ok(())
     }

--- a/amethyst_audio/src/bundle.rs
+++ b/amethyst_audio/src/bundle.rs
@@ -7,7 +7,7 @@ use rodio::default_output_device;
 use amethyst_assets::Processor;
 use amethyst_core::{
     bundle::{Result, SystemBundle},
-    specs::prelude::DispatcherBuilder,
+    SimpleDispatcherBuilder,
 };
 
 use crate::{source::*, systems::DjSystem};
@@ -50,12 +50,13 @@ impl<'a, F, R> AudioBundle<'a, F, R> {
     }
 }
 
-impl<'a, 'b, 'c, F, R> SystemBundle<'a, 'b> for AudioBundle<'c, F, R>
+impl<'a, 'b, 'c, F, R, D> SystemBundle<'a, 'b, 'c, D> for AudioBundle<'c, F, R>
 where
     F: FnMut(&mut R) -> Option<SourceHandle> + Send + 'static,
     R: Send + Sync + 'static,
+    D: SimpleDispatcherBuilder<'a, 'b, 'c>,
 {
-    fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<()> {
+    fn build(self, builder: &mut D) -> Result<()> {
         builder.add(Processor::<Source>::new(), "source_processor", &[]);
         if default_output_device().is_some() {
             builder.add(DjSystem::new(self.picker), "dj_system", self.dep);

--- a/amethyst_controls/src/bundles.rs
+++ b/amethyst_controls/src/bundles.rs
@@ -2,7 +2,7 @@ use std::{hash::Hash, marker::PhantomData};
 
 use amethyst_core::{
     bundle::{Result, SystemBundle},
-    specs::prelude::DispatcherBuilder,
+    SimpleDispatcherBuilder,
 };
 
 use super::*;
@@ -54,12 +54,13 @@ impl<A, B> FlyControlBundle<A, B> {
     }
 }
 
-impl<'a, 'b, A, B> SystemBundle<'a, 'b> for FlyControlBundle<A, B>
+impl<'a, 'b, 'c, A, B, D> SystemBundle<'a, 'b, 'c, D> for FlyControlBundle<A, B>
 where
     A: Send + Sync + Hash + Eq + Clone + 'static,
     B: Send + Sync + Hash + Eq + Clone + 'static,
+    D: SimpleDispatcherBuilder<'a, 'b, 'c>,
 {
-    fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<()> {
+    fn build(self, builder: &mut D) -> Result<()> {
         builder.add(
             FlyMovementSystem::<A, B>::new(
                 self.speed,
@@ -116,12 +117,13 @@ impl<A, B> ArcBallControlBundle<A, B> {
     }
 }
 
-impl<'a, 'b, A, B> SystemBundle<'a, 'b> for ArcBallControlBundle<A, B>
+impl<'a, 'b, 'c, A, B, D> SystemBundle<'a, 'b, 'c, D> for ArcBallControlBundle<A, B>
 where
     A: Send + Sync + Hash + Eq + Clone + 'static,
     B: Send + Sync + Hash + Eq + Clone + 'static,
+    D: SimpleDispatcherBuilder<'a, 'b, 'c>,
 {
-    fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<()> {
+    fn build(self, builder: &mut D) -> Result<()> {
         builder.add(ArcBallRotationSystem::default(), "arc_ball_rotation", &[]);
         builder.add(
             FreeRotationSystem::<A, B>::new(self.sensitivity_x, self.sensitivity_y),

--- a/amethyst_core/src/bundle.rs
+++ b/amethyst_core/src/bundle.rs
@@ -1,11 +1,14 @@
 //! Provides a trait for adding bundles of systems to a dispatcher.
 
-use specs::prelude::DispatcherBuilder;
+use crate::SimpleDispatcherBuilder;
 
 error_chain!{}
 
 /// A bundle of ECS components, resources and systems.
-pub trait SystemBundle<'a, 'b> {
+pub trait SystemBundle<'a, 'b, 'c, D>
+where
+    D: SimpleDispatcherBuilder<'a, 'b, 'c>,
+{
     /// Build and add ECS resources, register components, add systems etc to the Application.
-    fn build(self, dispatcher: &mut DispatcherBuilder<'a, 'b>) -> Result<()>;
+    fn build(self, dispatcher: &mut D) -> Result<()>;
 }

--- a/amethyst_core/src/dispatcher_builder.rs
+++ b/amethyst_core/src/dispatcher_builder.rs
@@ -1,0 +1,123 @@
+use specs::prelude::*;
+
+/// Simplified DispatcherBuilder
+///
+/// See `DispatcherBuilder` and `GameDataBuilder` for more details.
+pub trait SimpleDispatcherBuilder<'a, 'b, 'c>: Sized {
+    /// Adds a new system with a given name and a list of dependencies.
+    /// Please note that the dependency should be added before
+    /// you add the depending system.
+    ///
+    /// If you want to register systems which can not be specified as
+    /// dependencies, you can use `""` as their name, which will not panic
+    /// (using another name twice will).
+    ///
+    /// Same as [`add()`](struct.DispatcherBuilder.html#method.add), but
+    /// returns `self` to enable method chaining.
+    ///
+    /// # Panics
+    ///
+    /// * if the specified dependency does not exist
+    /// * if a system with the same name was already registered.
+    fn with<T>(mut self, system: T, name: &'c str, dep: &[&'c str]) -> Self
+    where
+        T: for<'d> System<'d> + Send + 'a + 'c,
+    {
+        self.add(system, name, dep);
+
+        self
+    }
+
+    /// Adds a new system with a given name and a list of dependencies.
+    /// Please note that the dependency should be added before
+    /// you add the depending system.
+    ///
+    /// If you want to register systems which can not be specified as
+    /// dependencies, you can use `""` as their name, which will not panic
+    /// (using another name twice will).
+    ///
+    /// # Panics
+    ///
+    /// * if the specified dependency does not exist
+    /// * if a system with the same name was already registered.
+    fn add<T>(&mut self, system: T, name: &'c str, dep: &[&'c str])
+    where
+        T: for<'d> System<'d> + Send + 'a + 'c;
+
+    /// Adds a new thread local system.
+    ///
+    /// Please only use this if your struct is not `Send` and `Sync`.
+    ///
+    /// Thread-local systems are dispatched in-order.
+    ///
+    /// Same as
+    /// [`add_thread_local()`](struct.DispatcherBuilder.html#method.add_thread_local),
+    /// but returns `self` to enable method chaining.
+    fn with_thread_local<T>(mut self, system: T) -> Self
+    where
+        T: for<'d> RunNow<'d> + 'b + 'c,
+    {
+        self.add_thread_local(system);
+
+        self
+    }
+
+    /// Adds a new thread local system.
+    ///
+    /// Please only use this if your struct is not `Send` and `Sync`.
+    ///
+    /// Thread-local systems are dispatched in-order.
+    fn add_thread_local<T>(&mut self, system: T)
+    where
+        T: for<'d> RunNow<'d> + 'b + 'c;
+
+    /// Inserts a barrier which assures that all systems
+    /// added before the barrier are executed before the ones
+    /// after this barrier.
+    ///
+    /// Does nothing if there were no systems added
+    /// since the last call to `add_barrier()`/`with_barrier()`.
+    ///
+    /// Thread-local systems are not affected by barriers;
+    /// they're always executed at the end.
+    ///
+    /// Same as
+    /// [`add_barrier()`](struct.DispatcherBuilder.html#method.add_barrier),
+    /// but returns `self` to enable method chaining.
+    fn with_barrier(mut self) -> Self {
+        self.add_barrier();
+
+        self
+    }
+
+    /// Inserts a barrier which assures that all systems
+    /// added before the barrier are executed before the ones
+    /// after this barrier.
+    ///
+    /// Does nothing if there were no systems added
+    /// since the last call to `add_barrier()`/`with_barrier()`.
+    ///
+    /// Thread-local systems are not affected by barriers;
+    /// they're always executed at the end.
+    fn add_barrier(&mut self);
+}
+
+impl<'a, 'b, 'c> SimpleDispatcherBuilder<'a, 'b, 'c> for DispatcherBuilder<'a, 'b> {
+    fn add<T>(&mut self, system: T, name: &'c str, dep: &[&'c str])
+    where
+        T: for<'d> System<'d> + Send + 'a + 'c,
+    {
+        DispatcherBuilder::add(self, system, name, dep);
+    }
+
+    fn add_thread_local<T>(&mut self, system: T)
+    where
+        T: for<'d> RunNow<'d> + 'b + 'c,
+    {
+        DispatcherBuilder::add_thread_local(self, system);
+    }
+
+    fn add_barrier(&mut self) {
+        DispatcherBuilder::add_barrier(self);
+    }
+}

--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -27,6 +27,7 @@ use std::sync::Arc;
 
 pub use crate::{
     bundle::{Error, ErrorKind, Result, SystemBundle},
+    dispatcher_builder::*,
     event::EventReader,
     system_ext::{Pausable, SystemExt},
     timing::*,
@@ -40,6 +41,7 @@ pub use self::{
 
 mod axis;
 pub mod bundle;
+mod dispatcher_builder;
 mod event;
 pub mod frame_limiter;
 mod named;

--- a/amethyst_core/src/transform/bundle.rs
+++ b/amethyst_core/src/transform/bundle.rs
@@ -1,11 +1,11 @@
 //! ECS transform bundle
 
-use specs::prelude::DispatcherBuilder;
 use specs_hierarchy::HierarchySystem;
 
 use crate::{
     bundle::{Result, SystemBundle},
     transform::*,
+    SimpleDispatcherBuilder,
 };
 
 /// Transform bundle
@@ -22,25 +22,28 @@ use crate::{
 /// Panics in `TransformSystem` registration if the bundle is applied twice in the same dispatcher.
 ///
 #[derive(Default)]
-pub struct TransformBundle<'a> {
-    dep: &'a [&'a str],
+pub struct TransformBundle<'a: 'b, 'b> {
+    dep: &'b [&'a str],
 }
 
-impl<'a> TransformBundle<'a> {
+impl<'a, 'b> TransformBundle<'a, 'b> {
     /// Create a new transform bundle
     pub fn new() -> Self {
         Default::default()
     }
 
     /// Set dependencies for the `TransformSystem`
-    pub fn with_dep(mut self, dep: &'a [&'a str]) -> Self {
+    pub fn with_dep(mut self, dep: &'b [&'a str]) -> Self {
         self.dep = dep;
         self
     }
 }
 
-impl<'a, 'b, 'c> SystemBundle<'a, 'b> for TransformBundle<'c> {
-    fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<()> {
+impl<'a, 'b, 'c, 'd, D> SystemBundle<'a, 'b, 'c, D> for TransformBundle<'c, 'd>
+where
+    D: SimpleDispatcherBuilder<'a, 'b, 'c>,
+{
+    fn build(self, builder: &mut D) -> Result<()> {
         builder.add(
             HierarchySystem::<Parent>::new(),
             "parent_hierarchy_system",

--- a/amethyst_input/src/bundle.rs
+++ b/amethyst_input/src/bundle.rs
@@ -6,7 +6,7 @@ use std::{hash::Hash, path::Path, result::Result as StdResult};
 use amethyst_config::{Config, ConfigError};
 use amethyst_core::{
     bundle::{Result, SystemBundle},
-    specs::prelude::DispatcherBuilder,
+    SimpleDispatcherBuilder,
 };
 
 use crate::{Bindings, InputSystem};
@@ -89,12 +89,13 @@ where
     }
 }
 
-impl<'a, 'b, AX, AC> SystemBundle<'a, 'b> for InputBundle<AX, AC>
+impl<'a, 'b, 'c, AX, AC, D> SystemBundle<'a, 'b, 'c, D> for InputBundle<AX, AC>
 where
     AX: Hash + Eq + Clone + Send + Sync + 'static,
     AC: Hash + Eq + Clone + Send + Sync + 'static,
+    D: SimpleDispatcherBuilder<'a, 'b, 'c>,
 {
-    fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<()> {
+    fn build(self, builder: &mut D) -> Result<()> {
         #[cfg(feature = "sdl_controller")]
         {
             use super::SdlEventsSystem;

--- a/amethyst_network/src/bundle.rs
+++ b/amethyst_network/src/bundle.rs
@@ -4,7 +4,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use amethyst_core::{
     bundle::{Result, ResultExt, SystemBundle},
-    shred::DispatcherBuilder,
+    SimpleDispatcherBuilder,
 };
 
 use crate::filter::NetFilter;
@@ -27,11 +27,12 @@ impl<T> NetworkBundle<T> {
     }
 }
 
-impl<'a, 'b, T> SystemBundle<'a, 'b> for NetworkBundle<T>
+impl<'a, 'b, 'c, T, D> SystemBundle<'a, 'b, 'c, D> for NetworkBundle<T>
 where
     T: Send + Sync + PartialEq + Serialize + Clone + DeserializeOwned + 'static,
+    D: SimpleDispatcherBuilder<'a, 'b, 'c>,
 {
-    fn build(self, builder: &mut DispatcherBuilder<'_, '_>) -> Result<()> {
+    fn build(self, builder: &mut D) -> Result<()> {
         let socket_system = NetSocketSystem::<T>::new(self.addr, self.filters)
             .chain_err(|| "Failed to open network system.")?;
 

--- a/amethyst_ui/src/bundle.rs
+++ b/amethyst_ui/src/bundle.rs
@@ -6,7 +6,7 @@ use amethyst_assets::Processor;
 use amethyst_audio::AudioFormat;
 use amethyst_core::{
     bundle::{Result, SystemBundle},
-    specs::prelude::DispatcherBuilder,
+    SimpleDispatcherBuilder,
 };
 use amethyst_renderer::TextureFormat;
 
@@ -31,13 +31,14 @@ impl<A, B, C> UiBundle<A, B, C> {
     }
 }
 
-impl<'a, 'b, A, B, C> SystemBundle<'a, 'b> for UiBundle<A, B, C>
+impl<'a, 'b, 'c, A, B, C, D> SystemBundle<'a, 'b, 'c, D> for UiBundle<A, B, C>
 where
     A: Send + Sync + Eq + Hash + Clone + 'static,
     B: Send + Sync + Eq + Hash + Clone + 'static,
     C: ToNativeWidget,
+    D: SimpleDispatcherBuilder<'a, 'b, 'c>,
 {
-    fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<()> {
+    fn build(self, builder: &mut D) -> Result<()> {
         builder.add(
             UiLoaderSystem::<
                 AudioFormat,

--- a/amethyst_utils/src/fps_counter.rs
+++ b/amethyst_utils/src/fps_counter.rs
@@ -1,9 +1,9 @@
 //! Util Resources
 
 use amethyst_core::{
-    specs::prelude::{DispatcherBuilder, Read, System, Write},
+    specs::prelude::{Read, System, Write},
     timing::{duration_to_nanos, Time},
-    {Result, SystemBundle},
+    SimpleDispatcherBuilder, {Result, SystemBundle},
 };
 
 use crate::circular_buffer::CircularBuffer;
@@ -77,8 +77,11 @@ impl<'a> System<'a> for FPSCounterSystem {
 #[derive(Default)]
 pub struct FPSCounterBundle;
 
-impl<'a, 'b> SystemBundle<'a, 'b> for FPSCounterBundle {
-    fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<()> {
+impl<'a, 'b, 'c, D> SystemBundle<'a, 'b, 'c, D> for FPSCounterBundle
+where
+    D: SimpleDispatcherBuilder<'a, 'b, 'c>,
+{
+    fn build(self, builder: &mut D) -> Result<()> {
         builder.add(FPSCounterSystem, "fps_counter_system", &[]);
         Ok(())
     }

--- a/examples/animation/main.rs
+++ b/examples/animation/main.rs
@@ -180,7 +180,7 @@ fn main() -> amethyst::Result<()> {
     let resources = format!("{}/examples/assets/", app_root);
 
     let game_data = GameDataBuilder::default()
-        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[])
+        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[], &[])
         .with_bundle(AnimationBundle::<AnimationId, Transform>::new(
             "animation_control_system",
             "sampler_interpolation_system",

--- a/examples/appendix_a/bundle.rs
+++ b/examples/appendix_a/bundle.rs
@@ -1,6 +1,6 @@
 use amethyst::{
     core::bundle::{Result, SystemBundle},
-    ecs::prelude::DispatcherBuilder,
+    GameDataBuilder,
 };
 use crate::systems::{BounceSystem, MoveBallsSystem, PaddleSystem, WinnerSystem};
 
@@ -9,19 +9,21 @@ use crate::systems::{BounceSystem, MoveBallsSystem, PaddleSystem, WinnerSystem};
 #[derive(Default)]
 pub struct PongBundle;
 
-impl<'a, 'b> SystemBundle<'a, 'b> for PongBundle {
-    fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<()> {
-        builder.add(PaddleSystem, "paddle_system", &["input_system"]);
-        builder.add(MoveBallsSystem, "ball_system", &[]);
+impl<'a, 'b, 'c> SystemBundle<'a, 'b, 'c, GameDataBuilder<'a, 'b, 'c>> for PongBundle {
+    fn build(self, builder: &mut GameDataBuilder<'a, 'b, 'c>) -> Result<()> {
+        builder.add(PaddleSystem, "paddle_system", &["input_system"], &[]);
+        builder.add(MoveBallsSystem, "ball_system", &[], &[]);
         builder.add(
             BounceSystem,
             "collision_system",
             &["paddle_system", "ball_system"],
+            &[],
         );
         builder.add(
             WinnerSystem,
             "winner_system",
             &["paddle_system", "ball_system"],
+            &[],
         );
         Ok(())
     }

--- a/examples/arc_ball_camera/main.rs
+++ b/examples/arc_ball_camera/main.rs
@@ -115,7 +115,7 @@ fn main() -> Result<(), Error> {
     };
 
     let game_data = GameDataBuilder::default()
-        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[])
+        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[], &[])
         .with_bundle(TransformBundle::new().with_dep(&[]))?
         .with_bundle(
             InputBundle::<String, String>::new().with_bindings_from_file(&key_bindings_path)?,
@@ -125,6 +125,7 @@ fn main() -> Result<(), Error> {
             CameraDistanceSystem::<String>::new(),
             "camera_distance_system",
             &["input_system"],
+            &[],
         );
     let mut game = Application::build(resources_directory, ExampleState)?.build(game_data)?;
     game.run();

--- a/examples/custom_game_data/game_data.rs
+++ b/examples/custom_game_data/game_data.rs
@@ -46,9 +46,9 @@ impl<'a, 'b> CustomGameDataBuilder<'a, 'b> {
         self
     }
 
-    pub fn with_base_bundle<B>(mut self, bundle: B) -> Result<Self>
+    pub fn with_base_bundle<'c, B>(mut self, bundle: B) -> Result<Self>
     where
-        B: SystemBundle<'a, 'b>,
+        B: SystemBundle<'a, 'b, 'c, DispatcherBuilder<'a, 'b>>,
     {
         bundle
             .build(&mut self.base)

--- a/examples/custom_ui/main.rs
+++ b/examples/custom_ui/main.rs
@@ -103,7 +103,7 @@ fn main() -> amethyst::Result<()> {
     let resources = format!("{}/examples/assets", app_root);
 
     let game_data = GameDataBuilder::default()
-        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[])
+        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[], &[])
         .with_bundle(TransformBundle::new())?
         .with_bundle(UiBundle::<String, String, CustomUi>::new())?
         .with_basic_renderer(display_config_path, DrawShaded::<PosNormTex>::new(), true)?;

--- a/examples/debug_lines/main.rs
+++ b/examples/debug_lines/main.rs
@@ -167,7 +167,7 @@ fn main() -> amethyst::Result<()> {
     let game_data = GameDataBuilder::default()
         .with_bundle(
             InputBundle::<String, String>::new().with_bindings_from_file(&key_bindings_path)?,
-        )?.with(ExampleLinesSystem, "example_lines_system", &[])
+        )?.with(ExampleLinesSystem, "example_lines_system", &[], &[])
         .with_bundle(fly_control_bundle)?
         .with_bundle(TransformBundle::new().with_dep(&["fly_movement"]))?
         .with_bundle(RenderBundle::new(pipe, Some(config)))?;

--- a/examples/fly_camera/main.rs
+++ b/examples/fly_camera/main.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), Error> {
     let key_bindings_path = format!("{}/examples/fly_camera/resources/input.ron", app_root);
 
     let game_data = GameDataBuilder::default()
-        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[])
+        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[], &[])
         .with_bundle(
             FlyControlBundle::<String, String>::new(
                 Some(String::from("move_x")),

--- a/examples/gltf/main.rs
+++ b/examples/gltf/main.rs
@@ -179,10 +179,12 @@ fn main() -> Result<(), amethyst::Error> {
             PrefabLoaderSystem::<ScenePrefabData>::default(),
             "scene_loader",
             &[],
+            &[],
         ).with(
             GltfSceneLoaderSystem::default(),
             "gltf_loader",
             &["scene_loader"], // This is important so that entity instantiation is performed in a single frame.
+            &[],
         ).with_basic_renderer(
             path,
             DrawPbmSeparate::new()

--- a/examples/locale/main.rs
+++ b/examples/locale/main.rs
@@ -78,7 +78,7 @@ fn main() -> Result<(), Error> {
 
     let resources_directory = format!("{}/examples/assets", application_root_dir());
 
-    let game_data = GameDataBuilder::default().with(Processor::<Locale>::new(), "proc", &[]);
+    let game_data = GameDataBuilder::default().with(Processor::<Locale>::new(), "proc", &[], &[]);
 
     let mut game = Application::new(resources_directory, Example::new(), game_data)?;
     game.run();

--- a/examples/net_client/main.rs
+++ b/examples/net_client/main.rs
@@ -18,8 +18,8 @@ fn main() -> Result<()> {
         .with_bundle(NetworkBundle::<()>::new(
             "127.0.0.1:3455".parse().unwrap(),
             vec![],
-        ))?.with(SpamSystem::new(), "spam", &[])
-        .with(ReaderSystem::new(), "reader", &[]);
+        ))?.with(SpamSystem::new(), "spam", &[], &[])
+        .with(ReaderSystem::new(), "reader", &[], &[]);
     let mut game = Application::build("./", State1)?
         .with_frame_limit(
             FrameRateLimitStrategy::SleepAndYield(Duration::from_millis(2)),

--- a/examples/net_server/main.rs
+++ b/examples/net_server/main.rs
@@ -18,7 +18,7 @@ fn main() -> Result<()> {
         .with_bundle(NetworkBundle::<()>::new(
             "127.0.0.1:3456".parse().unwrap(),
             vec![Box::new(FilterConnected::<()>::new())],
-        ))?.with(SpamReceiveSystem::new(), "rcv", &[]);
+        ))?.with(SpamReceiveSystem::new(), "rcv", &[], &[]);
     let mut game = Application::build("./", State1)?
         .with_frame_limit(
             FrameRateLimitStrategy::SleepAndYield(Duration::from_millis(2)),

--- a/examples/pong/bundle.rs
+++ b/examples/pong/bundle.rs
@@ -1,6 +1,6 @@
 use amethyst::{
     core::bundle::{Result, SystemBundle},
-    ecs::prelude::DispatcherBuilder,
+    GameDataBuilder,
 };
 use crate::systems::{BounceSystem, MoveBallsSystem, PaddleSystem, WinnerSystem};
 
@@ -8,19 +8,21 @@ use crate::systems::{BounceSystem, MoveBallsSystem, PaddleSystem, WinnerSystem};
 /// world. This bundle prepares the world for a game of pong.
 pub struct PongBundle;
 
-impl<'a, 'b> SystemBundle<'a, 'b> for PongBundle {
-    fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<()> {
-        builder.add(PaddleSystem, "paddle_system", &["input_system"]);
-        builder.add(MoveBallsSystem, "ball_system", &[]);
+impl<'a, 'b, 'c> SystemBundle<'a, 'b, 'c, GameDataBuilder<'a, 'b, 'c>> for PongBundle {
+    fn build(self, builder: &mut GameDataBuilder<'a, 'b, 'c>) -> Result<()> {
+        builder.add(PaddleSystem, "paddle_system", &["input_system"], &[]);
+        builder.add(MoveBallsSystem, "ball_system", &[], &[]);
         builder.add(
             BounceSystem,
             "collision_system",
             &["paddle_system", "ball_system"],
+            &[],
         );
         builder.add(
             WinnerSystem,
             "winner_system",
             &["paddle_system", "ball_system"],
+            &[],
         );
         Ok(())
     }

--- a/examples/pong_tutorial_03/main.rs
+++ b/examples/pong_tutorial_03/main.rs
@@ -46,7 +46,12 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(RenderBundle::new(pipe, Some(config)).with_sprite_sheet_processor())?
         .with_bundle(TransformBundle::new())?
         .with_bundle(input_bundle)?
-        .with(systems::PaddleSystem, "paddle_system", &["input_system"]);
+        .with(
+            systems::PaddleSystem,
+            "paddle_system",
+            &["input_system"],
+            &[],
+        );
     let mut game = Application::new(assets_dir, Pong, game_data)?;
     game.run();
     Ok(())

--- a/examples/pong_tutorial_04/main.rs
+++ b/examples/pong_tutorial_04/main.rs
@@ -46,12 +46,17 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(RenderBundle::new(pipe, Some(config)).with_sprite_sheet_processor())?
         .with_bundle(TransformBundle::new())?
         .with_bundle(input_bundle)?
-        .with(systems::PaddleSystem, "paddle_system", &["input_system"])
-        .with(systems::MoveBallsSystem, "ball_system", &[])
+        .with(
+            systems::PaddleSystem,
+            "paddle_system",
+            &["input_system"],
+            &[],
+        ).with(systems::MoveBallsSystem, "ball_system", &[], &[])
         .with(
             systems::BounceSystem,
             "collision_system",
             &["paddle_system", "ball_system"],
+            &[],
         );
 
     let mut game = Application::new(assets_dir, Pong, game_data)?;

--- a/examples/pong_tutorial_05/main.rs
+++ b/examples/pong_tutorial_05/main.rs
@@ -49,13 +49,23 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(TransformBundle::new())?
         .with_bundle(UiBundle::<String, String>::new())?
         .with_bundle(input_bundle)?
-        .with(systems::PaddleSystem, "paddle_system", &["input_system"])
-        .with(systems::MoveBallsSystem, "ball_system", &[])
+        .with(
+            systems::PaddleSystem,
+            "paddle_system",
+            &["input_system"],
+            &[],
+        ).with(systems::MoveBallsSystem, "ball_system", &[], &[])
         .with(
             systems::BounceSystem,
             "collision_system",
             &["paddle_system", "ball_system"],
-        ).with(systems::WinnerSystem, "winner_system", &["ball_system"]);
+            &[],
+        ).with(
+            systems::WinnerSystem,
+            "winner_system",
+            &["ball_system"],
+            &[],
+        );
 
     let mut game = Application::new(assets_dir, Pong, game_data)?;
     game.run();

--- a/examples/prefab/main.rs
+++ b/examples/prefab/main.rs
@@ -37,7 +37,7 @@ fn main() -> Result<(), Error> {
     let display_config_path = format!("{}/examples/prefab/resources/display_config.ron", app_root);
 
     let game_data = GameDataBuilder::default()
-        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[])
+        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[], &[])
         .with_bundle(TransformBundle::new())?
         .with_basic_renderer(display_config_path, DrawShaded::<PosNormTex>::new(), false)?;
 

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -178,7 +178,7 @@ fn main() -> Result<(), Error> {
 
     let game_data = GameDataBuilder::default()
         .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[], &[])
-        .with::<ExampleSystem>(ExampleSystem::default(), "example_system", &[], &[])
+        .with(ExampleSystem::default(), "example_system", &[], &[])
         .with_bundle(TransformBundle::new().with_dep(&["example_system"]))?
         .with_bundle(UiBundle::<String, String>::new())?
         .with_bundle(HotReloadBundle::default())?

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -177,8 +177,8 @@ fn main() -> Result<(), Error> {
     );
 
     let game_data = GameDataBuilder::default()
-        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[])
-        .with::<ExampleSystem>(ExampleSystem::default(), "example_system", &[])
+        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[], &[])
+        .with::<ExampleSystem>(ExampleSystem::default(), "example_system", &[], &[])
         .with_bundle(TransformBundle::new().with_dep(&["example_system"]))?
         .with_bundle(UiBundle::<String, String>::new())?
         .with_bundle(HotReloadBundle::default())?

--- a/examples/separate_sphere/main.rs
+++ b/examples/separate_sphere/main.rs
@@ -36,7 +36,7 @@ fn main() -> amethyst::Result<()> {
     let resources = format!("{}/examples/assets/", app_root);
 
     let game_data = GameDataBuilder::default()
-        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[])
+        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[], &[])
         .with_bundle(TransformBundle::new())?
         .with_basic_renderer(display_config_path, DrawShadedSeparate::new(), false)?;
     let mut game = Application::new(resources, Example, game_data)?;

--- a/examples/sphere/main.rs
+++ b/examples/sphere/main.rs
@@ -34,7 +34,7 @@ fn main() -> amethyst::Result<()> {
     let resources = format!("{}/examples/assets/", app_root);
 
     let game_data = GameDataBuilder::default()
-        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[])
+        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[], &[])
         .with_bundle(TransformBundle::new())?
         .with_basic_renderer(display_config_path, DrawShaded::<PosNormTex>::new(), false)?;
     let mut game = Application::new(resources, Example, game_data)?;

--- a/examples/sphere_multisample/main.rs
+++ b/examples/sphere_multisample/main.rs
@@ -37,7 +37,7 @@ fn main() -> amethyst::Result<()> {
     let resources = format!("{}/examples/assets/", app_root);
 
     let game_data = GameDataBuilder::default()
-        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[])
+        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[], &[])
         .with_bundle(TransformBundle::new())?
         .with_basic_renderer(display_config_path, DrawShaded::<PosNormTex>::new(), false)?;
     let mut game = Application::new(resources, Example, game_data)?;

--- a/examples/spotlights/main.rs
+++ b/examples/spotlights/main.rs
@@ -34,7 +34,7 @@ fn main() -> amethyst::Result<()> {
     let resources = format!("{}/examples/assets/", app_root);
 
     let game_data = GameDataBuilder::default()
-        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[])
+        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[], &[])
         .with_bundle(TransformBundle::new())?
         .with_basic_renderer(display_config_path, DrawPbm::<PosNormTangTex>::new(), false)?;
     let mut game = Application::new(resources, Example, game_data)?;

--- a/examples/sprite_camera_follow/main.rs
+++ b/examples/sprite_camera_follow/main.rs
@@ -161,7 +161,7 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(
             InputBundle::<String, String>::new()
                 .with_bindings_from_file(format!("{}/input.ron", root))?,
-        )?.with(MovementSystem, "movement", &[])
+        )?.with(MovementSystem, "movement", &[], &[])
         .with_bundle(
             RenderBundle::new(pipe, Some(config))
                 .with_sprite_sheet_processor()

--- a/examples/ui/main.rs
+++ b/examples/ui/main.rs
@@ -93,11 +93,11 @@ fn main() -> amethyst::Result<()> {
     let resources = format!("{}/examples/assets", app_root);
 
     let game_data = GameDataBuilder::default()
-        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[])
+        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[], &[])
         .with_bundle(TransformBundle::new())?
         .with_bundle(UiBundle::<String, String>::new())?
-        .with(Processor::<Source>::new(), "source_processor", &[])
-        .with(UiEventHandlerSystem::new(), "ui_event_handler", &[])
+        .with(Processor::<Source>::new(), "source_processor", &[], &[])
+        .with(UiEventHandlerSystem::new(), "ui_event_handler", &[], &[])
         .with_bundle(FPSCounterBundle::default())?
         .with_bundle(InputBundle::<String, String>::new())?
         .with_basic_renderer(display_config_path, DrawShaded::<PosNormTex>::new(), true)?;

--- a/src/game_data.rs
+++ b/src/game_data.rs
@@ -238,6 +238,7 @@ impl<'a, 'b, 'c> GameDataBuilder<'a, 'b, 'c> {
     /// ~~~no_run
     /// use amethyst::prelude::*;
     /// use amethyst::ecs::prelude::System;
+    /// use amethyst::AutoAddSystem;
     ///
     /// struct NopSystem;
     /// impl<'a> System<'a> for NopSystem {
@@ -245,12 +246,12 @@ impl<'a, 'b, 'c> GameDataBuilder<'a, 'b, 'c> {
     ///     fn run(&mut self, _: Self::SystemData) {}
     /// }
     ///
-    /// impl AutoAddSystem {
+    /// impl AutoAddSystem for NopSystem {
     ///     // If this system is added using GameDataBuilder::with_auto it will only run
     ///     // after the "foo" system has completed
     ///     const DEPENDENCIES: &'static [&'static str] = &["foo"];
     ///     // and the "bar" system will run only after this system has completed
-    ////    const REVERSE_DEPENDENCIES: &'static [&'static str] = &["bar"];
+    ///    const REVERSE_DEPENDENCIES: &'static [&'static str] = &["bar"];
     /// }
     ///
     /// GameDataBuilder::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub use self::{
     app::{Application, ApplicationBuilder, CoreApplication},
     callback_queue::{Callback, CallbackQueue},
     error::{Error, Result},
-    game_data::{DataInit, GameData, GameDataBuilder, AutoAddSystem},
+    game_data::{AutoAddSystem, DataInit, GameData, GameDataBuilder},
     logger::{start_logger, LevelFilter as LogLevelFilter, Logger, LoggerConfig, StdoutLog},
     state::{
         EmptyState, EmptyTrans, SimpleState, SimpleTrans, State, StateData, StateMachine, Trans,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub use self::{
     app::{Application, ApplicationBuilder, CoreApplication},
     callback_queue::{Callback, CallbackQueue},
     error::{Error, Result},
-    game_data::{DataInit, GameData, GameDataBuilder},
+    game_data::{DataInit, GameData, GameDataBuilder, AutoAddSystem},
     logger::{start_logger, LevelFilter as LogLevelFilter, Logger, LoggerConfig, StdoutLog},
     state::{
         EmptyState, EmptyTrans, SimpleState, SimpleTrans, State, StateData, StateMachine, Trans,

--- a/tests/amethyst_test/src/amethyst_application.rs
+++ b/tests/amethyst_test/src/amethyst_application.rs
@@ -340,7 +340,9 @@ where
     /// * `bundle`: Bundle to add.
     pub fn with_bundle<B>(mut self, bundle: B) -> Self
     where
-        B: SystemBundle<'static, 'static, 'static, GameDataBuilder<'static, 'static, 'static>> + Send + 'static,
+        B: SystemBundle<'static, 'static, 'static, GameDataBuilder<'static, 'static, 'static>>
+            + Send
+            + 'static,
     {
         // We need to use `SendBoxFnOnce` because:
         //
@@ -382,7 +384,8 @@ where
     pub fn with_bundle_fn<FnBundle, B>(mut self, bundle_function: FnBundle) -> Self
     where
         FnBundle: FnOnce() -> B + Send + 'static,
-        B: SystemBundle<'static, 'static, 'static, GameDataBuilder<'static, 'static, 'static>> + 'static,
+        B: SystemBundle<'static, 'static, 'static, GameDataBuilder<'static, 'static, 'static>>
+            + 'static,
     {
         self.bundle_add_fns.push(SendBoxFnOnce::from(
             move |game_data: GameDataBuilder<'static, 'static, 'static>| {
@@ -482,7 +485,12 @@ where
     /// * `system`: The `System` to register.
     /// * `name`: Name to register the system with, used for dependency ordering.
     /// * `deps`: Names of systems that must run before this system.
-    pub fn with_system<Sys>(self, system: Sys, name: &'static str, deps: &'static [&'static str]) -> Self
+    pub fn with_system<Sys>(
+        self,
+        system: Sys,
+        name: &'static str,
+        deps: &'static [&'static str],
+    ) -> Self
     where
         Sys: for<'sys_local> System<'sys_local> + Send + 'static,
     {
@@ -1169,7 +1177,9 @@ mod test {
     // === Bundles === //
     #[derive(Debug)]
     struct BundleZero;
-    impl<'a, 'b, 'c, D: SimpleDispatcherBuilder<'a, 'b, 'c>> SystemBundle<'a, 'b, 'c, D> for BundleZero {
+    impl<'a, 'b, 'c, D: SimpleDispatcherBuilder<'a, 'b, 'c>> SystemBundle<'a, 'b, 'c, D>
+        for BundleZero
+    {
         fn build(self, builder: &mut D) -> bundle::Result<()> {
             builder.add(SystemZero, "system_zero", &[]);
             Ok(())
@@ -1188,7 +1198,9 @@ mod test {
 
     #[derive(Debug)]
     struct BundleAsset;
-    impl<'a, 'b, 'c, D: SimpleDispatcherBuilder<'a, 'b, 'c>> SystemBundle<'a, 'b, 'c, D> for BundleAsset {
+    impl<'a, 'b, 'c, D: SimpleDispatcherBuilder<'a, 'b, 'c>> SystemBundle<'a, 'b, 'c, D>
+        for BundleAsset
+    {
         fn build(self, builder: &mut D) -> bundle::Result<()> {
             builder.add(Processor::<AssetZero>::new(), "asset_zero_processor", &[]);
             Ok(())

--- a/tests/amethyst_test/src/amethyst_application.rs
+++ b/tests/amethyst_test/src/amethyst_application.rs
@@ -28,8 +28,8 @@ use crate::{
 
 type BundleAddFn = SendBoxFnOnce<
     'static,
-    (GameDataBuilder<'static, 'static>,),
-    Result<GameDataBuilder<'static, 'static>>,
+    (GameDataBuilder<'static, 'static, 'static>,),
+    Result<GameDataBuilder<'static, 'static, 'static>>,
 >;
 // Hack: Ideally we want a `SendBoxFnOnce`. However implementing it got too crazy:
 //
@@ -232,7 +232,7 @@ where
 
     fn build_application<S>(
         first_state: S,
-        game_data: GameDataBuilder<'static, 'static>,
+        game_data: GameDataBuilder<'static, 'static, 'static>,
         resource_add_fns: Vec<FnResourceAdd>,
     ) -> Result<CoreApplication<'static, GameData<'static, 'static>, E, R>>
     where
@@ -360,7 +360,7 @@ where
         //
         // See <https://users.rust-lang.org/t/move-a-boxed-function-inside-a-closure/18199>
         self.bundle_add_fns.push(SendBoxFnOnce::from(
-            |game_data: GameDataBuilder<'static, 'static>| game_data.with_bundle(bundle),
+            |game_data: GameDataBuilder<'static, 'static, 'static>| game_data.with_bundle(bundle),
         ));
         self
     }
@@ -385,7 +385,7 @@ where
         B: SystemBundle<'static, 'static> + 'static,
     {
         self.bundle_add_fns.push(SendBoxFnOnce::from(
-            move |game_data: GameDataBuilder<'static, 'static>| {
+            move |game_data: GameDataBuilder<'static, 'static, 'static>| {
                 game_data.with_bundle(bundle_function())
             },
         ));

--- a/tests/amethyst_test/src/lib.rs
+++ b/tests/amethyst_test/src/lib.rs
@@ -148,7 +148,10 @@
 //! #
 //! # use amethyst_test::prelude::*;
 //! # use amethyst::{
-//! #     core::bundle::{self, SystemBundle},
+//! #     core::{
+//! #         bundle::{self, SystemBundle},
+//! #         SimpleDispatcherBuilder,
+//! #     },
 //! #     ecs::prelude::*,
 //! #     prelude::*,
 //! # };
@@ -172,8 +175,8 @@
 //! #
 //! # #[derive(Debug)]
 //! # struct MyBundle;
-//! # impl<'a, 'b> SystemBundle<'a, 'b> for MyBundle {
-//! #     fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> bundle::Result<()> {
+//! # impl<'a, 'b, 'c, D: SimpleDispatcherBuilder<'a, 'b, 'c>> SystemBundle<'a, 'b, 'c, D> for MyBundle {
+//! #     fn build(self, builder: &mut D) -> bundle::Result<()> {
 //! #         builder.add(MySystem, "my_system", &[]);
 //! #         Ok(())
 //! #     }

--- a/tests/amethyst_test/src/system_injection_bundle.rs
+++ b/tests/amethyst_test/src/system_injection_bundle.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
-use amethyst::core::SimpleDispatcherBuilder;
 use amethyst::core::bundle::{Result, SystemBundle};
+use amethyst::core::SimpleDispatcherBuilder;
 use amethyst::ecs::prelude::*;
 
 /// Adds a specified `System` to the dispatcher.
@@ -27,11 +27,7 @@ where
     D: SimpleDispatcherBuilder<'a, 'b, 'c>,
 {
     fn build(self, builder: &mut D) -> Result<()> {
-        builder.add(
-            self.system,
-            &self.system_name,
-            &self.system_dependencies,
-        );
+        builder.add(self.system, &self.system_name, &self.system_dependencies);
         Ok(())
     }
 }

--- a/tests/amethyst_test/src/system_injection_bundle.rs
+++ b/tests/amethyst_test/src/system_injection_bundle.rs
@@ -1,38 +1,36 @@
 use std::marker::PhantomData;
 
+use amethyst::core::SimpleDispatcherBuilder;
 use amethyst::core::bundle::{Result, SystemBundle};
 use amethyst::ecs::prelude::*;
 
 /// Adds a specified `System` to the dispatcher.
 #[derive(Debug, new)]
-pub(crate) struct SystemInjectionBundle<'a, Sys>
+pub(crate) struct SystemInjectionBundle<'a, 'b, Sys>
 where
     Sys: for<'s> System<'s> + Send + 'a,
 {
     /// `System` to add to the dispatcher.
     system: Sys,
     /// Name to register the system with.
-    system_name: String,
+    system_name: &'b str,
     /// Names of the system dependencies.
-    system_dependencies: Vec<String>,
+    system_dependencies: Vec<&'b str>,
     /// Marker for `'a` lifetime.
     #[new(default)]
     system_marker: PhantomData<&'a Sys>,
 }
 
-impl<'a, 'b, Sys> SystemBundle<'a, 'b> for SystemInjectionBundle<'a, Sys>
+impl<'a, 'b, 'c, D, Sys> SystemBundle<'a, 'b, 'c, D> for SystemInjectionBundle<'a, 'c, Sys>
 where
-    Sys: for<'s> System<'s> + Send + 'a,
+    Sys: for<'s> System<'s> + Send + 'a + 'c,
+    D: SimpleDispatcherBuilder<'a, 'b, 'c>,
 {
-    fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<()> {
+    fn build(self, builder: &mut D) -> Result<()> {
         builder.add(
             self.system,
             &self.system_name,
-            &self
-                .system_dependencies
-                .iter()
-                .map(|dep| dep.as_str())
-                .collect::<Vec<&str>>(),
+            &self.system_dependencies,
         );
         Ok(())
     }


### PR DESCRIPTION
When creating game with large amount of systems I need to split building `GameData` to multiple functions. Otherwise I would end up with unmaintainable code. Lots of time I want system to name it's dependencies including reverse dependencies. This RP tries to add support for such workflow.

Changes:
- Add reverse dependencies to `GameDataBuilder::with`
- `GameDataBuilder` evaluates dependencies when `DataInit::build` is called, so it is possible to reference system which has not been added yet.
- Introduce `SimpleDispatcherBuilder` to abstract over `DispatcherBuilder` and `GameDataBuilder`
- `SystemBundle::build` takes `SimpleDispatcherBuilder` instead of `DispatcherBuilder`
- Add by-ref API to GameDataBuilder
- Introduce `AutoAddSystem` to simplify adding system where it's dependencies are always the same.
- `GameDataBuilder` takes dependencies as iterator instead of slice