### PR TITLE
Refactor audio initialization to be bundle-centric.

### DIFF
--- a/amethyst_audio/src/bundle.rs
+++ b/amethyst_audio/src/bundle.rs
@@ -6,7 +6,11 @@ use amethyst_core::{
     specs::prelude::DispatcherBuilder,
 };
 
-use crate::source::*;
+use crate::{
+    systems::AudioSystem,
+    output::Output,
+    source::*
+};
 
 /// Audio bundle
 ///
@@ -14,10 +18,12 @@ use crate::source::*;
 ///
 /// `DjSystem` must be added separately if you want to use our background music system.
 ///
-pub struct AudioBundle;
+#[derive(Default)]
+pub struct AudioBundle(Output);
 
 impl<'a, 'b> SystemBundle<'a, 'b> for AudioBundle {
     fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<()> {
+        builder.add(AudioSystem::new(self.0), "audio_system", &[]);
         builder.add(Processor::<Source>::new(), "source_processor", &[]);
         Ok(())
     }

--- a/amethyst_audio/src/output.rs
+++ b/amethyst_audio/src/output.rs
@@ -9,9 +9,7 @@ use std::{
 use cpal::OutputDevices;
 use rodio::{default_output_device, output_devices, Decoder, Device, Sink, Source as RSource};
 
-use amethyst_core::shred::Resources;
-
-use crate::{sink::AudioSink, source::Source, DecoderError};
+use crate::{source::Source, DecoderError};
 
 /// A speaker(s) through which audio can be played.
 ///
@@ -19,6 +17,13 @@ use crate::{sink::AudioSink, source::Source, DecoderError};
 #[derive(Clone, Eq, PartialEq)]
 pub struct Output {
     pub(crate) device: Device,
+}
+
+impl Default for Output {
+    fn default() -> Self {
+        default_output_device().map(|re| Output { device: re })
+            .expect("No default output device")
+    }
 }
 
 impl Output {
@@ -102,16 +107,5 @@ pub fn default_output() -> Option<Output> {
 pub fn outputs() -> OutputIterator {
     OutputIterator {
         input: output_devices(),
-    }
-}
-
-/// Initialize default output
-pub fn init_output(res: &mut Resources) {
-    if let Some(o) = default_output() {
-        res.entry::<AudioSink>()
-            .or_insert_with(|| AudioSink::new(&o));
-        res.entry::<Output>().or_insert_with(|| o);
-    } else {
-        error!("Failed finding a default audio output to hook AudioSink to, audio will not work!")
     }
 }

--- a/amethyst_audio/src/systems/audio.rs
+++ b/amethyst_audio/src/systems/audio.rs
@@ -10,23 +10,25 @@ use std::{
 use rodio::SpatialSink;
 
 use amethyst_core::{
-    specs::prelude::{Entities, Entity, Join, Read, ReadStorage, System, WriteStorage},
+    specs::prelude::{Entities, Entity, Join, Read, Resources, ReadStorage, System, SystemData, WriteStorage},
     transform::GlobalTransform,
 };
 
 use crate::{
+    AudioSink,
     components::{AudioEmitter, AudioListener},
     end_signal::EndSignalSource,
+    output::Output,
 };
 
 /// Syncs 3D transform data with the audio engine to provide 3D audio.
 #[derive(Default)]
-pub struct AudioSystem;
+pub struct AudioSystem(Output);
 
 impl AudioSystem {
     /// Produces a new AudioSystem that uses the given listener.
-    pub fn new() -> AudioSystem {
-        Default::default()
+    pub fn new(output: Output) -> AudioSystem {
+        AudioSystem(output)
     }
 }
 
@@ -106,5 +108,12 @@ impl<'a> System<'a> for AudioSystem {
                 }
             }
         }
+    }
+
+    fn setup(&mut self, res: &mut Resources) {
+        Self::SystemData::setup(res);
+        let sink = AudioSink::new(&self.0);
+        res.insert(sink);
+        res.insert(self.0.clone());
     }
 }

--- a/amethyst_audio/src/systems/dj.rs
+++ b/amethyst_audio/src/systems/dj.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use amethyst_assets::AssetStorage;
 use amethyst_core::{
-    shred::{Resource, Resources},
+    shred::Resource,
     specs::{
         common::Errors,
         prelude::{Read, System, WriteExpect},
@@ -10,7 +10,6 @@ use amethyst_core::{
 };
 
 use crate::{
-    output::init_output,
     sink::AudioSink,
     source::{Source, SourceHandle},
 };
@@ -56,11 +55,5 @@ where
                 }
             }
         }
-    }
-
-    fn setup(&mut self, res: &mut Resources) {
-        use amethyst_core::specs::prelude::SystemData;
-        Self::SystemData::setup(res);
-        init_output(res);
     }
 }

