### PR TITLE
Update links to new docs URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["examples/*", "book/*"]
 keywords = ["game", "engine", "sdk", "amethyst"]
 categories = ["game-engines"]
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst"
+documentation = "https://www.amethyst-engine.org/doc/latest/doc/amethyst/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [s1]: https://travis-ci.org/amethyst/amethyst.svg?branch=master
 [s2]: https://img.shields.io/crates/v/amethyst.svg
 [docs-badge]: https://img.shields.io/badge/docs-website-blue.svg
-[docs]: https://www.amethyst.rs/doc/
+[docs]: https://www.amethyst-engine.org/doc/
 [s3]: https://img.shields.io/badge/license-MIT%2FApache-blue.svg
 [s4]: https://img.shields.io/discord/425678876929163284.svg?logo=discord
 [s6]: https://tokei.rs/b1/github/amethyst/amethyst?category=code

--- a/amethyst_animation/Cargo.toml
+++ b/amethyst_animation/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 description = "Animation support for Amethyst"
 keywords = ["game", "engine", "animation", "3d", "amethyst"]
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_animation/"
+documentation = "https://www.amethyst-engine.org/doc/master/doc/amethyst_animation/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT/Apache-2.0"
 keywords = ["game", "asset", "resource", "management", "amethyst"]
 categories = ["filesystem"]
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst/"
+documentation = "https://www.amethyst-engine.org/doc/master/doc/amethyst/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_audio/Cargo.toml
+++ b/amethyst_audio/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["examples/*"]
 keywords = ["game", "engine", "audio","amethyst"]
 categories = ["audio"]
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_audio/"
+documentation = "https://www.amethyst-engine.org/doc/master/doc/amethyst_audio/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_config/Cargo.toml
+++ b/amethyst_config/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 description = "Loading from .ron files into Rust structures with defaults to prevent hard errors."
 exclude = ["examples/*"]
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_config/"
+documentation = "https://www.amethyst-engine.org/doc/master/doc/amethyst_config/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_controls/Cargo.toml
+++ b/amethyst_controls/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Joël Lupien <jojolepromain@gmail.com>"]
 edition = "2018"
 description = "Amethyst controls"
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_controls/"
+documentation = "https://www.amethyst-engine.org/doc/master/doc/amethyst_controls/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Simon Rönnberg <seamonr@gmail.com>"]
 edition = "2018"
 description = "Amethyst core"
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_core/"
+documentation = "https://www.amethyst-engine.org/doc/master/doc/amethyst_core/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_derive/Cargo.toml
+++ b/amethyst_derive/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Simon Rönnberg <seamonr@gmail.com>"]
 edition = "2018"
 description = "Amethyst derive"
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_derive/"
+documentation = "https://www.amethyst-engine.org/doc/master/doc/amethyst_derive/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Rhuagh <seamonr@gmail.com>"]
 edition = "2018"
 description = "GLTF asset loading"
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_gltf/"
+documentation = "https://www.amethyst-engine.org/doc/master/doc/amethyst_gltf/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_input/Cargo.toml
+++ b/amethyst_input/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Rhuagh <seamonr@gmail.com>", "Xaeroxe <kieseljake@gmail.com>"]
 edition = "2018"
 description = "Input rebinding "
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_input/"
+documentation = "https://www.amethyst-engine.org/doc/master/doc/amethyst_input/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_locale/Cargo.toml
+++ b/amethyst_locale/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT/Apache-2.0"
 keywords = ["game", "localisation", "resource", "management", "amethyst"]
 categories = ["filesystem,localisation"]
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst/"
+documentation = "https://www.amethyst-engine.org/doc/master/doc/amethyst/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_network/Cargo.toml
+++ b/amethyst_network/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["networking", "specs", "ecs", "amethyst", "serialization"]
 categories = ["game-engines"]
 
 readme = "README.md"
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_network/index.html"
+documentation = "https://www.amethyst-engine.org/doc/master/doc/amethyst_network/index.html"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 license = "MIT/Apache-2.0"

