### PR TITLE
compare system font extension as lower case

### DIFF
--- a/amethyst_ui/src/font/default.rs
+++ b/amethyst_ui/src/font/default.rs
@@ -18,11 +18,16 @@ pub fn get_default_font(loader: &Loader, storage: &AssetStorage<FontAsset>) -> F
         Ok(handle) => match handle {
             FontKitHandle::Path { path, .. } => {
                 if let Some(file_extension) = path.extension() {
-                    let format = if file_extension == "ttf" || file_extension == "otf" {
-                        Some(TtfFormat)
-                    } else {
-                        error!("System font '{}' has unknown format", path.display());
-                        None
+                    let format = match file_extension.to_str() {
+                        Some(ext) => {
+                            let ext = ext.to_lowercase();
+                            if ext == "ttf" || ext == "otf" {
+                                Some(TtfFormat)
+                            } else {
+                                None
+                            }
+                        }
+                        None => None,
                     };
 
                     if let Some(format) = format {
@@ -33,6 +38,8 @@ pub fn get_default_font(loader: &Loader, storage: &AssetStorage<FontAsset>) -> F
                             },
                             Err(err) => warn!("System font at '{}' is not available for use. Fallback to default. Error: {}", path.display(), err)
                         }
+                    } else {
+                        error!("System font '{}' has unknown format", path.display());
                     }
                 } else {
                     warn!("System font has no file extension!");

--- a/amethyst_ui/src/font/default.rs
+++ b/amethyst_ui/src/font/default.rs
@@ -20,8 +20,7 @@ pub fn get_default_font(loader: &Loader, storage: &AssetStorage<FontAsset>) -> F
                 if let Some(file_extension) = path.extension() {
                     let format = match file_extension.to_str() {
                         Some(ext) => {
-                            let ext = ext.to_lowercase();
-                            if ext == "ttf" || ext == "otf" {
+                            if ext.eq_ignore_ascii_case("ttf") || ext.eq_ignore_ascii_case("otf") {
                                 Some(TtfFormat)
                             } else {
                                 None

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,9 @@ it is attached to. ([#1282])
 [#1281]: https://github.com/amethyst/amethyst/pull/1281
 [#1302]: https://github.com/amethyst/amethyst/pull/1302
 
+* Fixed default system font loading to accept uppercase extension ("TTF") ([#1328])
+[#1328] https://github.com/amethyst/amethyst/pull/1328
+
 ## [0.10.0] - 2018-12
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ it is attached to. ([#1282])
 ### Fixed
 
 * Fixed the "json" feature for amethyst_assets. ([#1302])
+* Fixed default system font loading to accept uppercase extension ("TTF"). ([#1328])
 
 [#1213]: https://github.com/amethyst/amethyst/pull/1213
 [#1237]: https://github.com/amethyst/amethyst/pull/1237
@@ -40,9 +41,7 @@ it is attached to. ([#1282])
 [#1282]: https://github.com/amethyst/amethyst/pull/1282
 [#1281]: https://github.com/amethyst/amethyst/pull/1281
 [#1302]: https://github.com/amethyst/amethyst/pull/1302
-
-* Fixed default system font loading to accept uppercase extension ("TTF") ([#1328])
-[#1328] https://github.com/amethyst/amethyst/pull/1328
+[#1328]: https://github.com/amethyst/amethyst/pull/1328
 
 ## [0.10.0] - 2018-12
 


### PR DESCRIPTION
Windows might return the default system font with the extension "TTF" (uppercase), so before comparing to "ttf" it should be converted to lowercase (for the comparison only).