### PR TITLE
Fix the "json" feature for 2018 edition

### DIFF
--- a/amethyst_assets/src/lib.rs
+++ b/amethyst_assets/src/lib.rs
@@ -21,8 +21,6 @@ extern crate log;
 
 #[macro_use]
 extern crate serde;
-#[cfg(feature = "json")]
-extern crate serde_json;
 use shred;
 #[macro_use]
 extern crate shred_derive;
@@ -45,7 +43,7 @@ pub use crate::{
     storage::{AssetStorage, Handle, ProcessingState, Processor, WeakHandle},
 };
 #[cfg(feature = "json")]
-pub use formats::JsonFormat;
+pub use crate::formats::JsonFormat;
 
 mod asset;
 mod cache;


### PR DESCRIPTION
Looks like we missed a bit of feature-gated code that needed to updated when switching to the 2018 edition. The fix is simple, but it would be good to also test make sure we're testing the "json" feature under CI. If someone could point me to the right place to do that, I'll add it to this PR.