### PR TITLE
Change the recommended donation website

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ you can look through the [issue tracker][it].
 
 ## Backers
 
-Thank you to all our backers! 🙏 [Become a backer](https://opencollective.com/amethyst#backer)
+Thank you to all our backers! 🙏 [Become a backer](https://www.amethyst-engine.org/donate)
 
 <a href="https://opencollective.com/amethyst#backers" target="_blank"><img src="https://opencollective.com/amethyst/backers.svg?width=890"></a>
 


### PR DESCRIPTION
This PR changes the donation link on the README to go to the donation page on the new website instead of OpenCollective, as the DonorBox platform available there is the recommended donation platform (as it takes a smaller cut on the donation).

Do we also want to modify/remove the OpenCollective backer avatars under it? I personally think we should just not refer to the OpenCollective platform as it is only here for donators that prefer it over anything else.

Also, is it okay to link to the new website or should we wait it has undergone all the rewording and refactoring? @happenslol 