### PR TITLE
Fix the SRV mipmap range

### DIFF
--- a/amethyst_renderer/src/tex.rs
+++ b/amethyst_renderer/src/tex.rs
@@ -203,8 +203,8 @@ where
         let desc = ResourceDesc {
             channel: self.channel_type,
             layer: None,
-            min: 1,
-            max: self.info.levels,
+            min: 0,
+            max: self.info.levels - 1,
             swizzle: Swizzle::new(),
         };
 


### PR DESCRIPTION
The old range was causing a panic on gfx-device-gl 0.15.5 since it was out of range of the source texture.