### PR TITLE
Add support for rendering entities with a simple RGBA value.

### DIFF
--- a/amethyst_renderer/src/color.rs
+++ b/amethyst_renderer/src/color.rs
@@ -1,10 +1,22 @@
 //! Color value types.
 
+use amethyst_core::specs::{Component, DenseVecStorage};
+
 use gfx::shade::{Formatted, ToUniform};
 use gfx_core::shade::{BaseType, ContainerType, UniformValue};
 use glsl_layout::{vec3, vec4};
 
 /// An RGBA color value.
+///
+/// ## As a Component
+/// If you attach this as a component to an entity then passes should multiply any rendered pixels
+/// in the component with this color.  Please note alpha multiplication will only produce
+/// transparency if the rendering pass would normally be capable of rendering that entity
+/// transparently.
+///
+/// ## More than a Component
+/// This structure has more uses than just as a component, and you'll find it in other places
+/// throughout the `amethyst_renderer` API.
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
 pub struct Rgba(pub f32, pub f32, pub f32, pub f32);
 
@@ -57,6 +69,10 @@ impl Default for Rgba {
     fn default() -> Rgba {
         Rgba::black()
     }
+}
+
+impl Component for Rgba {
+    type Storage = DenseVecStorage<Self>;
 }
 
 impl From<[f32; 3]> for Rgba {

--- a/amethyst_renderer/src/pass/debug_lines/interleaved.rs
+++ b/amethyst_renderer/src/pass/debug_lines/interleaved.rs
@@ -22,6 +22,7 @@ use crate::{
     },
     types::{Encoder, Factory},
     vertex::{Color, Normal, Position, Query},
+    Rgba,
 };
 
 use super::*;
@@ -145,7 +146,13 @@ where
             return;
         }
 
-        set_vertex_args(effect, encoder, camera, &GlobalTransform(na::one()));
+        set_vertex_args(
+            effect,
+            encoder,
+            camera,
+            &GlobalTransform(na::one()),
+            Rgba::WHITE,
+        );
 
         effect.draw(mesh.slice(), encoder);
         effect.clear();

--- a/amethyst_renderer/src/pass/flat/interleaved.rs
+++ b/amethyst_renderer/src/pass/flat/interleaved.rs
@@ -27,6 +27,7 @@ use crate::{
     types::{Encoder, Factory},
     vertex::{Position, Query, TexCoord},
     visibility::Visibility,
+    Rgba,
 };
 
 use super::*;
@@ -84,6 +85,7 @@ where
         ReadStorage<'a, MeshHandle>,
         ReadStorage<'a, Material>,
         ReadStorage<'a, GlobalTransform>,
+        ReadStorage<'a, Rgba>,
     );
 }
 
@@ -126,14 +128,22 @@ where
             mesh,
             material,
             global,
