### PR TITLE
Docs/1114/prefab guides adapter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,6 +207,10 @@ name = "prefab"
 path = "examples/prefab/main.rs"
 
 [[example]]
+name = "prefab_adapter"
+path = "examples/prefab_adapter/main.rs"
+
+[[example]]
 name = "prefab_basic"
 path = "examples/prefab_basic/main.rs"
 

--- a/book/src/prefabs/how_to_define_prefabs_adapter.md
+++ b/book/src/prefabs/how_to_define_prefabs_adapter.md
@@ -1,7 +1,175 @@
 # How to Define Prefabs: Adapter
 
-> **Note:** This guide is not yet written. Please check back later!
->
-> If you would like to contribute, please let us know in [#1114]
+This guide explains how to define a [`PrefabData`] for a [`Component`] using an intermediate type called an adapter. This pattern is used when there are multiple ways to serialize / construct the [`Component`]:
 
-[#1114]: https://github.com/amethyst/amethyst/issues/1114
+```rust,edition2018,no_run,noplaypen
+# extern crate amethyst;
+# extern crate serde;
+# extern crate specs_derive;
+#
+# use amethyst::ecs::{storage::DenseVecStorage, Component};
+# use serde::{Deserialize, Serialize};
+# use specs_derive::Component;
+#
+# #[derive(Component, Debug, Deserialize, Serialize /* .. */)]
+# pub struct Position(pub f32, pub f32, pub f32);
+#
+impl From<(i32, i32, i32)> for Position {
+    fn from((x, y, z): (i32, i32, i32)) -> Position {
+        Position(x as f32, y as f32, z as f32)
+    }
+}
+
+impl From<(f32, f32, f32)> for Position {
+    fn from((x, y, z): (f32, f32, f32)) -> Position {
+        Position(x, y, z)
+    }
+}
+```
+
+If you are attempting to adapt a more complex type, please choose the appropriate guide from the [available guides][bk_prefab_prelude].
+
+## Steps
+
+1. Ensure your crate has the following dependencies:
+
+    ```toml
+    [dependencies]
+    amethyst = ".." # Minimum version 0.10
+    serde = { version = "1.0", features = ["derive"] }
+    ```
+
+2. Define the adapter prefab data type.
+
+    Create a (de)serializable enum type with a variant for each representation. The following is an example of an adapter type for the [`Position`] component, which allows either `i32` or `f32` values to be specified in the prefab:
+
+    ```rust,edition2018,no_run,noplaypen
+    # extern crate amethyst;
+    # extern crate serde;
+    #
+    use amethyst::{
+        assets::{PrefabData, ProgressCounter},
+        ecs::{Entity, WriteStorage},
+        Error,
+    };
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Clone, Copy, Deserialize, PartialEq, Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub enum PositionPrefab {
+        Pos3f { x: f32, y: f32, z: f32 },
+        Pos3i { x: i32, y: i32, z: i32 },
+    }
+    ```
+
+    The [`#[serde(deny_unknown_fields)]`] ensures that deserialization produces an error if it encounters an unknown field. This will help expose mistakes in the prefab file, such as when there is a typo.
+
+    **Note:** You may already have a type that captures the multiple representations. For example, for the [`Camera`] component, the [`Projection`] enum captures the different representations:
+
+    ```rust,edition2018,no_run,noplaypen
+    # extern crate amethyst;
+    # extern crate serde;
+    #
+    # use amethyst::core::nalgebra::{Orthographic3, Perspective3};
+    # use serde::{Deserialize, Serialize};
+    #
+    #[derive(Clone, Deserialize, PartialEq, Serialize)]
+    pub enum Projection {
+        Orthographic(Orthographic3<f32>),
+        Perspective(Perspective3<f32>),
+    }
+    ```
+
+3. Implement the [`PrefabData`] trait for the adapter type.
+
+    ```rust,edition2018,no_run,noplaypen
+    # extern crate amethyst;
+    # extern crate specs_derive;
+    # extern crate serde;
+    #
+    # use amethyst::{
+    #     assets::{PrefabData, ProgressCounter},
+    #     ecs::{storage::DenseVecStorage, Component, Entity, WriteStorage},
+    #     Error,
+    # };
+    # use specs_derive::Component;
+    # use serde::{Deserialize, Serialize};
+    #
+    # #[derive(Component, Debug, Deserialize, Serialize /* .. */)]
+    # pub struct Position(pub f32, pub f32, pub f32);
+    #
+    # impl From<(i32, i32, i32)> for Position {
+    #     fn from((x, y, z): (i32, i32, i32)) -> Position {
+    #         Position(x as f32, y as f32, z as f32)
+    #     }
+    # }
+    #
+    # impl From<(f32, f32, f32)> for Position {
+    #     fn from((x, y, z): (f32, f32, f32)) -> Position {
+    #         Position(x, y, z)
+    #     }
+    # }
+    #
+    # #[derive(Clone, Copy, Deserialize, PartialEq, Serialize)]
+    # #[serde(deny_unknown_fields)]
+    # pub enum PositionPrefab {
+    #     Pos3f { x: f32, y: f32, z: f32 },
+    #     Pos3i { x: i32, y: i32, z: i32 },
+    # }
+    #
+    impl<'a> PrefabData<'a> for PositionPrefab {
+        // To attach the `Position` to the constructed entity,
+        // we write to the `Position` component storage.
+        type SystemData = WriteStorage<'a, Position>;
+
+        // This associated type is not used in this pattern,
+        // so the empty tuple is specified.
+        type Result = ();
+
+        fn add_to_entity(
+            &self,
+            entity: Entity,
+            positions: &mut Self::SystemData,
+            _entities: &[Entity],
+        ) -> Result<(), Error> {
+            let position = match *self {
+                PositionPrefab::Pos3f { x, y, z } => (x, y, z).into(),
+                PositionPrefab::Pos3i { x, y, z } => (x, y, z).into(),
+            };
+            positions.insert(entity, position).map(|_| ())?;
+            Ok(())
+        }
+    }
+    ```
+
+4. Now the adapter type can be used in a prefab to attach the component to the entity.
+
+    ```rust,ignore
+    #![enable(implicit_some)]
+    Prefab(
+        entities: [
+            PrefabEntity(
+                data: Pos3f(x: 1.0, y: 2.0, z: 3.0),
+            ),
+            PrefabEntity(
+                data: Pos3i(x: 4, y: 5, z: 6),
+            ),
+        ],
+    )
+    ```
+
+To see this in a complete example, run the [`prefab_adapter` example][repo_prefab_adapter] from the Amethyst repository:
+
+```bash
+cargo run --example prefab_adapter
+```
+
+[`#[serde(default)]`]: https://serde.rs/container-attrs.html#default
+[`#[serde(deny_unknown_fields)]`]: https://serde.rs/container-attrs.html#deny_unknown_fields
+[`Camera`]: https://www.amethyst.rs/doc/latest/doc/amethyst_renderer/struct.Camera.html
+[`Component`]: https://www.amethyst.rs/doc/latest/doc/specs/trait.Component.html
+[`Prefab`]: https://www.amethyst.rs/doc/latest/doc/amethyst_assets/struct.Prefab.html
+[`PrefabData`]: https://www.amethyst.rs/doc/latest/doc/amethyst_assets/trait.PrefabData.html#impl-PrefabData%3C%27a%3E
+[`Projection`]: https://www.amethyst.rs/doc/latest/doc/amethyst_renderer/enum.Projection.html
+[bk_prefab_prelude]: how_to_define_prefabs_prelude.html
+[repo_prefab_adapter]: https://github.com/amethyst/amethyst/tree/master/examples/prefab_adapter

--- a/book/src/prefabs/how_to_define_prefabs_prelude.md
+++ b/book/src/prefabs/how_to_define_prefabs_prelude.md
@@ -20,7 +20,7 @@ Component     | Serialized representation             | Example(s)            | 
 
     This is where the `Component` type itself is completely serializable &ndash; the data is self-contained.
 
-    ```rust,no_run,noplaypen
+    ```rust,edition2018,no_run,noplaypen
     # extern crate amethyst;
     # extern crate serde;
     # extern crate specs_derive;
@@ -39,7 +39,7 @@ Component     | Serialized representation             | Example(s)            | 
 
     This is where are multiple ways to construct the component, and a user should be able to choose which one to use.
 
-    ```rust,no_run,noplaypen
+    ```rust,edition2018,no_run,noplaypen
     # extern crate amethyst;
     # extern crate serde;
     # extern crate specs_derive;
@@ -71,7 +71,7 @@ Component     | Serialized representation             | Example(s)            | 
 
     This is where most of the component is serializable, but there is also data that is only accessible at runtime, such as a device ID or an asset handle.
 
-    ```rust,no_run,noplaypen
+    ```rust,edition2018,no_run,noplaypen
     # extern crate amethyst_audio;
     # extern crate amethyst_core;
     # extern crate specs_derive;
@@ -110,7 +110,7 @@ Component     | Serialized representation             | Example(s)            | 
 
     This is where the `Component` itself stores `Handle<_>`s.
 
-    ```rust,no_run,noplaypen
+    ```rust,edition2018,no_run,noplaypen
     # extern crate amethyst;
     #
     # use amethyst::{

--- a/book/src/prefabs/how_to_define_prefabs_prelude.md
+++ b/book/src/prefabs/how_to_define_prefabs_prelude.md
@@ -10,7 +10,7 @@ Component     | Serialized representation             | Example(s)            | 
 ------------- | ------------------------------------- | --------------------- | ------------------ | ---
 `YourType`    | `Self` &ndash; `YourType`             | `Position`            | `Position`         | [Simple]
 `YourType`    | Multiple &ndash; `V1(..)`, `V2(..)`   | [`Camera`]            | [`CameraPrefab`]   | [Adapter]
-`YourType`    | Subset of `YourType`                  | [`AudioListener`]     | [`AudioPrefab`]    | [Adapter]
+`YourType`    | Subset of `YourType`                  | [`AudioListener`]     | [`AudioPrefab`]    | [Asset]
 `Handle<A>`   | Loaded from `A::Data`                 | [`Mesh`], [`Texture`] | [`MeshData`], [`TexturePrefab`] | [Asset]
 `ManyHandles` | Data that component stores handles of | [`Material`]          | [`MaterialPrefab`] | [Multi-Handle]
 
@@ -44,25 +44,28 @@ Component     | Serialized representation             | Example(s)            | 
     # extern crate serde;
     # extern crate specs_derive;
     #
-    # use amethyst::{
-    #     core::nalgebra::{Orthographic3, Perspective3},
-    #     ecs::{storage::DenseVecStorage, Component},
-    # };
+    # use amethyst::ecs::{storage::DenseVecStorage, Component};
     # use serde::{Deserialize, Serialize};
     # use specs_derive::Component;
     #
-    #[derive(Component, /* .. */)]
-    pub struct Camera { /* .. */ }
-
-    #[derive(Clone, Deserialize, PartialEq, Serialize)]
-    pub enum Projection {
-        Orthographic(Orthographic3<f32>),
-        Perspective(Perspective3<f32>),
+    # #[derive(Component, Debug, Deserialize, Serialize /* .. */)]
+    # pub struct Position(pub f32, pub f32, pub f32);
+    #
+    impl From<(i32, i32, i32)> for Position {
+        fn from((x, y, z): (i32, i32, i32)) -> Position {
+            Position {
+                x: x as f32,
+                y: y as f32,
+                z: z as f32,
+            }
+        }
     }
 
-    // Camera can be constructed from multiple variants
-    impl From<Projection> for Camera /* { .. } */
-    # { fn from(proj: Projection) -> Self { unimplemented!() } }
+    impl From<(f32, f32, f32)> for Position {
+        fn from((x, y, z): (f32, f32, f32)) -> Position {
+            Position { x, y, z }
+        }
+    }
     ```
 
     Applicable guide: [How to Define Prefabs: Adapter][Adapter].
@@ -96,7 +99,7 @@ Component     | Serialized representation             | Example(s)            | 
     }
     ```
 
-    Applicable guide: [How to Define Prefabs: Adapter][Adapter].
+    Applicable guide: [How to Define Prefabs: Asset][Asset].
 
 * **Asset**
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -146,6 +146,10 @@ Keybindings:
 
 Shows how to load data using the `Prefab` system.
 
+### Prefab Adapter
+
+Shows how to create a `PrefabData` using the adapter pattern.
+
 ### Prefab Basic
 
 Shows how to create a trivial `PrefabData` and instantiate an entity using the `Prefab` system.

--- a/examples/assets/prefab/prefab_adapter.ron
+++ b/examples/assets/prefab/prefab_adapter.ron
@@ -1,0 +1,11 @@
+#![enable(implicit_some)]
+Prefab(
+    entities: [
+        PrefabEntity(
+            data: Pos3f(x: 1.0, y: 2.0, z: 3.0),
+        ),
+        PrefabEntity(
+            data: Pos3i(x: 4, y: 5, z: 6),
+        ),
+    ],
+)

--- a/examples/prefab_adapter/main.rs
+++ b/examples/prefab_adapter/main.rs
@@ -1,0 +1,182 @@
+//! Demonstrates loading a custom prefab using the Amethyst engine.
+
+use std::fmt::Debug;
+
+use amethyst::{
+    assets::{
+        AssetStorage, Handle, Prefab, PrefabData, PrefabLoader, PrefabLoaderSystem,
+        ProgressCounter, RonFormat,
+    },
+    ecs::{storage::DenseVecStorage, Component, Entities, Entity, Join, ReadStorage, WriteStorage},
+    prelude::*,
+    utils::application_root_dir,
+    Error,
+};
+use derive_new::new;
+use serde::{Deserialize, Serialize};
+use specs_derive::Component;
+
+#[derive(Clone, Copy, Component, Debug, Default)]
+pub struct Position(pub f32, pub f32, pub f32);
+
+impl From<(i32, i32, i32)> for Position {
+    fn from((x, y, z): (i32, i32, i32)) -> Position {
+        Position(x as f32, y as f32, z as f32)
+    }
+}
+
+impl From<(f32, f32, f32)> for Position {
+    fn from((x, y, z): (f32, f32, f32)) -> Position {
+        Position(x, y, z)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub enum PositionPrefab {
+    Pos3f { x: f32, y: f32, z: f32 },
+    Pos3i { x: i32, y: i32, z: i32 },
+}
+
+impl<'a> PrefabData<'a> for PositionPrefab {
+    // To attach the `Position` to the constructed entity,
+    // we write to the `Position` component storage.
+    type SystemData = WriteStorage<'a, Position>;
+
+    // This associated type is not used in this pattern,
+    // so the empty tuple is specified.
+    type Result = ();
+
+    fn add_to_entity(
+        &self,
+        entity: Entity,
+        positions: &mut Self::SystemData,
+        _entities: &[Entity],
+    ) -> Result<(), Error> {
+        let position = match *self {
+            PositionPrefab::Pos3f { x, y, z } => (x, y, z).into(),
+            PositionPrefab::Pos3i { x, y, z } => (x, y, z).into(),
+        };
+        positions.insert(entity, position).map(|_| ())?;
+        Ok(())
+    }
+}
+
+#[derive(new)]
+pub struct CustomPrefabState {
+    /// Tracks loaded assets.
+    #[new(default)]
+    pub progress_counter: ProgressCounter,
+    /// Handle to the loaded prefab.
+    #[new(default)]
+    pub prefab_handle: Option<Handle<Prefab<PositionPrefab>>>,
+}
+
+impl SimpleState for CustomPrefabState {
+    fn on_start(&mut self, data: StateData<'_, GameData<'_, '_>>) {
+        let prefab_handle = data.world.exec(|loader: PrefabLoader<'_, PositionPrefab>| {
+            loader.load(
+                "prefab/prefab_adapter.ron",
+                RonFormat,
+                (),
+                &mut self.progress_counter,
+            )
+        });
+
+        // Create one set of entities from the prefab.
+        (0..1).for_each(|_| {
+            data.world
+                .create_entity()
+                .with(prefab_handle.clone())
+                .build();
+        });
+
+        self.prefab_handle = Some(prefab_handle);
+    }
+
+    fn update(&mut self, data: &mut StateData<'_, GameData<'_, '_>>) -> SimpleTrans {
+        if self.progress_counter.is_complete() {
+            self.display_loaded_prefab(&data.world);
+            self.display_loaded_entities(&mut data.world);
+            Trans::Quit
+        } else {
+            Trans::None
+        }
+    }
+}
+
+impl CustomPrefabState {
+    // Displays the contents of the loaded prefab.
+    fn display_loaded_prefab(&self, world: &World) {
+        let prefab_assets = world.read_resource::<AssetStorage<Prefab<PositionPrefab>>>();
+        if let Some(handle) = self.prefab_handle.as_ref() {
+            let prefab = prefab_assets
+                .get(handle)
+                .expect("Expected prefab to be loaded.");
+
+            println!("Prefab");
+            println!("======");
+            prefab
+                .entities()
+                .for_each(|entity| println!("{:?}", entity));
+            println!("");
+        }
+    }
+
+    // Displays the `Component`s of entities in the `World`.
+    fn display_loaded_entities(&self, world: &mut World) {
+        println!("Entities");
+        println!("========");
+        println!();
+        println!(
+            "| {e:24} | {prefab_handle:30} | {pos:23} |",
+            e = "Entity",
+            prefab_handle = "Handle<Prefab<PositionPrefab>>",
+            pos = "Position",
+        );
+        println!("| {c:-^24} | {c:-^30} | {c:-^23} |", c = "",);
+        world.exec(
+            |(entities, prefab_handles, positions): (
+                Entities,
+                ReadStorage<Handle<Prefab<PositionPrefab>>>,
+                ReadStorage<Position>,
+            )| {
+                (&entities, prefab_handles.maybe(), positions.maybe())
+                    .join()
+                    .for_each(|(e, prefab_handle, pos)| {
+                        println!(
+                            "| {e:24} | {prefab_handle:30} | {pos:23} |",
+                            e = format!("{:?}", e),
+                            prefab_handle = Self::display(prefab_handle),
+                            pos = Self::display(pos),
+                        )
+                    });
+            },
+        )
+    }
+
+    fn display<T: Debug>(component: Option<T>) -> String {
+        if let Some(component) = component {
+            format!("{:?}", component)
+        } else {
+            format!("{:?}", component)
+        }
+    }
+}
+
+/// Wrapper around the main, so we can return errors easily.
+fn main() -> Result<(), Error> {
+    amethyst::start_logger(Default::default());
+
+    let app_root = application_root_dir()?;
+
+    // Add our meshes directory to the asset loader.
+    let resources_directory = app_root.join("examples/assets");
+
+    let game_data =
+        GameDataBuilder::default().with(PrefabLoaderSystem::<PositionPrefab>::default(), "", &[]);
+
+    let mut game = Application::new(resources_directory, CustomPrefabState::new(), game_data)?;
+    game.run();
+    Ok(())
+}


### PR DESCRIPTION
* Added `edition2018` to doc snippets.
* Added a `prefab_adapter` example to demonstrate creation of the `Component` from different enum variants.
* Added **How to Define Prefabs: Adapter** guide ([Rendered](https://github.com/amethyst/amethyst/blob/f19c9e0d6e9348da809ea7deb4a90cc2f7540c16/book/src/prefabs/how_to_define_prefabs_adapter.md)).

Issue #1114