### PR TITLE
Introduce amethyst_error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ amethyst_assets = { path = "amethyst_assets", version = "0.6.0" }
 amethyst_audio = { path = "amethyst_audio", version = "0.5.0" }
 amethyst_config = { path = "amethyst_config", version = "0.9.0" }
 amethyst_core = { path = "amethyst_core", version = "0.5.0" }
+amethyst_error = { path = "amethyst_error", version = "0.1.0" }
 amethyst_controls = { path = "amethyst_controls", version = "0.4.0" }
 amethyst_derive = { path = "amethyst_derive", version = "0.3.0" }
 amethyst_network = { path = "amethyst_network", version = "0.3.0" }

--- a/amethyst_error/Cargo.toml
+++ b/amethyst_error/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "amethyst_error"
+version = "0.1.0"
+authors = ["John-John Tedro <udoprog@tedro.se>"]
+readme = "README.md"
+description = """
+Internal error handling for Amethyst.
+"""
+keywords = ["game", "error", "amethyst"]
+categories = ["error"]
+
+documentation = "https://www.amethyst.rs/doc/master/doc/amethyst/"
+homepage = "https://www.amethyst.rs/"
+repository = "https://github.com/amethyst/amethyst"
+
+[badges]
+appveyor = { repository = "amethyst/amethyst", branch = "master" }
+travis-ci = { repository = "amethyst/amethyst" }
+
+[dependencies]
+backtrace = {version = "0.3.9", optional = true}
+
+[features]
+default = ["backtrace"]

--- a/amethyst_error/Cargo.toml
+++ b/amethyst_error/Cargo.toml
@@ -20,8 +20,5 @@ travis-ci = { repository = "amethyst/amethyst" }
 [dependencies]
 backtrace = {version = "0.3.9", optional = true}
 
-[dev-dependencies]
-failure = {version = "0.1"}
-
 [features]
 default = ["backtrace"]

--- a/amethyst_error/Cargo.toml
+++ b/amethyst_error/Cargo.toml
@@ -19,7 +19,4 @@ appveyor = { repository = "amethyst/amethyst", branch = "master" }
 travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
-backtrace = {version = "0.3.9", optional = true}
-
-[features]
-default = ["backtrace"]
+backtrace = "0.3.13"

--- a/amethyst_error/Cargo.toml
+++ b/amethyst_error/Cargo.toml
@@ -20,5 +20,8 @@ travis-ci = { repository = "amethyst/amethyst" }
 [dependencies]
 backtrace = {version = "0.3.9", optional = true}
 
+[dev-dependencies]
+failure = {version = "0.1"}
+
 [features]
 default = ["backtrace"]

--- a/amethyst_error/Cargo.toml
+++ b/amethyst_error/Cargo.toml
@@ -3,6 +3,7 @@ name = "amethyst_error"
 version = "0.1.0"
 authors = ["John-John Tedro <udoprog@tedro.se>"]
 readme = "README.md"
+edition = "2018"
 description = """
 Internal error handling for Amethyst.
 """

--- a/amethyst_error/README.md
+++ b/amethyst_error/README.md
@@ -14,5 +14,5 @@ MIT/Apache-2.
 
 ## License
 
-`amethyst_locale` is distributed under the terms of both the MIT
+`amethyst_error` is distributed under the terms of both the MIT
 license and the Apache License (Version 2.0).

--- a/amethyst_error/README.md
+++ b/amethyst_error/README.md
@@ -1,0 +1,18 @@
+# amethyst_error
+
+This crate contains types used internally and externally to handle and communicate errors.
+
+## Contribution
+
+Contribution is highly welcome! If you'd like another
+feature, just create an issue. You can also help
+out if you want to; just pick a "help wanted" issue.
+If you need any help, feel free to ask!
+
+All contributions are assumed to be dual-licensed under
+MIT/Apache-2.
+
+## License
+
+`amethyst_locale` is distributed under the terms of both the MIT
+license and the Apache License (Version 2.0).

--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -433,4 +433,14 @@ mod tests {
             .find(|n| *n == "a_really_unique_name_42")
             .is_some());
     }
