### PR TITLE
Add unit tests and errors to input

### DIFF
--- a/amethyst_input/src/bindings.rs
+++ b/amethyst_input/src/bindings.rs
@@ -1,5 +1,7 @@
 //! Defines binding structure used for saving and loading input settings.
 
+use std::error::Error;
+use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::{borrow::Borrow, hash::Hash};
 
 use fnv::FnvHashMap as HashMap;
@@ -36,8 +38,8 @@ use super::{Axis, Button};
 #[derivative(Default(bound = ""))]
 pub struct Bindings<AX = String, AC = String>
 where
-    AX: Hash + Eq,
-    AC: Hash + Eq,
+    AX: Clone + Hash + Eq,
+    AC: Clone + Hash + Eq,
 {
     pub(super) axes: HashMap<AX, Axis>,
     /// The inner array here is for button combinations, the other is for different possibilities.
@@ -47,10 +49,90 @@ where
     pub(super) actions: HashMap<AC, SmallVec<[SmallVec<[Button; 2]>; 4]>>,
 }
 
+/// An enum of possible errors that can occur when binding an action or axis.
+#[derive(Debug, Clone, PartialEq)]
+pub enum BindingError<AX, AC> {
+    /// Combo provided for action binding has two (or more) of the same button.
+    ComboContainsDuplicates,
+    /// Combo provided was already bound to contained action.
+    ComboAlreadyBound(AC),
+    /// A combo of length 1 was provided, and it overlaps with an axis binding.
+    ButtonBoundToAxis(AX, Axis),
+    /// Axis buttons provided have overlap with an existing axis
+    AxisButtonAlreadyBoundToAxis(AX, Axis),
+    /// Axis buttons have overlap with an action combo of length 1.
+    AxisButtonAlreadyBoundToAction(AC, Button),
+    /// That specific axis on that specific controller is already in use for an
+    /// axis binding.
+    ControllerAxisAlreadyBound(AX),
+}
+
+impl<AX, AC> Display for BindingError<AX, AC> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match *self {
+            BindingError::ComboContainsDuplicates => write!(
+                f,
+                "Combo provided contained two (or more) of the same button"
+            ),
+            BindingError::ComboAlreadyBound(ref _action) => {
+                write!(f, "Combo provided was already bound to another action")
+            }
+            BindingError::ButtonBoundToAxis(ref _id, ref _axis) => {
+                write!(f, "Button provided was a button in use by an axis")
+            }
+            BindingError::AxisButtonAlreadyBoundToAxis(ref _id, ref _axis) => write!(
+                f,
+                "Axis provided contained a button that's already in use by another axis"
+            ),
+            BindingError::AxisButtonAlreadyBoundToAction(ref _id, ref _action) => write!(
+                f,
+                "Axis provided contained a button that's already in use by a single button action"
+            ),
+            BindingError::ControllerAxisAlreadyBound(ref _id) => {
+                write!(f, "Controller axis provided is already in use")
+            }
+        }
+    }
+}
+
+impl<AX, AC> Error for BindingError<AX, AC>
+where
+    AX: Debug,
+    AC: Debug,
+{
+}
+
+/// An enum of possible errors that can occur when removing an action binding.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ActionRemovedError {
+    /// The action has bindings. but this isn't one of them.
+    ActionExistsButBindingDoesnt,
+    /// The action provided doesn't exist.
+    ActionMissing,
+    /// Combo provided for action binding has two (or more) of the same button.
+    BindingContainsDuplicates,
+}
+
+impl Display for ActionRemovedError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match *self {
+            ActionRemovedError::ActionExistsButBindingDoesnt => {
+                write!(f, "Action found, but binding isn't present")
+            }
+            ActionRemovedError::ActionMissing => write!(f, "Action not found"),
+            ActionRemovedError::BindingContainsDuplicates => {
+                write!(f, "Binding removal requested contains duplicate buttons")
+            }
+        }
+    }
+}
+
+impl Error for ActionRemovedError {}
+
 impl<AX, AC> Bindings<AX, AC>
 where
