### PR TITLE
Use Option::get_or_insert_with in UI example

### DIFF
--- a/examples/ui/main.rs
+++ b/examples/ui/main.rs
@@ -123,12 +123,10 @@ impl<'a> System<'a> for UiEventHandlerSystem {
     type SystemData = Write<'a, EventChannel<UiEvent>>;
 
     fn run(&mut self, mut events: Self::SystemData) {
-        if self.reader_id.is_none() {
-            self.reader_id = Some(events.register_reader());
-        }
+        let reader_id = self.reader_id.get_or_insert_with(|| events.register_reader());
 
         // Reader id was just initialized above if empty
-        for ev in events.read(self.reader_id.as_mut().unwrap()) {
+        for ev in events.read(reader_id) {
             info!("[SYSTEM] You just interacted with a ui element: {:?}", ev);
         }
     }

--- a/examples/ui/main.rs
+++ b/examples/ui/main.rs
@@ -123,7 +123,9 @@ impl<'a> System<'a> for UiEventHandlerSystem {
     type SystemData = Write<'a, EventChannel<UiEvent>>;
 
     fn run(&mut self, mut events: Self::SystemData) {
-        let reader_id = self.reader_id.get_or_insert_with(|| events.register_reader());
+        let reader_id = self
+            .reader_id
+            .get_or_insert_with(|| events.register_reader());
 
         // Reader id was just initialized above if empty
         for ev in events.read(reader_id) {


### PR DESCRIPTION
[Option::get_or_insert_with](https://doc.rust-lang.org/std/option/enum.Option.html#method.get_or_insert_with)

There's no need to `.unwrap()` or manually wrap the `Some()` when there's a method specifically for this pattern of using `Option`. This also makes it easier to see the Amethyst specific stuff.

(Since I'm submitting this by editing from github's tools, I haven't done Cargo build/fmt, although I have something similar in my own local code that I have built)