### PR TITLE
Add config file for GitLab CI/CD

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,34 @@
+image: 'rust:latest'
+
+stages:
+  - fmt
+  - test
+
+variables:
+  CARGO_HOME: $CI_PROJECT_DIR/cargo
+  APT_CACHE_DIR: $CI_PROJECT_DIR/apt
+  RUSTFLAGS: "-D warnings"
+
+before_script:
+  - apt-get update -yq
+  - rustup component add rustfmt
+  - apt-get install -o dir::cache::archives="$APT_CACHE_DIR" -y alsa-utils libasound2-dev cmake git libasound2-dev libx11-xcb-dev libssl-dev cmake libfreetype6-dev libexpat1-dev libxcb1-dev python3 build-essential libsdl2-dev
+
+check formatting:
+  stage: fmt
+  script:
+    - cargo fmt --version
+    - cargo fmt --all -- --check
+
+run tests:
+  stage: test
+  script:
+    - rustc --version
+    - cargo --version
+    - cargo test --verbose --all --all-features
+
+cache:
+  paths:
+    - apt/
+    - cargo/
+    - target/


### PR DESCRIPTION
Since we now have access to the Gold level features of GitLab, this PR adds a basic config for it. Auto-mirroring is already setup in GitLab, but we need the config file in the repo, otherwise the mirroring removes it. This CI/CD file has been tested and is mostly ported from the Concourse config.