### PR TITLE
add AutoFov for automatic resizing of camera

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,5 +225,9 @@ path = "examples/sprite_camera_follow/main.rs"
 name = "simple_image"
 path = "examples/simple_image/main.rs"
 
+[[example]]
+name = "auto_fov"
+path = "examples/auto_fov/main.rs"
+
 [workspace]
 members = ["amethyst_gltf", "tests/amethyst_test"]

--- a/amethyst_utils/src/auto_fov.rs
+++ b/amethyst_utils/src/auto_fov.rs
@@ -1,0 +1,251 @@
+//! Utility to adjust the aspect ratio of cameras automatically
+
+use amethyst_assets::{PrefabData, PrefabError};
+use amethyst_core::specs::{
+    Component, Entity, HashMapStorage, Join, ReadExpect, ReadStorage, System, WriteStorage,
+};
+use amethyst_renderer::{Camera, ScreenDimensions};
+
+/// A component describing the behavior of the camera in accordance with the screen dimensions
+#[derive(Clone, Deserialize, PrefabData, Serialize)]
+#[prefab(Component)]
+#[serde(default)]
+pub struct AutoFov {
+    /// The horizontal FOV value at the aspect ratio in the field `base_aspect_ratio`
+    base_fovx: f32,
+
+    /// The factor determining how sensitive the FOV change should be
+    fovx_growth_rate: f32,
+
+    /// If the FOV grow rate specified in the field `fovx_growth_rate` should be applied as-is
+    fixed_growth_rate: bool,
+
+    /// The aspect ratio when the camera's horizontal FOV is identical to `base_fovx`
+    base_aspect_ratio: (usize, usize),
+
+    /// The minimum value the horizontal FOV can have
+    min_fovx: f32,
+
+    /// The maximum value the horizontal FOV can have
+    max_fovx: f32,
+}
+
+impl AutoFov {
+    /// Creates a new instance with the default values for all fields
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// The horizontal FOV value at the aspect ratio in the field `base_aspect_ratio`
+    ///
+    /// This value should be between the `min_fovx` and `max_fovx` values. Value in radians.
+    /// Defaults to `1.861684535`, which is the horizontal FOV value when the vertial FOV and aspect
+    /// ratio for a camera is set to `1.0471975512`(60 deg) and `16/9`, respectively.
+    pub fn base_fovx(&self) -> f32 {
+        self.base_fovx
+    }
+
+    /// The factor determining how sensitive the FOV change should be
+    ///
+    /// Defaults to `1.0`.
+    pub fn fovx_growth_rate(&self) -> f32 {
+        self.fovx_growth_rate
+    }
+
+    /// If the FOV grow rate specified in the field `fovx_growth_rate` should be applied as-is
+    ///
+    /// Defaults to `false`. When `false`, the `fovx_growth_rate` field is multiplied with the
+    /// camera's current vertical FOV value.
+    pub fn fixed_growth_rate(&self) -> bool {
+        self.fixed_growth_rate
+    }
+
+    /// The aspect ratio when the camera's horizontal FOV is identical to `base_fovx`
+    ///
+    /// Defaults to `(16, 9)`.
+    pub fn base_aspect_ratio(&self) -> (usize, usize) {
+        self.base_aspect_ratio
+    }
+
+    /// The minimum value the horizontal FOV can have
+    ///
+    /// This value should be larger than 0. Defaults to `0.1`.
+    pub fn min_fovx(&self) -> f32 {
+        self.min_fovx
+    }
+
+    /// The maximum value the horizontal FOV can have
+    ///
+    /// This value should be larger than 0. Defaults to `PI`. The rendered view will be stretched if
+    /// the screen aspect ratio keeps growing after the point where the camera's horizontal FOV
+    /// reaches this maximum value.
+    pub fn max_fovx(&self) -> f32 {
+        self.max_fovx
+    }
+
+    /// Sets `base_fovx` to the given value
+    ///
+    /// This function panics if the given value is not between `min_fovx` and `max_fovx`.
+    pub fn set_base_fovx(&mut self, base_fovx: f32) {
+        assert!(
+            base_fovx >= self.min_fovx,
+            format!(
+                "`base_fovx` should be larger than `min_fovx` which is `{}`, but `{}` given",
+                self.min_fovx, base_fovx
+            )
+        );
+        assert!(
+            base_fovx <= self.max_fovx,
+            format!(
+                "`base_fovx` should be smaller than `max_fovx` which is `{}`, but `{}` given",
+                self.max_fovx, base_fovx
+            )
+        );
+
+        self.base_fovx = base_fovx;
+    }
+
+    /// Sets `fovx_growth_rate` to the given value
+    pub fn set_fovx_growth_rate(&mut self, fovx_growth_rate: f32) {
+        self.fovx_growth_rate = fovx_growth_rate;
+    }
+
+    /// Sets `fixed_growth_rate` to the given value
+    ///
+    /// You can optionally give the new `fovx_growth_rate` value to be set.
+    pub fn set_fixed_growth_rate(&mut self, fix: bool, new_growth_rate: Option<f32>) {
+        self.fixed_growth_rate = fix;
+
+        if let Some(fovx_growth_rate) = new_growth_rate {
+            self.fovx_growth_rate = fovx_growth_rate;
+        }
+    }
+
+    /// Sets `base_aspect_ratio` to the given value
+    ///
+    /// This function panics if the horizontal or vertical ratio value is zero.
+    pub fn set_base_aspect_ratio(&mut self, horizontal: usize, vertical: usize) {
+        assert!(
+            horizontal != 0,
+            "The horizontal value of aspect ratio should be larger than 0"
+        );
+        assert!(
+            vertical != 0,
+            "The vertical value of aspect ratio should be larger than 0"
+        );
+        self.base_aspect_ratio = (horizontal, vertical);
+    }
+
+    /// Sets `min_fovx` to the given value
+    ///
+    /// This function panics if the given `min_fovx` is not larger than zero or is larger than
+    /// `max_fovx`.
+    pub fn set_min(&mut self, min: f32) {
+        let max = self.max_fovx;
+        self.set_min_max(min, max);
+    }
+
+    /// Sets `max_fovx` to the given value
+    ///
+    /// This function panics if the given `max_fovx` is smaller than `min_fovx`.
+    pub fn set_max(&mut self, max: f32) {
+        let min = self.min_fovx;
+        self.set_min_max(min, max);
+    }
+
+    /// Sets `min_fovx` and `max_fovx` to the given vaues
+    ///
+    /// This function panics if the given `min_fovx` is not larger than zero, or if the given
+    /// `max_fovx` is smaller than the given `min_fovx`.
+    pub fn set_min_max(&mut self, min: f32, max: f32) {
+        assert!(
+            min > 0.0,
+            format!("`min_fovx` should be larger than 0, but `{}` given", min)
+        );
+        assert!(
+            max >= min,
+            format!(
+                "`max_fovx` should be larger than or equal to `min_fovx` which is `{}`, but `{}` given",
+                min,
+                max,
+            ),
+        );
+        self.min_fovx = min;
+        self.max_fovx = max;
+    }
+
+    /// Computes the new horizontal FOV from the current screen aspect ratio and vertical FOV
+    pub fn new_fovx(&self, current_aspect_ratio: f32, fovy: f32) -> f32 {
+        let delta_aspect = current_aspect_ratio - self.base_aspect_value();
+
+        if delta_aspect.abs() <= ::std::f32::EPSILON {
+            return self.base_fovx;
+        }
+
+        let fovy = if self.fixed_growth_rate { 1.0 } else { fovy };
+        let delta_fovx = self.fovx_growth_rate * fovy * delta_aspect;
+        let new_fovx = self.base_fovx + delta_fovx;
+
+        new_fovx.max(self.min_fovx).min(self.max_fovx)
+    }
+
+    #[inline]
+    fn base_aspect_value(&self) -> f32 {
+        self.base_aspect_ratio.0 as f32 / self.base_aspect_ratio.1 as f32
+    }
+}
+
+impl Component for AutoFov {
+    type Storage = HashMapStorage<Self>;
+}
+
+impl Default for AutoFov {
+    fn default() -> Self {
+        AutoFov {
+            base_fovx: 1.861684535,
+            fovx_growth_rate: 1.0,
+            fixed_growth_rate: false,
+            base_aspect_ratio: (16, 9),
+            min_fovx: 0.1,
+            max_fovx: std::f32::consts::PI,
+        }
+    }
+}
+
+/// System that automatically adjusts the horizontal FOV based on the screen dimensions
+///
+/// For a camera component to be managed by this system, the entity with the camera component should
+/// also have an `AutoFov` component attached to it.
+///
+/// If the camera is being loaded by a prefab, it is best to have the `PrefabLoaderSystem` loading
+/// the camera as a dependency of this system. It enables the system to adjust the camera right
+/// after it is created -- simply put, in the same frame.
+pub struct AutoFovSystem;
+
+impl<'a> System<'a> for AutoFovSystem {
+    type SystemData = (
+        ReadExpect<'a, ScreenDimensions>,
+        ReadStorage<'a, AutoFov>,
+        WriteStorage<'a, Camera>,
+    );
+
+    fn run(&mut self, (screen, auto_fovs, mut cameras): Self::SystemData) {
+        let current_aspect = screen.aspect_ratio();
+
+        for (camera, auto_fov) in (&mut cameras, &auto_fovs).join() {
+            let fovy = get_fovy(camera);
+            let fovx = auto_fov.new_fovx(current_aspect, fovy);
+            set_aspect(camera, fovx / fovy);
+        }
+    }
+}
+
+#[inline]
+fn get_fovy(camera: &Camera) -> f32 {
+    (1.0 / camera.proj[(1, 1)]).atan() * 2.0
+}
+
+#[inline]
+fn set_aspect(camera: &mut Camera, new_aspect: f32) {
+    camera.proj[(0, 0)] = camera.proj[(1, 1)] / new_aspect;
+}