+            rgba,
         ): <Self as PassData<'a>>::Data,
     ) {
         let camera = get_camera(active, &camera, &global);
 
         match visibility {
             None => {
-                for (mesh, material, global, _, _) in
-                    (&mesh, &material, &global, !&hidden, !&hidden_prop).join()
+                for (mesh, material, global, rgba, _, _) in (
+                    &mesh,
+                    &material,
+                    &global,
+                    rgba.maybe(),
+                    !&hidden,
+                    !&hidden_prop,
+                )
+                    .join()
                 {
                     draw_mesh(
                         encoder,
@@ -144,6 +154,7 @@ where
                         &tex_storage,
                         Some(material),
                         &material_defaults,
+                        rgba,
                         camera,
                         Some(global),
                         &[V::QUERIED_ATTRIBUTES],
@@ -152,8 +163,14 @@ where
                 }
             }
             Some(ref visibility) => {
-                for (mesh, material, global, _) in
-                    (&mesh, &material, &global, &visibility.visible_unordered).join()
+                for (mesh, material, global, rgba, _) in (
+                    &mesh,
+                    &material,
+                    &global,
+                    rgba.maybe(),
+                    &visibility.visible_unordered,
+                )
+                    .join()
                 {
                     draw_mesh(
                         encoder,
@@ -164,6 +181,7 @@ where
                         &tex_storage,
                         Some(material),
                         &material_defaults,
+                        rgba,
                         camera,
                         Some(global),
                         &[V::QUERIED_ATTRIBUTES],
@@ -182,6 +200,7 @@ where
                             &tex_storage,
                             material.get(*entity),
                             &material_defaults,
+                            rgba.get(*entity),
                             camera,
                             global.get(*entity),
                             &[V::QUERIED_ATTRIBUTES],

--- a/amethyst_renderer/src/pass/flat/separate.rs
+++ b/amethyst_renderer/src/pass/flat/separate.rs
@@ -29,6 +29,7 @@ use crate::{
     types::{Encoder, Factory},
     vertex::{Attributes, Position, Separate, TexCoord, VertexFormat},
     visibility::Visibility,
+    Rgba,
 };
 
 use super::*;
@@ -94,6 +95,7 @@ impl<'a> PassData<'a> for DrawFlatSeparate {
         ReadStorage<'a, Material>,
         ReadStorage<'a, GlobalTransform>,
         ReadStorage<'a, JointTransforms>,
+        ReadStorage<'a, Rgba>,
     );
 }
 
@@ -150,17 +152,19 @@ impl Pass for DrawFlatSeparate {
             material,
             global,
             joints,
+            rgba,
         ): <Self as PassData<'a>>::Data,
     ) {
         let camera = get_camera(active, &camera, &global);
 
         match visibility {
             None => {
-                for (joint, mesh, material, global, _, _) in (
+                for (joint, mesh, material, global, rgba, _, _) in (
                     joints.maybe(),
                     &mesh,
                     &material,
                     &global,
+                    rgba.maybe(),
                     !&hidden,
                     !&hidden_prop,
                 )
@@ -175,6 +179,7 @@ impl Pass for DrawFlatSeparate {
                         &tex_storage,
                         Some(material),
                         &material_defaults,
+                        rgba,
                         camera,
                         Some(global),
                         &ATTRIBUTES,
@@ -183,11 +188,12 @@ impl Pass for DrawFlatSeparate {
                 }
             }
             Some(ref visibility) => {
-                for (joint, mesh, material, global, _) in (
+                for (joint, mesh, material, global, rgba, _) in (
                     joints.maybe(),
                     &mesh,
                     &material,
                     &global,
+                    rgba.maybe(),
                     &visibility.visible_unordered,
                 )
                     .join()
@@ -201,6 +207,7 @@ impl Pass for DrawFlatSeparate {
                         &tex_storage,
                         Some(material),
                         &material_defaults,
+                        rgba,
                         camera,
                         Some(global),
                         &ATTRIBUTES,
@@ -219,6 +226,7 @@ impl Pass for DrawFlatSeparate {
                             &tex_storage,
                             material.get(*entity),
                             &material_defaults,
+                            rgba.get(*entity),
                             camera,
                             global.get(*entity),
                             &ATTRIBUTES,

--- a/amethyst_renderer/src/pass/flat2d/interleaved.rs
+++ b/amethyst_renderer/src/pass/flat2d/interleaved.rs
@@ -26,6 +26,7 @@ use crate::{
     tex::{Texture, TextureHandle},
     types::{Encoder, Factory, Slice},
     vertex::{Attributes, Query, VertexFormat},
+    Color, Rgba,
 };
 
 use super::*;
@@ -59,7 +60,7 @@ where
     }
 
     fn attributes() -> Attributes<'static> {
-        <SpriteInstance as Query<(DirX, DirY, Pos, OffsetU, OffsetV, Depth)>>::QUERIED_ATTRIBUTES
+        <SpriteInstance as Query<(DirX, DirY, Pos, OffsetU, OffsetV, Depth, Color)>>::QUERIED_ATTRIBUTES
     }
 }
 
@@ -77,6 +78,7 @@ impl<'a> PassData<'a> for DrawFlat2D {
         ReadStorage<'a, TextureHandle>,
         ReadStorage<'a, Flipped>,
         ReadStorage<'a, MeshHandle>,
+        ReadStorage<'a, Rgba>,
     );
 }
 
@@ -119,16 +121,18 @@ impl Pass for DrawFlat2D {
             texture_handle,
             flipped,
             mesh,
+            rgba,
         ): <Self as PassData<'a>>::Data,
     ) {
         let camera = get_camera(active, &camera, &global);
 
         match visibility {
             None => {
-                for (sprite_render, global, flipped, _, _) in (
+                for (sprite_render, global, flipped, rgba, _, _) in (
                     &sprite_render,
                     &global,
                     flipped.maybe(),
+                    rgba.maybe(),
                     !&hidden,
                     !&hidden_prop,
                 )
@@ -138,15 +142,17 @@ impl Pass for DrawFlat2D {
                         sprite_render,
                         Some(global),
                         flipped,
+                        rgba,
                         &sprite_sheet_storage,
                         &tex_storage,
                     );
                 }
 
-                for (image_render, global, flipped, _, _, _) in (
+                for (image_render, global, flipped, rgba, _, _, _) in (
                     &texture_handle,
                     &global,
                     flipped.maybe(),
+                    rgba.maybe(),
                     !&hidden,
                     !&hidden_prop,
                     !&mesh,
@@ -154,16 +160,17 @@ impl Pass for DrawFlat2D {
                     .join()
                 {
                     self.batch
-                        .add_image(image_render, Some(global), flipped, &tex_storage);
+                        .add_image(image_render, Some(global), flipped, rgba, &tex_storage);
                 }
 
                 self.batch.sort();
             }
             Some(ref visibility) => {
-                for (sprite_render, global, flipped, _) in (
+                for (sprite_render, global, flipped, rgba, _) in (
                     &sprite_render,
                     &global,
                     flipped.maybe(),
+                    rgba.maybe(),
                     &visibility.visible_unordered,
                 )
                     .join()
@@ -172,22 +179,24 @@ impl Pass for DrawFlat2D {
                         sprite_render,
                         Some(global),
                         flipped,
+                        rgba,
                         &sprite_sheet_storage,
                         &tex_storage,
                     );
                 }
 
-                for (image_render, global, flipped, _, _) in (
+                for (image_render, global, flipped, rgba, _, _) in (
                     &texture_handle,
                     &global,
                     flipped.maybe(),
+                    rgba.maybe(),
                     &visibility.visible_unordered,
                     !&mesh,
                 )
                     .join()
                 {
                     self.batch
-                        .add_image(image_render, Some(global), flipped, &tex_storage);
+                        .add_image(image_render, Some(global), flipped, rgba, &tex_storage);
                 }
 
                 // We are free to optimize the order of the opaque sprites.
@@ -199,6 +208,7 @@ impl Pass for DrawFlat2D {
                             sprite_render,
                             global.get(*entity),
                             flipped.get(*entity),
+                            rgba.get(*entity),
                             &sprite_sheet_storage,
                             &tex_storage,
                         );
@@ -207,6 +217,7 @@ impl Pass for DrawFlat2D {
                             texture_handle,
                             global.get(*entity),
                             flipped.get(*entity),
+                            rgba.get(*entity),
                             &tex_storage,
                         )
                     }
@@ -231,12 +242,14 @@ enum TextureDrawData {
         texture_handle: Handle<Texture>,
         render: SpriteRender,
         flipped: Option<Flipped>,
+        rgba: Option<Rgba>,
         transform: GlobalTransform,
     },
     Image {
         texture_handle: Handle<Texture>,
         transform: GlobalTransform,
         flipped: Option<Flipped>,
+        rgba: Option<Rgba>,
         width: usize,
         height: usize,
     },
@@ -276,6 +289,7 @@ impl TextureBatch {
         texture_handle: &TextureHandle,
         global: Option<&GlobalTransform>,
         flipped: Option<&Flipped>,
+        rgba: Option<&Rgba>,
         tex_storage: &AssetStorage<Texture>,
     ) {
         let global = match global {
@@ -294,7 +308,8 @@ impl TextureBatch {
         self.textures.push(TextureDrawData::Image {
             texture_handle: texture_handle.clone(),
             transform: *global,
-            flipped: flipped.map(|it| it.clone()),
+            flipped: flipped.cloned(),
+            rgba: rgba.cloned(),
             width: texture_dims.0,
             height: texture_dims.1,
         });
@@ -305,6 +320,7 @@ impl TextureBatch {
         sprite_render: &SpriteRender,
         global: Option<&GlobalTransform>,
         flipped: Option<&Flipped>,
+        rgba: Option<&Rgba>,
         sprite_sheet_storage: &AssetStorage<SpriteSheet>,
         tex_storage: &AssetStorage<Texture>,
     ) {
@@ -337,7 +353,8 @@ impl TextureBatch {
         self.textures.push(TextureDrawData::Sprite {
             texture_handle,
             render: sprite_render.clone(),
-            flipped: flipped.map(|it| it.clone()),
+            flipped: flipped.cloned(),
+            rgba: rgba.cloned(),
             transform: *global,
         });
     }
@@ -392,9 +409,12 @@ impl TextureBatch {
                 _ => (false, false),
             };
 
-            let (dir_x, dir_y, pos, uv_left, uv_right, uv_top, uv_bottom) = match quad {
+            let (dir_x, dir_y, pos, uv_left, uv_right, uv_top, uv_bottom, rgba) = match quad {
                 TextureDrawData::Sprite {
-                    render, transform, ..
+                    render,
+                    transform,
+                    rgba,
+                    ..
                 } => {
                     let sprite_sheet = sprite_sheet_storage
                         .get(&render.sprite_sheet)
@@ -430,12 +450,15 @@ impl TextureBatch {
                     let pos = transform
                         * Vector4::new(-sprite_data.offsets[0], -sprite_data.offsets[1], 0.0, 1.0);
 
-                    (dir_x, dir_y, pos, uv_left, uv_right, uv_top, uv_bottom)
+                    (
+                        dir_x, dir_y, pos, uv_left, uv_right, uv_top, uv_bottom, rgba,
+                    )
                 }
                 TextureDrawData::Image {
                     transform,
                     width,
                     height,
+                    rgba,
                     ..
                 } => {
                     let (uv_left, uv_right) = if flip_horizontal {
@@ -456,13 +479,15 @@ impl TextureBatch {
 
                     let pos = transform * Vector4::new(1.0, 1.0, 0.0, 1.0);
 
-                    (dir_x, dir_y, pos, uv_left, uv_right, uv_top, uv_bottom)
+                    (
+                        dir_x, dir_y, pos, uv_left, uv_right, uv_top, uv_bottom, rgba,
+                    )
                 }
             };
-
+            let rgba = rgba.unwrap_or(Rgba::WHITE);
             instance_data.extend(&[
                 dir_x.x, dir_x.y, dir_y.x, dir_y.y, pos.x, pos.y, uv_left, uv_right, uv_bottom,
-                uv_top, pos.z,
+                uv_top, pos.z, rgba.0, rgba.1, rgba.2, rgba.3,
             ]);
             num_instances += 1;
 

--- a/amethyst_renderer/src/pass/flat2d/mod.rs
+++ b/amethyst_renderer/src/pass/flat2d/mod.rs
@@ -11,6 +11,7 @@ use gfx::{
 use crate::{
     pass::util::TextureType,
     vertex::{Attribute, AttributeFormat, Attributes, VertexFormat, With},
+    Color,
 };
 
 static VERT_SRC: &[u8] = include_bytes!("../shaders/vertex/sprite.glsl");
@@ -81,6 +82,7 @@ struct SpriteInstance {
     pub u_offset: [f32; 2],
     pub v_offset: [f32; 2],
     pub depth: f32,
+    pub color: [f32; 4],
 }
 
 unsafe impl Pod for SpriteInstance {}
@@ -93,6 +95,7 @@ impl VertexFormat for SpriteInstance {
         (OffsetU::NAME, <Self as With<OffsetU>>::FORMAT),
         (OffsetV::NAME, <Self as With<OffsetV>>::FORMAT),
         (Depth::NAME, <Self as With<Depth>>::FORMAT),
+        (Color::NAME, <Self as With<Color>>::FORMAT),
     ];
 }
 
@@ -135,5 +138,12 @@ impl With<Depth> for SpriteInstance {
     const FORMAT: AttributeFormat = Element {
         offset: DirX::SIZE + DirY::SIZE + Pos::SIZE + OffsetU::SIZE + OffsetV::SIZE,
         format: Depth::FORMAT,
+    };
+}
+
+impl With<Color> for SpriteInstance {
+    const FORMAT: AttributeFormat = Element {
+        offset: DirX::SIZE + DirY::SIZE + Pos::SIZE + OffsetU::SIZE + OffsetV::SIZE + Depth::SIZE,
+        format: Color::FORMAT,
     };
 }

--- a/amethyst_renderer/src/pass/pbm/interleaved.rs
+++ b/amethyst_renderer/src/pass/pbm/interleaved.rs
@@ -31,6 +31,7 @@ use crate::{
     types::{Encoder, Factory},
     vertex::{Normal, Position, Query, Tangent, TexCoord},
     visibility::Visibility,
+    Rgba,
 };
 
 use super::*;
@@ -89,6 +90,7 @@ where
         ReadStorage<'a, Material>,
         ReadStorage<'a, GlobalTransform>,
         ReadStorage<'a, Light>,
+        ReadStorage<'a, Rgba>,
     );
 }
 
@@ -128,6 +130,7 @@ where
             material,
             global,
             light,
+            rgba,
         ): <Self as PassData<'a>>::Data,
     ) {
         let camera = get_camera(active, &camera, &global);
@@ -136,8 +139,15 @@ where
 
         match visibility {
             None => {
-                for (mesh, material, global, _, _) in
-                    (&mesh, &material, &global, !&hidden, !&hidden_prop).join()
+                for (mesh, material, global, rgba, _, _) in (
+                    &mesh,
+                    &material,
+                    &global,
+                    rgba.maybe(),
+                    !&hidden,
+                    !&hidden_prop,
+                )
+                    .join()
                 {
                     draw_mesh(
                         encoder,
@@ -148,6 +158,7 @@ where
                         &tex_storage,
                         Some(material),
                         &material_defaults,
+                        rgba,
                         camera,
                         Some(global),
                         &[V::QUERIED_ATTRIBUTES],
@@ -156,8 +167,14 @@ where
                 }
             }
             Some(ref visibility) => {
-                for (mesh, material, global, _) in
-                    (&mesh, &material, &global, &visibility.visible_unordered).join()
+                for (mesh, material, global, rgba, _) in (
+                    &mesh,
+                    &material,
+                    &global,
+                    rgba.maybe(),
+                    &visibility.visible_unordered,
+                )
+                    .join()
                 {
                     draw_mesh(
                         encoder,
@@ -168,6 +185,7 @@ where
                         &tex_storage,
                         Some(material),
                         &material_defaults,
+                        rgba,
                         camera,
                         Some(global),
                         &[V::QUERIED_ATTRIBUTES],
@@ -186,6 +204,7 @@ where
                             &tex_storage,
                             material.get(*entity),
                             &material_defaults,
+                            rgba.get(*entity),
                             camera,
                             global.get(*entity),
                             &[V::QUERIED_ATTRIBUTES],

--- a/amethyst_renderer/src/pass/pbm/separate.rs
+++ b/amethyst_renderer/src/pass/pbm/separate.rs
@@ -31,6 +31,7 @@ use crate::{
     types::{Encoder, Factory},
     vertex::{Attributes, Normal, Position, Separate, Tangent, TexCoord, VertexFormat},
     visibility::Visibility,
+    Rgba,
 };
 
 use super::*;
@@ -92,6 +93,7 @@ impl<'a> PassData<'a> for DrawPbmSeparate {
         ReadStorage<'a, GlobalTransform>,
         ReadStorage<'a, Light>,
         ReadStorage<'a, JointTransforms>,
+        ReadStorage<'a, Rgba>,
     );
 }
 
@@ -156,6 +158,7 @@ impl Pass for DrawPbmSeparate {
             global,
             light,
             joints,
+            rgba,
         ): <Self as PassData<'a>>::Data,
     ) {
         let camera = get_camera(active, &camera, &global);
@@ -164,11 +167,12 @@ impl Pass for DrawPbmSeparate {
 
         match visibility {
             None => {
-                for (joint, mesh, material, global, _, _) in (
+                for (joint, mesh, material, global, rgba, _, _) in (
                     joints.maybe(),
                     &mesh,
                     &material,
                     &global,
+                    rgba.maybe(),
                     !&hidden,
                     !&hidden_prop,
                 )
@@ -183,6 +187,7 @@ impl Pass for DrawPbmSeparate {
                         &tex_storage,
                         Some(material),
                         &material_defaults,
+                        rgba,
                         camera,
                         Some(global),
                         &ATTRIBUTES,
@@ -191,11 +196,12 @@ impl Pass for DrawPbmSeparate {
                 }
             }
             Some(ref visibility) => {
-                for (joint, mesh, material, global, _) in (
+                for (joint, mesh, material, global, rgba, _) in (
                     joints.maybe(),
                     &mesh,
                     &material,
                     &global,
+                    rgba.maybe(),
                     &visibility.visible_unordered,
                 )
                     .join()
@@ -209,6 +215,7 @@ impl Pass for DrawPbmSeparate {
                         &tex_storage,
                         Some(material),
                         &material_defaults,
+                        rgba,
                         camera,
                         Some(global),
                         &ATTRIBUTES,
@@ -227,6 +234,7 @@ impl Pass for DrawPbmSeparate {
                             &tex_storage,
                             material.get(*entity),
                             &material_defaults,
+                            rgba.get(*entity),
                             camera,
                             global.get(*entity),
                             &ATTRIBUTES,

--- a/amethyst_renderer/src/pass/shaded/interleaved.rs
+++ b/amethyst_renderer/src/pass/shaded/interleaved.rs
@@ -31,6 +31,7 @@ use crate::{
     types::{Encoder, Factory},
     vertex::{Normal, Position, Query, TexCoord},
     visibility::Visibility,
+    Rgba,
 };
 
 use super::*;
@@ -89,6 +90,7 @@ where
         ReadStorage<'a, Material>,
         ReadStorage<'a, GlobalTransform>,
         ReadStorage<'a, Light>,
+        ReadStorage<'a, Rgba>,
     );
 }
 
@@ -128,6 +130,7 @@ where
             material,
             global,
             light,
+            rgba,
         ): <Self as PassData<'a>>::Data,
     ) {
         let camera = get_camera(active, &camera, &global);
@@ -136,8 +139,15 @@ where
 
         match visibility {
             None => {
-                for (mesh, material, global, _, _) in
-                    (&mesh, &material, &global, !&hidden, !&hidden_prop).join()
+                for (mesh, material, global, rgba, _, _) in (
+                    &mesh,
+                    &material,
+                    &global,
+                    rgba.maybe(),
+                    !&hidden,
+                    !&hidden_prop,
+                )
+                    .join()
                 {
                     draw_mesh(
                         encoder,
@@ -148,6 +158,7 @@ where
                         &tex_storage,
                         Some(material),
                         &material_defaults,
+                        rgba,
                         camera,
                         Some(global),
                         &[V::QUERIED_ATTRIBUTES],
@@ -156,8 +167,14 @@ where
                 }
             }
             Some(ref visibility) => {
-                for (mesh, material, global, _) in
-                    (&mesh, &material, &global, &visibility.visible_unordered).join()
+                for (mesh, material, global, rgba, _) in (
+                    &mesh,
+                    &material,
+                    &global,
+                    rgba.maybe(),
+                    &visibility.visible_unordered,
+                )
+                    .join()
                 {
                     draw_mesh(
                         encoder,
@@ -168,6 +185,7 @@ where
                         &tex_storage,
                         Some(material),
                         &material_defaults,
+                        rgba,
                         camera,
                         Some(global),
                         &[V::QUERIED_ATTRIBUTES],
@@ -186,6 +204,7 @@ where
                             &tex_storage,
                             material.get(*entity),
                             &material_defaults,
+                            rgba.get(*entity),
                             camera,
                             global.get(*entity),
                             &[V::QUERIED_ATTRIBUTES],

--- a/amethyst_renderer/src/pass/shaded/separate.rs
+++ b/amethyst_renderer/src/pass/shaded/separate.rs
@@ -31,6 +31,7 @@ use crate::{
     types::{Encoder, Factory},
     vertex::{Attributes, Normal, Position, Separate, TexCoord, VertexFormat},
     visibility::Visibility,
+    Rgba,
 };
 
 use super::*;
@@ -91,6 +92,7 @@ impl<'a> PassData<'a> for DrawShadedSeparate {
         ReadStorage<'a, GlobalTransform>,
         ReadStorage<'a, Light>,
         ReadStorage<'a, JointTransforms>,
+        ReadStorage<'a, Rgba>,
     );
 }
 
@@ -152,6 +154,7 @@ impl Pass for DrawShadedSeparate {
             global,
             light,
             joints,
+            rgba,
         ): <Self as PassData<'a>>::Data,
     ) {
         trace!("Drawing shaded pass");
@@ -161,11 +164,12 @@ impl Pass for DrawShadedSeparate {
 
         match visibility {
             None => {
-                for (joint, mesh, material, global, _, _) in (
+                for (joint, mesh, material, global, rgba, _, _) in (
                     joints.maybe(),
                     &mesh,
                     &material,
                     &global,
+                    rgba.maybe(),
                     !&hidden,
                     !&hidden_prop,
                 )
@@ -180,6 +184,7 @@ impl Pass for DrawShadedSeparate {
                         &tex_storage,
                         Some(material),
                         &material_defaults,
+                        rgba,
                         camera,
                         Some(global),
                         &ATTRIBUTES,
@@ -188,11 +193,12 @@ impl Pass for DrawShadedSeparate {
                 }
             }
             Some(ref visibility) => {
-                for (joint, mesh, material, global, _) in (
+                for (joint, mesh, material, global, rgba, _) in (
                     joints.maybe(),
                     &mesh,
                     &material,
                     &global,
+                    rgba.maybe(),
                     &visibility.visible_unordered,
                 )
                     .join()
@@ -206,6 +212,7 @@ impl Pass for DrawShadedSeparate {
                         &tex_storage,
                         Some(material),
                         &material_defaults,
+                        rgba,
                         camera,
                         Some(global),
                         &ATTRIBUTES,
@@ -224,6 +231,7 @@ impl Pass for DrawShadedSeparate {
                             &tex_storage,
                             material.get(*entity),
                             &material_defaults,
+                            rgba.get(*entity),
                             camera,
                             global.get(*entity),
                             &ATTRIBUTES,

--- a/amethyst_renderer/src/pass/shaders/fragment/flat.glsl
+++ b/amethyst_renderer/src/pass/shaders/fragment/flat.glsl
@@ -14,6 +14,7 @@ in VertexData {
     vec3 normal;
     vec3 tangent;
     vec2 tex_coord;
+    vec4 color;
 } vertex;
 
 out vec4 color;
@@ -27,5 +28,5 @@ vec2 tex_coords(vec2 coord, vec2 u, vec2 v) {
 }
 
 void main() {
-    color = texture(albedo, tex_coords(vertex.tex_coord, albedo_offset.u_offset, albedo_offset.v_offset));
+    color = texture(albedo, tex_coords(vertex.tex_coord, albedo_offset.u_offset, albedo_offset.v_offset)) * vertex.color;
 }

--- a/amethyst_renderer/src/pass/shaders/fragment/pbm.glsl
+++ b/amethyst_renderer/src/pass/shaders/fragment/pbm.glsl
@@ -95,6 +95,7 @@ in VertexData {
     vec3 normal;
     vec3 tangent;
     vec2 tex_coord;
+    vec4 color;
 } vertex;
 
 out vec4 out_color;
@@ -282,5 +283,5 @@ void main() {
     vec3 ambient = ambient_color * albedo * ambient_occlusion;
     vec3 color = ambient + lighted + emission;
 
-    out_color = vec4(color, alpha);
+    out_color = vec4(color, alpha) * vertex.color;
 }

--- a/amethyst_renderer/src/pass/shaders/fragment/shaded.glsl
+++ b/amethyst_renderer/src/pass/shaders/fragment/shaded.glsl
@@ -48,6 +48,7 @@ in VertexData {
     vec3 normal;
     vec3 tangent;
     vec2 tex_coord;
+    vec4 color;
 } vertex;
 
 out vec4 out_color;
@@ -83,5 +84,5 @@ void main() {
         lighting += diffuse;
     }
     lighting += ambient_color;
-    out_color = vec4(lighting, 1.0) * color + ecolor;
+    out_color = (vec4(lighting, 1.0) * color + ecolor) * vertex.color;
 }

--- a/amethyst_renderer/src/pass/shaders/fragment/sprite.glsl
+++ b/amethyst_renderer/src/pass/shaders/fragment/sprite.glsl
@@ -4,10 +4,13 @@
 
 uniform sampler2D albedo;
 
-in vec2 tex_uv;
+in VertexData {
+    vec2 tex_uv;
+    vec4 color;
+} vertex;
 
 out vec4 color;
 
 void main() {
-    color = texture(albedo, tex_uv);
+    color = texture(albedo, vertex.tex_uv) * vertex.color;
 }

--- a/amethyst_renderer/src/pass/shaders/vertex/basic.glsl
+++ b/amethyst_renderer/src/pass/shaders/vertex/basic.glsl
@@ -6,6 +6,7 @@ layout (std140) uniform VertexArgs {
     uniform mat4 proj;
     uniform mat4 view;
     uniform mat4 model;
+    uniform vec4 color;
 };
 
 in vec3 position;
@@ -18,6 +19,7 @@ out VertexData {
     vec3 normal;
     vec3 tangent;
     vec2 tex_coord;
+    vec4 color;
 } vertex;
 
 void main() {
@@ -26,5 +28,6 @@ void main() {
     vertex.normal = mat3(model) * normal;
     vertex.tangent = mat3(model) * tangent;
     vertex.tex_coord = tex_coord;
+    vertex.color = color;
     gl_Position = proj * view * vertex_position;
 }

--- a/amethyst_renderer/src/pass/shaders/vertex/skinned.glsl
+++ b/amethyst_renderer/src/pass/shaders/vertex/skinned.glsl
@@ -10,6 +10,7 @@ layout (std140) uniform VertexArgs {
     uniform mat4 proj;
     uniform mat4 view;
     uniform mat4 model;
+    uniform vec4 color;
 };
 
 in vec3 position;
@@ -24,6 +25,7 @@ out VertexData {
     vec3 normal;
     vec3 tangent;
     vec2 tex_coord;
+    vec4 color;
 } vertex;
 
 
@@ -40,5 +42,6 @@ void main() {
     vertex.normal = mat3_transform * normal;
     vertex.tangent = mat3_transform * tangent;
     vertex.tex_coord = tex_coord;
+    vertex.color = color;
     gl_Position = proj * view * vertex_position;
 }

--- a/amethyst_renderer/src/pass/shaders/vertex/skybox.glsl
+++ b/amethyst_renderer/src/pass/shaders/vertex/skybox.glsl
@@ -6,6 +6,7 @@ layout (std140) uniform VertexArgs {
     uniform mat4 proj;
     uniform mat4 view;
     uniform mat4 model;
+    uniform vec4 color; // Ignored
 };
 
 in vec3 position;

--- a/amethyst_renderer/src/pass/shaders/vertex/sprite.glsl
+++ b/amethyst_renderer/src/pass/shaders/vertex/sprite.glsl
@@ -15,7 +15,13 @@ in float depth;
 in vec2 u_offset;
 in vec2 v_offset;
 
-out vec2 tex_uv;
+in vec4 color;
+
+
+out VertexData {
+    vec2 tex_uv;
+    vec4 color;
+} vertex;
 
 const vec2 positions[6] = vec2[](
     // First triangle
@@ -39,8 +45,8 @@ void main() {
     float tex_v = positions[gl_VertexID][1];
 
     vec2 uv = pos + tex_u * dir_x + tex_v * dir_y;
-    tex_uv = texture_coords(vec2(tex_u, tex_v), u_offset, v_offset);
-
+    vertex.tex_uv = texture_coords(vec2(tex_u, tex_v), u_offset, v_offset);
+    vertex.color = color;
     vec4 vertex = vec4(uv, depth, 1.0);
     gl_Position = proj * view * vertex;
 }

--- a/amethyst_renderer/src/pass/skybox/interleaved.rs
+++ b/amethyst_renderer/src/pass/skybox/interleaved.rs
@@ -13,7 +13,8 @@ use crate::{
         pass::{Pass, PassData},
         DepthMode, Effect, NewEffect,
     },
-    set_vertex_args, ActiveCamera, Camera, Encoder, Factory, Mesh, PosTex, Shape, VertexFormat,
+    set_vertex_args, ActiveCamera, Camera, Encoder, Factory, Mesh, PosTex, Rgba, Shape,
+    VertexFormat,
 };
 
 use gfx::pso::buffer::ElemStride;
@@ -86,7 +87,13 @@ impl Pass for DrawSkybox {
             .as_ref()
             .expect("Pass doesn't seem to be compiled.");
 
-        set_vertex_args(effect, encoder, camera, &GlobalTransform(na::one()));
+        set_vertex_args(
+            effect,
+            encoder,
+            camera,
+            &GlobalTransform(na::one()),
+            Rgba::WHITE,
+        );
 
         if let Some(vbuf) = mesh.buffer(PosTex::ATTRIBUTES) {
             effect.data.vertex_bufs.push(vbuf.clone());

--- a/amethyst_renderer/src/pass/util.rs
+++ b/amethyst_renderer/src/pass/util.rs
@@ -19,6 +19,7 @@ use crate::{
     tex::Texture,
     types::Encoder,
     vertex::Attributes,
+    Rgba,
 };
 
 pub(crate) enum TextureType {
@@ -44,6 +45,7 @@ pub(crate) struct VertexArgs {
     proj: mat4,
     view: mat4,
     model: mat4,
+    rgba: vec4,
 }
 
 #[repr(C, align(16))]
@@ -246,6 +248,7 @@ pub fn set_vertex_args(
     encoder: &mut Encoder,
     camera: Option<(&Camera, &GlobalTransform)>,
     global: &GlobalTransform,
+    rgba: Rgba,
 ) {
     let vertex_args = camera
         .as_ref()
@@ -261,6 +264,7 @@ pub fn set_vertex_args(
                 proj: proj.into(),
                 view: view.into(),
                 model: model.into(),
+                rgba: rgba.into(),
             }
         })
         .unwrap_or_else(|| {
@@ -271,6 +275,7 @@ pub fn set_vertex_args(
                 proj: proj.into(),
                 view: view.into(),
                 model: model.into(),
+                rgba: rgba.into(),
             }
         });
     effect.update_constant_buffer("VertexArgs", &vertex_args.std140(), encoder);
@@ -314,6 +319,7 @@ pub(crate) fn draw_mesh(
     tex_storage: &AssetStorage<Texture>,
     material: Option<&Material>,
     material_defaults: &MaterialDefaults,
+    rgba: Option<&Rgba>,
     camera: Option<(&Camera, &GlobalTransform)>,
     global: Option<&GlobalTransform>,
     attributes: &[Attributes<'static>],
@@ -333,7 +339,13 @@ pub(crate) fn draw_mesh(
         return;
     }
 
-    set_vertex_args(effect, encoder, camera, global);
+    set_vertex_args(
+        effect,
+        encoder,
+        camera,
+        global,
+        rgba.cloned().unwrap_or(Rgba::WHITE),
+    );
 
     if skinning {
         if let Some(joint) = joint {

--- a/amethyst_ui/src/shaders/frag.glsl
+++ b/amethyst_ui/src/shaders/frag.glsl
@@ -7,10 +7,11 @@ uniform sampler2D albedo;
 in VertexData {
   vec4 position;
   vec2 tex_coord;
+  vec4 color;
 } vertex;
 
 out vec4 color;
 
 void main() {
-    color = texture(albedo, vertex.tex_coord);
+    color = texture(albedo, vertex.tex_coord) * vertex.color;
 }

--- a/amethyst_ui/src/shaders/vertex.glsl
+++ b/amethyst_ui/src/shaders/vertex.glsl
@@ -7,6 +7,7 @@ layout (std140) uniform VertexArgs {
     uniform vec2 invert_window_size;
     uniform vec2 coord;
     uniform vec2 dimension;
+    uniform vec4 color;
 };
 
 // Square [-1.0,1.0]
@@ -16,6 +17,7 @@ in vec2 tex_coord;
 out VertexData {
   vec4 position;
   vec2 tex_coord;
+  vec4 color;
 } vertex;
 
 void main() {
@@ -37,5 +39,6 @@ void main() {
     vertex.position += vec4(-1, -1, 0, 0);
 
     vertex.tex_coord = tex_coord;
+    vertex.color = color;
     gl_Position = vertex.position;
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * Derive `Copy`, `PartialEq`, `Eq`, `Serialize`, `Deserialize` for `Flipped` component. ([#1237])
 * A way to change the default `Source` using `set_default_source` and `with_default_source`. ([#1256])
 * "How To" guides for using assets and defining custom assets. ([#1251])
+* `amethyst_renderer::Rgba` is now a `Component` that changes the color and transparency of the entity
+it is attached to. ([#1282])
 
 ### Changed
 
@@ -30,6 +32,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1251]: https://github.com/amethyst/amethyst/pull/1251
 [#1256]: https://github.com/amethyst/amethyst/pull/1256
 [#1267]: https://github.com/amethyst/amethyst/pull/1267
+[#1282]: https://github.com/amethyst/amethyst/pull/1282
 
 ## [0.10.0] - 2018-12
 
@@ -735,4 +738,3 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [0.4.1]: https://github.com/amethyst/amethyst/compare/v0.4...v0.4.1
 [0.4.0]: https://github.com/amethyst/amethyst/compare/v0.3.1...v0.4
 [0.3.1]: https://github.com/amethyst/amethyst/compare/v0.3...v0.3.1
-


### PR DESCRIPTION
I wanted to programatically control a sprite's alpha value and I realized there wasn't an easy way to do that.  I figured while I was at it, why not also allow all four RGBA channels to be controlled like this?