### PR TITLE
Fix Skybox crash introduced in #1282

### DIFF
--- a/amethyst_renderer/src/pass/skybox/interleaved.rs
+++ b/amethyst_renderer/src/pass/skybox/interleaved.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 use gfx::pso::buffer::ElemStride;
-use glsl_layout::{mat4, Uniform};
+use glsl_layout::{mat4, vec4, Uniform};
 
 use super::{SkyboxColor, FRAG_SRC, VERT_SRC};
 
@@ -28,6 +28,7 @@ pub(crate) struct VertexArgs {
     proj: mat4,
     view: mat4,
     model: mat4,
+    rgba: vec4,
 }
 
 /// Draw a simple gradient skybox


### PR DESCRIPTION
#1282 seems to introduce a crash when using the Skybox Pass.
The program crashes during the first update with `Error InvalidValue executing command: UpdateBuffer(2, DataPointer { offset: 0, size: 208 }, 0)`

The pass sets up the `raw_constant_buffer` with a `VertexArgs` struct containing only proj, view and model, but later uses `util::set_vertex_args`.

`util::set_vertex_args` calls `update_constant_buffer` with a `VertexArgs` struct containing an additional field for color.

This way `update_constant_buffer` assumes the buffer is bigger than in reality, leading to a Error.

For now setting up the buffer with a color field fixes the problem. Maybe the functions in util should be more dynamic.