### PR TITLE
Parallel Packet Processing

### DIFF
--- a/amethyst_network/src/bundle.rs
+++ b/amethyst_network/src/bundle.rs
@@ -7,21 +7,36 @@ use amethyst_core::{
     shred::DispatcherBuilder,
 };
 
-use crate::{filter::NetFilter, NetSocketSystem};
+use crate::{filter::NetFilter, server::ServerConfig};
+
+use super::NetSocketSystem;
 
 /// A convenience bundle to create the infrastructure needed to send and receive network messages.
 pub struct NetworkBundle<T> {
-    /// Local socket address
-    addr: SocketAddr,
+    /// the configuration used for the networking crate.
+    config: ServerConfig,
 
     /// The filters applied on received network events.
     filters: Vec<Box<dyn NetFilter<T>>>,
 }
 
 impl<T> NetworkBundle<T> {
-    /// Creates a new NetworkBundle that connects to the `addr`.
-    pub fn new(addr: SocketAddr, filters: Vec<Box<dyn NetFilter<T>>>) -> Self {
-        NetworkBundle { addr, filters }
+    /// Creates a new NetworkBundle.
+    ///
+    /// `receive_addr`: this is the address on which we will receive incoming packets.
+    /// `send_addr`: this is the address from which we will send outgoing packets.
+    pub fn new(
+        receive_addr: SocketAddr,
+        send_addr: SocketAddr,
+        filters: Vec<Box<dyn NetFilter<T>>>,
+    ) -> Self {
+        let config = ServerConfig {
+            udp_recv_addr: receive_addr,
+            udp_send_addr: send_addr,
+            max_throughput: 5000,
+        };
+
+        NetworkBundle { config, filters }
     }
 }
 
@@ -29,8 +44,9 @@ impl<'a, 'b, T> SystemBundle<'a, 'b> for NetworkBundle<T>
 where
     T: Send + Sync + PartialEq + Serialize + Clone + DeserializeOwned + 'static,
 {
+    /// Build the networking bundle by adding the networking system to the application.
     fn build(self, builder: &mut DispatcherBuilder<'_, '_>) -> Result<()> {
-        let socket_system = NetSocketSystem::<T>::new(self.addr, self.filters)
+        let socket_system = NetSocketSystem::<T>::new(self.config, self.filters)
             .chain_err(|| "Failed to open network system.")?;
 
         builder.add(socket_system, "net_socket", &[]);

--- a/amethyst_network/src/connection.rs
+++ b/amethyst_network/src/connection.rs
@@ -14,8 +14,10 @@ use crate::NetEvent;
 #[derive(Serialize)]
 #[serde(bound = "")]
 pub struct NetConnection<E: 'static> {
-    /// The remote socket address of this connection.
-    pub target: SocketAddr,
+    /// The target remote socket address who is listening for incoming packets.
+    pub target_receiver: SocketAddr,
+    /// The target remote socket address who is sending packets to us.
+    pub target_sender: SocketAddr,
     /// The state of the connection.
     pub state: ConnectionState,
     /// The buffer of events to be sent.
@@ -31,12 +33,13 @@ pub struct NetConnection<E: 'static> {
 
 impl<E: Send + Sync + 'static> NetConnection<E> {
     /// Construct a new NetConnection. `SocketAddr` is the address that will be connected to.
-    pub fn new(target: SocketAddr) -> Self {
+    pub fn new(target_receiver: SocketAddr, target_sender: SocketAddr) -> Self {
         let mut send_buffer = EventChannel::new();
         let send_reader = send_buffer.register_reader();
 
         NetConnection {
-            target,
+            target_receiver,
+            target_sender,
             state: ConnectionState::Connecting,
             send_buffer,
             receive_buffer: EventChannel::<NetEvent<E>>::new(),
@@ -58,7 +61,10 @@ impl<E: Send + Sync + 'static> NetConnection<E> {
 
 impl<E> PartialEq for NetConnection<E> {
     fn eq(&self, other: &Self) -> bool {
-        self.target == other.target && self.state == other.state
+        self.target_receiver == other.target_receiver
+            && self.state == other.state
+            && self.target_sender == other.target_sender
+            && self.state == other.state
     }
 }
 

--- a/amethyst_network/src/error.rs
+++ b/amethyst_network/src/error.rs
@@ -1,0 +1,74 @@
+//! Module containing error handling logic.
+
+use std::{
+    fmt::{self, Display, Formatter},
+    io,
+    sync::mpsc,
+};
+
+use crate::server::ServerSocketEvent;
+
+/// The `amethyst_network` result type.
+pub type Result<T> = std::result::Result<T, ErrorKind>;
+
+/// Wrapper for all errors who could occur in `amethyst_network`.
+#[derive(Debug)]
+pub enum ErrorKind {
+    /// Error that could occur on the UDP-socket
+    UdpError(laminar::error::NetworkError),
+    /// Error that could occur whit IO.
+    IoError(io::Error),
+    /// Error that could occur when serializing whit `bincode`
+    SerializeError(bincode::ErrorKind),
+    /// Error that could occur when sending an `ServerSocketEvent` to some channel.
+    ChannelSendError(mpsc::SendError<ServerSocketEvent>),
+    #[doc(hidden)]
+    __Nonexhaustive,
+}
+
+impl std::error::Error for ErrorKind {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match *self {
+            ErrorKind::IoError(ref e) => Some(e),
+            ErrorKind::ChannelSendError(ref e) => Some(e),
+            ErrorKind::SerializeError(ref e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl Display for ErrorKind {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+        match *self {
+            ErrorKind::UdpError(_) => write!(fmt, "UDP-error occurred"),
+            ErrorKind::IoError(_) => write!(fmt, "IO-error occurred"),
+            ErrorKind::ChannelSendError(_) => write!(fmt, "Channel send error occurred"),
+            ErrorKind::SerializeError(_) => write!(fmt, "Channel send error occurred"),
+            _ => write!(fmt, "Some error has occurred"),
+        }
+    }
+}
+
+impl From<io::Error> for ErrorKind {
+    fn from(e: io::Error) -> ErrorKind {
+        ErrorKind::IoError(e)
+    }
+}
+
+impl From<mpsc::SendError<ServerSocketEvent>> for ErrorKind {
+    fn from(e: mpsc::SendError<ServerSocketEvent>) -> ErrorKind {
+        ErrorKind::ChannelSendError(e)
+    }
+}
+
+impl From<laminar::error::NetworkError> for ErrorKind {
+    fn from(e: laminar::error::NetworkError) -> ErrorKind {
+        ErrorKind::UdpError(e)
+    }
+}
+
+impl From<Box<bincode::ErrorKind>> for ErrorKind {
+    fn from(e: Box<bincode::ErrorKind>) -> ErrorKind {
+        ErrorKind::SerializeError(*e)
+    }
+}

--- a/amethyst_network/src/lib.rs
+++ b/amethyst_network/src/lib.rs
@@ -6,37 +6,45 @@ extern crate serde;
 
 mod bundle;
 mod connection;
+mod error;
 mod filter;
 mod net_event;
 mod network_socket;
+mod server;
 mod test;
 
 pub use crate::{
     bundle::NetworkBundle,
     connection::{ConnectionState, NetConnection, NetIdentity},
+    error::Result,
     filter::{FilterConnected, NetFilter},
     net_event::NetEvent,
     network_socket::NetSocketSystem,
+    server::{Host, ServerConfig, ServerSocketEvent},
 };
 
-use bincode::{deserialize, serialize, ErrorKind};
-use laminar::{net::UdpSocket, Packet};
+use bincode::{deserialize, serialize};
+use laminar::Packet;
 use log::error;
 use serde::{de::DeserializeOwned, Serialize};
 use std::net::SocketAddr;
+use std::sync::mpsc::SyncSender;
 
 /// Sends an event to the target NetConnection using the provided network Socket.
 /// The socket has to be bound.
-pub fn send_event<T>(event: &NetEvent<T>, addr: &SocketAddr, socket: &mut UdpSocket)
+pub fn send_event<T>(event: NetEvent<T>, addr: SocketAddr, sender: &SyncSender<ServerSocketEvent>)
 where
     T: Serialize,
 {
-    let ser = serialize(event);
+    let ser = serialize(&event);
     match ser {
         Ok(s) => {
             let slice = s.as_slice();
             // send an unreliable `Packet` from laminar which is basically just a bare UDP packet.
-            match socket.send(&Packet::unreliable(*addr, slice.to_vec())) {
+            match sender.send(ServerSocketEvent::Packet(Packet::unreliable(
+                addr,
+                slice.to_owned(),
+            ))) {
                 Ok(_qty) => {}
                 Err(e) => error!("Failed to send data to network socket: {}", e),
             }
@@ -45,10 +53,10 @@ where
     }
 }
 
-/// Attempts to deserialize an event from the raw byte data.
-fn deserialize_event<T>(data: &[u8]) -> Result<NetEvent<T>, Box<ErrorKind>>
+// Attempts to deserialize an event from the raw byte data.
+fn deserialize_event<T>(data: &[u8]) -> Result<NetEvent<T>>
 where
     T: DeserializeOwned,
 {
-    deserialize::<NetEvent<T>>(data)
+    Ok(deserialize::<NetEvent<T>>(data)?)
 }

--- a/amethyst_network/src/net_event.rs
+++ b/amethyst_network/src/net_event.rs
@@ -46,7 +46,7 @@ impl<T> NetEvent<T> {
     /// Tries to convert a NetEvent to a custom event type.
     pub fn custom(&self) -> Option<&T> {
         if let NetEvent::Custom(ref t) = self {
-            Some(t)
+            Some(&t)
         } else {
             None
         }

--- a/amethyst_network/src/network_socket.rs
+++ b/amethyst_network/src/network_socket.rs
@@ -2,18 +2,27 @@
 
 use std::{
     clone::Clone,
-    io::{Error, ErrorKind},
     net::SocketAddr,
-    sync::mpsc::{channel, Receiver, Sender},
+    sync::{
+        mpsc::{self, Receiver, Sender},
+        Arc, Mutex,
+    },
     thread,
 };
 
 use amethyst_core::specs::{Join, Resources, System, SystemData, WriteStorage};
-use laminar::{error, net::UdpSocket, DeliveryMethod, NetworkConfig, Packet};
+
+use laminar::Packet;
 use log::{error, warn};
 use serde::{de::DeserializeOwned, Serialize};
 
-use crate::{deserialize_event, send_event, ConnectionState, NetConnection, NetEvent, NetFilter};
+use super::{
+    deserialize_event,
+    error::Result,
+    send_event,
+    server::{Host, ReceiveHandler, SendHandler, ServerConfig, ServerSocketEvent},
+    ConnectionState, NetConnection, NetEvent, NetFilter,
+};
 
 enum InternalSocketEvent<E> {
     SendEvents {
@@ -21,34 +30,6 @@ enum InternalSocketEvent<E> {
         events: Vec<NetEvent<E>>,
     },
     Stop,
-}
-
-struct RawEvent {
-    pub byte_count: usize,
-    pub data: Vec<u8>,
-    pub source: SocketAddr,
-    pub delivery_method: DeliveryMethod,
-}
-
-impl From<Packet> for RawEvent {
-    fn from(packet: Packet) -> Self {
-        RawEvent {
-            byte_count: packet.payload().len(),
-            data: packet.payload().to_vec(),
-            source: packet.addr(),
-            delivery_method: packet.delivery_method(),
-        }
-    }
-}
-
-impl From<RawEvent> for Packet {
-    fn from(raw_event: RawEvent) -> Self {
-        Packet::new(
-            raw_event.source,
-            raw_event.data.into_boxed_slice(),
-            raw_event.delivery_method,
-        )
-    }
 }
 
 // If a client sends both a connect event and other events,
@@ -69,9 +50,11 @@ where
 {
     /// The list of filters applied on the events received.
     pub filters: Vec<Box<dyn NetFilter<E>>>,
-
-    tx: Sender<InternalSocketEvent<E>>,
-    rx: Receiver<RawEvent>,
+    // sender on which you can queue packets to send to some endpoint.
+    transport_sender: Sender<InternalSocketEvent<E>>,
+    // receiver from which you can read received packets.
+    transport_receiver: Receiver<Packet>,
+    config: ServerConfig,
 }
 
 impl<E> NetSocketSystem<E>
@@ -79,79 +62,83 @@ where
     E: Serialize + PartialEq + Send + 'static,
 {
     /// Creates a `NetSocketSystem` and binds the Socket on the ip and port added in parameters.
-    pub fn new(addr: SocketAddr, filters: Vec<Box<dyn NetFilter<E>>>) -> Result<Self, Error> {
-        if addr.port() < 1024 {
+    pub fn new(config: ServerConfig, filters: Vec<Box<dyn NetFilter<E>>>) -> Result<Self> {
+        if config.udp_recv_addr.port() < 1024 {
             // Just warning the user here, just in case they want to use the root port.
             warn!("Using a port below 1024, this will require root permission and should not be done.");
         }
 
-        let mut socket = UdpSocket::bind(addr, NetworkConfig::default())
-            .map_err(|x| Error::new(ErrorKind::Other, x.to_string()))?;
+        let server = Host::run(&config)?;
 
-        socket.set_nonblocking(true).map_err(|_| {
-            Error::new(
-                ErrorKind::Other,
-                "Unable to set `UdpSocket` to non-blocking mode",
-            )
-        })?;
+        let udp_send_handle = server.udp_send_handle();
+        let udp_receive_handle = server.udp_receive_handle();
 
-        // this -> thread
-        let (tx1, rx1) = channel();
-        // thread -> this
-        let (tx2, rx2) = channel();
+        let server_sender = NetSocketSystem::<E>::start_sending(udp_send_handle);
+        let server_receiver = NetSocketSystem::<E>::start_receiving(udp_receive_handle);
 
-        thread::spawn(move || {
-            //rx1,tx2
-            let send_queue = rx1;
-            let receive_queue = tx2;
-            let mut socket = socket;
+        Ok(NetSocketSystem {
+            filters,
+            transport_sender: server_sender,
+            transport_receiver: server_receiver,
+            config,
+        })
+    }
 
-            'outer: loop {
-                // send
-                for control_event in send_queue.try_iter() {
-                    match control_event {
-                        InternalSocketEvent::SendEvents { target, events } => {
-                            for ev in events {
-                                send_event(&ev, &target, &mut socket);
-                            }
+    /// Start a thread to send all queued packets.
+    fn start_sending(sender: Arc<SendHandler>) -> Sender<InternalSocketEvent<E>> {
+        let (tx, send_queue) = mpsc::channel();
+
+        thread::spawn(move || loop {
+            for control_event in send_queue.try_iter() {
+                match control_event {
+                    InternalSocketEvent::SendEvents { target, events } => {
+                        for ev in events {
+                            send_event(ev, target, &sender.get_sender());
                         }
-                        InternalSocketEvent::Stop => break 'outer,
                     }
-                }
-
-                // receive
-                loop {
-                    match socket.recv() {
-                        // Data received
-                        Ok(Some(packet)) => {
-                            if let Err(_) = receive_queue.send(RawEvent::from(packet)) {
-                                error!("`NetworkSocketSystem` was dropped");
-                                break 'outer;
-                            }
-                        }
-                        Err(e) => match e.kind() {
-                            error::NetworkErrorKind::IOError(io_error) => {
-                                if io_error.kind() == ErrorKind::WouldBlock {
-                                    break;
-                                } else {
-                                    error!("Could not receive datagram: {}", e);
-                                }
-                            }
-                            _ => {
-                                error!("Could not receive datagram: {:?}", e);
-                            }
-                        },
-                        Ok(None) => {}
+                    InternalSocketEvent::Stop => {
+                        break;
                     }
                 }
             }
         });
 
-        Ok(NetSocketSystem {
-            filters,
-            tx: tx1,
-            rx: rx2,
-        })
+        tx
+    }
+
+    /// Starts a thread which receives incoming packets and sends them onto the 'Receiver' channel.
+    fn start_receiving(receiver: Arc<Mutex<ReceiveHandler>>) -> Receiver<Packet> {
+        let (receive_queue, rx) = mpsc::channel();
+
+        thread::spawn(move || {
+            // take note that this lock will be there as long this thread lives.
+            // We only have one receiver, if one tries to have two receivers the program should panic.
+            // Why is there one receiver? This is because how a channel works. Once we read the messages it will be removed from the channel.
+            match receiver.try_lock() {
+                Ok(receiver) => loop {
+                    for event in receiver.iter() {
+                        match event {
+                            ServerSocketEvent::Packet(packet) => {
+                                if let Err(error) = receive_queue.send(packet.clone()) {
+                                    error!(
+                                        "`NetworkSocketSystem` was dropped. Reason: {:?}",
+                                        error
+                                    );
+                                    break;
+                                }
+                            }
+                            ServerSocketEvent::Error(error) => error!("{:?}", error),
+                            _ => error!("Event not supported"),
+                        }
+                    }
+                },
+                Err(_) => {
+                    panic!("Two packet receivers can't run at the same time");
+                }
+            }
+        });
+
+        rx
     }
 }
 
@@ -161,50 +148,56 @@ where
 {
     type SystemData = (WriteStorage<'a, NetConnection<E>>);
 
-    fn setup(&mut self, res: &mut Resources) {
-        Self::SystemData::setup(res);
-    }
-
     fn run(&mut self, mut net_connections: Self::SystemData) {
         for net_connection in (&mut net_connections).join() {
-            let target = net_connection.target;
+            let target = net_connection.target_receiver;
 
             if net_connection.state == ConnectionState::Connected
                 || net_connection.state == ConnectionState::Connecting
             {
-                self.tx
+                self.transport_sender
                     .send(InternalSocketEvent::SendEvents {
                         target,
                         events: net_connection.send_buffer_early_read().cloned().collect(),
                     })
                     .expect("Unreachable: Channel will be alive until a stop event is sent");
             } else if net_connection.state == ConnectionState::Disconnected {
-                self.tx
+                self.transport_sender
                     .send(InternalSocketEvent::Stop)
                     .expect("Already sent a stop event to the channel");
             }
         }
 
-        for raw_event in self.rx.try_iter() {
+        for (counter, raw_event) in self.transport_receiver.try_iter().enumerate() {
             // Get the NetConnection from the source
             for net_connection in (&mut net_connections).join() {
-                // We found the origin
-                if net_connection.target == raw_event.source {
+                if net_connection.target_sender == raw_event.addr() {
                     // Get the event
-                    let net_event = deserialize_event::<E>(raw_event.data.as_slice());
-                    match net_event {
+                    match deserialize_event::<E>(raw_event.payload()) {
                         Ok(ev) => {
                             net_connection.receive_buffer.single_write(ev);
                         }
                         Err(e) => error!(
                             "Failed to deserialize an incoming network event: {} From source: {:?}",
-                            e, raw_event.source
+                            e,
+                            raw_event.addr()
                         ),
                     }
                 } else {
                     warn!("Received packet from unknown source");
                 }
             }
+
+            // this will prevent our system to be stuck in the iterator.
+            // After 10000 packets we will continue and leave the other packets for the next run.
+            // eventually some congestion prevention should be done.
+            if counter >= self.config.max_throughput as usize {
+                break;
+            }
         }
+    }
+
+    fn setup(&mut self, res: &mut Resources) {
+        Self::SystemData::setup(res);
     }
 }

--- a/amethyst_network/src/server/config.rs
+++ b/amethyst_network/src/server/config.rs
@@ -1,0 +1,25 @@
+use std::net::SocketAddr;
+
+#[derive(Clone, Debug)]
+/// The configuration used for the networking system.
+pub struct ServerConfig {
+    /// Address at which the UDP server will listen for incoming packets.
+    pub udp_recv_addr: SocketAddr,
+    /// Address from which the UDP server will be sending packets.
+    pub udp_send_addr: SocketAddr,
+    /// Specifies what the maximal packets that could be handled by the server.
+    /// This value is meant for preventing some loops to read infinitely long when many packets are send and received.
+    /// This value is by default 5000.
+    pub max_throughput: u16,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        ServerConfig {
+            // by passing in :0 port the OS will give an available port.
+            udp_recv_addr: "0.0.0.0:0".parse().unwrap(),
+            udp_send_addr: "0.0.0.0:0".parse().unwrap(),
+            max_throughput: 5000,
+        }
+    }
+}

--- a/amethyst_network/src/server/host.rs
+++ b/amethyst_network/src/server/host.rs
@@ -1,0 +1,61 @@
+/// This module is about the communication with this host to some other endpoints.
+///
+/// 1. Sending Data
+/// 2. Receiving Data
+/// 3. Broadcasting
+use crate::error::Result;
+use crate::server::{
+    ReceiveHandler, SendHandler, ServerConfig, ServerSocketEvent, UdpReceiver, UdpSender,
+};
+use laminar::Packet;
+use std::sync::{Arc, Mutex};
+
+/// 'Host' abstracts TCP and UDP sockets away.
+pub struct Host {
+    // Handler to access the internals of the UDP receiving thread
+    udp_receiver: Arc<Mutex<ReceiveHandler>>,
+    // Handler to access the internals of the UDP sender thread
+    udp_sender: Arc<SendHandler>,
+}
+
+impl Host {
+    /// This will start and return an instance of the host.
+    /// 1: Fire up a TCP-sender and TCP-receiver if enabled in config.
+    /// 2: Fire up a UDP-sender and UDP-receiver.
+    /// 3: Set up some `channels` to communicate with underlying threads.
+    ///
+    /// The method uses the config provided when creating a `host` instance.
+    pub fn run(config: &ServerConfig) -> Result<Host> {
+        // setup a UDP-receiver which will receive packets from any endpoint.
+        let udp_receiver = Arc::new(Mutex::new(UdpReceiver::run(config.udp_recv_addr, &config)?));
+
+        // setup the UDP-sender which will send packets to an certain endpoint.
+        let udp_sender = Arc::new(UdpSender::run(config.udp_send_addr)?);
+
+        Ok(Host {
+            udp_sender,
+            udp_receiver,
+        })
+    }
+
+    /// Get the handle to the internals of the UDP-receiving threat.
+    pub fn udp_receive_handle(&self) -> Arc<Mutex<ReceiveHandler>> {
+        self.udp_receiver.clone()
+    }
+
+    /// Get the handle to the internals of the UDP-sending thread.
+    pub fn udp_send_handle(&self) -> Arc<SendHandler> {
+        self.udp_sender.clone()
+    }
+
+    /// Schedule a TCP-packet for sending.
+    pub fn send_tcp(&mut self, _payload: &[u8]) -> Result<()> {
+        unimplemented!()
+    }
+
+    /// Schedule a UDP-packet for sending.
+    pub fn send_udp(&mut self, packet: Packet) -> Result<()> {
+        self.udp_sender.send(ServerSocketEvent::Packet(packet))?;
+        Ok(())
+    }
+}

--- a/amethyst_network/src/server/mod.rs
+++ b/amethyst_network/src/server/mod.rs
@@ -1,0 +1,29 @@
+mod config;
+mod host;
+mod receive_handler;
+mod send_handler;
+mod server_socket_event;
+mod udp;
+
+pub use self::config::ServerConfig;
+pub use self::host::Host;
+pub use self::receive_handler::ReceiveHandler;
+pub use self::send_handler::SendHandler;
+pub use self::udp::{UdpReceiver, UdpSender};
+
+pub use self::server_socket_event::{ClientEvent, ServerSocketEvent};
+use std::sync::mpsc::{Receiver, Sender};
+
+/// Can be implemented for the receiving side of a socket.
+pub trait PacketReceiving {
+    /// Start receiving data.
+    /// You have to pass the `Sender` side of a channel to this function so that the `Receiver` side of the channel can read all received packets send on this `Sender` by this function.
+    fn start_receiving(&mut self, tx: Sender<ServerSocketEvent>);
+}
+
+/// Can be implemented for the sending side of a socket.
+pub trait PacketSending {
+    /// This will send all data.
+    /// You have to pass the `Receiver` side of a channel to this function so that packets send on the `Sender` could be read by this function.
+    fn start_sending(&mut self, rx: Receiver<ServerSocketEvent>);
+}

--- a/amethyst_network/src/server/receive_handler.rs
+++ b/amethyst_network/src/server/receive_handler.rs
@@ -1,0 +1,36 @@
+//! The receive handler is used to communicate between a receiving thread and it's owner.
+//! The `ReceiveHandler` communicates via `mpsc::channel`s.
+
+use crate::server::ServerSocketEvent;
+use std::sync::mpsc::{Iter, Receiver};
+use std::thread::JoinHandle;
+
+/// Handler to access the internals of a receiving socket.
+pub struct ReceiveHandler {
+    /// handle that should be used for reading received packets from a given socket
+    pub receiver: Receiver<ServerSocketEvent>,
+    /// thread handle to the thread that receives packets on a given socket
+    _thread_handle: JoinHandle<()>,
+}
+
+impl ReceiveHandler {
+    /// Create a new receive handler by specifying:
+    /// 1: the max throughput in packets a host can read at once.
+    /// 2: handle that should be used for reading received packets from a given socket.
+    /// 3: handle that should be used for reading received packets from a given socket.
+    pub fn new(
+        receiver: Receiver<ServerSocketEvent>,
+        thread_handle: JoinHandle<()>,
+    ) -> ReceiveHandler {
+        ReceiveHandler {
+            receiver,
+            _thread_handle: thread_handle,
+        }
+    }
+
+    // Returns an iterator that will block waiting for messages from the receiver but which will never panic!.
+    // It will return None when the channel has hung up.
+    pub fn iter(&self) -> Iter<'_, ServerSocketEvent> {
+        self.receiver.iter()
+    }
+}

--- a/amethyst_network/src/server/send_handler.rs
+++ b/amethyst_network/src/server/send_handler.rs
@@ -1,0 +1,41 @@
+//! The send handler is used to communicate between a sending thread and it's owner.
+//! The `SendHandler` communicates via `mpsc::channel`s.
+
+use crate::error::Result;
+use crate::server::ServerSocketEvent;
+use std::sync::mpsc::SyncSender;
+use std::thread::JoinHandle;
+
+/// Handler to access the internals of a sending socket.
+pub struct SendHandler {
+    /// handle that should be used fro reading the received packets on a given socket
+    sender: SyncSender<ServerSocketEvent>,
+    /// thread handle to the thread that sends packets
+    _thread_handle: JoinHandle<()>,
+}
+
+impl SendHandler {
+    /// Create a new receive handler by specifying:
+    /// 1: handle that should be used fro reading the received packets on a given socket.
+    /// 2: thread handle to the thread that sends packets.
+    pub fn new(
+        sender: SyncSender<ServerSocketEvent>,
+        thread_handle: JoinHandle<()>,
+    ) -> SendHandler {
+        SendHandler {
+            sender,
+            _thread_handle: thread_handle,
+        }
+    }
+
+    /// Send an event on the internal channel, by doing this it will be scheduled for sending.
+    pub fn send(&self, event: ServerSocketEvent) -> Result<()> {
+        self.sender.send(event)?;
+        Ok(())
+    }
+
+    /// Get the sending channel of this `SendHandler` to which you can send  
+    pub fn get_sender(&self) -> &SyncSender<ServerSocketEvent> {
+        &self.sender
+    }
+}

--- a/amethyst_network/src/server/server_socket_event.rs
+++ b/amethyst_network/src/server/server_socket_event.rs
@@ -1,0 +1,38 @@
+use laminar::error::NetworkError;
+use laminar::{Event, Packet};
+
+/// Net event which occurred on the network.
+pub enum ServerSocketEvent {
+    /// event containing a packet with received data
+    Packet(Packet),
+    /// event containing an error that has occurred in the network
+    Error(NetworkError),
+    /// events that can happen with a client
+    ClientEvent(ClientEvent),
+    /// Event used for a default initialisation.
+    Empty,
+}
+
+/// Event that could occur with a client.
+pub enum ClientEvent {
+    /// represents a connecting client
+    Connected,
+    /// represents a disconnecting client
+    Disconnected,
+    /// represents a client who is timing out
+    Timedout,
+    /// represents an default value for this enum.
+    QualityChange,
+}
+
+/// Convert a `laminar` client event to our own client event.
+impl From<Event> for ClientEvent {
+    fn from(event: Event) -> Self {
+        match event {
+            Event::Connected(_) => ClientEvent::Connected,
+            Event::Disconnected(_) => ClientEvent::Disconnected,
+            Event::TimedOut(_) => ClientEvent::Timedout,
+            Event::QualityChange { .. } => ClientEvent::QualityChange,
+        }
+    }
+}

--- a/amethyst_network/src/server/udp.rs
+++ b/amethyst_network/src/server/udp.rs
@@ -1,0 +1,125 @@
+//! All UDP related logic for getting and sending data out to the other side.
+
+use crate::{
+    error::Result,
+    server::{
+        ClientEvent, PacketReceiving, PacketSending, ReceiveHandler, SendHandler, ServerConfig,
+        ServerSocketEvent,
+    },
+};
+use laminar::net::UdpSocket;
+use laminar::NetworkConfig;
+use log::{error, warn};
+use std::net::SocketAddr;
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::thread;
+
+/// An UDP receiver, wrapper for starting the UDP-receiving thread.
+pub struct UdpReceiver {
+    // socket used for receiving packets
+    socket: UdpSocket,
+    /// The max throughput in packets a host can read at once
+    pub max_throughput: usize,
+}
+
+impl UdpReceiver {
+    /// This will run the udp receiver on it's own thread.
+    pub fn run(addr: SocketAddr, config: &ServerConfig) -> Result<ReceiveHandler> {
+        let socket = UdpSocket::bind(&addr, NetworkConfig::default())?;
+
+        let mut receiver = UdpReceiver {
+            socket,
+            max_throughput: config.max_throughput as usize,
+        };
+
+        // channel used for communicating about received packets.
+        let (tx, rx) = mpsc::channel();
+
+        let thread_handle = thread::spawn(move || {
+            receiver.start_receiving(tx);
+        });
+
+        Ok(ReceiveHandler::new(rx, thread_handle))
+    }
+}
+
+impl PacketReceiving for UdpReceiver {
+    // 1. Receive data from socket.
+    // 2. Analyze data.
+    // 3. Check if there are events from laminar.
+    // 3. Notify the receiver with the received data over send channel.
+    fn start_receiving(&mut self, tx: Sender<ServerSocketEvent>) {
+        loop {
+            let result = self.socket.recv();
+            match result {
+                Ok(Some(packet)) => {
+                    if let Err(e) = tx.send(ServerSocketEvent::Packet(packet)) {
+                        error!("Send channel error. Reason: {:?}", e)
+                    }
+                }
+                Ok(None) => {
+                    if let Err(e) = tx.send(ServerSocketEvent::Empty) {
+                        error!("Send channel error. Reason: {:?}", e)
+                    }
+                }
+                Err(e) => {
+                    if let Err(e) = tx.send(ServerSocketEvent::Error(e)) {
+                        error!("Send channel error. Reason: {:?}", e)
+                    }
+                }
+            };
+
+            // iter over client events occurred from within laminar.
+            self.socket.events().into_iter().for_each(|event| {
+                if let Err(e) = tx.send(ServerSocketEvent::ClientEvent(ClientEvent::from(event))) {
+                    error!("Send channel error. Reason: {:?}", e)
+                }
+            });
+        }
+    }
+}
+
+/// An UDP-sender, wrapper for the UDP-sending thread.
+pub struct UdpSender {
+    // socket used for sending packets
+    socket: UdpSocket,
+}
+
+impl UdpSender {
+    /// This will run the udp sender on it's own thread.
+    pub fn run(addr: SocketAddr) -> Result<SendHandler> {
+        let socket = UdpSocket::bind(&addr, NetworkConfig::default())?;
+        let mut udp_sender = UdpSender { socket };
+
+        let (tx, rx) = mpsc::sync_channel(500);
+
+        let thread_handle = thread::spawn(move || {
+            udp_sender.start_sending(rx);
+        });
+
+        Ok(SendHandler::new(tx, thread_handle))
+    }
+}
+
+impl PacketSending for UdpSender {
+    // 1. Receives a packets from the channel containing packets to send to some endpoint.
+    // 2. Sent the packet to a specific client.
+    fn start_sending(&mut self, rx: Receiver<ServerSocketEvent>) {
+        loop {
+            match rx.recv() {
+                Ok(packet) => match packet {
+                    ServerSocketEvent::Packet(packet) => {
+                        if let Err(e) = self.socket.send(&packet) {
+                            error!("Something went wrong when trying to send a packet with UDP socket. Reason: {:?}", e)
+                        }
+                    }
+                    _ => warn!("The UDP-sender can only send packets"),
+                },
+                Err(e) => error!(
+                    "Something went wrong when receiving from channel. Reason: {:?}",
+                    e
+                ),
+            }
+        }
+    }
+}

--- a/amethyst_network/src/test.rs
+++ b/amethyst_network/src/test.rs
@@ -7,21 +7,33 @@ mod test {
         specs::{Builder, Join, World, WriteStorage},
     };
 
-    use crate::{NetConnection, NetEvent, NetSocketSystem};
+    use crate::server::ServerConfig;
+    use crate::*;
 
     #[test]
     fn single_packet_early() {
-        let addr1: SocketAddr = "127.0.0.1:21200".parse().unwrap();
-        let addr2: SocketAddr = "127.0.0.1:21201".parse().unwrap();
-        let (mut world_cl, mut cl_dispatch, mut world_sv, mut sv_dispatch) =
-            build(addr1.clone(), addr2.clone());
+        // server got one socket receiving and one sending
+        let server_send: SocketAddr = "127.0.0.1:21200".parse().unwrap();
+        let server_receive: SocketAddr = "127.0.0.1:21201".parse().unwrap();
 
-        let mut conn_to_server = NetConnection::<()>::new(addr2);
-        let mut conn_to_client = NetConnection::<()>::new(addr1);
+        // client got one socket receiving and one sending
+        let client_send: SocketAddr = "127.0.0.1:21202".parse().unwrap();
+        let client_receive: SocketAddr = "127.0.0.1:21203".parse().unwrap();
+
+        let (mut world_cl, mut cl_dispatch, mut world_sv, mut sv_dispatch) = build(
+            server_send.clone(),
+            server_receive.clone(),
+            client_send.clone(),
+            client_receive.clone(),
+        );
+
+        let mut conn_to_server = NetConnection::<()>::new(server_receive, server_send);
+        let mut conn_to_client = NetConnection::<()>::new(client_receive, client_send);
 
         let test_event = NetEvent::TextMessage {
             msg: "1".to_string(),
         };
+
         conn_to_server.send_buffer.single_write(test_event.clone());
         world_cl.create_entity().with(conn_to_server).build();
 
@@ -29,7 +41,7 @@ mod test {
         let conn_to_client_entity = world_sv.create_entity().with(conn_to_client).build();
 
         cl_dispatch.dispatch(&mut world_cl.res);
-        sleep(Duration::from_millis(1000));
+        sleep(Duration::from_millis(500));
         sv_dispatch.dispatch(&mut world_sv.res);
 
         let storage = world_sv.read_storage::<NetConnection<()>>();
@@ -42,13 +54,25 @@ mod test {
 
     #[test]
     fn send_receive_100_packets() {
-        let addr1: SocketAddr = "127.0.0.1:21205".parse().unwrap();
-        let addr2: SocketAddr = "127.0.0.1:21204".parse().unwrap();
-        let (mut world_cl, mut cl_dispatch, mut world_sv, mut sv_dispatch) =
-            build(addr1.clone(), addr2.clone());
+        // server got one socket receiving and one sending
+        let server_send: SocketAddr = "127.0.0.1:21204".parse().unwrap();
+        let server_receive: SocketAddr = "127.0.0.1:21205".parse().unwrap();
 
-        let conn_to_server = NetConnection::<()>::new(addr2);
-        let mut conn_to_client = NetConnection::<()>::new(addr1);
+        // client got one socket receiving and one sending
+        let client_send: SocketAddr = "127.0.0.1:21206".parse().unwrap();
+        let client_receive: SocketAddr = "127.0.0.1:21207".parse().unwrap();
+
+        // setup world for client and server
+        let (mut world_cl, mut cl_dispatch, mut world_sv, mut sv_dispatch) = build(
+            server_send.clone(),
+            server_receive.clone(),
+            client_send.clone(),
+            client_receive.clone(),
+        );
+
+        // setup connections from client -> server and server -> client
+        let conn_to_server = NetConnection::<()>::new(server_receive, server_send);
+        let mut conn_to_client = NetConnection::<()>::new(client_receive, client_send);
 
         let test_event = NetEvent::TextMessage {
             msg: "Test Message From Client1".to_string(),
@@ -70,23 +94,40 @@ mod test {
             }
         }
         cl_dispatch.dispatch(&mut world_cl.res);
-        sleep(Duration::from_millis(500));
+        sleep(Duration::from_millis(100));
         sv_dispatch.dispatch(&mut world_sv.res);
+
         let storage = world_sv.read_storage::<NetConnection<()>>();
         let comp = storage.get(conn_to_client_entity).unwrap();
         assert_eq!(comp.receive_buffer.read(&mut rcv).count(), 100);
     }
 
     fn build<'a, 'b>(
-        addr1: SocketAddr,
-        addr2: SocketAddr,
+        server_send: SocketAddr,
+        server_receive: SocketAddr,
+        client_send: SocketAddr,
+        client_receive: SocketAddr,
     ) -> (World, Dispatcher<'a, 'b>, World, Dispatcher<'a, 'b>) {
         let mut world_cl = World::new();
         let mut world_sv = World::new();
 
+        // client config
+        let client_config = ServerConfig {
+            udp_send_addr: client_send,
+            udp_recv_addr: client_receive,
+            max_throughput: 10000,
+        };
+
+        // server config
+        let server_config = ServerConfig {
+            udp_send_addr: server_send,
+            udp_recv_addr: server_receive,
+            max_throughput: 10000,
+        };
+
         let mut cl_dispatch = DispatcherBuilder::new()
             .with(
-                NetSocketSystem::<()>::new(addr1, Vec::new()).unwrap(),
+                NetSocketSystem::<()>::new(client_config, Vec::new()).unwrap(),
                 "s",
                 &[],
             )
@@ -94,7 +135,7 @@ mod test {
         cl_dispatch.setup(&mut world_cl.res);
         let mut sv_dispatch = DispatcherBuilder::new()
             .with(
-                NetSocketSystem::<()>::new(addr2, Vec::new()).unwrap(),
+                NetSocketSystem::<()>::new(server_config, Vec::new()).unwrap(),
                 "s",
                 &[],
             )

--- a/examples/net_client/main.rs
+++ b/examples/net_client/main.rs
@@ -14,13 +14,14 @@ use std::time::Duration;
 
 fn main() -> Result<()> {
     amethyst::start_logger(Default::default());
+
     let game_data = GameDataBuilder::default()
         .with_bundle(NetworkBundle::<()>::new(
-            "127.0.0.1:3455".parse().unwrap(),
+            "127.0.0.1:3457".parse().unwrap(),
+            "127.0.0.1:3456".parse().unwrap(),
             vec![],
         ))?
-        .with(SpamSystem::new(), "spam", &[])
-        .with(ReaderSystem::new(), "reader", &[]);
+        .with(SpamSystem::new(), "spam", &[]);
     let mut game = Application::build("./", State1)?
         .with_frame_limit(
             FrameRateLimitStrategy::SleepAndYield(Duration::from_millis(2)),
@@ -30,14 +31,16 @@ fn main() -> Result<()> {
     game.run();
     Ok(())
 }
-
 /// Default empty state
 pub struct State1;
 impl SimpleState for State1 {
     fn on_start(&mut self, data: StateData<'_, GameData<'_, '_>>) {
         data.world
             .create_entity()
-            .with(NetConnection::<()>::new("127.0.0.1:3456".parse().unwrap()))
+            .with(NetConnection::<()>::new(
+                "127.0.0.1:3455".parse().unwrap(),
+                "127.0.0.1:3454".parse().unwrap(),
+            ))
             .build();
     }
 }
@@ -75,11 +78,13 @@ impl<'a> System<'a> for SpamSystem {
 
 /// A simple system reading received events.
 /// Used to see events sent by the net_echo_server example.
+#[allow(unused)]
 struct ReaderSystem {
     pub reader: Option<ReaderId<NetEvent<()>>>,
 }
 
 impl ReaderSystem {
+    #[allow(unused)]
     pub fn new() -> Self {
         ReaderSystem { reader: None }
     }

--- a/examples/net_server/main.rs
+++ b/examples/net_server/main.rs
@@ -10,13 +10,16 @@ use amethyst::{
     shrev::ReaderId,
     Result,
 };
+
 use std::time::Duration;
 
 fn main() -> Result<()> {
     amethyst::start_logger(Default::default());
+
     let game_data = GameDataBuilder::default()
         .with_bundle(NetworkBundle::<()>::new(
-            "127.0.0.1:3456".parse().unwrap(),
+            "127.0.0.1:3455".parse().unwrap(),
+            "127.0.0.1:3454".parse().unwrap(),
             vec![Box::new(FilterConnected::<()>::new())],
         ))?
         .with(SpamReceiveSystem::new(), "rcv", &[]);
@@ -36,7 +39,10 @@ impl SimpleState for State1 {
     fn on_start(&mut self, data: StateData<'_, GameData<'_, '_>>) {
         data.world
             .create_entity()
-            .with(NetConnection::<()>::new("127.0.0.1:3455".parse().unwrap()))
+            .with(NetConnection::<()>::new(
+                "127.0.0.1:3457".parse().unwrap(),
+                "127.0.0.1:3456".parse().unwrap(),
+            ))
             .build();
     }
 }


### PR DESCRIPTION
Removed any dependencies to specs by abstracting away all socket logic to the `Server` type. 

The current network library does send and receiving in one thread. This could cause the program to not receive some packets at high server load when the thread is in the send loop. I moved the receiving logic and sending logic into separate threads so that we can receive and send in parallel.

_A diagram of the implemented code:_
![untitled diagram](https://user-images.githubusercontent.com/19969910/50450660-24887880-08e4-11e9-9509-4ec8697db561.png)
