### PR TITLE
Add unit tests to input handler

### DIFF
--- a/amethyst_input/Cargo.toml
+++ b/amethyst_input/Cargo.toml
@@ -22,7 +22,7 @@ amethyst_renderer = { path = "../amethyst_renderer/", version = "0.10.0" }
 derivative = "1.0"
 fnv = "1"
 serde = { version = "1", features = ["serde_derive"] }
-winit = { version = "0.18", features = ["serde"] }
+winit = { version = "0.18.1", features = ["serde"] }
 sdl2 = { version = "0.31.0", optional = true }
 
 thread_profiler = { version = "0.3", optional = true }

--- a/amethyst_input/src/bindings.rs
+++ b/amethyst_input/src/bindings.rs
@@ -34,7 +34,7 @@ use super::{Axis, Button};
 /// ```
 #[derive(Derivative, Serialize, Deserialize, Clone)]
 #[derivative(Default(bound = ""))]
-pub struct Bindings<AX, AC>
+pub struct Bindings<AX = String, AC = String>
 where
     AX: Hash + Eq,
     AC: Hash + Eq,

--- a/amethyst_input/src/button.rs
+++ b/amethyst_input/src/button.rs
@@ -10,7 +10,7 @@ pub enum Button {
     Key(VirtualKeyCode),
 
     /// Scan code from keyboard, use this when the position of the key matters
-    /// more than letter on the key.
+    /// more than the letter on the key.
     ScanCode(u32),
 
     /// Mouse buttons

--- a/amethyst_input/src/event.rs
+++ b/amethyst_input/src/event.rs
@@ -10,7 +10,7 @@ use super::{
 ///
 /// Type parameter T is the type assigned to your Actions for your
 /// InputBundle or InputHandler.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(PartialEq, Serialize, Deserialize, Debug, Clone)]
 pub enum InputEvent<T> {
     /// A key was pressed down, sent exactly once per key press.
     KeyPressed {

--- a/amethyst_input/src/input_handler.rs
+++ b/amethyst_input/src/input_handler.rs
@@ -641,7 +641,7 @@ mod tests {
     /// Compares two sets for equality, but not the order
     fn sets_equal<T>(a: &[T], b: &[T])
     where
-        T: PartialEq<T> + Clone + Debug,
+        T: PartialEq<T> + Debug,
     {
         let mut ret = a.len() == b.len();
         

--- a/amethyst_input/src/input_handler.rs
+++ b/amethyst_input/src/input_handler.rs
@@ -639,7 +639,7 @@ mod tests {
     };
 
     /// Compares two sets for equality, but not the order
-    fn sets_equal<T>(a: &[T], b: &[T])
+    fn sets_are_equal<T>(a: &[T], b: &[T])
     where
         T: PartialEq<T> + Debug,
     {
@@ -655,7 +655,6 @@ mod tests {
                     break;
                 }
             }
-            assert_eq!(b.len(), 0);
         };
         if !ret {
             panic!(
@@ -704,7 +703,7 @@ right: `{:?}`",
         );
         assert_eq!(handler.action_is_down("test_key_action"), Some(true));
         let event_vec = events.read(&mut reader).cloned().collect::<Vec<_>>();
-        sets_equal(
+        sets_are_equal(
             &event_vec,
             &[
                 InputEvent::ActionPressed(String::from("test_key_action")),
@@ -739,7 +738,7 @@ right: `{:?}`",
         );
         assert_eq!(handler.action_is_down("test_key_action"), Some(false));
         let event_vec = events.read(&mut reader).cloned().collect::<Vec<_>>();
-        sets_equal(
+        sets_are_equal(
             &event_vec,
             &[
                 InputEvent::ActionReleased(String::from("test_key_action")),
@@ -787,7 +786,7 @@ right: `{:?}`",
         );
         assert_eq!(handler.action_is_down("test_mouse_action"), Some(true));
         let event_vec = events.read(&mut reader).cloned().collect::<Vec<_>>();
-        sets_equal(
+        sets_are_equal(
             &event_vec,
             &[
                 InputEvent::ActionPressed(String::from("test_mouse_action")),
@@ -815,7 +814,7 @@ right: `{:?}`",
         );
         assert_eq!(handler.action_is_down("test_mouse_action"), Some(false));
         let event_vec = events.read(&mut reader).cloned().collect::<Vec<_>>();
-        sets_equal(
+        sets_are_equal(
             &event_vec,
             &[
                 InputEvent::ActionReleased(String::from("test_mouse_action")),
@@ -869,7 +868,7 @@ right: `{:?}`",
         );
         assert_eq!(handler.action_is_down("test_combo_action"), Some(false));
         let event_vec = events.read(&mut reader).cloned().collect::<Vec<_>>();
-        sets_equal(
+        sets_are_equal(
             &event_vec,
             &[
                 InputEvent::KeyPressed {
@@ -903,7 +902,7 @@ right: `{:?}`",
         );
         assert_eq!(handler.action_is_down("test_combo_action"), Some(true));
         let event_vec = events.read(&mut reader).cloned().collect::<Vec<_>>();
-        sets_equal(
+        sets_are_equal(
             &event_vec,
             &[
                 ActionPressed(String::from("test_combo_action")),
@@ -938,7 +937,7 @@ right: `{:?}`",
         );
         assert_eq!(handler.action_is_down("test_combo_action"), Some(false));
         let event_vec = events.read(&mut reader).cloned().collect::<Vec<_>>();
-        sets_equal(
+        sets_are_equal(
             &event_vec,
             &[
                 InputEvent::ActionReleased(String::from("test_combo_action")),
@@ -972,9 +971,9 @@ right: `{:?}`",
             &mut events,
             1.0,
         );
-        assert!(!handler.action_is_down("test_combo_action").unwrap());
+        assert_eq!(handler.action_is_down("test_combo_action"), Some(false));
         let event_vec = events.read(&mut reader).cloned().collect::<Vec<_>>();
-        sets_equal(
+        sets_are_equal(
             &event_vec,
             &[
                 InputEvent::KeyReleased {
@@ -1012,7 +1011,7 @@ right: `{:?}`",
                 event: WindowEvent::KeyboardInput {
                     device_id: unsafe { DeviceId::dummy() },
                     input: KeyboardInput {
-                        scancode: 112,
+                        scancode: 104,
                         state: ElementState::Pressed,
                         virtual_keycode: Some(VirtualKeyCode::Up),
                         modifiers: ModifiersState {
@@ -1034,7 +1033,7 @@ right: `{:?}`",
                 event: WindowEvent::KeyboardInput {
                     device_id: unsafe { DeviceId::dummy() },
                     input: KeyboardInput {
-                        scancode: 112,
+                        scancode: 104,
                         state: ElementState::Released,
                         virtual_keycode: Some(VirtualKeyCode::Up),
                         modifiers: ModifiersState {
@@ -1078,7 +1077,7 @@ right: `{:?}`",
                 event: WindowEvent::KeyboardInput {
                     device_id: unsafe { DeviceId::dummy() },
                     input: KeyboardInput {
-                        scancode: 112,
+                        scancode: 104,
                         state: ElementState::Pressed,
                         virtual_keycode: Some(VirtualKeyCode::Up),
                         modifiers: ModifiersState {
@@ -1100,7 +1099,7 @@ right: `{:?}`",
                 event: WindowEvent::KeyboardInput {
                     device_id: unsafe { DeviceId::dummy() },
                     input: KeyboardInput {
-                        scancode: 112,
+                        scancode: 104,
                         state: ElementState::Released,
                         virtual_keycode: Some(VirtualKeyCode::Up),
                         modifiers: ModifiersState {

--- a/amethyst_ui/src/bundle.rs
+++ b/amethyst_ui/src/bundle.rs
@@ -24,7 +24,7 @@ use crate::{
 ///
 /// Will fail with error 'No resource with the given id' if the InputBundle is not added.
 #[derive(new)]
-pub struct UiBundle<A, B, C = NoCustomUi, G = ()> {
+pub struct UiBundle<A = String, B = String, C = NoCustomUi, G = ()> {
     #[new(default)]
     _marker: PhantomData<(A, B, C, G)>,
 }


### PR DESCRIPTION
Since winit permits this now I'm going to be slowly adding unit tests to the input handler. This is the first PR of several.