### PR TITLE
UI hidpi fix

### DIFF
--- a/amethyst_input/Cargo.toml
+++ b/amethyst_input/Cargo.toml
@@ -17,6 +17,7 @@ travis-ci = { repository = "amethyst/amethyst" }
 [dependencies]
 amethyst_core = { path = "../amethyst_core/", version = "0.4.0" }
 amethyst_config = { path = "../amethyst_config/", version = "0.8.0" }
+amethyst_renderer = { path = "../amethyst_renderer/", version = "0.9.0" }
 derivative = "1.0"
 fnv = "1"
 serde = { version = "1", features = ["serde_derive"] }

--- a/amethyst_input/src/input_handler.rs
+++ b/amethyst_input/src/input_handler.rs
@@ -63,7 +63,12 @@ where
     ///
     /// The Amethyst game engine will automatically call this if the InputHandler is attached to
     /// the world as a resource with id 0.
-    pub fn send_event(&mut self, event: &Event, event_handler: &mut EventChannel<InputEvent<AC>>) {
+    pub fn send_event(
+        &mut self,
+        event: &Event,
+        event_handler: &mut EventChannel<InputEvent<AC>>,
+        hidpi: f64,
+    ) {
         match *event {
             Event::WindowEvent { ref event, .. } => match *event {
                 WindowEvent::ReceivedCharacter(c) => {
@@ -221,11 +226,11 @@ where
                 } => {
                     if let Some((old_x, old_y)) = self.mouse_position {
                         event_handler.single_write(CursorMoved {
-                            delta_x: x - old_x,
-                            delta_y: y - old_y,
+                            delta_x: x * hidpi - old_x,
+                            delta_y: y * hidpi - old_y,
                         });
                     }
-                    self.mouse_position = Some((x, y));
+                    self.mouse_position = Some((x * hidpi, y * hidpi));
                 }
                 WindowEvent::Focused(false) => {
                     self.pressed_keys.clear();

--- a/amethyst_input/src/lib.rs
+++ b/amethyst_input/src/lib.rs
@@ -4,6 +4,7 @@
 
 extern crate amethyst_config;
 extern crate amethyst_core;
+extern crate amethyst_renderer;
 #[macro_use]
 extern crate derivative;
 extern crate fnv;

--- a/amethyst_renderer/src/resources.rs
+++ b/amethyst_renderer/src/resources.rs
@@ -94,7 +94,7 @@ impl ScreenDimensions {
     /// This is returned as a float for user convenience, as this is typically used with other
     /// float values.  This will only ever be a non-negative integer though.
     pub fn width(&self) -> f32 {
-        self.w
+        self.w * self.hidpi_factor() as f32
     }
 
     /// Returns the current height of the window.
@@ -102,7 +102,7 @@ impl ScreenDimensions {
     /// This is returned as a float for user convenience, as this is typically used with other
     /// float values.  This will only ever be a non-negative integer though.
     pub fn height(&self) -> f32 {
-        self.h
+        self.h * self.hidpi_factor() as f32
     }
 
     /// Returns the current aspect ratio of the window.

--- a/amethyst_renderer/src/resources.rs
+++ b/amethyst_renderer/src/resources.rs
@@ -79,10 +79,10 @@ pub struct ScreenDimensions {
 
 impl ScreenDimensions {
     /// Creates a new screen dimensions object with the given width and height.
-    pub fn new(w: f64, h: f64, hidpi: f64) -> Self {
+    pub fn new(w: u32, h: u32, hidpi: f64) -> Self {
         ScreenDimensions {
-            w,
-            h,
+            w: w as f64,
+            h: h as f64,
             aspect_ratio: w as f32 / h as f32,
             hidpi,
             dirty: false,

--- a/amethyst_renderer/src/resources.rs
+++ b/amethyst_renderer/src/resources.rs
@@ -66,9 +66,9 @@ impl WindowMessages {
 #[derive(Debug)]
 pub struct ScreenDimensions {
     /// Screen width in pixels (px).
-    w: f32,
+    pub(crate) w: f64,
     /// Screen height in pixels (px).
-    h: f32,
+    pub(crate) h: f64,
     /// Width divided by height.
     aspect_ratio: f32,
     /// The ratio between the backing framebuffer resolution and the window size in screen pixels.
@@ -79,10 +79,10 @@ pub struct ScreenDimensions {
 
 impl ScreenDimensions {
     /// Creates a new screen dimensions object with the given width and height.
-    pub fn new(w: u32, h: u32, hidpi: f64) -> Self {
+    pub fn new(w: f64, h: f64, hidpi: f64) -> Self {
         ScreenDimensions {
-            w: w as f32,
-            h: h as f32,
+            w,
+            h,
             aspect_ratio: w as f32 / h as f32,
             hidpi,
             dirty: false,
@@ -90,19 +90,13 @@ impl ScreenDimensions {
     }
 
     /// Returns the current width of the window.
-    ///
-    /// This is returned as a float for user convenience, as this is typically used with other
-    /// float values.  This will only ever be a non-negative integer though.
     pub fn width(&self) -> f32 {
-        self.w * self.hidpi_factor() as f32
+        self.w as f32
     }
 
     /// Returns the current height of the window.
-    ///
-    /// This is returned as a float for user convenience, as this is typically used with other
-    /// float values.  This will only ever be a non-negative integer though.
     pub fn height(&self) -> f32 {
-        self.h * self.hidpi_factor() as f32
+        self.h as f32
     }
 
     /// Returns the current aspect ratio of the window.
@@ -122,9 +116,9 @@ impl ScreenDimensions {
     /// Only use this if you need to programmatically set the resolution of your game.
     /// This resource is updated automatically by the engine when a resize occurs so you don't need
     /// this unless you want to resize the game window.
-    pub fn update(&mut self, w: u32, h: u32) {
-        self.w = w as f32;
-        self.h = h as f32;
+    pub fn update(&mut self, w: f64, h: f64) {
+        self.w = w;
+        self.h = h;
         self.aspect_ratio = w as f32 / h as f32;
         self.dirty = true;
     }

--- a/amethyst_renderer/src/system.rs
+++ b/amethyst_renderer/src/system.rs
@@ -32,7 +32,7 @@ pub struct RenderSystem<P> {
     pipe: P,
     #[derivative(Debug = "ignore")]
     renderer: Renderer,
-    cached_size: (u32, u32),
+    cached_size: (f64, f64),
     // This only exists to allow the system to re-use a vec allocation
     // during event compression.  It's length 0 except during `fn render`.
     event_vec: Vec<Event>,
@@ -116,8 +116,8 @@ where
             command(self.renderer.window());
         }
 
-        let width = screen_dimensions.width() as u32;
-        let height = screen_dimensions.height() as u32;
+        let width = screen_dimensions.w;
+        let height = screen_dimensions.h;
 
         // Send resource size changes to the window
         if screen_dimensions.dirty {
@@ -128,11 +128,13 @@ where
         }
 
         if let Some(size) = self.renderer.window().get_inner_size() {
-            let (window_width, window_height): (u32, u32) = size.into();
+            let (window_width, window_height): (f64, f64) = size.into();
 
             // Send window size changes to the resource
             if (window_width, window_height) != (width, height) {
+                info!("resized. screendim {} {} winsize {} {}.", width, height, window_width, window_height);
                 screen_dimensions.update(window_width, window_height);
+                info!("done resizing {} {}", screen_dimensions.w, screen_dimensions.h);
 
                 // We don't need to send the updated size of the window back to the window itself,
                 // so set dirty to false.

--- a/amethyst_renderer/src/system.rs
+++ b/amethyst_renderer/src/system.rs
@@ -132,9 +132,7 @@ where
 
             // Send window size changes to the resource
             if (window_width, window_height) != (width, height) {
-                info!("resized. screendim {} {} winsize {} {}.", width, height, window_width, window_height);
                 screen_dimensions.update(window_width, window_height);
-                info!("done resizing {} {}", screen_dimensions.w, screen_dimensions.h);
 
                 // We don't need to send the updated size of the window back to the window itself,
                 // so set dirty to false.

--- a/amethyst_ui/src/bundle.rs
+++ b/amethyst_ui/src/bundle.rs
@@ -49,6 +49,11 @@ where
             &[],
         );
         builder.add(
+            UiTransformSystem::default(),
+            "ui_transform",
+            &["transform_system"],
+        );
+        builder.add(
             Processor::<FontAsset>::new(),
             "font_processor",
             &["ui_loader"],
@@ -60,14 +65,9 @@ where
         );
         builder.add(ResizeSystem::new(), "ui_resize_system", &[]);
         builder.add(
-            UiTransformSystem::default(),
-            "ui_transform",
-            &["transform_system"],
-        );
-        builder.add(
             UiMouseSystem::<A, B>::new(),
             "ui_mouse_system",
-            &["ui_transform"],
+            &["ui_transform", "ui_keyboard_system"],
         );
         builder.add(
             UiButtonSystem::new(),

--- a/amethyst_ui/src/pass.rs
+++ b/amethyst_ui/src/pass.rs
@@ -303,7 +303,7 @@ impl Pass for DrawUi {
                 };
                 let rendered_string = password_string.as_ref().unwrap_or(&ui_text.text);
                 let hidpi = screen_dimensions.hidpi_factor() as f32;
-                let size = ui_text.font_size * hidpi;
+                let size = ui_text.font_size;
                 let scale = Scale::uniform(size);
                 let text = editing
                     .and_then(|editing| {
@@ -376,18 +376,13 @@ impl Pass for DrawUi {
                     // instead of the expected [0,1]
                     screen_position: (
                         (ui_transform.pixel_x
-                            + ui_transform.pixel_width * ui_text.align.norm_offset().0)
-                            * hidpi,
+                            + ui_transform.pixel_width * ui_text.align.norm_offset().0),
                         // invert y because gfx-glyph inverts it back
                         (screen_dimensions.height()
                             - ui_transform.pixel_y
-                            - ui_transform.pixel_height * ui_text.align.norm_offset().1)
-                            * hidpi,
+                            - ui_transform.pixel_height * ui_text.align.norm_offset().1),
                     ),
-                    bounds: (
-                        ui_transform.pixel_width * hidpi,
-                        ui_transform.pixel_height * hidpi,
-                    ),
+                    bounds: (ui_transform.pixel_width, ui_transform.pixel_height),
                     // Invert z because of gfx-glyph using z+ forward
                     z: ui_transform.global_z / highest_abs_z,
                     layout,
@@ -548,10 +543,10 @@ impl Pass for DrawUi {
                             pos.y =
                                 screen_dimensions.height() - ui_transform.pixel_y + ascent / 2.0;
 
-                            let mut x = pos.x / hidpi;
+                            let mut x = pos.x;
                             if let Some(glyph) = glyph {
                                 if at_end {
-                                    x += glyph.unpositioned().h_metrics().advance_width / hidpi;
+                                    x += glyph.unpositioned().h_metrics().advance_width;
                                 }
                             }
                             let mut y = pos.y;

--- a/amethyst_ui/src/text.rs
+++ b/amethyst_ui/src/text.rs
@@ -316,12 +316,10 @@ impl<'a> System<'a> for UiKeyboardSystem {
                     ..
                 } => {
                     let hidpi = screen_dimensions.hidpi_factor() as f32;
-                    info!("ScreenDimensions: {:?}", screen_dimensions);
                     self.mouse_position = (
                         position.x as f32 * hidpi,
-                        (screen_dimensions.height() - position.y as f32) * hidpi,
+                        (screen_dimensions.height() - position.y as f32 * hidpi),
                     );
-                    info!("Mouse Position: {:?}", self.mouse_position);
                     if self.left_mouse_button_pressed {
                         let mut focused_text_edit = focused.entity.and_then(|entity| {
                             zip_options(text.get_mut(entity), editable.get_mut(entity))

--- a/amethyst_ui/src/text.rs
+++ b/amethyst_ui/src/text.rs
@@ -316,10 +316,12 @@ impl<'a> System<'a> for UiKeyboardSystem {
                     ..
                 } => {
                     let hidpi = screen_dimensions.hidpi_factor() as f32;
+                    info!("ScreenDimensions: {:?}", screen_dimensions);
                     self.mouse_position = (
                         position.x as f32 * hidpi,
                         (screen_dimensions.height() - position.y as f32) * hidpi,
                     );
+                    info!("Mouse Position: {:?}", self.mouse_position);
                     if self.left_mouse_button_pressed {
                         let mut focused_text_edit = focused.entity.and_then(|entity| {
                             zip_options(text.get_mut(entity), editable.get_mut(entity))


### PR DESCRIPTION
This fixes some of the logic issues related to hidpi. It also disables automatic text scaling. This will be replaced soon by automatic text resizing and proper layouting techniques, which should be prefered to hidpi anyway.

Breaking change: ScreenDimensions takes hidpi into account. (logical size instead of previous physical size).