### PR TITLE
Update cargo toml with release docs and remove appveyor badge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["examples/*", "book/*"]
 keywords = ["game", "engine", "sdk", "amethyst"]
 categories = ["game-engines"]
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst"
+documentation = "https://www.amethyst.rs/doc/latest/doc/amethyst"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 
@@ -16,7 +16,6 @@ readme = "README.md"
 license = "MIT/Apache-2.0"
 
 [badges]
-appveyor = { repository = "amethyst/amethyst", branch = "master" }
 travis-ci = { repository = "amethyst/amethyst", branch = "master" }
 
 [features]
@@ -230,4 +229,7 @@ name = "auto_fov"
 path = "examples/auto_fov/main.rs"
 
 [workspace]
-members = ["amethyst_gltf", "tests/amethyst_test"]
+members = [
+  "amethyst_gltf",
+  "tests/amethyst_test"
+]

--- a/amethyst_animation/Cargo.toml
+++ b/amethyst_animation/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 description = "Animation support for Amethyst"
 keywords = ["game", "engine", "animation", "3d", "amethyst"]
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_animation/"
+documentation = "https://www.amethyst.rs/doc/latest/doc/amethyst_animation/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT/Apache-2.0"
 keywords = ["game", "asset", "resource", "management", "amethyst"]
 categories = ["filesystem"]
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst/"
+documentation = "https://www.amethyst.rs/doc/latest/doc/amethyst/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_audio/Cargo.toml
+++ b/amethyst_audio/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["examples/*"]
 keywords = ["game", "engine", "audio","amethyst"]
 categories = ["audio"]
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_audio/"
+documentation = "https://www.amethyst.rs/doc/latest/doc/amethyst_audio/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_config/Cargo.toml
+++ b/amethyst_config/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 description = "Loading from .ron files into Rust structures with defaults to prevent hard errors."
 exclude = ["examples/*"]
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_config/"
+documentation = "https://www.amethyst.rs/doc/latest/doc/amethyst_config/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_controls/Cargo.toml
+++ b/amethyst_controls/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Joël Lupien <jojolepromain@gmail.com>"]
 edition = "2018"
 description = "Amethyst controls"
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_controls/"
+documentation = "https://www.amethyst.rs/doc/latest/doc/amethyst_controls/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Simon Rönnberg <seamonr@gmail.com>"]
 edition = "2018"
 description = "Amethyst core"
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_core/"
+documentation = "https://www.amethyst.rs/doc/latest/doc/amethyst_core/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_derive/Cargo.toml
+++ b/amethyst_derive/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Simon Rönnberg <seamonr@gmail.com>"]
 edition = "2018"
 description = "Amethyst derive"
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_derive/"
+documentation = "https://www.amethyst.rs/doc/latest/doc/amethyst_derive/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Rhuagh <seamonr@gmail.com>"]
 edition = "2018"
 description = "GLTF asset loading"
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_gltf/"
+documentation = "https://www.amethyst.rs/doc/latest/doc/amethyst_gltf/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_input/Cargo.toml
+++ b/amethyst_input/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Rhuagh <seamonr@gmail.com>", "Xaeroxe <kieseljake@gmail.com>"]
 edition = "2018"
 description = "Input rebinding "
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_input/"
+documentation = "https://www.amethyst.rs/doc/latest/doc/amethyst_input/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_locale/Cargo.toml
+++ b/amethyst_locale/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT/Apache-2.0"
 keywords = ["game", "localisation", "resource", "management", "amethyst"]
 categories = ["filesystem,localisation"]
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst/"
+documentation = "https://www.amethyst.rs/doc/latest/doc/amethyst_locale/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_network/Cargo.toml
+++ b/amethyst_network/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["networking", "specs", "ecs", "amethyst", "serialization"]
 categories = ["game-engines"]
 
 readme = "README.md"
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_network/index.html"
+documentation = "https://www.amethyst.rs/doc/latest/doc/amethyst_network/index.html"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 license = "MIT/Apache-2.0"

--- a/amethyst_renderer/Cargo.toml
+++ b/amethyst_renderer/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["examples/*"]
 keywords = ["game", "engine", "renderer", "3d", "amethyst"]
 categories = ["rendering", "rendering::engine"]
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_renderer/"
+documentation = "https://www.amethyst.rs/doc/latest/doc/amethyst_renderer/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -7,7 +7,7 @@ description = "Amethyst UI crate"
 keywords = ["ui", "specs", "ecs", "amethyst"]
 categories = ["game-engines"]
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_ui/"
+documentation = "https://www.amethyst.rs/doc/latest/doc/amethyst_ui/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 license = "MIT/Apache-2.0"