--- a/amethyst_renderer/Cargo.toml
+++ b/amethyst_renderer/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["examples/*"]
 keywords = ["game", "engine", "renderer", "3d", "amethyst"]
 categories = ["rendering", "rendering::engine"]
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_renderer/"
+documentation = "https://www.amethyst-engine.org/doc/master/doc/amethyst_renderer/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -7,7 +7,7 @@ description = "Amethyst UI crate"
 keywords = ["ui", "specs", "ecs", "amethyst"]
 categories = ["game-engines"]
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_ui/"
+documentation = "https://www.amethyst-engine.org/doc/master/doc/amethyst_ui/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 license = "MIT/Apache-2.0"

--- a/amethyst_utils/Cargo.toml
+++ b/amethyst_utils/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Simon Rönnberg <seamonr@gmail.com>", "Joël Lupien <jojolepromain@g
 edition = "2018"
 description = "Amethyst utils"
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_utils/"
+documentation = "https://www.amethyst-engine.org/doc/master/doc/amethyst_utils/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/book/src/assets/how_to_define_custom_assets.md
+++ b/book/src/assets/how_to_define_custom_assets.md
@@ -275,6 +275,6 @@ This guide explains how to define a new asset type to be used in an Amethyst app
     If the asset data is stored in a format that is not supported by Amethyst, a [custom format][bk_custom_formats] can be implemented and provided to the `Loader` to load the asset data.
 
 [bk_custom_formats]: assets/how_to_define_custom_formats.html
-[doc_asset]: https://www.amethyst.rs/doc/latest/doc/amethyst_assets/trait.Asset.html
-[doc_processor_system]: https://www.amethyst.rs/doc/latest/doc/amethyst_assets/struct.Processor.html
+[doc_asset]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_assets/trait.Asset.html
+[doc_processor_system]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_assets/struct.Processor.html
 [gh_contributing]: https://github.com/amethyst/amethyst/blob/master/docs/CONTRIBUTING.md