--- a/amethyst_utils/src/lib.rs
+++ b/amethyst_utils/src/lib.rs
@@ -12,6 +12,7 @@ use shred;
 extern crate shred_derive;
 
 pub mod app_root_dir;
+pub mod auto_fov;
 pub mod circular_buffer;
 pub mod fps_counter;
 pub mod ortho_camera;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * "How To" guides for using assets and defining custom assets. ([#1251])
 * `amethyst_renderer::Rgba` is now a `Component` that changes the color and transparency of the entity
 it is attached to. ([#1282])
+* `AutoFov` and `AutoFovSystem` to adjust horizontal FOV to screen aspect ratio. ([#1281])
 
 ### Changed
 
@@ -35,6 +36,7 @@ it is attached to. ([#1282])
 [#1267]: https://github.com/amethyst/amethyst/pull/1267
 [#1280]: https://github.com/amethyst/amethyst/pull/1280
 [#1282]: https://github.com/amethyst/amethyst/pull/1282
+[#1281]: https://github.com/amethyst/amethyst/pull/1281
 
 ## [0.10.0] - 2018-12
 

--- a/examples/assets/prefab/auto_fov.ron
+++ b/examples/assets/prefab/auto_fov.ron
@@ -1,0 +1,137 @@
+#![enable(implicit_some)]
+Prefab (
+    entities: [
+        (
+            data: (
+                light: (ambient_color: ((0.01, 0.01, 0.01, 1.0))),
+            ),
+        ),
+        (
+            data: (
+                graphics: (
+                    mesh: Asset(File("mesh/lid.obj", ObjFormat, ())),
+                    material: (
+                        albedo: Data(Rgba((1.0, 0.0, 0.0, 1.0,), (channel: Srgb,
+                            sampler: (filter: Anisotropic(8), wrap_mode: (Clamp, Clamp, Clamp)),))),
+                    ),
+                ),
+                transform: (
+                    translation: (5.0, 5.0, 0.0),
+                    rotation: (0.5, 0.5, -0.5, -0.5),
+                ),
+            ),
+        ),
+        (
+            data: (
+                graphics: (
+                    mesh: Asset(File("mesh/teapot.obj", ObjFormat, ())),
+                    material: (
+                        albedo: Data(Rgba((1.0, 0.0, 0.0, 1.0,), (channel: Srgb,
+                            sampler: (filter: Anisotropic(8), wrap_mode: (Clamp, Clamp, Clamp)),))),
+                    ),
+                ),
+                transform: (
+                    translation: (5.0, 5.0, 0.0),
+                    rotation: (0.5, 0.5, -0.5, -0.5),
+                ),
+            ),
+        ),
+        (
+            data: (
+                graphics: (
+                    mesh: Asset(File("mesh/cube.obj", ObjFormat, ())),
+                    material: (
+                        albedo: File("texture/logo.png", Png, (channel: Srgb),),
+                    ),
+                ),
+                transform: (
+                    translation: (5.0, -5.0, 2.0),
+                    scale: (2.0, 2.0, 2.0),
+                ),
+            ),
+        ),
+        (
+            data: (
+                graphics: (
+                    mesh: Asset(File("mesh/cone.obj", ObjFormat, ())),
+                    material: (
+                        albedo: Data(Rgba((1.0, 1.0, 1.0, 1.0,), (channel: Srgb),)),
+                    ),
+                ),
+                transform: (
+                    translation: (-5.0, 5.0, 0.0),
+                    scale: (2.0, 2.0, 2.0),
+                ),
+            ),
+        ),
+        (
+            data: (
+                graphics: (
+                    mesh: Asset(File("mesh/cube.obj", ObjFormat, ())),
+                    material: (
+                        albedo: Data(Rgba((1.0, 0.0, 0.0, 1.0,), (channel: Srgb),)),
+                    ),
+                ),
+                transform: (
+                    translation: (-5.0, -5.0, 1.0),
+                    scale: (2.0, 2.0, 2.0),
+                ),
+            ),
+        ),
+        (
+            data: (
+                graphics: (
+                    mesh: Asset(File("mesh/rectangle.obj", ObjFormat, ())),
+                    material: (
+                        albedo: Data(Rgba((1.0, 1.0, 1.0, 1.0,), (channel: Srgb),)),
+                    ),
+                ),
+                transform: (
+                    scale: (10.0, 10.0, 10.0),
+                ),
+            ),
+        ),
+        (
+            data: (
+                transform: (
+                    translation: (1.0, 1.0, 6.0),
+                ),
+                light: (
+                    light: Point((
+                        intensity: 50.0,
+                        color: (1.0, 1.0, 1.0, 1.0),
+                    )),
+                ),
+            ),
+        ),
+        (
+            data: (
+                light: (
+                    light: Directional((
+                        direction: (-1.0, -1.0, -1.0),
+                        color: (0.2, 0.2, 0.2, 0.2,),
+                    )),
+                ),
+            ),
+        ),
+        (
+            data: (
+                transform: Transform (
+                    translation: (0.0, -20.0, 10.0),
+                    rotation: (0.7933533, 0.6087614, 0.0, 0.0),
+                ),
+                camera: Perspective((
+                    aspect: 1.3,
+                    fovy: 1.0471975512,
+                    znear: 0.1,
+                    zfar: 2000.0,
+                )),
+                auto_fov: (
+                    base_fovx: 1.361356817,
+                    base_aspect_ratio: (13, 10),
+                ),
+                show_fov_tag: (),
+            ),
+        ),
+    ],
+)

--- a/examples/assets/ui/fov.ron
+++ b/examples/assets/ui/fov.ron
@@ -1,0 +1,69 @@
+#![enable(implicit_some)]
+Container(
+    transform: (
+        id: "fov_container",
+        anchor: TopLeft,
+        x: 370.0,
+        y: -80.0,
+        width: 350.0,
+        height: 80.0,
+        transparent: true,
+    ),
+    background: None,
+    children: [
+        Text(
+            transform: (
+                id: "screen_aspect",
+                anchor: TopLeft,
+                x: 0.0,
+                y: 0.0,
+                width: 350.0,
+                height: 25.0,
+                transparent: true,
+            ),
+            text: (
+                text: "Screen Aspect Ratio: N/A",
+                align: MiddleLeft,
+                font_size: 25.0,
+                color: (1.0, 1.0, 1.0, 1.0),
+                font: File("font/square.ttf", Ttf, ()),
+            ),
+        ),
+        Text(
+            transform: (
+                id: "camera_aspect",
+                anchor: MiddleLeft,
+                x: 0.0,
+                y: 0.0,
+                width: 350.0,
+                height: 25.0,
+                transparent: true,
+            ),
+            text: (
+                text: "Camera Aspect Ratio: N/A",
+                align: MiddleLeft,
+                font_size: 25.0,
+                color: (1.0, 1.0, 1.0, 1.0),
+                font: File("font/square.ttf", Ttf, ()),
+            ),
+        ),
+        Text(
+            transform: (
+                id: "camera_fov",
+                anchor: BottomLeft,
+                x: 0.0,
+                y: 0.0,
+                width: 350.0,
+                height: 25.0,
+                transparent: true,
+            ),
+            text: (
+                text: "Camera Fov: N/A",
+                align: MiddleLeft,
+                font_size: 25.0,
+                color: (1.0, 1.0, 1.0, 1.0),
+                font: File("font/square.ttf", Ttf, ()),
+            ),
+        ),
+    ],
+)

--- a/examples/auto_fov/main.rs
+++ b/examples/auto_fov/main.rs
@@ -1,0 +1,190 @@
+#[macro_use]
+extern crate amethyst;
+#[macro_use]
+extern crate log;
+#[macro_use]
+extern crate serde;
+
+use amethyst::assets::{
+    Completion, Handle, Prefab, PrefabData, PrefabError, PrefabLoader, PrefabLoaderSystem,
+    ProgressCounter, RonFormat,
+};
+use amethyst::core::{Transform, TransformBundle};
+use amethyst::ecs::{Entity, ReadExpect, ReadStorage, System, WriteStorage};
+use amethyst::input::{is_close_requested, is_key_down, InputBundle};
+use amethyst::prelude::{
+    Application, Builder, GameData, GameDataBuilder, SimpleState, SimpleTrans, StateData,
+    StateEvent, Trans,
+};
+use amethyst::renderer::{
+    Camera, CameraPrefab, DrawShaded, GraphicsPrefab, LightPrefab, PosNormTex, ScreenDimensions,
+    VirtualKeyCode,
+};
+use amethyst::ui::{UiBundle, UiCreator, UiFinder, UiText};
+use amethyst::utils::auto_fov::{AutoFov, AutoFovSystem};
+use amethyst::utils::tag::{Tag, TagFinder};
+
+fn main() -> amethyst::Result<()> {
+    amethyst::start_logger(Default::default());
+
+    let app_dir = amethyst::utils::application_dir("examples")?;
+    let display_config = app_dir.join("auto_fov/resources/display.ron");
+    let assets = app_dir.join("assets");
+
+    let game_data = GameDataBuilder::new()
+        .with(PrefabLoaderSystem::<ScenePrefab>::default(), "prefab", &[])
+        .with(AutoFovSystem, "auto_fov", &["prefab"]) // This makes the system adjust the camera right after it has been loaded (in the same frame), preventing any flickering
+        .with(ShowFovSystem, "show_fov", &["auto_fov"])
+        .with_bundle(TransformBundle::new())?
+        .with_bundle(InputBundle::<String, String>::new())?
+        .with_bundle(UiBundle::<String, String>::new())?
+        .with_basic_renderer(display_config, DrawShaded::<PosNormTex>::new(), true)?;
+
+    let mut game = Application::build(assets, Loading::new())?.build(game_data)?;
+    game.run();
+
+    Ok(())
+}
+
+#[derive(Default, Deserialize, PrefabData, Serialize)]
+#[serde(default)]
+struct ScenePrefab {
+    graphics: Option<GraphicsPrefab<Vec<PosNormTex>>>,
+    transform: Option<Transform>,
+    light: Option<LightPrefab>,
+    camera: Option<CameraPrefab>,
+    auto_fov: Option<AutoFov>, // `AutoFov` implements `PrefabData` trait
+    show_fov_tag: Option<Tag<ShowFov>>,
+}
+
+#[derive(Clone, Default)]
+struct ShowFov;
+
+struct Loading {
+    progress: ProgressCounter,
+    scene: Option<Handle<Prefab<ScenePrefab>>>,
+}
+
+impl Loading {
+    fn new() -> Self {
+        Loading {
+            progress: ProgressCounter::new(),
+            scene: None,
+        }
+    }
+}
+
+impl SimpleState for Loading {
+    fn on_start(&mut self, data: StateData<GameData>) {
+        data.world.exec(|mut creator: UiCreator<'_>| {
+            creator.create("ui/loading.ron", &mut self.progress);
+            creator.create("ui/fov.ron", &mut self.progress);
+        });
+
+        let handle = data.world.exec(|loader: PrefabLoader<'_, ScenePrefab>| {
+            loader.load("prefab/auto_fov.ron", RonFormat, (), &mut self.progress)
+        });
+        self.scene = Some(handle);
+    }
+
+    fn update(&mut self, _: &mut StateData<'_, GameData<'_, '_>>) -> SimpleTrans {
+        match self.progress.complete() {
+            Completion::Loading => Trans::None,
+            Completion::Failed => {
+                error!("Failed to load the scene");
+                Trans::Quit
+            }
+            Completion::Complete => {
+                info!("Loading finished. Moving to the main state.");
+                Trans::Switch(Box::new(Example {
+                    scene: self.scene.take().unwrap(),
+                }))
+            }
+        }
+    }
+}
+
+struct Example {
+    scene: Handle<Prefab<ScenePrefab>>,
+}
+
+impl SimpleState for Example {
+    fn on_start(&mut self, data: StateData<'_, GameData<'_, '_>>) {
+        data.world.create_entity().with(self.scene.clone()).build();
+        data.world
+            .exec(|finder: UiFinder| finder.find("loading"))
+            .map_or_else(
+                || error!("Unable to find Ui Text `loading`"),
+                |e| {
+                    data.world
+                        .delete_entity(e)
+                        .unwrap_or_else(|err| error!("{}", err))
+                },
+            );
+    }
+
+    fn handle_event(
+        &mut self,
+        _: StateData<'_, GameData<'_, '_>>,
+        event: StateEvent,
+    ) -> SimpleTrans {
+        if let StateEvent::Window(ref event) = event {
+            if is_close_requested(event) || is_key_down(event, VirtualKeyCode::Escape) {
+                Trans::Quit
+            } else {
+                Trans::None
+            }
+        } else {
+            Trans::None
+        }
+    }
+}
+
+struct ShowFovSystem;
+
+impl<'a> System<'a> for ShowFovSystem {
+    type SystemData = (
+        TagFinder<'a, ShowFov>,
+        UiFinder<'a>,
+        WriteStorage<'a, UiText>,
+        ReadStorage<'a, Camera>,
+        ReadExpect<'a, ScreenDimensions>,
+    );
+
+    fn run(&mut self, (tag_finder, ui_finder, mut ui_texts, cameras, screen): Self::SystemData) {
+        let screen_aspect = screen.aspect_ratio();
+        ui_finder
+            .find("screen_aspect")
+            .and_then(|e| ui_texts.get_mut(e))
+            .map(|t| {
+                t.text = format!("Screen Aspect Ratio: {:.2}", screen_aspect);
+            });
+
+        if let Some(entity) = tag_finder.find() {
+            if let Some(camera) = cameras.get(entity) {
+                let fovy = get_fovy(camera);
+                let camera_aspect = get_aspect(camera);
+                ui_finder
+                    .find("camera_aspect")
+                    .and_then(|e| ui_texts.get_mut(e))
+                    .map(|t| {
+                        t.text = format!("Camera Aspect Ratio: {:.2}", camera_aspect);
+                    });
+                ui_finder
+                    .find("camera_fov")
+                    .and_then(|e| ui_texts.get_mut(e))
+                    .map(|t| {
+                        t.text = format!("Camera Fov: ({:.2}, {:.2})", fovy * camera_aspect, fovy);
+                    });
+            }
+        }
+    }
+}
+
+fn get_fovy(camera: &Camera) -> f32 {
+    (1.0 / camera.proj[(1, 1)]).atan() * 2.0
+}
+
+fn get_aspect(camera: &Camera) -> f32 {
+    camera.proj[(1, 1)] / camera.proj[(0, 0)]
+}

--- a/examples/auto_fov/resources/display.ron
+++ b/examples/auto_fov/resources/display.ron
@@ -1,0 +1,7 @@
+(
+  fullscreen: false,
+  multisampling: 0,
+  title: "AutoFov Example",
+  visibility: true,
+  vsync: false,
+)


### PR DESCRIPTION
issue #1193 
Currently, when the screen aspect ratio exceeds the point where the horizontal fov reaches its specified maximum, the rendered view stretches to fit the screen. I added a `TODO` label to handle that bc I couldn't figure out what to do with it. Any ideas? Or would it be just fine to leave it like that?