### PR TITLE
Add backers to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ you can look through the [issue tracker][it].
 [it]: https://github.com/amethyst/amethyst/issues
 [gfi]: https://github.com/amethyst/amethyst/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
 
+## Backers
+
+Thank you to all our backers! 🙏 [Become a backer](https://opencollective.com/amethyst#backer)
+
+<a href="https://opencollective.com/amethyst#backers" target="_blank"><img src="https://opencollective.com/amethyst/backers.svg?width=890"></a>
+
 ## Sponsors
 Amethyst is supported by:
 <p>


### PR DESCRIPTION
I had a little trouble finding a way to donate, so I used the donation box in the announcement post.

I think having backers in the README will make the process of finding the Amethyst OpenCollective a bit easier.