--- a/amethyst_utils/Cargo.toml
+++ b/amethyst_utils/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Simon Rönnberg <seamonr@gmail.com>", "Joël Lupien <jojolepromain@g
 edition = "2018"
 description = "Amethyst utils"
 
-documentation = "https://www.amethyst.rs/doc/master/doc/amethyst_utils/"
+documentation = "https://www.amethyst.rs/doc/latest/doc/amethyst_utils/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -47,7 +47,7 @@ This book is split into several sections, with this introduction being the first
 
 Read the crate-level [API documentation][ad] for more details.
 
-[ad]: https://www.amethyst.rs/doc/master/doc/amethyst/index.html
+[ad]: https://www.amethyst.rs/doc/latest/doc/amethyst/index.html
 
 [db]: https://github.com/amethyst/amethyst/
 

--- a/book/src/pong-tutorial/pong-tutorial-01.md
+++ b/book/src/pong-tutorial/pong-tutorial-01.md
@@ -208,8 +208,8 @@ It should look something like this:
 
 
 [ron]: https://github.com/ron-rs/ron
-[st]: https://www.amethyst.rs/doc/master/doc/amethyst/prelude/trait.SimpleState.html
-[ap]: https://www.amethyst.rs/doc/master/doc/amethyst/struct.Application.html
+[st]: https://www.amethyst.rs/doc/latest/doc/amethyst/prelude/trait.SimpleState.html
+[ap]: https://www.amethyst.rs/doc/latest/doc/amethyst/struct.Application.html
 [gs]: ../getting-started.html
-[displayconf]: https://www.amethyst.rs/doc/master/doc/amethyst_renderer/struct.DisplayConfig.html
+[displayconf]: https://www.amethyst.rs/doc/latest/doc/amethyst_renderer/struct.DisplayConfig.html
 

--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -626,5 +626,5 @@ moving!
 
 [sb]: https://slide-rs.github.io/specs/
 [sb-storage]: https://slide-rs.github.io/specs/05_storages.html#densevecstorage
-[2d]: https://www.amethyst.rs/doc/master/doc/amethyst_renderer/struct.Camera.html#method.standard_2d
+[2d]: https://www.amethyst.rs/doc/latest/doc/amethyst_renderer/struct.Camera.html#method.standard_2d
 [ss]: ../images/pong_tutorial/pong_spritesheet.png

--- a/book/src/pong-tutorial/pong-tutorial-03.md
+++ b/book/src/pong-tutorial/pong-tutorial-03.md
@@ -389,5 +389,5 @@ keypresses, and move our game's paddles accordingly. In the next chapter, we'll
 explore another key concept in real-time games: time. We'll make our game aware
 of time, and add a ball for our paddles to bounce back and forth.
 
-[doc_time]: https://www.amethyst.rs/doc/master/doc/amethyst_core/timing/struct.Time.html
+[doc_time]: https://www.amethyst.rs/doc/latest/doc/amethyst_core/timing/struct.Time.html
 [doc_bindings]: https://www.amethyst.rs/doc/latest/doc/amethyst_input/struct.Bindings.html 

--- a/book/src/pong-tutorial/pong-tutorial-04.md
+++ b/book/src/pong-tutorial/pong-tutorial-04.md
@@ -374,6 +374,6 @@ In the next chapter, we'll add a system checking when a player loses the game,
 and add a scoring system!
 
 [pong_02_drawing]: pong-tutorial-02.html#drawing
-[doc_time]: https://www.amethyst.rs/doc/master/doc/amethyst_core/timing/struct.Time.html
+[doc_time]: https://www.amethyst.rs/doc/latest/doc/amethyst_core/timing/struct.Time.html
 [delta_timing]: https://en.wikipedia.org/wiki/Delta_timing
 


### PR DESCRIPTION
This change updates the docs linked from crates.io to point to the
latest release instead of just master which may have diverged from the
last release. This also removes the appveyor badge since it is no
longer used so therefore it is no longer accurate. Also adds small
formatting changes.