### PR TITLE
lib.rs Formatting

### DIFF
--- a/amethyst_animation/src/lib.rs
+++ b/amethyst_animation/src/lib.rs
@@ -46,14 +46,20 @@
 //! [ex_gltf]: https://github.com/amethyst/amethyst/tree/master/examples/gltf
 
 #![warn(missing_docs, rust_2018_idioms, rust_2018_compatibility)]
+
 #[macro_use]
 extern crate amethyst_derive;
+
 #[macro_use]
 extern crate derivative;
+
 #[macro_use]
 extern crate log;
+
 #[macro_use]
 extern crate serde;
+
+pub use minterpolate::{InterpolationFunction, InterpolationPrimitive};
 
 pub use self::{
     bundle::{AnimationBundle, SamplingBundle, VertexSkinningBundle},
@@ -72,8 +78,6 @@ pub use self::{
     transform::TransformChannel,
     util::{get_animation_set, SamplerPrimitive},
 };
-
-pub use minterpolate::{InterpolationFunction, InterpolationPrimitive};
 
 mod bundle;
 mod material;

--- a/amethyst_assets/src/lib.rs
+++ b/amethyst_assets/src/lib.rs
@@ -3,16 +3,18 @@
 //! Asset management crate.
 //! Designed with the following goals in mind:
 //!
-//! * extensibility
-//! * asynchronous & parallel using rayon
-//! * allow different sources
+//! * Extensibility
+//! * Asynchronous & Parallel using Rayon
+//! * Allow different sources
 
 #![warn(missing_docs, rust_2018_idioms, rust_2018_compatibility)]
 
-use amethyst_core;
+#[cfg(feature = "json")]
+pub use crate::formats::JsonFormat;
 
 #[macro_use]
 extern crate derivative;
+
 #[macro_use]
 extern crate error_chain;
 
@@ -21,7 +23,7 @@ extern crate log;
 
 #[macro_use]
 extern crate serde;
-use shred;
+
 #[macro_use]
 extern crate shred_derive;
 
@@ -29,8 +31,6 @@ extern crate shred_derive;
 #[cfg(feature = "profiler")]
 extern crate thread_profiler;
 
-#[cfg(feature = "json")]
-pub use crate::formats::JsonFormat;
 pub use crate::{
     asset::{Asset, Format, FormatValue, SimpleFormat},
     cache::Cache,
@@ -44,6 +44,10 @@ pub use crate::{
     source::{Directory, Source},
     storage::{AssetStorage, Handle, ProcessingState, Processor, WeakHandle},
 };
+
+use shred;
+
+use amethyst_core;
 
 mod asset;
 mod cache;

--- a/amethyst_audio/src/lib.rs
+++ b/amethyst_audio/src/lib.rs
@@ -1,6 +1,7 @@
+//! Loading and playing of audio files.
+
 #![warn(missing_docs, rust_2018_idioms, rust_2018_compatibility)]
 
-//! Loading and playing of audio files.
 #[macro_use]
 extern crate log;
 
@@ -20,12 +21,12 @@ pub use self::{
     systems::*,
 };
 
-pub mod output;
-
 use std::{
     error::Error,
     fmt::{Display, Formatter, Result as FmtResult},
 };
+
+pub mod output;
 
 mod bundle;
 mod components;

--- a/amethyst_config/src/lib.rs
+++ b/amethyst_config/src/lib.rs
@@ -1,5 +1,4 @@
 //! Loads RON files into a structure for easy / statically typed usage.
-//!
 
 #![crate_name = "amethyst_config"]
 #![doc(html_logo_url = "https://www.amethyst.rs/assets/amethyst.svg")]
@@ -7,7 +6,6 @@
 
 #[macro_use]
 extern crate log;
-use ron;
 
 use std::{
     error::Error,
@@ -15,6 +13,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use ron;
 use ron::{de::Error as DeError, ser::Error as SerError};
 use serde::{Deserialize, Serialize};
 

--- a/amethyst_controls/src/lib.rs
+++ b/amethyst_controls/src/lib.rs
@@ -1,15 +1,9 @@
 //! Amethyst control crate.
 
 #![warn(missing_docs, rust_2018_idioms, rust_2018_compatibility)]
-use amethyst_core;
 
 #[macro_use]
 extern crate serde;
-
-mod bundles;
-mod components;
-mod resources;
-mod systems;
 
 pub use self::{
     bundles::{ArcBallControlBundle, FlyControlBundle},
@@ -20,3 +14,10 @@ pub use self::{
         MouseFocusUpdateSystem,
     },
 };
+
+use amethyst_core;
+
+mod bundles;
+mod components;
+mod resources;
+mod systems;

--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -2,15 +2,12 @@
 
 #![warn(missing_docs, rust_2018_idioms, rust_2018_compatibility)]
 
-pub use approx;
-pub use nalgebra;
-pub use shred;
-pub use shrev;
-pub use specs;
+#[cfg(all(target_os = "emscripten", not(no_threading)))]
+compile_error!("the cfg flag \"no_threading\" is required when building for emscripten");
 
 #[macro_use]
 extern crate error_chain;
-use rayon;
+
 #[macro_use]
 extern crate serde;
 
@@ -18,10 +15,11 @@ extern crate serde;
 #[cfg(feature = "profiler")]
 extern crate thread_profiler;
 
-#[cfg(all(target_os = "emscripten", not(no_threading)))]
-compile_error!("the cfg flag \"no_threading\" is required when building for emscripten");
-
-use std::sync::Arc;
+pub use approx;
+pub use nalgebra;
+pub use shred;
+pub use shrev;
+pub use specs;
 
 pub use crate::{
     bundle::{Error, ErrorKind, Result, SystemBundle},
@@ -36,14 +34,19 @@ pub use self::{
     named::{Named, WithNamed},
 };
 
-mod axis;
+use std::sync::Arc;
+
+use rayon;
+
 pub mod bundle;
-mod event;
 pub mod frame_limiter;
-mod named;
-mod system_ext;
 pub mod timing;
 pub mod transform;
+
+mod axis;
+mod event;
+mod named;
+mod system_ext;
 
 /// A rayon thread pool wrapped in an `Arc`. This should be used as resource in `World`.
 pub type ArcThreadPool = Arc<rayon::ThreadPool>;

--- a/amethyst_derive/src/lib.rs
+++ b/amethyst_derive/src/lib.rs
@@ -5,6 +5,7 @@ extern crate proc_macro;
 
 #[macro_use]
 extern crate syn;
+
 #[macro_use]
 extern crate quote;
 

--- a/amethyst_gltf/src/lib.rs
+++ b/amethyst_gltf/src/lib.rs
@@ -2,27 +2,29 @@
 
 #![warn(missing_docs, rust_2018_idioms, rust_2018_compatibility)]
 
-use amethyst_animation as animation;
-use amethyst_assets as assets;
-use amethyst_core as core;
-use amethyst_renderer as renderer;
-use base64;
-
-use gltf;
-
-#[macro_use]
-extern crate log;
-use mikktspace;
-#[macro_use]
-extern crate serde;
-
 #[macro_use]
 #[cfg(feature = "profiler")]
 extern crate thread_profiler;
 
-use std::{collections::HashMap, ops::Range};
+#[macro_use]
+extern crate log;
+
+#[macro_use]
+extern crate serde;
 
 pub use crate::format::GltfSceneFormat;
+
+use std::{collections::HashMap, ops::Range};
+
+use base64;
+use gltf;
+use mikktspace;
+
+use amethyst_animation as animation;
+use amethyst_assets as assets;
+use amethyst_core as core;
+use amethyst_renderer as renderer;
+
 use crate::{
     animation::{AnimatablePrefab, SkinnablePrefab},
     assets::{Handle, Prefab, PrefabData, PrefabLoaderSystem, ProgressCounter},

--- a/amethyst_input/src/lib.rs
+++ b/amethyst_input/src/lib.rs
@@ -1,18 +1,15 @@
 //! A collection of abstractions for various input devices to be used with Amethyst.
 
 #![warn(missing_docs, rust_2018_idioms, rust_2018_compatibility)]
-use amethyst_core;
 
 #[macro_use]
 extern crate derivative;
 
-#[macro_use]
-extern crate serde;
-use smallvec;
-use winit;
-
 #[cfg(feature = "sdl_controller")]
 extern crate sdl2;
+
+#[macro_use]
+extern crate serde;
 
 #[cfg(feature = "sdl_controller")]
 pub use self::sdl_events_system::SdlEventsSystem;
@@ -30,7 +27,12 @@ pub use self::{
 };
 
 use std::iter::Iterator;
+
+use smallvec;
+use winit;
 use winit::VirtualKeyCode;
+
+use amethyst_core;
 
 mod axis;
 mod bindings;

--- a/amethyst_locale/src/lib.rs
+++ b/amethyst_locale/src/lib.rs
@@ -1,7 +1,9 @@
 //! # amethyst_locale
 //!
 //! Localisation binding a `Fluent` file to an Asset<Locale> via the use of amethyst_assets.
+
 #![warn(missing_docs, rust_2018_idioms, rust_2018_compatibility)]
+
 use fluent::bundle::FluentBundle;
 
 use amethyst_assets::{Asset, Handle, ProcessingState, Result, SimpleFormat};

--- a/amethyst_network/src/lib.rs
+++ b/amethyst_network/src/lib.rs
@@ -1,17 +1,9 @@
 //! Provides a client-server networking architecture to amethyst.
 
 #![warn(missing_docs, rust_2018_idioms, rust_2018_compatibility)]
+
 #[macro_use]
 extern crate serde;
-
-mod bundle;
-mod connection;
-mod error;
-mod filter;
-mod net_event;
-mod network_socket;
-mod server;
-mod test;
 
 pub use crate::{
     bundle::NetworkBundle,
@@ -23,12 +15,21 @@ pub use crate::{
     server::{Host, ServerConfig, ServerSocketEvent},
 };
 
+use std::{net::SocketAddr, sync::mpsc::SyncSender};
+
 use bincode::{deserialize, serialize};
 use laminar::Packet;
 use log::error;
 use serde::{de::DeserializeOwned, Serialize};
-use std::net::SocketAddr;
-use std::sync::mpsc::SyncSender;
+
+mod bundle;
+mod connection;
+mod error;
+mod filter;
+mod net_event;
+mod network_socket;
+mod server;
+mod test;
 
 /// Sends an event to the target NetConnection using the provided network Socket.
 /// The socket has to be bound.

--- a/amethyst_renderer/src/lib.rs
+++ b/amethyst_renderer/src/lib.rs
@@ -27,36 +27,30 @@
 #![doc(html_logo_url = "https://www.amethyst.rs/assets/amethyst.svg")]
 #![warn(missing_docs, rust_2018_idioms, rust_2018_compatibility)]
 
-use amethyst_core;
 #[macro_use]
 extern crate amethyst_derive;
+
 #[macro_use]
 extern crate derivative;
+
 #[macro_use]
 extern crate error_chain;
-use gfx;
-use gfx_core;
+
 #[macro_use]
 extern crate gfx_macros;
+
 #[macro_use]
 extern crate log;
-use rayon;
+
 #[macro_use]
 extern crate serde;
-use shred;
+
 #[macro_use]
 extern crate shred_derive;
-use wavefront_obj;
-use winit;
+
 #[macro_use]
 #[cfg(feature = "profiler")]
 extern crate thread_profiler;
-#[cfg(feature = "opengl")]
-use gfx_device_gl;
-#[cfg(feature = "opengl")]
-use gfx_window_glutin;
-#[cfg(feature = "opengl")]
-use glutin;
 
 pub use crate::{
     blink::{Blink, BlinkSystem},
@@ -116,6 +110,24 @@ pub use crate::{
     },
     visibility::{Visibility, VisibilitySortingSystem},
 };
+
+#[cfg(feature = "opengl")]
+use gfx_device_gl;
+
+#[cfg(feature = "opengl")]
+use gfx_window_glutin;
+
+#[cfg(feature = "opengl")]
+use glutin;
+
+use gfx;
+use gfx_core;
+use rayon;
+use shred;
+use wavefront_obj;
+use winit;
+
+use amethyst_core;
 
 pub mod error;
 pub mod mouse;

--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -3,53 +3,23 @@
 #![doc(html_logo_url = "https://www.amethyst.rs/assets/amethyst.svg")]
 #![warn(missing_docs, rust_2018_idioms, rust_2018_compatibility)]
 
-use amethyst_assets;
-use amethyst_audio;
-use amethyst_core;
-
-use amethyst_renderer;
-use clipboard;
 #[macro_use]
 extern crate derivative;
+
 #[macro_use]
 extern crate derive_new;
-use fnv;
-use gfx;
-use gfx_glyph;
-use glsl_layout;
-use hibitset;
+
 #[macro_use]
 extern crate log;
-use ron;
+
 #[macro_use]
 extern crate serde;
-use shred;
+
 #[macro_use]
 extern crate shred_derive;
 
-use winit;
 #[macro_use]
 extern crate smallvec;
-
-use unicode_normalization;
-use unicode_segmentation;
-
-mod bundle;
-mod button;
-mod event;
-mod event_retrigger;
-mod font;
-mod format;
-mod layout;
-mod pass;
-mod prefab;
-mod resize;
-mod selection;
-mod selection_order_cache;
-mod sound;
-mod text;
-mod text_editing;
-mod transform;
 
 pub use self::{
     bundle::UiBundle,
@@ -78,3 +48,37 @@ pub use self::{
     text_editing::TextEditingInputSystem,
     transform::{UiFinder, UiTransform},
 };
+
+use clipboard;
+use fnv;
+use gfx;
+use gfx_glyph;
+use glsl_layout;
+use hibitset;
+use ron;
+use shred;
+use unicode_normalization;
+use unicode_segmentation;
+use winit;
+
+use amethyst_assets;
+use amethyst_audio;
+use amethyst_core;
+use amethyst_renderer;
+
+mod bundle;
+mod button;
+mod event;
+mod event_retrigger;
+mod font;
+mod format;
+mod layout;
+mod pass;
+mod prefab;
+mod resize;
+mod selection;
+mod selection_order_cache;
+mod sound;
+mod text;
+mod text_editing;
+mod transform;

--- a/amethyst_utils/src/lib.rs
+++ b/amethyst_utils/src/lib.rs
@@ -1,15 +1,22 @@
 //! A collection of useful amethyst utilities, designed to make your game dev life easier.
 
 #![warn(missing_docs, rust_2018_idioms, rust_2018_compatibility)]
+
 #[macro_use]
 extern crate amethyst_derive;
+
 #[macro_use]
 extern crate log;
+
 #[macro_use]
 extern crate serde;
-use shred;
+
 #[macro_use]
 extern crate shred_derive;
+
+pub use self::app_root_dir::*;
+
+use shred;
 
 pub mod app_root_dir;
 pub mod auto_fov;
@@ -20,4 +27,3 @@ pub mod removal;
 pub mod scene;
 pub mod tag;
 pub mod time_destroy;
-pub use self::app_root_dir::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,22 @@
 #![warn(missing_docs, rust_2018_idioms, rust_2018_compatibility)]
 
 #[macro_use]
+pub extern crate amethyst_derive as derive;
+
+#[macro_use]
+extern crate derivative;
+
+#[macro_use]
+extern crate log;
+
+#[macro_use]
+extern crate serde_derive;
+
+#[macro_use]
 #[cfg(feature = "profiler")]
 pub extern crate thread_profiler;
+
+pub use winit;
 
 pub use amethyst_animation as animation;
 pub use amethyst_assets as assets;
@@ -66,27 +80,16 @@ pub use amethyst_audio as audio;
 pub use amethyst_config as config;
 pub use amethyst_controls as controls;
 pub use amethyst_core as core;
-#[macro_use]
-pub extern crate amethyst_derive as derive;
 pub use amethyst_input as input;
 pub use amethyst_locale as locale;
 pub use amethyst_network as network;
 pub use amethyst_renderer as renderer;
 pub use amethyst_ui as ui;
 pub use amethyst_utils as utils;
-pub use winit;
-
-#[macro_use]
-extern crate derivative;
-use fern;
-#[macro_use]
-extern crate log;
-
-use rustc_version_runtime;
-#[macro_use]
-extern crate serde_derive;
 
 pub use crate::core::{shred, shrev, specs as ecs};
+#[doc(hidden)]
+pub use crate::derive::*;
 
 pub use self::{
     app::{Application, ApplicationBuilder, CoreApplication},
@@ -101,8 +104,8 @@ pub use self::{
     state_event::{StateEvent, StateEventReader},
 };
 
-#[doc(hidden)]
-pub use crate::derive::*;
+use fern;
+use rustc_version_runtime;
 
 pub mod prelude;
 


### PR DESCRIPTION
So, I know that rustfmt is supposed to be used for this but why? This order seems to make more sense then what was there previous. 

My order:
-> #![doc( ... 
-> #![warn( ...
-> #![macro_use( ... 
-> pub use ...
-> use ...
-> pub use crate::{...
-> pub use self::{...
-> mod ...
-> public mod ...

 amethyst_core/src/lib.rs is a good example, in general I tried to logically group stuff together.