--- a/book/src/assets/how_to_define_custom_formats.md
+++ b/book/src/assets/how_to_define_custom_formats.md
@@ -183,6 +183,6 @@ If you are defining a new format that may be useful to others, [please send us a
     ```
 
 [bk_custom_assets]: assets/how_to_define_custom_assets.html
-[doc_hrs]: https://www.amethyst.rs/doc/latest/doc/amethyst_assets/struct.HotReloadStrategy.html
-[doc_ron_format]: https://www.amethyst.rs/doc/latest/doc/amethyst_assets/struct.RonFormat.html
+[doc_hrs]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_assets/struct.HotReloadStrategy.html
+[doc_ron_format]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_assets/struct.RonFormat.html
 [gh_contributing]: https://github.com/amethyst/amethyst/blob/master/docs/CONTRIBUTING.md

--- a/book/src/assets/how_to_use_assets.md
+++ b/book/src/assets/how_to_use_assets.md
@@ -212,10 +212,10 @@ This guide covers the basic usage of assets into Amethyst for existing supported
     }
     ```
 
-[doc_asset]: https://www.amethyst.rs/doc/latest/doc/amethyst_assets/trait.Asset.html
-[doc_asset_get]: https://www.amethyst.rs/doc/latest/doc/amethyst_assets/struct.AssetStorage.html#method.get
-[doc_loader]: https://www.amethyst.rs/doc/latest/doc/amethyst_assets/struct.Loader.html
-[doc_load]: https://www.amethyst.rs/doc/latest/doc/amethyst_assets/struct.Loader.html#method.load
-[doc_processor_system]: https://www.amethyst.rs/doc/latest/doc/amethyst_assets/struct.Processor.html
-[doc_read_resource]: https://www.amethyst.rs/doc/latest/doc/specs/world/struct.World.html#method.read_resource
-[doc_search_format]: https://www.amethyst.rs/doc/latest/doc/amethyst/?search=Format
+[doc_asset]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_assets/trait.Asset.html
+[doc_asset_get]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_assets/struct.AssetStorage.html#method.get
+[doc_loader]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_assets/struct.Loader.html
+[doc_load]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_assets/struct.Loader.html#method.load
+[doc_processor_system]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_assets/struct.Processor.html
+[doc_read_resource]: https://www.amethyst-engine.org/doc/latest/doc/specs/world/struct.World.html#method.read_resource
+[doc_search_format]: https://www.amethyst-engine.org/doc/latest/doc/amethyst/?search=Format

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -47,7 +47,7 @@ This book is split into several sections, with this introduction being the first
 
 Read the crate-level [API documentation][ad] for more details.
 
-[ad]: https://www.amethyst.rs/doc/master/doc/amethyst/index.html
+[ad]: https://www.amethyst-engine.org/doc/master/doc/amethyst/index.html
 
 [db]: https://github.com/amethyst/amethyst/
 

--- a/book/src/pong-tutorial/contribution.md
+++ b/book/src/pong-tutorial/contribution.md
@@ -4,7 +4,7 @@ And... that's where the pong chapter ends.
 Amethyst is still in development and writing good tutorials is hard, so the guide is not complete yet.
 We are sorry this might feel a bit disappointing.
 
-Fortunately, the pong example is complete, and you can find the entire code with balls, score and music on the example pages available [here](https://www.amethyst.rs/doc). You can get additional help by leaving a post on [our subreddit](https://www.reddit.com/r/Amethyst) or on our [Discord server](https://discord.gg/amethyst).
+Fortunately, the pong example is complete, and you can find the entire code with balls, score and music on the example pages available [here](https://www.amethyst-engine.org/doc). You can get additional help by leaving a post on [our subreddit](https://www.reddit.com/r/Amethyst) or on our [Discord server](https://discord.gg/amethyst).
 
 We hate to have an incomplete tutorial as much as you do, and you can help us complete it!
 As stated above, the code is ready, tested and working. If you have some experience with the engine and you know how to write a tutorial, you can reach us out and we will help you do it by giving you details on how things work and how to structure it.

--- a/book/src/pong-tutorial/pong-tutorial-01.md
+++ b/book/src/pong-tutorial/pong-tutorial-01.md
@@ -208,8 +208,8 @@ It should look something like this:
 
 
 [ron]: https://github.com/ron-rs/ron
-[st]: https://www.amethyst.rs/doc/master/doc/amethyst/prelude/trait.SimpleState.html
-[ap]: https://www.amethyst.rs/doc/master/doc/amethyst/struct.Application.html
+[st]: https://www.amethyst-engine.org/doc/master/doc/amethyst/prelude/trait.SimpleState.html
+[ap]: https://www.amethyst-engine.org/doc/master/doc/amethyst/struct.Application.html
 [gs]: ../getting-started.html
-[displayconf]: https://www.amethyst.rs/doc/master/doc/amethyst_renderer/struct.DisplayConfig.html
+[displayconf]: https://www.amethyst-engine.org/doc/master/doc/amethyst_renderer/struct.DisplayConfig.html
 

--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -626,5 +626,5 @@ moving!
 
 [sb]: https://slide-rs.github.io/specs/
 [sb-storage]: https://slide-rs.github.io/specs/05_storages.html#densevecstorage
-[2d]: https://www.amethyst.rs/doc/master/doc/amethyst_renderer/struct.Camera.html#method.standard_2d
+[2d]: https://www.amethyst-engine.org/doc/master/doc/amethyst_renderer/struct.Camera.html#method.standard_2d
 [ss]: ../images/pong_tutorial/pong_spritesheet.png

--- a/book/src/pong-tutorial/pong-tutorial-03.md
+++ b/book/src/pong-tutorial/pong-tutorial-03.md
@@ -389,5 +389,5 @@ keypresses, and move our game's paddles accordingly. In the next chapter, we'll
 explore another key concept in real-time games: time. We'll make our game aware
 of time, and add a ball for our paddles to bounce back and forth.
 
-[doc_time]: https://www.amethyst.rs/doc/master/doc/amethyst_core/timing/struct.Time.html
-[doc_bindings]: https://www.amethyst.rs/doc/latest/doc/amethyst_input/struct.Bindings.html 
+[doc_time]: https://www.amethyst-engine.org/doc/master/doc/amethyst_core/timing/struct.Time.html
+[doc_bindings]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_input/struct.Bindings.html 

--- a/book/src/pong-tutorial/pong-tutorial-04.md
+++ b/book/src/pong-tutorial/pong-tutorial-04.md
@@ -374,6 +374,6 @@ In the next chapter, we'll add a system checking when a player loses the game,
 and add a scoring system!
 
 [pong_02_drawing]: pong-tutorial-02.html#drawing
-[doc_time]: https://www.amethyst.rs/doc/master/doc/amethyst_core/timing/struct.Time.html
+[doc_time]: https://www.amethyst-engine.org/doc/master/doc/amethyst_core/timing/struct.Time.html
 [delta_timing]: https://en.wikipedia.org/wiki/Delta_timing
 

--- a/book/src/pong-tutorial/pong-tutorial-05.md
+++ b/book/src/pong-tutorial/pong-tutorial-05.md
@@ -724,8 +724,8 @@ it to either side, so we'll add that next!
 
 
 [font-download]: https://github.com/amethyst/amethyst/raw/master/examples/assets/font/square.ttf
-[input-handler]: https://www.amethyst.rs/doc/latest/doc/amethyst_input/struct.InputHandler.html
-[ui-bundle]: https://www.amethyst.rs/doc/latest/doc/amethyst_ui/struct.UiBundle.html
+[input-handler]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_input/struct.InputHandler.html
+[ui-bundle]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_ui/struct.UiBundle.html
 
 
 ## Updating the Scoreboard

--- a/book/src/sprites.md
+++ b/book/src/sprites.md
@@ -9,7 +9,7 @@ In Amethyst, these are represented by the [`Texture`][doc_tex] and [`SpriteSheet
 
 > **Note:** The code snippets in this section explain the parts of setting up sprite rendering separately. For complete application examples, please refer to the [*sprites_ordered*][ex_ordered] example in the [examples][ex_all] directory.
 
-[doc_ss]: https://www.amethyst.rs/doc/latest/doc/amethyst_renderer/struct.SpriteSheet.html
-[doc_tex]: https://www.amethyst.rs/doc/latest/doc/amethyst_renderer/struct.Texture.html
+[doc_ss]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_renderer/struct.SpriteSheet.html
+[doc_tex]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_renderer/struct.Texture.html
 [ex_all]: https://github.com/amethyst/amethyst/tree/master/examples
 [ex_ordered]: https://github.com/amethyst/amethyst/tree/master/examples/sprites_ordered

--- a/book/src/sprites/display_the_texture.md
+++ b/book/src/sprites/display_the_texture.md
@@ -55,8 +55,8 @@ impl SimpleState for ExampleState {
 }
 ```
 
-[doc_drawflat2d]: https://www.amethyst.rs/doc/latest/doc/amethyst_renderer/struct.DrawFlat2D.html
-[doc_tex_handle]: https://www.amethyst.rs/doc/latest/doc/amethyst_renderer/type.TextureHandle.html
-[doc_component]: https://www.amethyst.rs/doc/latest/doc/specs/trait.Component.html
-[doc_handle]: https://www.amethyst.rs/doc/latest/doc/amethyst_assets/struct.Handle.html
-[doc_flipped]: https://www.amethyst.rs/doc/latest/doc/amethyst_renderer/struct.Flipped.html
+[doc_drawflat2d]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_renderer/struct.DrawFlat2D.html
+[doc_tex_handle]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_renderer/type.TextureHandle.html
+[doc_component]: https://www.amethyst-engine.org/doc/latest/doc/specs/trait.Component.html
+[doc_handle]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_assets/struct.Handle.html
+[doc_flipped]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_renderer/struct.Flipped.html

--- a/book/src/sprites/load_the_texture.md
+++ b/book/src/sprites/load_the_texture.md
@@ -44,14 +44,14 @@ There is one thing that may surprise you.
 
 The loaded texture will use linear filter, e.g. screen pixels will be linearly interpolated between the closest image pixels. In layman's terms, if your images have small resolution, sprites will look blury. Use `TextureMetadata::srgb_scale()` instead to avoid such effect. Screen pixel will be taken from nearest pixel of texture in that case.
 
-[doc_asset]: https://www.amethyst.rs/doc/latest/doc/amethyst_assets/trait.Asset.html
-[doc_asset_get]: https://www.amethyst.rs/doc/latest/doc/amethyst_assets/struct.AssetStorage.html#method.get
-[doc_fmt_bmp]: https://www.amethyst.rs/doc/latest/doc/amethyst_renderer/struct.BmpFormat.html
-[doc_fmt_jpg]: https://www.amethyst.rs/doc/latest/doc/amethyst_renderer/struct.JpgFormat.html
-[doc_fmt_png]: https://www.amethyst.rs/doc/latest/doc/amethyst_renderer/struct.PngFormat.html
-[doc_fmt_tga]: https://www.amethyst.rs/doc/latest/doc/amethyst_renderer/struct.TgaFormat.html
-[doc_load]: https://www.amethyst.rs/doc/latest/doc/amethyst_assets/struct.Loader.html#method.load
-[doc_read_resource]: https://www.amethyst.rs/doc/latest/doc/specs/world/struct.World.html#method.read_resource
-[doc_ss]: https://www.amethyst.rs/doc/latest/doc/amethyst_renderer/struct.SpriteSheet.html
-[doc_tex]: https://www.amethyst.rs/doc/latest/doc/amethyst_renderer/struct.Texture.html
-[doc_tex_hd]: https://www.amethyst.rs/doc/latest/doc/amethyst_renderer/type.TextureHandle.html
+[doc_asset]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_assets/trait.Asset.html
+[doc_asset_get]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_assets/struct.AssetStorage.html#method.get
+[doc_fmt_bmp]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_renderer/struct.BmpFormat.html
+[doc_fmt_jpg]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_renderer/struct.JpgFormat.html
+[doc_fmt_png]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_renderer/struct.PngFormat.html
+[doc_fmt_tga]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_renderer/struct.TgaFormat.html
+[doc_load]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_assets/struct.Loader.html#method.load
+[doc_read_resource]: https://www.amethyst-engine.org/doc/latest/doc/specs/world/struct.World.html#method.read_resource
+[doc_ss]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_renderer/struct.SpriteSheet.html
+[doc_tex]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_renderer/struct.Texture.html
+[doc_tex_hd]: https://www.amethyst-engine.org/doc/latest/doc/amethyst_renderer/type.TextureHandle.html

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -199,7 +199,7 @@ There are two types of documentation in Amethyst you can work on:
 1. [API documentation][ad]
 2. [The Amethyst book][ab]
 
-[ad]: https://www.amethyst.rs/doc/master/doc/amethyst/
+[ad]: https://www.amethyst-engine.org/doc/master/doc/amethyst/
 [ab]: https://www.amethyst.rs/book/master/
 
 Our Rust API documentation is generated directly from source code comments


### PR DESCRIPTION
Waiting to hear if this is what we're ready to do, but this was a simple `sed` replace across all files in the repo. I reviewed the diff, there doesn't appear to be any bad edits, but there might be missing edits.