### PR TITLE
Set width and height of Pong Paddles

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,7 @@ it is attached to. ([#1282])
 
 * Fixed the "json" feature for amethyst_assets. ([#1302])
 * Fixed default system font loading to accept uppercase extension ("TTF"). ([#1328])
+* Set width and height of Pong Paddles ([#1363])
 
 [#1114]: https://github.com/amethyst/amethyst/pull/1114
 [#1213]: https://github.com/amethyst/amethyst/pull/1213
@@ -47,6 +48,7 @@ it is attached to. ([#1282])
 [#1302]: https://github.com/amethyst/amethyst/pull/1302
 [#1328]: https://github.com/amethyst/amethyst/pull/1328
 [#1356]: https://github.com/amethyst/amethyst/pull/1356
+[#1363]: https://github.com/amethyst/amethyst/pull/1363
 
 ## [0.10.0] - 2018-12
 

--- a/examples/pong_tutorial_02/pong.rs
+++ b/examples/pong_tutorial_02/pong.rs
@@ -12,7 +12,7 @@ use amethyst::{
 const ARENA_HEIGHT: f32 = 100.0;
 const ARENA_WIDTH: f32 = 100.0;
 
-const _PADDLE_HEIGHT: f32 = 16.0; // As this constant is not used yet, we introduce the `_` so that we don't get a warning
+const PADDLE_HEIGHT: f32 = 16.0;
 const PADDLE_WIDTH: f32 = 4.0;
 
 pub struct Pong;
@@ -49,8 +49,8 @@ impl Paddle {
     fn new(side: Side) -> Paddle {
         Paddle {
             side: side,
-            width: 1.0,
-            height: 1.0,
+            width: PADDLE_WIDTH,
+            height: PADDLE_HEIGHT,
         }
     }
 }

--- a/examples/pong_tutorial_03/pong.rs
+++ b/examples/pong_tutorial_03/pong.rs
@@ -49,8 +49,8 @@ impl Paddle {
     fn new(side: Side) -> Paddle {
         Paddle {
             side: side,
-            width: 1.0,
-            height: 1.0,
+            width: PADDLE_WIDTH,
+            height: PADDLE_HEIGHT,
         }
     }
 }

--- a/examples/pong_tutorial_04/pong.rs
+++ b/examples/pong_tutorial_04/pong.rs
@@ -52,8 +52,8 @@ impl Paddle {
     fn new(side: Side) -> Paddle {
         Paddle {
             side: side,
-            width: 1.0,
-            height: 1.0,
+            width: PADDLE_WIDTH,
+            height: PADDLE_HEIGHT,
         }
     }
 }

--- a/examples/pong_tutorial_05/pong.rs
+++ b/examples/pong_tutorial_05/pong.rs
@@ -54,8 +54,8 @@ impl Paddle {
     fn new(side: Side) -> Paddle {
         Paddle {
             side: side,
-            width: 1.0,
-            height: 1.0,
+            width: PADDLE_WIDTH,
+            height: PADDLE_HEIGHT,
         }
     }
 }


### PR DESCRIPTION
I am not sure, whether this is taken care somewhere else / at some different time, but the master version of the book already changed this (see line 182ff [here](https://github.com/amethyst/amethyst/blob/master/book/src/pong-tutorial/pong-tutorial-02.md)):

In the example, the paddle come with a dimension of 1x1:
```rust
impl Paddle {
    fn new(side: Side) -> Paddle {
        Paddle {
            side: side,
            width: 1.0,
            height: 1.0,
        }
    }
}
```

The `BounceSystem` later use these width / height to compute collisions ... so only exact hits in the center of the paddle give a collision.