### PR TITLE
refactor: Encapsulate texture + texture offset in a texture view.

### DIFF
--- a/amethyst_renderer/src/lib.rs
+++ b/amethyst_renderer/src/lib.rs
@@ -47,7 +47,7 @@ pub use crate::{
     },
     light::{DirectionalLight, Light, LightPrefab, PointLight, SpotLight, SunLight},
     mesh::{vertex_data, Mesh, MeshBuilder, MeshHandle, VertexBuffer},
-    mtl::{Material, MaterialDefaults, TextureOffset},
+    mtl::{Material, MaterialDefaults},
     pass::{
         get_camera, set_vertex_args, DebugLinesParams, DrawDebugLines, DrawFlat, DrawFlat2D,
         DrawFlatSeparate, DrawPbm, DrawPbmSeparate, DrawShaded, DrawShadedSeparate, DrawSkybox,
@@ -72,7 +72,8 @@ pub use crate::{
     sprite_visibility::{SpriteVisibility, SpriteVisibilitySortingSystem},
     system::RenderSystem,
     tex::{
-        FilterMethod, SamplerInfo, SurfaceType, Texture, TextureBuilder, TextureHandle, WrapMode,
+        FilterMethod, SamplerInfo, SurfaceType, Texture, TextureBuilder, TextureHandle,
+        TextureOffset, TextureView, WrapMode,
     },
     transparent::{
         Blend, BlendChannel, BlendValue, ColorMask, Equation, Factor, Transparent, ALPHA, REPLACE,

--- a/amethyst_renderer/src/mtl.rs
+++ b/amethyst_renderer/src/mtl.rs
@@ -2,27 +2,7 @@
 
 use amethyst_core::specs::prelude::{Component, DenseVecStorage};
 
-use serde::{Deserialize, Serialize};
-
-use crate::tex::TextureHandle;
-
-/// Material reference this part of the texture
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct TextureOffset {
-    /// Start and end offset for U coordinate
-    pub u: (f32, f32),
-    /// Start and end offset for V coordinate
-    pub v: (f32, f32),
-}
-
-impl Default for TextureOffset {
-    fn default() -> Self {
-        TextureOffset {
-            u: (0., 1.),
-            v: (0., 1.),
-        }
-    }
-}
+use crate::tex::TextureView;
 
 /// Material struct.
 #[derive(Clone, PartialEq)]
@@ -30,33 +10,19 @@ pub struct Material {
     /// Alpha cutoff: the value at which we do not draw the pixel
     pub alpha_cutoff: f32,
     /// Diffuse map.
-    pub albedo: TextureHandle,
-    /// Diffuse texture offset
-    pub albedo_offset: TextureOffset,
+    pub albedo: TextureView,
     /// Emission map.
-    pub emission: TextureHandle,
-    /// Emission texture offset
-    pub emission_offset: TextureOffset,
+    pub emission: TextureView,
     /// Normal map.
-    pub normal: TextureHandle,
-    /// Normal texture offset
-    pub normal_offset: TextureOffset,
+    pub normal: TextureView,
     /// Metallic map.
-    pub metallic: TextureHandle,
-    /// Metallic texture offset
-    pub metallic_offset: TextureOffset,
+    pub metallic: TextureView,
     /// Roughness map.
-    pub roughness: TextureHandle,
-    /// Roughness texture offset
-    pub roughness_offset: TextureOffset,
+    pub roughness: TextureView,
     /// Ambient occlusion map.
-    pub ambient_occlusion: TextureHandle,
-    /// Ambient occlusion texture offset
-    pub ambient_occlusion_offset: TextureOffset,
+    pub ambient_occlusion: TextureView,
     /// Caveat map.
-    pub caveat: TextureHandle,
-    /// Caveat texture offset
-    pub caveat_offset: TextureOffset,
+    pub caveat: TextureView,
 }
 
 impl Component for Material {

--- a/amethyst_renderer/src/pass/util.rs
+++ b/amethyst_renderer/src/pass/util.rs
@@ -16,11 +16,11 @@ use amethyst_core::{
 use crate::{
     cam::{ActiveCamera, Camera},
     mesh::Mesh,
-    mtl::{Material, MaterialDefaults, TextureOffset},
+    mtl::{Material, MaterialDefaults},
     pass::set_skinning_buffers,
     pipe::{Effect, EffectBuilder},
     skinning::JointTransforms,
-    tex::Texture,
+    tex::{Texture, TextureOffset},
     types::Encoder,
     vertex::Attributes,
     Rgba,
@@ -128,26 +128,26 @@ pub(crate) fn add_textures(
     for ty in types {
         let texture = match *ty {
             Albedo => storage
-                .get(&material.albedo)
-                .or_else(|| storage.get(&default.albedo)),
+                .get(&material.albedo.texture)
+                .or_else(|| storage.get(&default.albedo.texture)),
             Emission => storage
-                .get(&material.emission)
-                .or_else(|| storage.get(&default.emission)),
+                .get(&material.emission.texture)
+                .or_else(|| storage.get(&default.emission.texture)),
             Normal => storage
-                .get(&material.normal)
-                .or_else(|| storage.get(&default.normal)),
+                .get(&material.normal.texture)
+                .or_else(|| storage.get(&default.normal.texture)),
             Metallic => storage
-                .get(&material.metallic)
-                .or_else(|| storage.get(&default.metallic)),
+                .get(&material.metallic.texture)
+                .or_else(|| storage.get(&default.metallic.texture)),
             Roughness => storage
-                .get(&material.roughness)
-                .or_else(|| storage.get(&default.roughness)),
+                .get(&material.roughness.texture)
+                .or_else(|| storage.get(&default.roughness.texture)),
             AmbientOcclusion => storage
-                .get(&material.ambient_occlusion)
-                .or_else(|| storage.get(&default.ambient_occlusion)),
+                .get(&material.ambient_occlusion.texture)
+                .or_else(|| storage.get(&default.ambient_occlusion.texture)),
             Caveat => storage
-                .get(&material.caveat)
-                .or_else(|| storage.get(&default.caveat)),
+                .get(&material.caveat.texture)
+                .or_else(|| storage.get(&default.caveat.texture)),
         };
         add_texture(effect, texture.expect("Texture missing in asset storage"));
     }
@@ -213,37 +213,37 @@ pub(crate) fn set_texture_offsets(
         match *ty {
             Albedo => effect.update_constant_buffer(
                 "AlbedoOffset",
-                &TextureOffsetPod::from_offset(&material.albedo_offset).std140(),
+                &TextureOffsetPod::from_offset(&material.albedo.offset).std140(),
                 encoder,
             ),
             Emission => effect.update_constant_buffer(
                 "EmissionOffset",
-                &TextureOffsetPod::from_offset(&material.emission_offset).std140(),
+                &TextureOffsetPod::from_offset(&material.emission.offset).std140(),
                 encoder,
             ),
             Normal => effect.update_constant_buffer(
                 "NormalOffset",
-                &TextureOffsetPod::from_offset(&material.normal_offset).std140(),
+                &TextureOffsetPod::from_offset(&material.normal.offset).std140(),
                 encoder,
             ),
             Metallic => effect.update_constant_buffer(
                 "MetallicOffset",
-                &TextureOffsetPod::from_offset(&material.metallic_offset).std140(),
+                &TextureOffsetPod::from_offset(&material.metallic.offset).std140(),
                 encoder,
             ),
             Roughness => effect.update_constant_buffer(
                 "RoughnessOffset",
-                &TextureOffsetPod::from_offset(&material.roughness_offset).std140(),
+                &TextureOffsetPod::from_offset(&material.roughness.offset).std140(),
                 encoder,
             ),
             AmbientOcclusion => effect.update_constant_buffer(
                 "AmbientOcclusionOffset",
-                &TextureOffsetPod::from_offset(&material.ambient_occlusion_offset).std140(),
+                &TextureOffsetPod::from_offset(&material.ambient_occlusion.offset).std140(),
                 encoder,
             ),
             Caveat => effect.update_constant_buffer(
                 "CaveatOffset",
-                &TextureOffsetPod::from_offset(&material.caveat_offset).std140(),
+                &TextureOffsetPod::from_offset(&material.caveat.offset).std140(),
                 encoder,
             ),
         };

--- a/amethyst_renderer/src/system.rs
+++ b/amethyst_renderer/src/system.rs
@@ -27,7 +27,7 @@ use crate::{
     pipe::{PipelineBuild, PipelineData, PolyPipeline},
     renderer::Renderer,
     resources::{ScreenDimensions, WindowMessages},
-    tex::Texture,
+    tex::{Texture, TextureView},
 };
 
 /// Rendering system.
@@ -217,8 +217,6 @@ where
 }
 
 fn create_default_mat(res: &mut Resources) -> Material {
-    use crate::mtl::TextureOffset;
-
     use amethyst_assets::Loader;
 
     let loader = res.fetch::<Loader>();
@@ -243,20 +241,13 @@ fn create_default_mat(res: &mut Resources) -> Material {
 
     Material {
         alpha_cutoff: 0.01,
-        albedo,
-        albedo_offset: TextureOffset::default(),
-        emission,
-        emission_offset: TextureOffset::default(),
-        normal,
-        normal_offset: TextureOffset::default(),
-        metallic,
-        metallic_offset: TextureOffset::default(),
-        roughness,
-        roughness_offset: TextureOffset::default(),
-        ambient_occlusion,
-        ambient_occlusion_offset: TextureOffset::default(),
-        caveat,
-        caveat_offset: TextureOffset::default(),
+        albedo: TextureView::from(albedo),
+        emission: TextureView::from(emission),
+        normal: TextureView::from(normal),
+        metallic: TextureView::from(metallic),
+        roughness: TextureView::from(roughness),
+        ambient_occlusion: TextureView::from(ambient_occlusion),
+        caveat: TextureView::from(caveat),
     }
 }
 

--- a/amethyst_renderer/src/tex.rs
+++ b/amethyst_renderer/src/tex.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 
 use amethyst_assets::{Asset, Handle};
-use amethyst_core::specs::prelude::DenseVecStorage;
+use amethyst_core::specs::{Component, DenseVecStorage};
 
 use crate::{
     error::Result,
@@ -215,4 +215,58 @@ where
             view,
         })
     }
+}
+
+/// `TextureOffset` controls what part of a texture the texture coordinates refer to.
+/// An example: A vertex that refer to texture coordinates (0.5, 0.5), and `TextureOffset` as below,
+/// the vertex will get the actual texture coordinates (0.25, 0.25).
+///
+/// ```
+/// # use amethyst_renderer::TextureOffset;
+/// TextureOffset {
+///     u: (0.0, 0.5),
+///     v: (0.0, 0.5),
+/// };
+/// ```
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct TextureOffset {
+    /// Start and end offset for U coordinate
+    pub u: (f32, f32),
+    /// Start and end offset for V coordinate
+    pub v: (f32, f32),
+}
+
+impl Default for TextureOffset {
+    fn default() -> Self {
+        TextureOffset {
+            u: (0., 1.),
+            v: (0., 1.),
+        }
+    }
+}
+
+/// `TextureView` encapsulates a texture and what part of the texture the texture coordinates refer
+/// to. This can be used in many ways:
+///
+/// * As a `Component` directly, as part of the `DrawFlat2D` pass.
+/// * As a part of `Material` in the other passes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TextureView {
+    /// Texture
+    pub texture: TextureHandle,
+    /// Texture offset
+    pub offset: TextureOffset,
+}
+
+impl From<TextureHandle> for TextureView {
+    fn from(texture: TextureHandle) -> Self {
+        TextureView {
+            texture,
+            offset: TextureOffset::default(),
+        }
+    }
+}
+
+impl Component for TextureView {
+    type Storage = DenseVecStorage<Self>;
 }


### PR DESCRIPTION
BREAKING CHANGE: Material is now split into a TextureView per texture type, instead of containing Texture + TextureOffset directly in the Material.
DrawFlat2D now have support to render entities with only a TextureView linked (instead of SpriteRender/TextureHandle).

https://favro.com/organization/6ede1867e67716a0dd0b8a15/14a6fa43afc95c4735e435e2?card=ame-499

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amethyst/amethyst/1369)
<!-- Reviewable:end -->
