### PR TITLE
Maintenance/update vergen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ genmesh = "0.6"
 ron = "0.4"
 
 [build-dependencies]
-vergen = "2.0"
+vergen = "3.0"
 
 [[example]]
 name = "hello_world"

--- a/build.rs
+++ b/build.rs
@@ -1,14 +1,8 @@
-use vergen::{ConstantsFlags, Vergen};
+use vergen::{self, ConstantsFlags};
 
 fn main() {
-    let vergen = Vergen::new(ConstantsFlags::all()).unwrap_or_else(|e| {
-        panic!(
-            "Vergen crate failed to generate version information! {:?}",
-            e
-        );
-    });
+    vergen::generate_cargo_keys(ConstantsFlags::all())
+        .unwrap_or_else(|e| panic!("Vergen crate failed to generate version information! {}", e));
 
-    for (k, v) in vergen.build_info() {
-        println!("cargo:rustc-env={}={}", k.name(), v);
-    }
+    println!("cargo:rerun-if-changed=build.rs");
 }


### PR DESCRIPTION
`vergen` doesn't have docs on docs.rs for version `3.0.0~4` for some reason, I checked the source code for the changes.