+
+    #[test]
+    fn test_backtrace_disabled() {
+        use super::BACKTRACE_ENABLED;
+        use std::sync::atomic;
+
+        BACKTRACE_ENABLED.store(1, atomic::Ordering::Relaxed);
+
+        assert!(Error::from_string("an error").backtrace().is_none());
+    }
 }

--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -382,11 +382,11 @@ mod internal {
     fn new() -> Option<Backtrace> {
         static ENABLED: atomic::AtomicUsize = atomic::ATOMIC_USIZE_INIT;
 
-        match ENABLED.load(atomic::Ordering::SeqCst) {
+        match ENABLED.load(atomic::Ordering::Relaxed) {
             0 => {
                 let enabled = is_backtrace_enabled(|var| env::var_os(var));
 
-                ENABLED.store(enabled as usize + 1, atomic::Ordering::SeqCst);
+                ENABLED.store(enabled as usize + 1, atomic::Ordering::Relaxed);
 
                 if !enabled {
                     return None;

--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -318,11 +318,11 @@ static BACKTRACE_STATUS: atomic::AtomicUsize = atomic::ATOMIC_USIZE_INIT;
 
 /// Constructs a new backtrace, if backtraces are enabled.
 fn new_backtrace() -> Option<Backtrace> {
-    match BACKTRACE_ENABLED.load(atomic::Ordering::Relaxed) {
+    match BACKTRACE_STATUS.load(atomic::Ordering::Relaxed) {
         0 => {
             let enabled = is_backtrace_enabled(|var| env::var_os(var));
 
-            BACKTRACE_ENABLED.store(enabled as usize + 1, atomic::Ordering::Relaxed);
+            BACKTRACE_STATUS.store(enabled as usize + 1, atomic::Ordering::Relaxed);
 
             if !enabled {
                 return None;
@@ -410,10 +410,10 @@ mod tests {
 
     #[test]
     fn test_backtrace() {
-        use super::BACKTRACE_ENABLED;
+        use super::BACKTRACE_STATUS;
         use std::sync::atomic;
 
-        BACKTRACE_ENABLED.store(2, atomic::Ordering::Relaxed);
+        BACKTRACE_STATUS.store(2, atomic::Ordering::Relaxed);
 
         #[inline(never)]
         #[no_mangle]
@@ -439,10 +439,10 @@ mod tests {
 
     #[test]
     fn test_backtrace_disabled() {
-        use super::BACKTRACE_ENABLED;
+        use super::BACKTRACE_STATUS;
         use std::sync::atomic;
 
-        BACKTRACE_ENABLED.store(1, atomic::Ordering::Relaxed);
+        BACKTRACE_STATUS.store(1, atomic::Ordering::Relaxed);
 
         assert!(Error::from_string("an error").backtrace().is_none());
     }

--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -1,0 +1,402 @@
+//! Contains the `Error` type and company as used by Amethyst.
+//!
+//! **Note:** This type is not intended to be used outside of Amethyst.
+//! If you are integrating a crate from amethyst to use this, it is recommended that you treat this
+//! type as an opaque [`std::error::Error`].
+//!
+//! [`std::error::Error`]: https://doc.rust-lang.org/std/error/trait.Error.html
+use self::internal::{Backtrace, HAS_BACKTRACE};
+use std::borrow::Cow;
+use std::env;
+use std::error;
+use std::ffi;
+use std::fmt;
+use std::result;
+use std::sync::atomic;
+
+/// Private
+enum ErrorImpl {
+    Message(Cow<'static, str>),
+    Error(Box<dyn error::Error + Send + Sync>),
+}
+
+impl fmt::Debug for ErrorImpl {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ErrorImpl::Message(ref message) => fmt::Debug::fmt(message, fmt),
+            ErrorImpl::Error(ref e) => fmt::Debug::fmt(e, fmt),
+        }
+    }
+}
+
+impl From<&'static str> for ErrorImpl {
+    fn from(message: &'static str) -> Self {
+        ErrorImpl::Message(Cow::from(message))
+    }
+}
+
+impl From<String> for ErrorImpl {
+    fn from(message: String) -> Self {
+        ErrorImpl::Message(Cow::from(message))
+    }
+}
+
+impl From<Box<dyn error::Error + Send + Sync>> for ErrorImpl {
+    fn from(error: Box<dyn error::Error + Send + Sync>) -> Self {
+        ErrorImpl::Error(error)
+    }
+}
+
+/// The error type used by Amethyst.
+///
+/// Wraps error diagnostics like messages and other errors, and keeps track of causal chains and
+/// backtraces.
+pub struct Error {
+    error_impl: ErrorImpl,
+    source: Option<Box<Error>>,
+    backtrace: Option<Backtrace>,
+}
+
+impl Error {
+    /// Default constructor for our error types.
+    ///
+    /// Wraps anything that is an error in a box.
+    pub fn new<E>(error: E) -> Self
+    where
+        E: 'static + error::Error + Send + Sync,
+    {
+        Self {
+            error_impl: ErrorImpl::Error(Box::new(error)),
+            source: None,
+            backtrace: new_backtrace(),
+        }
+    }
+
+    /// Construct a new error from a string.
+    pub fn from_string<M>(message: M) -> Self
+    where
+        M: Into<Cow<'static, str>>,
+    {
+        Self {
+            error_impl: ErrorImpl::Message(message.into()),
+            source: None,
+            backtrace: new_backtrace(),
+        }
+    }
+
+    /// Get backtrace.
+    pub fn backtrace(&self) -> Option<&Backtrace> {
+        self.backtrace.as_ref()
+    }
+
+    /// Get the source of the error.
+    ///
+    /// # Examples
+    ///
+    /// The only way to set the source is through [`ResultExt`](ResultExt) using
+    /// [`with_context`](ResultExt::with_context).
+    ///
+    /// ```rust
+    /// use amethyst_error::{Error, ResultExt};
+    /// use std::io;
+    ///
+    /// let e = io::Error::new(io::ErrorKind::Other, "wrapped");
+    /// let a = Error::new(e);
+    ///
+    /// let res = Result::Err::<(), Error>(a).with_context(|_| Error::from_string("top"));
+    /// let e = res.expect_err("no error");
+    ///
+    /// assert_eq!("top", e.to_string());
+    /// assert_eq!("wrapped", e.source().expect("no source").to_string());
+    /// ```
+    pub fn source(&self) -> Option<&Error> {
+        self.source.as_ref().map(|e| &**e)
+    }
+
+    /// Iterate over all causes, including this one.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use amethyst_error::{Error, ResultExt};
+    ///
+    /// fn failing_function() -> Result<(), Error> {
+    ///     Err(Error::from_string("failing"))
+    /// }
+    ///
+    /// fn other_function() -> Result<(), Error> {
+    ///     Ok(failing_function().with_context(|_| Error::from_string("other"))?)
+    /// }
+    ///
+    /// let e = other_function().expect_err("no error");
+    ///
+    /// let messages = e.causes().map(|e| e.to_string()).collect::<Vec<_>>();
+    /// assert_eq!(vec!["other", "failing"], messages);
+    /// ```
+    pub fn causes(&self) -> Causes {
+        Causes {
+            current: Some(self),
+        }
+    }
+}
+
+/// Blanket implementation.
+///
+/// Encapsulate errors which are Send + Sync.
+impl<T> From<T> for Error
+where
+    T: 'static + error::Error + Send + Sync,
+{
+    fn from(value: T) -> Error {
+        Error::new(value)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self.error_impl {
+            ErrorImpl::Message(ref message) => message.fmt(fmt),
+            ErrorImpl::Error(ref e) => e.fmt(fmt),
+        }
+    }
+}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Error")
+            .field("error_impl", &self.error_impl)
+            .field("source", &self.source)
+            .finish()
+    }
+}
+
+/// Extra convenience functions for results based on core errors.
+pub trait ResultExt<T>
+where
+    Self: Sized,
+{
+    /// Provide a context for the result in case it is an error.
+    ///
+    /// The context callback is expected to return a new error, which will replace the given error
+    /// and set the replaced error as its [`source`](Error::source).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use amethyst_error::{Error, ResultExt};
+    ///
+    /// fn failing_function() -> Result<(), Error> {
+    ///     Err(Error::from_string("failing"))
+    /// }
+    ///
+    /// fn other_function() -> Result<(), Error> {
+    ///     Ok(failing_function().with_context(|_| Error::from_string("other"))?)
+    /// }
+    ///
+    /// let e = other_function().expect_err("no error");
+    ///
+    /// assert_eq!("other", e.to_string());
+    /// assert_eq!("failing", e.source().expect("no source").to_string());
+    /// assert!(e.source().expect("no source").source().is_none());
+    /// ```
+    fn with_context<C, D>(self, chain: C) -> Result<T, Error>
+    where
+        C: FnOnce(&Error) -> D,
+        D: Into<Error>;
+}
+
+impl<T, E> ResultExt<T> for result::Result<T, E>
+where
+    E: Into<Error>,
+{
+    fn with_context<C, D>(self, chain: C) -> Result<T, Error>
+    where
+        C: FnOnce(&Error) -> D,
+        D: Into<Error>,
+    {
+        match self {
+            Err(e) => {
+                let e = e.into();
+                let mut new = chain(&e).into();
+                new.source = Some(Box::new(e));
+                Err(new)
+            }
+            Ok(value) => Ok(value),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Causes<'a> {
+    current: Option<&'a Error>,
+}
+
+impl<'a> Iterator for Causes<'a> {
+    type Item = &'a Error;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(e) = self.current {
+            self.current = e.source();
+            return Some(e);
+        }
+
+        None
+    }
+}
+
+/// Constructs an `Error` using the standard string interpolation syntax.
+///
+/// ```rust
+/// #[macro_use] extern crate amethyst_error;
+///
+/// fn main() {
+///     let err = format_err!("number: {}", 42);
+///     assert_eq!("number: 42", err.to_string());
+/// }
+/// ```
+#[macro_export]
+macro_rules! format_err {
+    ($($arg:tt)*) => { $crate::Error::from_string(format!($($arg)*)) }
+}
+
+/// Constructs an [`Error`](Error) from a string.
+pub fn err_msg<M>(message: M) -> Error
+where
+    M: 'static + Send + Sync + fmt::Debug + fmt::Display,
+{
+    Error::new(ErrMsgError { message })
+}
+
+/// Treat something that can be displayed as an error.
+struct ErrMsgError<M> {
+    message: M,
+}
+
+impl<M> error::Error for ErrMsgError<M> where M: 'static + Send + Sync + fmt::Debug + fmt::Display {}
+
+impl<M> fmt::Display for ErrMsgError<M>
+where
+    M: fmt::Display,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        self.message.fmt(fmt)
+    }
+}
+
+impl<M> fmt::Debug for ErrMsgError<M>
+where
+    M: fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        self.message.fmt(fmt)
+    }
+}
+
+/// Test if backtracing is enabled.
+fn is_backtrace_enabled<F: Fn(&str) -> Option<ffi::OsString>>(get_var: F) -> bool {
+    match get_var(RUST_BACKTRACE) {
+        Some(ref val) if val != "0" => true,
+        _ => false,
+    }
+}
+
+fn new_backtrace() -> Option<Backtrace> {
+    if !HAS_BACKTRACE {
+        return None;
+    }
+
+    static ENABLED: atomic::AtomicUsize = atomic::ATOMIC_USIZE_INIT;
+
+    match ENABLED.load(atomic::Ordering::SeqCst) {
+        0 => {
+            let enabled = is_backtrace_enabled(|var| env::var_os(var));
+
+            ENABLED.store(enabled as usize + 1, atomic::Ordering::SeqCst);
+
+            if !enabled {
+                return None;
+            }
+        }
+        1 => return None,
+        _ => {}
+    }
+
+    Some(Backtrace::new())
+}
+
+const RUST_BACKTRACE: &str = "RUST_BACKTRACE";
+
+#[cfg(all(feature = "backtrace", feature = "std"))]
+mod internal {
+    pub const HAS_BACKTRACE: bool = true;
+
+    pub use backtrace::Backtrace;
+}
+
+#[cfg(not(all(feature = "backtrace", feature = "std")))]
+mod internal {
+    pub const HAS_BACKTRACE: bool = false;
+
+    use std::fmt;
+
+    /// Fake internal representation.
+    pub struct Backtrace(());
+
+    impl Backtrace {
+        pub fn new() -> Backtrace {
+            Backtrace(())
+        }
+    }
+
+    impl fmt::Debug for Backtrace {
+        fn fmt(&self, _fmt: &mut fmt::Formatter) -> fmt::Result {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Error, ResultExt};
+
+    #[test]
+    fn test_error_from_string() {
+        assert_eq!("foo", Error::from_string("foo").to_string());
+    }
+
+    #[test]
+    fn test_error_from_error() {
+        use std::io;
+        let e = io::Error::new(io::ErrorKind::Other, "i/o other");
+        assert_eq!("i/o other", Error::new(e).to_string());
+    }
+
+    #[test]
+    fn test_result_ext_source() {
+        use std::io;
+
+        let e = io::Error::new(io::ErrorKind::Other, "wrapped");
+        let a = Error::new(e);
+
+        let res = Result::Err::<(), Error>(a).with_context(|_| Error::from_string("top"));
+        let e = res.expect_err("no error");
+
+        assert_eq!("top", e.to_string());
+        assert_eq!("wrapped", e.source().expect("no source").to_string());
+    }
+
+    #[test]
+    fn test_sources() {
+        use std::io;
+
+        let e = io::Error::new(io::ErrorKind::Other, "wrapped");
+        let a = Error::new(e);
+
+        let res = Result::Err::<(), Error>(a).with_context(|_| Error::from_string("top"));
+        let e = res.expect_err("no error");
+
+        let messages = e.causes().map(|e| e.to_string()).collect::<Vec<_>>();
+
+        assert_eq!(vec!["top", "wrapped"], messages);
+    }
+}

--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -283,7 +283,7 @@ struct ErrMsgError<M> {
     message: M,
 }
 
-impl<M> error::Error for ErrMsgError<M> where M: 'static + Send + Sync + fmt::Debug + fmt::Display {}
+impl<M> error::Error for ErrMsgError<M> where M: fmt::Debug + fmt::Display {}
 
 impl<M> fmt::Display for ErrMsgError<M>
 where

--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -408,6 +408,8 @@ mod tests {
         assert_eq!(e.source().map(|e| e.to_string()), Some(String::from("bar")));
     }
 
+    // Note: all backtrace tests have to be in the same test case since they
+    // depend on the state of the global `BACKTRACE_STATUS`.
     #[test]
     fn test_backtrace() {
         use super::BACKTRACE_STATUS;
@@ -435,15 +437,9 @@ mod tests {
             .iter()
             .find(|n| n.ends_with("a_really_unique_name_42"))
             .is_some());
-    }
 
-    #[test]
-    fn test_backtrace_disabled() {
-        use super::BACKTRACE_STATUS;
-        use std::sync::atomic;
-
+        // Test disabled.
         BACKTRACE_STATUS.store(1, atomic::Ordering::Relaxed);
-
         assert!(Error::from_string("an error").backtrace().is_none());
     }
 }

--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -5,7 +5,6 @@
 //! type as an opaque [`std::error::Error`].
 //!
 //! [`std::error::Error`]: https://doc.rust-lang.org/std/error/trait.Error.html
-//!
 
 // Parts copied from failure:
 // https://github.com/rust-lang-nursery/failure

--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -9,7 +9,7 @@
 // Parts copied from failure:
 // https://github.com/rust-lang-nursery/failure
 
-#![warn(missing_docs, rust_2018_idioms, rust_2018_compatibility)]
+#![warn(missing_docs)]
 
 #[cfg(all(feature = "backtrace", feature = "std"))]
 extern crate backtrace;

--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -5,6 +5,10 @@
 //! type as an opaque [`std::error::Error`].
 //!
 //! [`std::error::Error`]: https://doc.rust-lang.org/std/error/trait.Error.html
+//!
+
+// Parts copied from failure:
+// https://github.com/rust-lang-nursery/failure
 
 #![warn(missing_docs, rust_2018_idioms, rust_2018_compatibility)]
 

--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -433,7 +433,7 @@ mod tests {
 
         assert!(frame_names
             .iter()
-            .find(|n| *n == "a_really_unique_name_42")
+            .find(|n| n.ends_with("a_really_unique_name_42"))
             .is_some());
     }
 

--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -151,7 +151,7 @@ impl Error {
     ///
     /// **Warning:** This erases most diagnostics in favor of returning only the top error.
     /// `std::error::Error` is expanded further.
-    pub fn as_error(&self) -> &dyn error::Error {
+    pub fn as_error(&self) -> &(dyn error::Error + 'static) {
         &self.inner.error
     }
 }

--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -311,7 +311,10 @@ fn is_backtrace_enabled<F: Fn(&str) -> Option<ffi::OsString>>(get_var: F) -> boo
     }
 }
 
-static BACKTRACE_ENABLED: atomic::AtomicUsize = atomic::ATOMIC_USIZE_INIT;
+// 0: unchecked
+// 1: disabled
+// 2: enabled
+static BACKTRACE_STATUS: atomic::AtomicUsize = atomic::ATOMIC_USIZE_INIT;
 
 /// Constructs a new backtrace, if backtraces are enabled.
 fn new_backtrace() -> Option<Backtrace> {


### PR DESCRIPTION
Following #1214 

This introduces the minimal API necessary to convert existing Error types (some which includes causes).

It currently mimics the `failure::Error` API, with methods named according to the ["fix Error" RFC](https://github.com/rust-lang/rfcs/blob/master/text/2504-fix-error.md).

That means:
* We include the `format_err!` macro and the `ResultExt` trait with an implementation of `with_context` from `failure`.
* The error type includes backtraces directly (instead of wrapping it in through e.g. `Context<D>`) in comparison to `failure`.
* We include a blanket `From<E> where E: std::error::Error` implementation to convert any type that implements `std::error::Error` into `Error`.
  * Note: this has the side-effect that this `Error` can't implement `std::error::Error`.
* We are using `source` from `std::error::Error` instead of `cause`.
* We don't implement `std::error::Error` directly, but we do implement some methods which are similar (`source`). We implement `as_error` to access a reference to the underlying `std::error::Error`. Similarly to how `failure::Error` doesn't implement `Fail` directly but provides `as_fail`.

Note that since this RFC is so sparse, there's really not much to implement, and most other methods which are used to actually build errors are local to this crate (e.g. `ResultExt::with_context`).

I have a branch where I've tried to apply this crate here:
https://github.com/udoprog/amethyst/commit/amethyst-error-full

I think I might have accidentally botched some of the `From<T>` implementations, but it should still give an idea of how this type is used.

#### Composite APIs

Composite APIs are APIs which potentially make use of local error information. Today these tend to lead to "stringy" errors where most of the underlying error information is lost and the errors undergoes a conversion. These are candidates to make use of `amethyst_error::Error` directly right now.

The traits I've so far identified that has a tendency to lead to this are:

* [`amethyst_assets::Source`](/amethyst/amethyst/blob/master/amethyst_assets/src/source/mod.rs)
* [`amethyst_assets::PrefabData`](/amethyst/amethyst/blob/master/amethyst_assets/src/prefab/mod.rs)
* [`amethyst_assets::SimpleFormat`](/amethyst/amethyst/blob/master/amethyst_assets/src/asset.rs)
  * Here's an example where SimpleFormat "stringifies" errors instead of propagating them to work around error constraints: https://github.com/amethyst/amethyst/blob/master/amethyst_ui/src/prefab.rs#L736
* [`amethyst_renderer::Pass/Pipeline` stuff](/amethyst/amethyst/blob/master/amethyst_renderer/src/pipe/pass.rs). Unsure because it spans over to UI and I don't know how "end user" this is.

#### Open Discussions

* Dropping the `Sync` constraint ([comment](https://github.com/amethyst/amethyst/pull/1220#discussion_r239030384)).
* ~~Either drop `no_std` support or improve it ([comment 1](https://github.com/amethyst/amethyst/pull/1220#discussion_r239052724), [comment 2](https://github.com/amethyst/amethyst/pull/1220#discussion_r243899686)).~~ backtrace is no longer optional.