### PR TITLE
Re-add Concourse back in

### DIFF
--- a/.concourse/pr.yml
+++ b/.concourse/pr.yml
@@ -1,0 +1,66 @@
+---
+resource_types:
+- name: pull-request
+  type: docker-image
+  source:
+    repository: teliaoss/github-pr-resource
+    tag: v0.7.0
+
+resources:
+- name: pull-request
+  type: pull-request
+  check_every: 24h
+  webhook_token: ((webhook_token))
+  source:
+    repository: amethyst/amethyst
+    access_token: ((access_token))
+
+- name: amethyst-dependencies
+  type: docker-image
+  source: { repository: magnonellie/amethyst-dependencies }
+
+jobs:
+- name: linux-rust-stable
+  max_in_flight: 2
+  public: true
+  interruptible: true
+  plan:
+  - aggregate:
+    - get: amethyst
+      resource: pull-request
+      trigger: true
+      version: every
+    - get: amethyst-dependencies
+
+  - put: pull-request
+    params: { path: amethyst, status: pending, context: linux-tests }
+  - task: tests
+    image: amethyst-dependencies
+    file: amethyst/.concourse/tasks/linux-test.yml
+    on_failure:
+      do:
+      - put: pull-request
+        params: { path: amethyst, status: failure, context: linux-tests }
+  - put: pull-request
+    params: { path: amethyst, status: success, context: linux-tests }
+
+- name: linux-rustfmt
+  public: true
+  plan:
+  - aggregate:
+    - get: amethyst
+      resource: pull-request
+      trigger: true
+      version: every
+    - get: amethyst-dependencies
+
+  - put: pull-request
+    params: { path: amethyst, status: pending, context: rustfmt }
+  - task: check
+    image: amethyst-dependencies
+    file: amethyst/.concourse/tasks/linux-rustfmt.yml
+    on_failure: # TODO: We should also send an actual message with a helpful hint here.
+      put: pull-request
+      params: { path: amethyst, status: failure, context: rustfmt }
+  - put: pull-request
+    params: { path: amethyst, status: success, context: rustfmt }

--- a/.concourse/tasks/linux-rustfmt.yml
+++ b/.concourse/tasks/linux-rustfmt.yml
@@ -1,0 +1,14 @@
+---
+platform: linux
+
+inputs:
+- name: amethyst
+
+run:
+  path: sh
+  dir: amethyst
+  args:
+  - -exc
+  - |
+    cargo fmt --version
+    cargo fmt --all -- --check

--- a/.concourse/tasks/linux-test.yml
+++ b/.concourse/tasks/linux-test.yml
@@ -1,0 +1,23 @@
+---
+platform: linux
+
+inputs:
+- name: amethyst
+
+outputs:
+- name: target
+  path: target
+
+run:
+  path: sh
+  dir: amethyst
+  args:
+  - -exc
+  - |
+    rustc --version
+    export RUSTFLAGS="-D warnings"
+    cargo check --all --features sdl_controller,profiler
+    export CARGO_TARGET_DIR="../target"
+    cargo test --all
+caches:
+- path: target


### PR DESCRIPTION
This adds Concourse back in. Due to a bug in GitLab, it cannot detect PRs from forks. So we'll need to stick with this for awhile, at least.