### PR TITLE
Docs - Typo in PrefabLoader example doc.

### DIFF
--- a/amethyst_assets/src/prefab/mod.rs
+++ b/amethyst_assets/src/prefab/mod.rs
@@ -401,7 +401,7 @@ where
 ///
 /// ```rust,ignore
 /// let prefab_handle = world.exec(|loader: PrefabLoader<SomePrefab>| {
-///     loader.load("prefab.ron", RonFormat, (), ()
+///     loader.load("prefab.ron", RonFormat, (), ());
 /// });
 /// ```
 #[derive(SystemData)]


### PR DESCRIPTION
Accidentally missing closing parenthesis.
Added `;` because load doesn't return a Result.