### PR TITLE
Ignore Rustfmt warning on stable for unstable configuration key.

### DIFF
--- a/.concourse/tasks/linux-rustfmt.yml
+++ b/.concourse/tasks/linux-rustfmt.yml
@@ -5,10 +5,22 @@ inputs:
 - name: amethyst
 
 run:
-  path: sh
+  path: bash
   dir: amethyst
   args:
   - -exc
   - |
+    #! /bin/bash
     cargo fmt --version
-    cargo fmt --all -- --check
+
+    # Ignore Rustfmt warnings
+    function rustfmt_nowarn {
+      exec 3<> >(grep -vF "Warning: can't set \`merge_imports = true\`, unstable features are only available in nightly channel" 1>&2)
+
+      cargo fmt --all -- --check; result=$?
+
+      exec 3<&- # Close 3
+      return $result
+    }
+
+    rustfmt_nowarn

--- a/.concourse/tasks/linux-rustfmt.yml
+++ b/.concourse/tasks/linux-rustfmt.yml
@@ -15,9 +15,9 @@ run:
 
     # Ignore Rustfmt warnings
     function rustfmt_nowarn {
-      exec 3<> >(grep -vF "Warning: can't set \`merge_imports = true\`, unstable features are only available in nightly channel" 1>&2)
+      exec 3<> >(grep -v "Warning: can't set .\+, unstable features are only available in nightly channel" 1>&2)
 
-      cargo fmt --all -- --check; result=$?
+      cargo fmt --all -- --check 2>&3; result=$?
 
       exec 3<&- # Close 3
       return $result

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,9 +21,9 @@ check formatting:
     - |
       # Ignore Rustfmt warnings
       function rustfmt_nowarn {
-        exec 3<> >(grep -vF "Warning: can't set \`merge_imports = true\`, unstable features are only available in nightly channel" 1>&2)
+        exec 3<> >(grep -v "Warning: can't set .\+, unstable features are only available in nightly channel" 1>&2)
 
-        cargo fmt --all -- --check; result=$?
+        cargo fmt --all -- --check 2>&3; result=$?
 
         exec 3<&- # Close 3
         return $result

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,19 @@ check formatting:
   stage: fmt
   script:
     - cargo fmt --version
-    - cargo fmt --all -- --check
+    - |
+      # Ignore Rustfmt warnings
+      function rustfmt_nowarn {
+        exec 3<> >(grep -vF "Warning: can't set \`merge_imports = true\`, unstable features are only available in nightly channel")
+
+        cargo fmt --all -- --check; result=$?
+
+        exec 3<&- # Close 3
+        return $result
+      }
+
+      rustfmt_nowarn
+
   only:
     - branches
     - merge_requests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ check formatting:
     - |
       # Ignore Rustfmt warnings
       function rustfmt_nowarn {
-        exec 3<> >(grep -vF "Warning: can't set \`merge_imports = true\`, unstable features are only available in nightly channel")
+        exec 3<> >(grep -vF "Warning: can't set \`merge_imports = true\`, unstable features are only available in nightly channel" 1>&2)
 
         cargo fmt --all -- --check; result=$?
 


### PR DESCRIPTION
Compare [before](https://teamcity.amethyst-engine.org/viewLog.html?tab=buildLog&logTab=tree&filter=debug&expand=all&buildId=241&_focus=113) and [after](https://teamcity.amethyst-engine.org/viewLog.html?buildId=281&buildTypeId=Amethyst_RunTests&tab=buildLog&branch_Amethyst=pull%2F1360&_focus=59#_state=)

Changes this:

```
 ... Over 9000 of these ...
[22:21:17][Step 1/2] Warning: can't set `merge_imports = true`, unstable features are only available in nightly channel.
[22:21:17][Step 1/2] Warning: can't set `merge_imports = true`, unstable features are only available in nightly channel.
[22:21:17][Step 1/2] Warning: can't set `merge_imports = true`, unstable features are only available in nightly channel.
[22:21:17][Step 1/2] Warning: can't set `merge_imports = true`, unstable features are only available in nightly channel.
[22:21:17][Step 1/2] Warning: can't set `merge_imports = true`, unstable features are only available in nightly channel.
[22:21:17][Step 1/2] Diff in /opt/buildagent/work/712b0670149e53ef/amethyst_audio/src/bundle.rs at line 6:
[22:21:17][Step 1/2]      specs::prelude::DispatcherBuilder,
[22:21:17][Step 1/2]  };
[22:21:17][Step 1/2]  
[22:21:17][Step 1/2] -use crate::{
[22:21:17][Step 1/2] -    source::*,
[22:21:17][Step 1/2] -    systems::AudioSystem,
[22:21:17][Step 1/2] -};
[22:21:17][Step 1/2] +use crate::{source::*, systems::AudioSystem};
[22:21:17][Step 1/2]  
[22:21:17][Step 1/2]  /// Audio bundle
[22:21:17][Step 1/2]  ///
[22:21:17][Step 1/2] Warning: can't set `merge_imports = true`, unstable features are only available in nightly channel.
[22:21:17][Step 1/2] Warning: can't set `merge_imports = true`, unstable features are only available in nightly channel.
[22:21:17][Step 1/2] Warning: can't set `merge_imports = true`, unstable features are only available in nightly channel.
[22:21:17][Step 1/2] Warning: can't set `merge_imports = true`, unstable features are only available in nightly channel.
[22:21:17][Step 1/2] Warning: can't set `merge_imports = true`, unstable features are only available in nightly channel.
[22:21:17][Step 1/2] Warning: can't set `merge_imports = true`, unstable features are only available in nightly channel.
[22:21:17][Step 1/2] Warning: can't set `merge_imports = true`, unstable features are only available in nightly channel.
[22:21:17][Step 1/2] Warning: can't set `merge_imports = true`, unstable features are only available in nightly channel.
[22:21:17][Step 1/2] Process exited with code 1
[22:21:18][Step 1/2] Process exited with code 1 (Step: Run rustfmt (Command Line))
[22:21:18][Step 1/2] Step Run rustfmt (Command Line) failed
```

into this:

```
[22:21:17][Step 1/2] Diff in /opt/buildagent/work/712b0670149e53ef/amethyst_audio/src/bundle.rs at line 6:
[22:21:17][Step 1/2]      specs::prelude::DispatcherBuilder,
[22:21:17][Step 1/2]  };
[22:21:17][Step 1/2]  
[22:21:17][Step 1/2] -use crate::{
[22:21:17][Step 1/2] -    source::*,
[22:21:17][Step 1/2] -    systems::AudioSystem,
[22:21:17][Step 1/2] -};
[22:21:17][Step 1/2] +use crate::{source::*, systems::AudioSystem};
[22:21:17][Step 1/2]  
[22:21:17][Step 1/2]  /// Audio bundle
[22:21:17][Step 1/2]  ///
[22:21:17][Step 1/2] Process exited with code 1
[22:21:18][Step 1/2] Process exited with code 1 (Step: Run rustfmt (Command Line))
[22:21:18][Step 1/2] Step Run rustfmt (Command Line) failed
```