--- a/examples/pong/main.rs
+++ b/examples/pong/main.rs
@@ -72,7 +72,7 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(PongBundle)?
         .with_bundle(RenderBundle::new(pipe, Some(config)).with_sprite_sheet_processor())?
         .with_bundle(TransformBundle::new().with_dep(&["ball_system", "paddle_system"]))?
-        .with_bundle(AudioBundle)?
+        .with_bundle(AudioBundle::default())?
         .with(
             DjSystem::new(|music: &mut Music| music.music.next()),
             "dj_system",

--- a/examples/ui/main.rs
+++ b/examples/ui/main.rs
@@ -6,7 +6,7 @@ extern crate log;
 
 use amethyst::{
     assets::{PrefabLoader, PrefabLoaderSystem, Processor, RonFormat},
-    audio::{output::init_output, Source},
+    audio::{AudioBundle, Source},
     core::{frame_limiter::FrameRateLimitStrategy, transform::TransformBundle, Time},
     ecs::prelude::{Entity, System, Write},
     input::{is_close_requested, is_key_down, InputBundle},
@@ -38,7 +38,6 @@ impl SimpleState for Example {
             loader.load("prefab/sphere.ron", RonFormat, (), ())
         });
         world.create_entity().with(handle).build();
-        init_output(&mut world.res);
         world.exec(|mut creator: UiCreator<'_>| {
             creator.create("ui/example.ron", ());
         });
@@ -124,8 +123,8 @@ fn main() -> amethyst::Result<()> {
     let game_data = GameDataBuilder::default()
         .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[])
         .with_bundle(TransformBundle::new())?
+        .with_bundle(AudioBundle::default())?
         .with_bundle(UiBundle::<String, String>::new())?
-        .with(Processor::<Source>::new(), "source_processor", &[])
         .with(UiEventHandlerSystem::new(), "ui_event_handler", &[])
         .with_bundle(FPSCounterBundle::default())?
         .with_bundle(InputBundle::<String, String>::new())?


### PR DESCRIPTION
I haven't yet written the changelog entry for this because this is my biggest change so far, and I'd like feedback on its implementation so I'm not rewriting the changelog entries.

This change addresses the following points of confusion for me:

 * We have a thing called an `AudioSystem` which seems to only manage spatial audio. There's another thing called a `DjSystem` that manages background music.
 * Device initialization seems to happen outside of either system. It isn't enough to add a single bundle to get sound support, and to look to that bundle's entrypoints for guidance on how to do that. Instead, you initialize the device, and it isn't clear if I even *can* select something other than the default output device.
 * There is an `AudioBundle`, but it really doesn't seem to add very much value.

This PR gets rid of the separate functionality for initializing audio devices, moving it into `AudioBundle`. The `Default` implementation of this bundle initializes a default `AudioSystem` which, in turn, initializes the default audio device. Other devices can be passed to `AudioSystem::new(device)`, or to `AudioBundle::new(...)` which, in turn, propagates it to the system.

It's possible that `AudioSystem` should be broken into `SpatialAudioSystem` with `AudioSystem` only managing sound hardware more conveniently. It's also possible that `AudioSystem` may eventually manage both non-spatial and spatial audio. I'd like to eventually see a more seamless joining of spatial audio, non-spatial audio, and music. Technically, music is just non-spatial audio, as are some ambiences, UI sounds, etc. and the only difference is that you've got a `SoundEmitter` without a `Transform`.

But for now I'm just trying to get a handle on cleaning up initialization, and would like to punt potentially splitting systems to future work. It just makes sense to me that, just as the `RenderSystem` manages display devices, the `AudioSystem` should be the single source of truth for audio hardware, and the entrypoint for picking a device should be `AudioBundle`. It was the first place I looked when trying to figure things out.

Thanks.