### PR TITLE
Minor fix to resolve compile error.

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-03.md
+++ b/book/src/pong-tutorial/pong-tutorial-03.md
@@ -128,7 +128,7 @@ use amethyst::ecs::{Join, Read, ReadStorage, System, WriteStorage};
 use amethyst::input::InputHandler;
 
 // You'll have to mark PADDLE_HEIGHT as public in pong.rs
-use pong::{Paddle, Side, ARENA_HEIGHT, PADDLE_HEIGHT};
+use crate::pong::{Paddle, Side, ARENA_HEIGHT, PADDLE_HEIGHT};
 
 pub struct PaddleSystem;
 


### PR DESCRIPTION
Absolute path is required for using the pong module, otherwise there's a compile error on rust stable (1.31.1); https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html