-    AX: Hash + Eq,
-    AC: Hash + Eq,
+    AX: Hash + Eq + Clone,
+    AC: Hash + Eq + Clone,
 {
     /// Creates a new empty Bindings structure
     pub fn new() -> Self {
@@ -67,8 +149,14 @@ where
     ///
     /// This will insert a new axis if no entry for this id exists.
     /// If one does exist this will replace the axis at that id and return it.
-    pub fn insert_axis<A: Into<AX>>(&mut self, id: A, axis: Axis) -> Option<Axis> {
-        self.axes.insert(id.into(), axis)
+    pub fn insert_axis<A: Into<AX>>(
+        &mut self,
+        id: A,
+        axis: Axis,
+    ) -> Result<Option<Axis>, BindingError<AX, AC>> {
+        let id = id.into();
+        self.check_axis_invariants(&id, &axis)?;
+        Ok(self.axes.insert(id, axis))
     }
 
     /// Removes an axis, this will return the removed axis if successful.
@@ -88,26 +176,24 @@ where
     }
 
     /// Gets a list of all axes
-    pub fn axes(&self) -> Vec<AX> {
-        self.axes.keys().cloned().collect::<Vec<AX>>()
+    pub fn axes(&self) -> impl Iterator<Item = &AX> {
+        self.axes.keys()
     }
 
     /// Add a button or button combination to an action.
     ///
-    /// This will insert a new binding between this action and the button(s).
-    pub fn insert_action_binding<A, B: IntoIterator<Item = Button>>(&mut self, id: A, binding: B)
-    where
-        A: Hash + Eq + Into<AC>,
-        AC: Borrow<A>,
-    {
+    /// This will attempt to insert a new binding between this action and the button(s).
+    pub fn insert_action_binding<B: IntoIterator<Item = Button>>(
+        &mut self,
+        id: AC,
+        binding: B,
+    ) -> Result<(), BindingError<AX, AC>> {
         let bind: SmallVec<[Button; 2]> = binding.into_iter().collect();
-
+        self.check_action_invariants(bind.as_slice())?;
         let mut make_new = false;
         match self.actions.get_mut(&id) {
             Some(action_bindings) => {
-                if action_bindings.iter().all(|b| b != &bind) {
-                    action_bindings.push(bind.clone());
-                }
+                action_bindings.push(bind.clone());
             }
             None => {
                 make_new = true;
@@ -118,14 +204,26 @@ where
             bindings.push(bind.clone());
             self.actions.insert(id.into(), bindings);
         }
+        Ok(())
     }
 
     /// Removes an action binding that was assigned previously.
-    pub fn remove_action_binding<T: Hash + Eq + ?Sized>(&mut self, id: &T, binding: &[Button])
+    pub fn remove_action_binding<T: Hash + Eq + ?Sized>(
+        &mut self,
+        id: &T,
+        binding: &[Button],
+    ) -> Result<(), ActionRemovedError>
     where
         AC: Borrow<T>,
     {
-        let mut kill_it = false;
+        for i in 0..binding.len() {
+            for j in 0..binding.len() {
+                if i != j && binding[i] == binding[j] {
+                    return Err(ActionRemovedError::BindingContainsDuplicates);
+                }
+            }
+        }
+        let kill_it;
         if let Some(action_bindings) = self.actions.get_mut(id) {
             let index = action_bindings.iter().position(|b| {
                 b.len() == binding.len()
@@ -135,27 +233,504 @@ where
             });
             if let Some(index) = index {
                 action_bindings.swap_remove(index);
+            } else {
+                return Err(ActionRemovedError::ActionExistsButBindingDoesnt);
             }
             kill_it = action_bindings.is_empty();
+        } else {
+            return Err(ActionRemovedError::ActionMissing);
         }
         if kill_it {
             self.actions.remove(id);
         }
+        Ok(())
     }
 
     /// Returns an action's bindings.
-    pub fn action_bindings<T: Hash + Eq + ?Sized>(
-        &self,
-        id: &T,
-    ) -> Option<impl Iterator<Item = &[Button]>>
+    pub fn action_bindings<T: Hash + Eq + ?Sized>(&self, id: &T) -> impl Iterator<Item = &[Button]>
     where
         AC: Borrow<T>,
     {
-        self.actions.get(id).map(|a| a.iter().map(|a| a.as_slice()))
+        self.actions
+            .get(id)
+            .map(|a| a.as_slice())
+            .unwrap_or(&[])
+            .iter()
+            .map(|a| a.as_slice())
     }
 
     /// Gets a list of all action bindings
-    pub fn actions(&self) -> Vec<AC> {
-        self.actions.keys().cloned().collect::<Vec<AC>>()
+    pub fn actions(&self) -> impl Iterator<Item = &AC> {
+        self.actions.keys()
+    }
+
+    /// Check that this structure upholds its guarantees. Should only be necessary when serializing or deserializing the bindings.
+    pub fn check_invariants(&mut self) -> Result<(), BindingError<AX, AC>> {
+        // The easiest way to do this is to use the existing code that checks for invariants when adding bindings.
+        // So we'll just remove and then re-add all of the bindings.
+
+        let action_bindings = self
+            .actions
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect::<Vec<_>>();
+        for (k, v) in action_bindings {
+            for c in v {
+                self.remove_action_binding(&k, &c)
+                    .expect("Unreachable: We just cloned the bindings, they can't be incorrect.");
+                self.insert_action_binding(k.clone(), c)?;
+            }
+        }
+        let axis_bindings = self
+            .axes
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect::<Vec<_>>();
+        for (k, a) in axis_bindings {
+            self.remove_axis(&k);
+            self.insert_axis(k, a)?;
+        }
+        Ok(())
+    }
+
+    fn check_action_invariants(&self, bind: &[Button]) -> Result<(), BindingError<AX, AC>> {
+        // Guarantee each button is unique.
+        for i in 0..bind.len() {
+            for j in 0..bind.len() {
+                if i != j && bind[i] == bind[j] {
+                    return Err(BindingError::ComboContainsDuplicates);
+                }
+            }
+        }
+        if bind.len() == 1 {
+            for (k, a) in self.axes.iter() {
+                match a {
+                    Axis::Emulated { pos, neg } => {
+                        if bind[0] == *pos || bind[0] == *neg {
+                            return Err(BindingError::ButtonBoundToAxis(k.clone(), a.clone()));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        for (k, a) in self.actions.iter() {
+            for c in a {
+                if c.len() == bind.len() && bind.iter().all(|bind| c.iter().any(|c| c == bind)) {
+                    return Err(BindingError::ComboAlreadyBound(k.clone()));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn check_axis_invariants(&self, id: &AX, axis: &Axis) -> Result<(), BindingError<AX, AC>> {
+        match axis {
+            Axis::Emulated {
+                pos: ref axis_pos,
+                neg: ref axis_neg,
+            } => {
+                for (k, a) in self.axes.iter().filter(|(k, _a)| *k != id) {
+                    match a {
+                        Axis::Emulated { pos, neg } => {
+                            if axis_pos == pos
+                                || axis_pos == neg
+                                || axis_neg == pos
+                                || axis_neg == neg
+                            {
+                                return Err(BindingError::AxisButtonAlreadyBoundToAxis(
+                                    k.clone(),
+                                    a.clone(),
+                                ));
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                for (k, a) in self.actions.iter() {
+                    for c in a {
+                        // Since you can't bind combos to an axis we only need to check combos with length 1.
+                        if c.len() == 1 {
+                            if c[0] == *axis_pos || c[0] == *axis_neg {
+                                return Err(BindingError::AxisButtonAlreadyBoundToAction(
+                                    k.clone(),
+                                    c[0].clone(),
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+            Axis::Controller {
+                controller_id: ref input_controller_id,
+                axis: ref input_axis,
+                ..
+            } => {
+                for (k, a) in self.axes.iter().filter(|(k, _a)| *k != id) {
+                    match a {
+                        Axis::Controller {
+                            controller_id,
+                            axis,
+                            ..
+                        } => {
+                            if controller_id == input_controller_id && axis == input_axis {
+                                return Err(BindingError::ControllerAxisAlreadyBound(k.clone()));
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::button::*;
+    use crate::controller::ControllerAxis;
+    use winit::{MouseButton, VirtualKeyCode};
+
+    #[test]
+    fn add_and_remove_actions() {
+        let mut bindings = Bindings::<String, String>::new();
+        assert_eq!(bindings.actions().next(), None);
+        assert_eq!(bindings.action_bindings("test_action").next(), None);
+
+        bindings
+            .insert_action_binding(
+                String::from("test_action"),
+                [Button::Mouse(MouseButton::Left)].iter().cloned(),
+            )
+            .unwrap();
+        assert_eq!(
+            bindings.actions().collect::<Vec<_>>(),
+            vec![&String::from("test_action")]
+        );
+        let action_bindings = bindings.action_bindings("test_action").collect::<Vec<_>>();
+        assert_eq!(action_bindings, vec![[Button::Mouse(MouseButton::Left)]]);
+        bindings
+            .remove_action_binding("test_action", &[Button::Mouse(MouseButton::Left)])
+            .unwrap();
+        assert_eq!(bindings.actions().next(), None);
+        assert_eq!(bindings.action_bindings("test_action").next(), None);
+
+        bindings
+            .insert_action_binding(
+                String::from("test_action"),
+                [
+                    Button::Mouse(MouseButton::Left),
+                    Button::Mouse(MouseButton::Right),
+                ]
+                .iter()
+                .cloned(),
+            )
+            .unwrap();
+        assert_eq!(
+            bindings.actions().collect::<Vec<_>>(),
+            vec![&String::from("test_action")],
+        );
+        let action_bindings = bindings.action_bindings("test_action").collect::<Vec<_>>();
+        assert_eq!(
+            action_bindings,
+            vec![[
+                Button::Mouse(MouseButton::Left),
+                Button::Mouse(MouseButton::Right)
+            ]]
+        );
+        bindings
+            .remove_action_binding(
+                "test_action",
+                &[
+                    Button::Mouse(MouseButton::Left),
+                    Button::Mouse(MouseButton::Right),
+                ],
+            )
+            .unwrap();
+        assert_eq!(bindings.actions().next(), None);
+        assert_eq!(bindings.action_bindings("test_action").next(), None);
+
+        bindings
+            .insert_action_binding(
+                String::from("test_action"),
+                [
+                    Button::Mouse(MouseButton::Left),
+                    Button::Mouse(MouseButton::Right),
+                ]
+                .iter()
+                .cloned(),
+            )
+            .unwrap();
+        assert_eq!(
+            bindings
+                .remove_action_binding(
+                    "test_action",
+                    &[
+                        Button::Mouse(MouseButton::Right),
+                        Button::Mouse(MouseButton::Right),
+                    ],
+                )
+                .unwrap_err(),
+            ActionRemovedError::BindingContainsDuplicates
+        );
+        assert_eq!(
+            bindings
+                .remove_action_binding("test_action", &[Button::Mouse(MouseButton::Left),],)
+                .unwrap_err(),
+            ActionRemovedError::ActionExistsButBindingDoesnt
+        );
+        assert_eq!(
+            bindings
+                .remove_action_binding("nonsense_action", &[Button::Mouse(MouseButton::Left),],)
+                .unwrap_err(),
+            ActionRemovedError::ActionMissing
+        );
+        assert_eq!(
+            bindings
+                .remove_action_binding(
+                    "test_action",
+                    &[
+                        Button::Mouse(MouseButton::Right),
+                        Button::Mouse(MouseButton::Right),
+                    ],
+                )
+                .unwrap_err(),
+            ActionRemovedError::BindingContainsDuplicates
+        );
+        let actions = bindings.actions().collect::<Vec<_>>();
+        assert_eq!(actions, vec![&String::from("test_action")]);
+        let action_bindings = bindings.action_bindings("test_action").collect::<Vec<_>>();
+        assert_eq!(
+            action_bindings,
+            vec![[
+                Button::Mouse(MouseButton::Left),
+                Button::Mouse(MouseButton::Right)
+            ]]
+        );
+        bindings
+            .remove_action_binding(
+                "test_action",
+                &[
+                    Button::Mouse(MouseButton::Right),
+                    Button::Mouse(MouseButton::Left),
+                ],
+            )
+            .unwrap();
+        assert_eq!(bindings.actions().next(), None);
+        assert_eq!(bindings.action_bindings("test_action").next(), None);
+    }
+    #[test]
+    fn insert_errors() {
+        let mut bindings = Bindings::<String, String>::new();
+        assert_eq!(
+            bindings
+                .insert_action_binding(
+                    String::from("test_action"),
+                    [
+                        Button::Mouse(MouseButton::Left),
+                        Button::Mouse(MouseButton::Right),
+                        Button::Mouse(MouseButton::Left),
+                    ]
+                    .iter()
+                    .cloned(),
+                )
+                .unwrap_err(),
+            BindingError::ComboContainsDuplicates
+        );
+        bindings
+            .insert_action_binding(
+                String::from("test_action"),
+                [Button::Mouse(MouseButton::Left)].iter().cloned(),
+            )
+            .unwrap();
+        assert_eq!(
+            bindings
+                .insert_action_binding(
+                    String::from("test_action"),
+                    [Button::Mouse(MouseButton::Left),].iter().cloned(),
+                )
+                .unwrap_err(),
+            BindingError::ComboAlreadyBound(String::from("test_action"))
+        );
+        assert_eq!(
+            bindings
+                .insert_action_binding(
+                    String::from("test_action_2"),
+                    [Button::Mouse(MouseButton::Left),].iter().cloned(),
+                )
+                .unwrap_err(),
+            BindingError::ComboAlreadyBound(String::from("test_action"))
+        );
+        assert_eq!(
+            bindings
+                .insert_axis(
+                    String::from("test_axis"),
+                    Axis::Emulated {
+                        pos: Button::Mouse(MouseButton::Left),
+                        neg: Button::Mouse(MouseButton::Right),
+                    },
+                )
+                .unwrap_err(),
+            BindingError::AxisButtonAlreadyBoundToAction(
+                String::from("test_action"),
+                Button::Mouse(MouseButton::Left)
+            )
+        );
+        assert_eq!(
+            bindings
+                .insert_axis(
+                    String::from("test_axis"),
+                    Axis::Emulated {
+                        pos: Button::Key(VirtualKeyCode::Left),
+                        neg: Button::Key(VirtualKeyCode::Right),
+                    },
+                )
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            bindings
+                .insert_action_binding(
+                    String::from("test_action_2"),
+                    [Button::Key(VirtualKeyCode::Left),].iter().cloned(),
+                )
+                .unwrap_err(),
+            BindingError::ButtonBoundToAxis(
+                String::from("test_axis"),
+                Axis::Emulated {
+                    pos: Button::Key(VirtualKeyCode::Left),
+                    neg: Button::Key(VirtualKeyCode::Right),
+                }
+            )
+        );
+        assert_eq!(
+            bindings
+                .insert_action_binding(
+                    String::from("test_axis_2"),
+                    [Button::Key(VirtualKeyCode::Left),].iter().cloned(),
+                )
+                .unwrap_err(),
+            BindingError::ButtonBoundToAxis(
+                String::from("test_axis"),
+                Axis::Emulated {
+                    pos: Button::Key(VirtualKeyCode::Left),
+                    neg: Button::Key(VirtualKeyCode::Right),
+                }
+            )
+        );
+        assert_eq!(
+            bindings
+                .insert_axis(
+                    String::from("test_axis_2"),
+                    Axis::Emulated {
+                        pos: Button::Key(VirtualKeyCode::Left),
+                        neg: Button::Key(VirtualKeyCode::Up),
+                    },
+                )
+                .unwrap_err(),
+            BindingError::AxisButtonAlreadyBoundToAxis(
+                String::from("test_axis"),
+                Axis::Emulated {
+                    pos: Button::Key(VirtualKeyCode::Left),
+                    neg: Button::Key(VirtualKeyCode::Right),
+                }
+            )
+        );
+        assert_eq!(
+            bindings
+                .insert_axis(
+                    String::from("test_controller_axis"),
+                    Axis::Controller {
+                        controller_id: 0,
+                        axis: ControllerAxis::RightX,
+                        invert: false,
+                        dead_zone: 0.25,
+                    },
+                )
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            bindings
+                .insert_axis(
+                    String::from("test_controller_axis"),
+                    Axis::Controller {
+                        controller_id: 0,
+                        axis: ControllerAxis::LeftX,
+                        invert: false,
+                        dead_zone: 0.25,
+                    },
+                )
+                .unwrap(),
+            Some(Axis::Controller {
+                controller_id: 0,
+                axis: ControllerAxis::RightX,
+                invert: false,
+                dead_zone: 0.25,
+            })
+        );
+        assert_eq!(
+            bindings
+                .insert_axis(
+                    String::from("test_controller_axis_2"),
+                    Axis::Controller {
+                        controller_id: 0,
+                        axis: ControllerAxis::LeftX,
+                        invert: true,
+                        dead_zone: 0.1,
+                    },
+                )
+                .unwrap_err(),
+            BindingError::ControllerAxisAlreadyBound(String::from("test_controller_axis"))
+        );
+    }
+
+    #[test]
+    fn add_and_remove_axes() {
+        let mut bindings = Bindings::<String, String>::new();
+        assert_eq!(
+            bindings
+                .insert_axis(
+                    String::from("test_axis"),
+                    Axis::Emulated {
+                        pos: Button::Key(VirtualKeyCode::Left),
+                        neg: Button::Key(VirtualKeyCode::Right),
+                    },
+                )
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            bindings.remove_axis("test_axis"),
+            Some(Axis::Emulated {
+                pos: Button::Key(VirtualKeyCode::Left),
+                neg: Button::Key(VirtualKeyCode::Right),
+            })
+        );
+        assert_eq!(
+            bindings
+                .insert_axis(
+                    String::from("test_controller_axis"),
+                    Axis::Controller {
+                        controller_id: 0,
+                        axis: ControllerAxis::RightX,
+                        invert: false,
+                        dead_zone: 0.25,
+                    },
+                )
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            bindings.remove_axis("test_controller_axis"),
+            Some(Axis::Controller {
+                controller_id: 0,
+                axis: ControllerAxis::RightX,
+                invert: false,
+                dead_zone: 0.25,
+            })
+        );
     }
 }

--- a/amethyst_input/src/bindings.rs
+++ b/amethyst_input/src/bindings.rs
@@ -227,8 +227,8 @@ where
         AC: Borrow<T>,
     {
         for i in 0..binding.len() {
-            for j in 0..binding.len() {
-                if i != j && binding[i] == binding[j] {
+            for j in (i + 1)..binding.len() {
+                if binding[i] == binding[j] {
                     return Err(ActionRemovedError::BindingContainsDuplicates);
                 }
             }
@@ -303,11 +303,15 @@ where
         Ok(())
     }
 
-    fn check_action_invariants(&self, id: &AC, bind: &[Button]) -> Result<(), BindingError<AX, AC>> {
+    fn check_action_invariants(
+        &self,
+        id: &AC,
+        bind: &[Button],
+    ) -> Result<(), BindingError<AX, AC>> {
         // Guarantee each button is unique.
         for i in 0..bind.len() {
-            for j in 0..bind.len() {
-                if i != j && bind[i] == bind[j] {
+            for j in (i + 1)..bind.len() {
+                if bind[i] == bind[j] {
                     return Err(BindingError::ComboContainsDuplicates(id.clone()));
                 }
             }
@@ -535,7 +539,7 @@ mod tests {
                     .cloned(),
                 )
                 .unwrap_err(),
-            BindingError::ComboContainsDuplicates
+            BindingError::ComboContainsDuplicates(String::from("test_action"))
         );
         bindings
             .insert_action_binding(

--- a/amethyst_input/src/bundle.rs
+++ b/amethyst_input/src/bundle.rs
@@ -1,7 +1,14 @@
 //! ECS input bundle
 
 use serde::{de::DeserializeOwned, Serialize};
-use std::{hash::Hash, path::Path, result::Result as StdResult};
+use std::{
+    convert::From,
+    error::Error,
+    fmt::{Debug, Display, Formatter, Result as FmtResult},
+    hash::Hash,
+    path::Path,
+    result::Result as StdResult,
+};
 
 use amethyst_config::{Config, ConfigError};
 use amethyst_core::{
@@ -9,7 +16,7 @@ use amethyst_core::{
     specs::prelude::DispatcherBuilder,
 };
 
-use crate::{Bindings, InputSystem};
+use crate::{BindingError, Bindings, InputSystem};
 
 #[cfg(feature = "sdl_controller")]
 use crate::sdl_events_system::ControllerMappings;
@@ -34,8 +41,8 @@ use crate::sdl_events_system::ControllerMappings;
 #[derivative(Default(bound = ""))]
 pub struct InputBundle<AX, AC>
 where
-    AX: Hash + Eq,
-    AC: Hash + Eq,
+    AX: Hash + Eq + Clone,
+    AC: Hash + Eq + Clone,
 {
     bindings: Option<Bindings<AX, AC>>,
     #[cfg(feature = "sdl_controller")]
@@ -44,8 +51,8 @@ where
 
 impl<AX, AC> InputBundle<AX, AC>
 where
-    AX: Hash + Eq,
-    AC: Hash + Eq,
+    AX: Hash + Eq + Clone,
+    AC: Hash + Eq + Clone,
 {
     /// Create a new input bundle with no bindings
     pub fn new() -> Self {
@@ -59,12 +66,17 @@ where
     }
 
     /// Load bindings from file
-    pub fn with_bindings_from_file<P: AsRef<Path>>(self, file: P) -> StdResult<Self, ConfigError>
+    pub fn with_bindings_from_file<P: AsRef<Path>>(
+        self,
+        file: P,
+    ) -> StdResult<Self, BindingsFileError<AX, AC>>
     where
         AX: DeserializeOwned + Serialize,
         AC: DeserializeOwned + Serialize,
     {
-        Ok(self.with_bindings(Bindings::load_no_fallback(file)?))
+        let mut bindings = Bindings::load_no_fallback(file)?;
+        bindings.check_invariants()?;
+        Ok(self.with_bindings(bindings))
     }
 
     /// Load SDL controller mappings from file
@@ -109,5 +121,42 @@ where
             &[],
         );
         Ok(())
+    }
+}
+
+/// An error occurred while loading the bindings file.
+#[derive(Debug)]
+pub enum BindingsFileError<AX, AC> {
+    /// Problem in amethyst_config
+    ConfigError(ConfigError),
+    /// Problem with the bindings themselves.
+    BindingError(BindingError<AX, AC>),
+}
+
+impl<AX, AC> Display for BindingsFileError<AX, AC> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            BindingsFileError::ConfigError(ref err) => Display::fmt(err, f),
+            BindingsFileError::BindingError(ref err) => Display::fmt(err, f),
+        }
+    }
+}
+
+impl<AX, AC> Error for BindingsFileError<AX, AC>
+where
+    AX: Debug,
+    AC: Debug,
+{
+}
+
+impl<AX, AC> From<BindingError<AX, AC>> for BindingsFileError<AX, AC> {
+    fn from(error: BindingError<AX, AC>) -> Self {
+        BindingsFileError::BindingError(error)
+    }
+}
+
+impl<AX, AC> From<ConfigError> for BindingsFileError<AX, AC> {
+    fn from(error: ConfigError) -> Self {
+        BindingsFileError::ConfigError(error)
     }
 }

--- a/amethyst_input/src/bundle.rs
+++ b/amethyst_input/src/bundle.rs
@@ -71,8 +71,8 @@ where
         file: P,
     ) -> StdResult<Self, BindingsFileError<AX, AC>>
     where
-        AX: DeserializeOwned + Serialize,
-        AC: DeserializeOwned + Serialize,
+        AX: DeserializeOwned + Serialize + Display,
+        AC: DeserializeOwned + Serialize + Display,
     {
         let mut bindings = Bindings::load_no_fallback(file)?;
         bindings.check_invariants()?;
@@ -133,7 +133,11 @@ pub enum BindingsFileError<AX, AC> {
     BindingError(BindingError<AX, AC>),
 }
 
-impl<AX, AC> Display for BindingsFileError<AX, AC> {
+impl<AX, AC> Display for BindingsFileError<AX, AC>
+where
+    AX: Display,
+    AC: Display,
+{
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             BindingsFileError::ConfigError(ref err) => Display::fmt(err, f),
@@ -144,8 +148,8 @@ impl<AX, AC> Display for BindingsFileError<AX, AC> {
 
 impl<AX, AC> Error for BindingsFileError<AX, AC>
 where
-    AX: Debug,
-    AC: Debug,
+    AX: Debug + Display,
+    AC: Debug + Display,
 {
 }
 

--- a/amethyst_input/src/input_handler.rs
+++ b/amethyst_input/src/input_handler.rs
@@ -25,8 +25,8 @@ use super::{
 #[derivative(Default(bound = ""))]
 pub struct InputHandler<AX = String, AC = String>
 where
-    AX: Hash + Eq,
-    AC: Hash + Eq,
+    AX: Hash + Eq + Clone,
+    AC: Hash + Eq + Clone,
 {
     /// Maps inputs to actions and axes.
     pub bindings: Bindings<AX, AC>,
@@ -45,8 +45,8 @@ where
 
 impl<AX, AC> InputHandler<AX, AC>
 where
-    AX: Hash + Eq,
-    AC: Hash + Eq,
+    AX: Hash + Eq + Clone,
+    AC: Hash + Eq + Clone,
 {
     /// Creates a new input handler.
     pub fn new() -> Self {
@@ -650,10 +650,13 @@ mod tests {
         let mut handler = InputHandler::<String, String>::new();
         let mut events = EventChannel::<InputEvent<String>>::new();
         let mut reader = events.register_reader();
-        handler.bindings.insert_action_binding(
-            String::from("test_key_action"),
-            [Button::Key(VirtualKeyCode::Up)].iter().cloned(),
-        );
+        handler
+            .bindings
+            .insert_action_binding(
+                String::from("test_key_action"),
+                [Button::Key(VirtualKeyCode::Up)].iter().cloned(),
+            )
+            .unwrap();
         assert_eq!(handler.action_is_down("test_key_action"), Some(false));
         handler.send_event(&key_press(104, VirtualKeyCode::Up), &mut events, HIDPI);
         assert_eq!(handler.action_is_down("test_key_action"), Some(true));
@@ -696,10 +699,13 @@ mod tests {
         let mut handler = InputHandler::<String, String>::new();
         let mut events = EventChannel::<InputEvent<String>>::new();
         let mut reader = events.register_reader();
-        handler.bindings.insert_action_binding(
-            String::from("test_mouse_action"),
-            [Button::Mouse(MouseButton::Left)].iter().cloned(),
-        );
+        handler
+            .bindings
+            .insert_action_binding(
+                String::from("test_mouse_action"),
+                [Button::Mouse(MouseButton::Left)].iter().cloned(),
+            )
+            .unwrap();
         assert_eq!(handler.action_is_down("test_mouse_action"), Some(false));
         handler.send_event(&mouse_press(MouseButton::Left), &mut events, HIDPI);
         assert_eq!(handler.action_is_down("test_mouse_action"), Some(true));
@@ -736,15 +742,18 @@ mod tests {
         let mut handler = InputHandler::<String, String>::new();
         let mut events = EventChannel::<InputEvent<String>>::new();
         let mut reader = events.register_reader();
-        handler.bindings.insert_action_binding(
-            String::from("test_combo_action"),
-            [
-                Button::Key(VirtualKeyCode::Up),
-                Button::Key(VirtualKeyCode::Down),
-            ]
-            .iter()
-            .cloned(),
-        );
+        handler
+            .bindings
+            .insert_action_binding(
+                String::from("test_combo_action"),
+                [
+                    Button::Key(VirtualKeyCode::Up),
+                    Button::Key(VirtualKeyCode::Down),
+                ]
+                .iter()
+                .cloned(),
+            )
+            .unwrap();
         assert_eq!(handler.action_is_down("test_combo_action"), Some(false));
         handler.send_event(&key_press(104, VirtualKeyCode::Up), &mut events, HIDPI);
         assert_eq!(handler.action_is_down("test_combo_action"), Some(false));
@@ -818,13 +827,16 @@ mod tests {
 
         let mut handler = InputHandler::<String, String>::new();
         let mut events = EventChannel::<InputEvent<String>>::new();
-        handler.bindings.insert_axis(
-            String::from("test_axis"),
-            Axis::Emulated {
-                pos: Button::Key(VirtualKeyCode::Up),
-                neg: Button::Key(VirtualKeyCode::Down),
-            },
-        );
+        handler
+            .bindings
+            .insert_axis(
+                String::from("test_axis"),
+                Axis::Emulated {
+                    pos: Button::Key(VirtualKeyCode::Up),
+                    neg: Button::Key(VirtualKeyCode::Down),
+                },
+            )
+            .unwrap();
         assert_eq!(handler.axis_value("test_axis"), Some(0.0));
         handler.send_event(&key_press(104, VirtualKeyCode::Up), &mut events, HIDPI);
         assert_eq!(handler.axis_value("test_axis"), Some(1.0));

--- a/amethyst_input/src/lib.rs
+++ b/amethyst_input/src/lib.rs
@@ -15,8 +15,8 @@ extern crate serde;
 pub use self::sdl_events_system::SdlEventsSystem;
 pub use self::{
     axis::Axis,
-    bindings::Bindings,
-    bundle::InputBundle,
+    bindings::{BindingError, Bindings},
+    bundle::{BindingsFileError, InputBundle},
     button::Button,
     controller::{ControllerAxis, ControllerButton, ControllerEvent},
     event::InputEvent,

--- a/amethyst_input/src/system.rs
+++ b/amethyst_input/src/system.rs
@@ -18,8 +18,8 @@ use crate::{Bindings, InputEvent, InputHandler};
 /// and push the results in `EventHandler<InputEvent>`.
 pub struct InputSystem<AX, AC>
 where
-    AX: Hash + Eq,
-    AC: Hash + Eq,
+    AX: Hash + Eq + Clone,
+    AC: Hash + Eq + Clone,
 {
     reader: Option<ReaderId<Event>>,
     bindings: Option<Bindings<AX, AC>>,
@@ -27,8 +27,8 @@ where
 
 impl<AX, AC> InputSystem<AX, AC>
 where
-    AX: Hash + Eq,
-    AC: Hash + Eq,
+    AX: Hash + Eq + Clone,
+    AC: Hash + Eq + Clone,
 {
     /// Create a new input system. Needs a reader id for `EventHandler<winit::Event>`.
     pub fn new(bindings: Option<Bindings<AX, AC>>) -> Self {

--- a/src/error.rs
+++ b/src/error.rs
@@ -85,7 +85,11 @@ impl From<io::Error> for Error {
     }
 }
 
-impl<AX, AC> From<BindingsFileError<AX, AC>> for Error {
+impl<AX, AC> From<BindingsFileError<AX, AC>> for Error
+where
+    AX: Display,
+    AC: Display,
+{
     fn from(e: BindingsFileError<AX, AC>) -> Self {
         match e {
             BindingsFileError::ConfigError(err) => Error::Config(err),

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ use std::{
     result::Result as StdResult,
 };
 
-use crate::{config::ConfigError, core, renderer, state::StateError};
+use crate::{config::ConfigError, core, input::BindingsFileError, renderer, state::StateError};
 
 /// Engine result type.
 pub type Result<T> = StdResult<T, Error>;
@@ -82,5 +82,16 @@ impl From<ConfigError> for Error {
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Self {
         Error::Io(e)
+    }
+}
+
+impl<AX, AC> From<BindingsFileError<AX, AC>> for Error {
+    fn from(e: BindingsFileError<AX, AC>) -> Self {
+        match e {
+            BindingsFileError::ConfigError(err) => Error::Config(err),
+            BindingsFileError::BindingError(err) => Error::Core(core::Error::from_kind(
+                core::ErrorKind::Msg(err.to_string()),
+            )),
+        }
     }
 }


### PR DESCRIPTION
Decided to add some unit tests to `amethyst_input::Bindings`. Along the way I discovered a lot of holes in the API, so I fixed them. The bindings now have much stronger guarantees which they uphold for all operations.