### PR TITLE
Minor fixes to resolve compile errors.

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-04.md
+++ b/book/src/pong-tutorial/pong-tutorial-04.md
@@ -161,7 +161,7 @@ use amethyst::{
     ecs::prelude::{Join, Read, ReadStorage, System, WriteStorage},
 };
 
-use pong::Ball;
+use crate::pong::Ball;
 
 pub struct MoveBallsSystem;
 
@@ -241,7 +241,7 @@ use amethyst::{
     ecs::prelude::{Join, ReadStorage, System, WriteStorage},
 };
 
-use pong::{Ball, Side, Paddle, ARENA_HEIGHT};
+use crate::pong::{Ball, Side, Paddle, ARENA_HEIGHT};
 
 pub struct BounceSystem;
 

--- a/book/src/pong-tutorial/pong-tutorial-05.md
+++ b/book/src/pong-tutorial/pong-tutorial-05.md
@@ -46,7 +46,7 @@ use amethyst::{
     ecs::prelude::{Join, System, WriteStorage},
 };
 
-use pong::{Ball, ARENA_WIDTH};
+use crate::pong::{Ball, ARENA_WIDTH};
 
 pub struct WinnerSystem;
 
@@ -770,7 +770,7 @@ use amethyst::{
     ui::UiText,
 };
 
-use pong::{Ball, ScoreBoard, ScoreText, ARENA_WIDTH};
+use crate::pong::{Ball, ScoreBoard, ScoreText, ARENA_WIDTH};
 
 pub struct WinnerSystem;
 


### PR DESCRIPTION
Absolute path is required for using the pong module, otherwise there's a compile error on rust stable (1.31.1); https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html

Ideally my previous commit would have included these cases, sorry about that.