### PR TITLE
Correct pixel perfect texture coordinates using from_pixel_values

### DIFF
--- a/amethyst_renderer/src/sprite.rs
+++ b/amethyst_renderer/src/sprite.rs
@@ -121,12 +121,15 @@ impl Sprite {
         // Texture coordinates are expressed as fractions of the position on the image.
         // Y axis texture coordinates start at the bottom of the image, so we have to invert them.
         //
-        // The 0.5 offsets is to get pixel perfection. See
+        // For pixel perfect result, the sprite border must be rendered exactly at
+        // screen pixel border or use nearest-neighbor sampling.
         // <http://www.mindcontrol.org/~hplus/graphics/opengl-pixel-perfect.html>
-        let left = (pixel_left + 0.5) / image_w;
-        let right = (pixel_right - 0.5) / image_w;
-        let top = (image_h - (pixel_top + 0.5)) / image_h;
-        let bottom = (image_h - (pixel_bottom - 0.5)) / image_h;
+        // NOTE: Maybe we should provide an option to round coordinates from `Transform`
+        // to nearest integer in `DrawFlat2D` pass before rendering.
+        let left = (pixel_left) / image_w;
+        let right = (pixel_right) / image_w;
+        let top = (image_h - pixel_top) / image_h;
+        let bottom = (image_h - pixel_bottom) / image_h;
 
         let tex_coords = TextureCoordinates {
             left,
@@ -399,9 +402,9 @@ mod test {
 
         assert_eq!(
             Sprite::from((
-                (10., 20.),                                    // Sprite w and h
-                [-5., -10.],                                   // Offsets
-                [0.5 / 30., 9.5 / 30., 0.5 / 40., 19.5 / 40.], // Texture coordinates
+                (10., 20.),                     // Sprite w and h
+                [-5., -10.],                    // Offsets
+                [0., 10. / 30., 0., 20. / 40.], // Texture coordinates
             )),
             Sprite::from_pixel_values(
                 image_w, image_h, sprite_w, sprite_h, pixel_left, pixel_top, offsets

--- a/book/src/sprites/define_the_sprite_sheet.md
+++ b/book/src/sprites/define_the_sprite_sheet.md
@@ -81,7 +81,6 @@ The following table lists the differences between the coordinate systems:
 | Begin at the top left of the image    | Begin at the bottom left of the image     |
 | Increase to the right and down        | Increase to the right and up              |
 | Range from 0 to (width or height - 1) | Range from 0.0 to 1.0                     |
-| Use pixel values at exact coordinates | Takes average value of surrounding pixels |
 
 In Amethyst, pixel dimensions and texture coordinates are stored in the `Sprite` struct. Since texture coordinates can be derived from pixel coordinates, Amethyst provides the `Sprite::from_pixel_values` function to create a `Sprite`.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 ### Changed
 
 * Make `application_root_dir` return a `Result<Path>` instead of a `String` ([#1213])
+* Remove unnecessary texture coordinates offset in `Sprite::from_pixel_values` ([#1267])
 
 ### Removed
 
@@ -107,6 +108,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1188]: https://github.com/amethyst/amethyst/pull/1188
 [#1198]: https://github.com/amethyst/amethyst/pull/1198
 [#1224]: https://github.com/amethyst/amethyst/pull/1224
+[#1267]: https://github.com/amethyst/amethyst/pull/1267
 [winit_018]: https://github.com/tomaka/winit/blob/v0.18.0/CHANGELOG.md#version-0180-2018-11-07
 [glutin_019]: https://github.com/tomaka/glutin/blob/master/CHANGELOG.md#version-0190-2018-11-09
 


### PR DESCRIPTION
Texture coordinates were miscalculated, resulting in artifacts when rendering in situations different from perfect, that is when any texture filtering is present or framebuffer pixel grid was not exactly the same density as sprite's, which is common when hidpi factor is different than 1.