### PR TITLE
Implement widget structs and traits

### DIFF
--- a/amethyst_animation/src/prefab.rs
+++ b/amethyst_animation/src/prefab.rs
@@ -88,6 +88,7 @@ where
         _: Entity,
         _: &mut Self::SystemData,
         _: &[Entity],
+        _: &[Entity],
     ) -> Result<Handle<Animation<T>>, Error> {
         Ok(self
             .handle
@@ -155,6 +156,7 @@ where
         entity: Entity,
         system_data: &mut Self::SystemData,
         entities: &[Entity],
+        _: &[Entity],
     ) -> Result<(), Error> {
         let set = system_data
             .0
@@ -163,7 +165,7 @@ where
         for (id, animation_prefab) in &self.animations {
             set.insert(
                 id.clone(),
-                animation_prefab.add_to_entity(entity, &mut system_data.1, entities)?,
+                animation_prefab.add_to_entity(entity, &mut system_data.1, entities, &[])?,
             );
         }
         Ok(())
@@ -208,6 +210,7 @@ where
         entity: Entity,
         storage: &mut Self::SystemData,
         entities: &[Entity],
+        _: &[Entity],
     ) -> Result<(), Error> {
         storage
             .insert(

--- a/amethyst_animation/src/skinning/resources.rs
+++ b/amethyst_animation/src/skinning/resources.rs
@@ -74,6 +74,7 @@ impl<'a> PrefabData<'a> for JointPrefab {
         entity: Entity,
         storage: &mut Self::SystemData,
         entities: &[Entity],
+        _: &[Entity],
     ) -> Result<(), Error> {
         storage
             .insert(
@@ -110,6 +111,7 @@ impl<'a> PrefabData<'a> for SkinPrefab {
         entity: Entity,
         storage: &mut Self::SystemData,
         entities: &[Entity],
+        _: &[Entity],
     ) -> Result<(), Error> {
         storage
             .insert(

--- a/amethyst_assets/src/prefab/impls.rs
+++ b/amethyst_assets/src/prefab/impls.rs
@@ -18,9 +18,15 @@ where
         entity: Entity,
         system_data: &mut Self::SystemData,
         entities: &[Entity],
+        children: &[Entity],
     ) -> Result<Self::Result, Error> {
         if let Some(ref prefab) = self {
-            Ok(Some(prefab.add_to_entity(entity, system_data, entities)?))
+            Ok(Some(prefab.add_to_entity(
+                entity,
+                system_data,
+                entities,
+                children,
+            )?))
         } else {
             Ok(None)
         }
@@ -48,6 +54,7 @@ impl<'a> PrefabData<'a> for GlobalTransform {
         entity: Entity,
         storage: &mut Self::SystemData,
         _: &[Entity],
+        _: &[Entity],
     ) -> Result<(), Error> {
         storage.insert(entity, self.clone()).map(|_| ())?;
         Ok(())
@@ -66,6 +73,7 @@ impl<'a> PrefabData<'a> for Transform {
         entity: Entity,
         storages: &mut Self::SystemData,
         _: &[Entity],
+        _: &[Entity],
     ) -> Result<(), Error> {
         storages.1.insert(entity, GlobalTransform::default())?;
         storages.0.insert(entity, self.clone()).map(|_| ())?;
@@ -81,6 +89,7 @@ impl<'a> PrefabData<'a> for Named {
         &self,
         entity: Entity,
         storages: &mut Self::SystemData,
+        _: &[Entity],
         _: &[Entity],
     ) -> Result<(), Error> {
         storages.0.insert(entity, self.clone()).map(|_| ())?;
@@ -106,10 +115,11 @@ macro_rules! impl_data {
                 entity: Entity,
                 system_data: &mut Self::SystemData,
                 entities: &[Entity],
+                children: &[Entity],
             ) -> Result<(), Error> {
                 #![allow(unused_variables)]
                 $(
-                    self.$i.add_to_entity(entity, &mut system_data.$i, entities)?;
+                    self.$i.add_to_entity(entity, &mut system_data.$i, entities, children)?;
                 )*
                 Ok(())
             }

--- a/amethyst_assets/src/prefab/mod.rs
+++ b/amethyst_assets/src/prefab/mod.rs
@@ -34,11 +34,15 @@ pub trait PrefabData<'a> {
     /// - `system_data`: `SystemData` needed to do the loading
     /// - `entities`: Some components need access to the entities that was created as part of the
     ///               full prefab, for linking purposes, so this contains all those `Entity`s.
+    /// - `children`: Entities that need access to the `Hierarchy`  in this function won't be able
+    ///               to access it yet, since it is only updated after this function runs. As a work-
+    ///               around, this slice includes all hierarchical children of the entity being passed.
     fn add_to_entity(
         &self,
         entity: Entity,
         system_data: &mut Self::SystemData,
         entities: &[Entity],
+        children: &[Entity],
     ) -> Result<Self::Result, Error>;
 
     /// Trigger asset loading for any sub assets.
@@ -358,6 +362,7 @@ where
         &self,
         entity: Entity,
         system_data: &mut Self::SystemData,
+        _: &[Entity],
         _: &[Entity],
     ) -> Result<Handle<A>, Error> {
         let handle = match *self {

--- a/amethyst_assets/src/prefab/system.rs
+++ b/amethyst_assets/src/prefab/system.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, ops::Deref};
+use std::{collections::HashMap, marker::PhantomData, ops::Deref};
 
 use log::error;
 
@@ -112,6 +112,8 @@ where
                 // create entities
                 self.entities.clear();
                 self.entities.push(root_entity);
+
+                let mut children = HashMap::new();
                 for entity_data in prefab.entities.iter().skip(1) {
                     let new_entity = entities.create();
                     self.entities.push(new_entity);
@@ -124,6 +126,11 @@ where
                                 },
                             )
                             .expect("Unable to insert `Parent` for prefab");
+
+                        children
+                            .entry(parent)
+                            .or_insert(vec![])
+                            .push(new_entity.clone());
                     }
                     tags.insert(
                         new_entity,
@@ -143,6 +150,10 @@ where
                                 self.entities[index],
                                 &mut prefab_system_data,
                                 &self.entities,
+                                children
+                                    .get(&index)
+                                    .map(|children| &children[..])
+                                    .unwrap_or(&[]),
                             )
                             .expect("Unable to add prefab system data to entity");
                     }

--- a/amethyst_audio/src/components/mod.rs
+++ b/amethyst_audio/src/components/mod.rs
@@ -39,6 +39,7 @@ impl<'a> PrefabData<'a> for AudioPrefab {
         entity: Entity,
         system_data: &mut Self::SystemData,
         _: &[Entity],
+        _: &[Entity],
     ) -> Result<(), Error> {
         if self.emitter {
             system_data.0.insert(entity, AudioEmitter::default())?;

--- a/amethyst_audio/src/source.rs
+++ b/amethyst_audio/src/source.rs
@@ -43,6 +43,7 @@ impl<'a> PrefabData<'a> for AudioData {
         _: Entity,
         system_data: &mut Self::SystemData,
         _: &[Entity],
+        _: &[Entity],
     ) -> Result<Handle<Source>, Error> {
         Ok(system_data
             .0

--- a/amethyst_controls/src/components.rs
+++ b/amethyst_controls/src/components.rs
@@ -50,6 +50,7 @@ impl<'a> PrefabData<'a> for ControlTagPrefab {
         entity: Entity,
         system_data: &mut Self::SystemData,
         entities: &[Entity],
+        _: &[Entity],
     ) -> Result<(), Error> {
         system_data.0.insert(entity, FlyControlTag)?;
         if let Some((index, distance)) = self.arc_ball {

--- a/amethyst_derive/src/lib.rs
+++ b/amethyst_derive/src/lib.rs
@@ -8,6 +8,7 @@ use syn::{parse_macro_input, DeriveInput};
 
 mod event_reader;
 mod prefab_data;
+mod widget_id;
 
 #[proc_macro_derive(EventReader, attributes(reader))]
 pub fn event_reader_derive(input: TokenStream) -> TokenStream {
@@ -23,5 +24,17 @@ pub fn event_reader_derive(input: TokenStream) -> TokenStream {
 pub fn prefab_data_derive(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     let gen = prefab_data::impl_prefab_data(&ast);
+    gen.into()
+}
+
+/// This allows the use of an enum as an ID for the `Widgets` resource. One
+/// variant has to be marked as the default variant with `#[widget_id_default]
+/// and will be used when a `Widget` is added to the resource without an
+/// explicit ID. Note that when using `Widgets::add`, this will overwrite
+/// an existing widget with the same default id!
+#[proc_macro_derive(WidgetId, attributes(widget_id))]
+pub fn widget_id_derive(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let gen = widget_id::impl_widget_id(&ast);
     gen.into()
 }

--- a/amethyst_derive/src/prefab_data.rs
+++ b/amethyst_derive/src/prefab_data.rs
@@ -24,6 +24,7 @@ fn impl_prefab_data_component(ast: &DeriveInput) -> TokenStream {
             fn add_to_entity(&self,
                              entity: Entity,
                              system_data: &mut Self::SystemData,
+                             _: &[Entity],
                              _: &[Entity]) -> ::std::result::Result<(), Error> {
                 system_data.insert(entity, self.clone()).map(|_| ())?;
                 Ok(())
@@ -55,7 +56,7 @@ fn impl_prefab_data_aggregate(ast: &DeriveInput) -> TokenStream {
             }
         } else {
             quote! {
-                self.#name.add_to_entity(entity, &mut system_data.#n, entities)?;
+                self.#name.add_to_entity(entity, &mut system_data.#n, entities, children)?;
             }
         }
     });
@@ -86,7 +87,8 @@ fn impl_prefab_data_aggregate(ast: &DeriveInput) -> TokenStream {
             fn add_to_entity(&self,
                              entity: Entity,
                              system_data: &mut Self::SystemData,
-                             entities: &[Entity]) -> ::std::result::Result<(), Error> {
+                             entities: &[Entity],
+                             children: &[Entity]) -> ::std::result::Result<(), Error> {
                 #(#adds)*
                 Ok(())
             }

--- a/amethyst_derive/src/widget_id.rs
+++ b/amethyst_derive/src/widget_id.rs
@@ -1,0 +1,44 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Ident};
+
+pub fn impl_widget_id(ast: &DeriveInput) -> TokenStream {
+    // For now, we can only derive this on enums
+    let default_variant = match &ast.data {
+        Data::Enum(ref data_enum) => {
+            let maybe_marked_default = data_enum
+                .variants
+                .iter()
+                .filter(|v| {
+                    v.attrs
+                        .iter()
+                        .any(|attr| attr.path.segments[0].ident == "widget_id_default")
+                })
+                .map(|v| v.ident.clone())
+                .collect::<Vec<Ident>>();
+
+            if maybe_marked_default.len() > 1 {
+                panic!("Only 1 variant can be marked as default widget id")
+            }
+
+            let default_variant = if !maybe_marked_default.is_empty() {
+                maybe_marked_default[0].clone()
+            } else {
+                data_enum.variants[0].ident.clone()
+            };
+
+            default_variant
+        }
+        _ => panic!("WidgetId derive only supports enums"),
+    };
+
+    let name = ast.ident.clone();
+
+    quote! {
+        impl WidgetId for #name {
+            fn generate(last: &Option<Self>) -> Self {
+                Self::#default_variant
+            }
+        }
+    }
+}

--- a/amethyst_gltf/src/lib.rs
+++ b/amethyst_gltf/src/lib.rs
@@ -195,6 +195,7 @@ impl<'a> PrefabData<'a> for GltfPrefab {
         entity: Entity,
         system_data: &mut Self::SystemData,
         entities: &[Entity],
+        children: &[Entity],
     ) -> Result<(), Error> {
         let (
             ref mut transforms,
@@ -208,7 +209,7 @@ impl<'a> PrefabData<'a> for GltfPrefab {
             _,
         ) = system_data;
         if let Some(ref transform) = self.transform {
-            transform.add_to_entity(entity, transforms, entities)?;
+            transform.add_to_entity(entity, transforms, entities, children)?;
         }
         if let Some(ref mesh) = self.mesh {
             mesh_data.insert(entity, mesh.clone())?;
@@ -217,16 +218,16 @@ impl<'a> PrefabData<'a> for GltfPrefab {
             meshes.1.insert(entity, mesh.clone())?;
         }
         if let Some(ref name) = self.name {
-            name.add_to_entity(entity, names, entities)?;
+            name.add_to_entity(entity, names, entities, children)?;
         }
         if let Some(ref material) = self.material {
-            material.add_to_entity(entity, materials, entities)?;
+            material.add_to_entity(entity, materials, entities, children)?;
         }
         if let Some(ref animatable) = self.animatable {
-            animatable.add_to_entity(entity, animatables, entities)?;
+            animatable.add_to_entity(entity, animatables, entities, children)?;
         }
         if let Some(ref skinnable) = self.skinnable {
-            skinnable.add_to_entity(entity, skinnables, entities)?;
+            skinnable.add_to_entity(entity, skinnables, entities, children)?;
         }
         if let Some(ref extent) = self.extent {
             extents.insert(entity, extent.clone())?;

--- a/amethyst_renderer/src/cam.rs
+++ b/amethyst_renderer/src/cam.rs
@@ -142,6 +142,7 @@ impl<'a> PrefabData<'a> for CameraPrefab {
         entity: Entity,
         storage: &mut Self::SystemData,
         _: &[Entity],
+        _: &[Entity],
     ) -> Result<(), Error> {
         let proj = match *self {
             CameraPrefab::Matrix(mat) => mat,
@@ -165,6 +166,7 @@ impl<'a> PrefabData<'a> for ActiveCameraPrefab {
         _: Entity,
         system_data: &mut Self::SystemData,
         entities: &[Entity],
+        _: &[Entity],
     ) -> Result<(), Error> {
         system_data.0.entity = Some(entities[self.0]);
         // TODO: if no `ActiveCamera` insert using `LazyUpdate`, require changes to `specs`

--- a/amethyst_renderer/src/formats/mesh.rs
+++ b/amethyst_renderer/src/formats/mesh.rs
@@ -104,6 +104,7 @@ impl<'a> PrefabData<'a> for MeshData {
         entity: Entity,
         system_data: &mut Self::SystemData,
         _: &[Entity],
+        _: &[Entity],
     ) -> Result<(), Error> {
         let handle = system_data
             .0

--- a/amethyst_renderer/src/formats/mod.rs
+++ b/amethyst_renderer/src/formats/mod.rs
@@ -77,17 +77,18 @@ where
         entity: Entity,
         system_data: &mut <Self as PrefabData<'_>>::SystemData,
         entities: &[Entity],
+        children: &[Entity],
     ) -> Result<(), Error> {
         match self.mesh {
             MeshPrefab::Asset(ref m) => {
-                m.add_to_entity(entity, &mut system_data.0, entities)?;
+                m.add_to_entity(entity, &mut system_data.0, entities, children)?;
             }
             MeshPrefab::Shape(ref s) => {
-                s.add_to_entity(entity, &mut system_data.0, entities)?;
+                s.add_to_entity(entity, &mut system_data.0, entities, children)?;
             }
         }
         self.material
-            .add_to_entity(entity, &mut system_data.1, entities)?;
+            .add_to_entity(entity, &mut system_data.1, entities, children)?;
         Ok(())
     }
 

--- a/amethyst_renderer/src/formats/mtl.rs
+++ b/amethyst_renderer/src/formats/mtl.rs
@@ -93,7 +93,7 @@ where
 {
     prefab
         .as_ref()
-        .and_then(|tp| tp.add_to_entity(entity, tp_data, &[]).ok())
+        .and_then(|tp| tp.add_to_entity(entity, tp_data, &[], &[]).ok())
         .unwrap_or_else(|| def.clone())
 }
 
@@ -113,6 +113,7 @@ where
         &self,
         entity: Entity,
         system_data: &mut Self::SystemData,
+        _: &[Entity],
         _: &[Entity],
     ) -> Result<(), Error> {
         let &mut (ref mut material, ref mat_default, ref mut tp_data, ref mut transparent) =

--- a/amethyst_renderer/src/formats/texture.rs
+++ b/amethyst_renderer/src/formats/texture.rs
@@ -189,6 +189,7 @@ impl<'a> PrefabData<'a> for TextureData {
         _: Entity,
         system_data: &mut Self::SystemData,
         _: &[Entity],
+        _: &[Entity],
     ) -> Result<Handle<Texture>, Error> {
         Ok(system_data
             .0
@@ -231,6 +232,7 @@ where
         &self,
         _: Entity,
         system_data: &mut Self::SystemData,
+        _: &[Entity],
         _: &[Entity],
     ) -> Result<Handle<Texture>, Error> {
         let handle = match *self {

--- a/amethyst_renderer/src/resources.rs
+++ b/amethyst_renderer/src/resources.rs
@@ -29,6 +29,7 @@ impl<'a> PrefabData<'a> for AmbientColor {
         _: Entity,
         ambient: &mut Self::SystemData,
         _: &[Entity],
+        _: &[Entity],
     ) -> Result<(), Error> {
         ambient.0 = self.0;
         Ok(())

--- a/amethyst_renderer/src/shape.rs
+++ b/amethyst_renderer/src/shape.rs
@@ -58,6 +58,7 @@ where
         entity: Entity,
         system_data: &mut Self::SystemData,
         _: &[Entity],
+        _: &[Entity],
     ) -> Result<(), Error> {
         let (_, ref mut meshes, _) = system_data;
         let self_handle = self.handle.as_ref().expect(

--- a/amethyst_renderer/src/skinning.rs
+++ b/amethyst_renderer/src/skinning.rs
@@ -127,6 +127,7 @@ impl<'a> PrefabData<'a> for JointTransformsPrefab {
         entity: Entity,
         storage: &mut Self::SystemData,
         entities: &[Entity],
+        _: &[Entity],
     ) -> Result<(), Error> {
         storage
             .insert(

--- a/amethyst_renderer/src/sprite/prefab.rs
+++ b/amethyst_renderer/src/sprite/prefab.rs
@@ -117,6 +117,7 @@ impl<'a> PrefabData<'a> for SpriteSheetPrefab {
         _entity: Entity,
         _system_data: &mut Self::SystemData,
         _entities: &[Entity],
+        _children: &[Entity],
     ) -> Result<Self::Result, Error> {
         match self {
             SpriteSheetPrefab::Handle(handle) => Ok(handle.clone()),
@@ -215,7 +216,8 @@ impl<'a> PrefabData<'a> for SpriteRenderPrefab {
         &self,
         entity: Entity,
         system_data: &mut <Self as PrefabData<'a>>::SystemData,
-        _: &[Entity],
+        _entities: &[Entity],
+        _children: &[Entity],
     ) -> Result<(), Error> {
         if let Some(handle) = self.handle.clone() {
             system_data.0.insert(
@@ -275,12 +277,13 @@ impl<'a> PrefabData<'a> for SpriteScenePrefab {
         entity: Entity,
         system_data: &mut Self::SystemData,
         entities: &[Entity],
+        children: &[Entity],
     ) -> Result<(), Error> {
         if let Some(render) = &self.render {
-            render.add_to_entity(entity, &mut system_data.1, entities)?;
+            render.add_to_entity(entity, &mut system_data.1, entities, children)?;
         }
         if let Some(transform) = &self.transform {
-            transform.add_to_entity(entity, &mut system_data.2, entities)?;
+            transform.add_to_entity(entity, &mut system_data.2, entities, children)?;
         }
         Ok(())
     }
@@ -521,7 +524,7 @@ mod tests {
         };
         let entity = world.create_entity().build();
         let handle = prefab
-            .add_to_entity(entity, &mut world.system_data(), &[entity])
+            .add_to_entity(entity, &mut world.system_data(), &[entity], &[])
             .unwrap();
         assert_eq!(h, handle);
     }
@@ -540,7 +543,7 @@ mod tests {
             .load_sub_assets(&mut ProgressCounter::default(), &mut world.system_data())
             .unwrap();
         prefab
-            .add_to_entity(entity, &mut world.system_data(), &[entity])
+            .add_to_entity(entity, &mut world.system_data(), &[entity], &[])
             .unwrap();
         let storage = world.read_storage::<SpriteRender>();
         let render = storage.get(entity);

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -39,6 +39,8 @@ unicode-segmentation = "1.2"
 winit = { version = "0.18", features = ["serde"] }
 log = "0.4.6"
 font-kit = "0.1"
+paste = "0.1"
+rand = "0.6"
 
 thread_profiler = { version = "0.3", optional = true }
 

--- a/amethyst_ui/src/bundle.rs
+++ b/amethyst_ui/src/bundle.rs
@@ -14,7 +14,7 @@ use crate::{
     CacheSelectionOrderSystem, FontAsset, FontFormat, NoCustomUi, ResizeSystem,
     SelectionKeyboardSystem, SelectionMouseSystem, TextEditingInputSystem, TextEditingMouseSystem,
     ToNativeWidget, UiButtonActionRetriggerSystem, UiButtonSystem, UiLoaderSystem, UiMouseSystem,
-    UiSoundRetriggerSystem, UiSoundSystem, UiTransformSystem,
+    UiSoundRetriggerSystem, UiSoundSystem, UiTransformSystem, WidgetId,
 };
 
 /// UI bundle
@@ -24,16 +24,17 @@ use crate::{
 ///
 /// Will fail with error 'No resource with the given id' if the InputBundle is not added.
 #[derive(new)]
-pub struct UiBundle<A = String, B = String, C = NoCustomUi, G = ()> {
+pub struct UiBundle<A = String, B = String, C = NoCustomUi, W = u32, G = ()> {
     #[new(default)]
-    _marker: PhantomData<(A, B, C, G)>,
+    _marker: PhantomData<(A, B, C, W, G)>,
 }
 
-impl<'a, 'b, A, B, C, G> SystemBundle<'a, 'b> for UiBundle<A, B, C, G>
+impl<'a, 'b, A, B, C, W, G> SystemBundle<'a, 'b> for UiBundle<A, B, C, W, G>
 where
     A: Send + Sync + Eq + Hash + Clone + 'static,
     B: Send + Sync + Eq + Hash + Clone + 'static,
     C: ToNativeWidget,
+    W: WidgetId,
     G: Send + Sync + PartialEq + 'static,
 {
     fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<(), Error> {
@@ -43,6 +44,7 @@ where
                 TextureFormat,
                 FontFormat,
                 <C as ToNativeWidget>::PrefabData,
+                W,
             >::default(),
             "ui_loader",
             &[],

--- a/amethyst_ui/src/button/mod.rs
+++ b/amethyst_ui/src/button/mod.rs
@@ -9,28 +9,22 @@ pub use self::{
     retrigger::{UiButtonActionRetrigger, UiButtonActionRetriggerSystem},
     system::UiButtonSystem,
 };
-///! A clickable button.
-use amethyst_core::ecs::prelude::{Component, DenseVecStorage};
 
-use serde::{Deserialize, Serialize};
+use crate::{define_widget, Interactable, UiSoundRetrigger, UiText, UiTransform};
+use amethyst_core::Parent;
+use amethyst_renderer::TextureHandle;
 
-/// A clickable button, this must be paired with a `TextureHandle`
-/// and this entity must have a child entity with a `UiText`.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct UiButton {
-    /// Default text color
-    text_color: [f32; 4],
-}
+define_widget!(UiButton =>
+    entities: [text_entity, image_entity]
+    components: [
+        (has UiTransform as position on image_entity),
+        (has UiTransform as text_position on text_entity),
+        (has TextureHandle as texture on image_entity),
+        (has Interactable as mouse_reactive on image_entity),
+        (has UiText as text on text_entity),
 
-impl UiButton {
-    /// A constructor for this component.  It's recommended to use
-    /// either a prefab or `UiButtonBuilder` rather than this function
-    /// if possible.
-    pub fn new(text_color: [f32; 4]) -> Self {
-        Self { text_color }
-    }
-}
-
-impl Component for UiButton {
-    type Storage = DenseVecStorage<Self>;
-}
+        (maybe_has Parent as parent on image_entity),
+        (maybe_has UiButtonActionRetrigger as action_retrigger on image_entity),
+        (maybe_has UiSoundRetrigger as sound_retrigger on image_entity)
+    ]
+);

--- a/amethyst_ui/src/label.rs
+++ b/amethyst_ui/src/label.rs
@@ -1,0 +1,219 @@
+use crate::{
+    define_widget, font::default::get_default_font, Anchor, FontAsset, FontHandle, Stretch, UiText,
+    UiTransform, WidgetId, Widgets,
+};
+use shred::SystemData;
+use shred_derive::SystemData;
+
+use amethyst_assets::{AssetStorage, Loader};
+use amethyst_core::ecs::prelude::{
+    Entities, Entity, Read, ReadExpect, World, WriteExpect, WriteStorage,
+};
+
+const DEFAULT_Z: f32 = 1.0;
+const DEFAULT_WIDTH: f32 = 128.0;
+const DEFAULT_HEIGHT: f32 = 64.0;
+const DEFAULT_TXT_COLOR: [f32; 4] = [0.0, 0.0, 0.0, 1.0];
+
+define_widget!(UiLabel =>
+    entities: [text_entity]
+    components: [
+        (has UiTransform as position on text_entity),
+        (has UiText as text on text_entity)
+    ]
+);
+
+/// Container for all the resources the builder needs to make a new UiLabel.
+#[derive(SystemData)]
+pub struct UiLabelBuilderResources<'a, I: WidgetId = u32>
+where
+    I: WidgetId,
+{
+    font_asset: Read<'a, AssetStorage<FontAsset>>,
+    loader: ReadExpect<'a, Loader>,
+    entities: Entities<'a>,
+    text: WriteStorage<'a, UiText>,
+    transform: WriteStorage<'a, UiTransform>,
+    label_widgets: WriteExpect<'a, Widgets<UiLabel, I>>,
+}
+
+/// Convenience structure for building a label
+pub struct UiLabelBuilder<I = u32>
+where
+    I: WidgetId,
+{
+    id: Option<I>,
+    x: f32,
+    y: f32,
+    z: f32,
+    width: f32,
+    height: f32,
+    anchor: Anchor,
+    stretch: Stretch,
+    text: String,
+    text_color: [f32; 4],
+    font: Option<FontHandle>,
+    font_size: f32,
+    parent: Option<Entity>,
+}
+
+impl<'a, I> Default for UiLabelBuilder<I>
+where
+    I: WidgetId + 'static,
+{
+    fn default() -> Self {
+        UiLabelBuilder {
+            id: None,
+            x: 0.,
+            y: 0.,
+            z: DEFAULT_Z,
+            width: DEFAULT_WIDTH,
+            height: DEFAULT_HEIGHT,
+            anchor: Anchor::TopLeft,
+            stretch: Stretch::NoStretch,
+            text: "".to_string(),
+            text_color: DEFAULT_TXT_COLOR,
+            font: None,
+            font_size: 32.,
+            parent: None,
+        }
+    }
+}
+
+impl<'a, I> UiLabelBuilder<I>
+where
+    I: WidgetId + 'static,
+{
+    /// Construct a new UiLabelBuilder.
+    /// This allows the user to easily build a UI element with a text that can
+    /// easily be retrieved and updated through the appropriate resource,
+    /// see [`Widgets`](../struct.Widgets.html).
+    pub fn new<S: ToString>(text: S) -> UiLabelBuilder<I> {
+        let mut builder = UiLabelBuilder::default();
+        builder.text = text.to_string();
+        builder
+    }
+
+    /// Sets an ID for this widget. The type of this ID will determine which `Widgets`
+    /// resource this widget will be added to, see [`Widgets`](../struct.Widgets.html).
+    pub fn with_id(mut self, id: I) -> Self {
+        self.id = Some(id);
+        self
+    }
+
+    /// Set button size
+    pub fn with_size(mut self, width: f32, height: f32) -> Self {
+        self.width = width;
+        self.height = height;
+        self
+    }
+
+    /// This will create a default UiTransform if one is not already attached.
+    /// See `DEFAULT_Z`, `DEFAULT_WIDTH`, `DEFAULT_HEIGHT`, and `DEFAULT_TAB_ORDER` for
+    /// the values that will be provided to the default UiTransform.
+    pub fn with_position(mut self, x: f32, y: f32) -> Self {
+        self.x = x;
+        self.y = y;
+        self
+    }
+
+    /// Add an anchor to the button.
+    pub fn with_anchor(mut self, anchor: Anchor) -> Self {
+        self.anchor = anchor;
+        self
+    }
+
+    /// Stretch the button.
+    pub fn with_stretch(mut self, stretch: Stretch) -> Self {
+        self.stretch = stretch;
+        self
+    }
+
+    /// This will set the rendered characters within the button. Use this to just change what
+    /// characters will appear. If you need to change the font size, color, etc., then you should
+    /// use
+    /// [`with_uitext`](#with_uitext) and provide a new `UiText` object.
+    pub fn with_text<S>(mut self, text: S) -> Self
+    where
+        S: ToString,
+    {
+        self.text = text.to_string();
+        self
+    }
+
+    /// Set text color
+    pub fn with_text_color(mut self, text_color: [f32; 4]) -> Self {
+        self.text_color = text_color;
+        self
+    }
+
+    /// Use a different font for the button text.
+    pub fn with_font(mut self, font: FontHandle) -> Self {
+        self.font = Some(font);
+        self
+    }
+
+    /// Set font size
+    pub fn with_font_size(mut self, size: f32) -> Self {
+        self.font_size = size;
+        self
+    }
+
+    /// Add a parent to the button.
+    pub fn with_parent(mut self, parent: Entity) -> Self {
+        self.parent = Some(parent);
+        self
+    }
+
+    /// Build this with the `UiLabelBuilderResources`.
+    pub fn build(self, mut res: UiLabelBuilderResources<'a, I>) -> (I, UiLabel) {
+        let text_entity = res.entities.create();
+        let widget = UiLabel::new(text_entity);
+
+        let id = {
+            let widget = widget.clone();
+
+            if let Some(id) = self.id {
+                let added_id = id.clone();
+                res.label_widgets.add_with_id(id, widget);
+                added_id
+            } else {
+                res.label_widgets.add(widget)
+            }
+        };
+
+        res.transform
+            .insert(
+                text_entity,
+                UiTransform::new(
+                    format!("{}_label", id),
+                    self.anchor,
+                    self.x,
+                    self.y,
+                    self.z,
+                    self.width,
+                    self.height,
+                )
+                .with_stretch(self.stretch),
+            )
+            .expect("Unreachable: Inserting newly created entity");
+
+        let font_handle = self
+            .font
+            .unwrap_or_else(|| get_default_font(&res.loader, &res.font_asset));
+
+        res.text
+            .insert(
+                text_entity,
+                UiText::new(font_handle, self.text, self.text_color, self.font_size),
+            )
+            .expect("Unreachable: Inserting newly created entity");
+
+        (id, widget)
+    }
+
+    /// Create the UiLabel based on provided configuration parameters.
+    pub fn build_from_world(self, world: &World) -> (I, UiLabel) {
+        self.build(UiLabelBuilderResources::<I>::fetch(&world.res))
+    }
+}

--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -15,6 +15,7 @@ pub use self::{
         systemfont::{default_system_font, get_all_font_handles, list_system_font_families},
     },
     format::{FontAsset, FontFormat, FontHandle, OtfFormat, TtfFormat},
+    label::{UiLabel, UiLabelBuilder, UiLabelBuilderResources},
     layout::{Anchor, ScaleMode, Stretch, UiTransformSystem},
     pass::DrawUi,
     prefab::{
@@ -28,7 +29,11 @@ pub use self::{
     text::{LineMode, TextEditing, TextEditingMouseSystem, UiText},
     text_editing::TextEditingInputSystem,
     transform::{UiFinder, UiTransform},
+    widgets::{Widget, WidgetId, Widgets},
 };
+
+pub(crate) use amethyst_core::ecs::prelude::Entity;
+pub(crate) use paste;
 
 mod bundle;
 mod button;
@@ -36,6 +41,7 @@ mod event;
 mod event_retrigger;
 mod font;
 mod format;
+mod label;
 mod layout;
 mod pass;
 mod prefab;
@@ -46,3 +52,4 @@ mod sound;
 mod text;
 mod text_editing;
 mod transform;
+mod widgets;

--- a/amethyst_ui/src/prefab.rs
+++ b/amethyst_ui/src/prefab.rs
@@ -8,7 +8,7 @@ use amethyst_assets::{
     Progress, ProgressCounter, SimpleFormat,
 };
 use amethyst_audio::{AudioFormat, Source as Audio};
-use amethyst_core::ecs::prelude::{Entities, Entity, Read, ReadExpect, WriteStorage};
+use amethyst_core::ecs::prelude::{Entities, Entity, Read, ReadExpect, Write, WriteStorage};
 use amethyst_error::{format_err, Error, ResultExt};
 use amethyst_renderer::{
     HiddenPropagate, Texture, TextureFormat, TextureHandle, TextureMetadata, TexturePrefab,
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     get_default_font, Anchor, FontAsset, FontFormat, Interactable, LineMode, Selectable, Stretch,
     TextEditing, UiButton, UiButtonAction, UiButtonActionRetrigger, UiButtonActionType,
-    UiPlaySoundAction, UiSoundRetrigger, UiText, UiTransform,
+    UiPlaySoundAction, UiSoundRetrigger, UiText, UiTransform, WidgetId, Widgets,
 };
 
 /// Loadable `UiTransform` data.
@@ -143,6 +143,7 @@ where
         entity: Entity,
         system_data: &mut Self::SystemData,
         _: &[Entity],
+        _: &[Entity],
     ) -> Result<(), Error> {
         let mut transform = UiTransform::new(
             self.id.clone(),
@@ -251,13 +252,14 @@ where
         entity: Entity,
         system_data: &mut Self::SystemData,
         _: &[Entity],
+        _: &[Entity],
     ) -> Result<(), Error> {
         let (ref mut texts, ref mut editables, ref mut fonts) = system_data;
         let font_handle = self
             .font
             .as_ref()
             .ok_or_else(|| format_err!("did not load sub assets"))?
-            .add_to_entity(entity, fonts, &[])?;
+            .add_to_entity(entity, fonts, &[], &[])?;
         let mut ui_text = UiText::new(font_handle, self.text.clone(), self.color, self.font_size);
         ui_text.password = self.password;
 
@@ -329,9 +331,12 @@ where
         entity: Entity,
         system_data: &mut Self::SystemData,
         entities: &[Entity],
+        children: &[Entity],
     ) -> Result<(), Error> {
         let (ref mut images, ref mut textures) = system_data;
-        let texture_handle = self.image.add_to_entity(entity, textures, entities)?;
+        let texture_handle = self
+            .image
+            .add_to_entity(entity, textures, entities, children)?;
         images.insert(entity, texture_handle)?;
         Ok(())
     }
@@ -350,54 +355,59 @@ where
 ///
 /// ### Type parameters:
 ///
-/// - `TF`: `Format` used for loading `Texture`s
-/// - `AF`: `Format` used for loading sounds
-/// - `FF`: `Format` used for loading fonts
+/// - `I`: `Format` used for loading `Texture`s
+/// - `A`: `Format` used for loading sounds
+/// - `F`: `Format` used for loading fonts
+/// - `W`: Type used for Widget IDs
 #[derive(Deserialize, Serialize, Clone)]
-pub struct UiButtonBuilder<AF = AudioFormat, TF = TextureFormat, FF = FontFormat>
+pub struct UiButtonBuilder<A = AudioFormat, I = TextureFormat, F = FontFormat, W = u32>
 where
-    TF: Format<Texture, Options = TextureMetadata>,
-    FF: Format<FontAsset, Options = ()>,
-    AF: Format<Audio, Options = ()>,
+    I: Format<Texture, Options = TextureMetadata>,
+    F: Format<FontAsset, Options = ()>,
+    A: Format<Audio, Options = ()>,
+    W: WidgetId,
 {
+    /// Id for the widget
+    pub id: Option<W>,
     /// Text to display
     pub text: String,
     /// Font size
     pub font_size: f32,
     /// Font
-    pub font: Option<AssetPrefab<FontAsset, FF>>,
+    pub font: Option<AssetPrefab<FontAsset, F>>,
     /// Default text color
     pub normal_text_color: [f32; 4],
     /// Default image
-    pub normal_image: Option<TexturePrefab<TF>>,
+    pub normal_image: Option<TexturePrefab<I>>,
     /// Image used when the mouse hovers over this element
-    pub hover_image: Option<TexturePrefab<TF>>,
+    pub hover_image: Option<TexturePrefab<I>>,
     /// Text color used when this button is hovered over
     pub hover_text_color: Option<[f32; 4]>,
     /// Image used when button is pressed
-    pub press_image: Option<TexturePrefab<TF>>,
+    pub press_image: Option<TexturePrefab<I>>,
     /// Text color used when this button is pressed
     pub press_text_color: Option<[f32; 4]>,
     /// Sound made when this button is hovered over
-    pub hover_sound: Option<AssetPrefab<Audio, AF>>,
+    pub hover_sound: Option<AssetPrefab<Audio, A>>,
     /// Sound made when this button is pressed.
-    pub press_sound: Option<AssetPrefab<Audio, AF>>,
+    pub press_sound: Option<AssetPrefab<Audio, A>>,
     /// Sound made when this button is released.
-    pub release_sound: Option<AssetPrefab<Audio, AF>>,
+    pub release_sound: Option<AssetPrefab<Audio, A>>,
 }
 
-impl<'a, AF, TF, FF> PrefabData<'a> for UiButtonBuilder<AF, TF, FF>
+impl<'a, A, I, F, W> PrefabData<'a> for UiButtonBuilder<A, I, F, W>
 where
-    TF: Format<Texture, Options = TextureMetadata> + Clone + Sync,
-    FF: Format<FontAsset, Options = ()> + Clone,
-    AF: Format<Audio, Options = ()> + Clone,
+    I: Format<Texture, Options = TextureMetadata> + Clone + Sync,
+    F: Format<FontAsset, Options = ()> + Clone,
+    A: Format<Audio, Options = ()> + Clone,
+    W: WidgetId,
 {
     type SystemData = (
-        WriteStorage<'a, UiButton>,
         WriteStorage<'a, UiSoundRetrigger>,
         WriteStorage<'a, UiButtonActionRetrigger>,
-        <TexturePrefab<TF> as PrefabData<'a>>::SystemData,
-        <AssetPrefab<Audio, AF> as PrefabData<'a>>::SystemData,
+        Write<'a, Widgets<UiButton, W>>,
+        <TexturePrefab<I> as PrefabData<'a>>::SystemData,
+        <AssetPrefab<Audio, A> as PrefabData<'a>>::SystemData,
     );
     type Result = ();
 
@@ -406,32 +416,43 @@ where
         entity: Entity,
         system_data: &mut Self::SystemData,
         entity_set: &[Entity],
+        children: &[Entity],
     ) -> Result<(), Error> {
         let (
-            ref mut buttons,
             ref mut sound_retrigger,
             ref mut button_action_retrigger,
+            ref mut widgets,
             ref mut textures,
             ref mut sounds,
         ) = system_data;
 
+        let text_entity = children.get(0).expect("Invalid: Should have text child");
+        let widget = UiButton::new(entity.clone(), text_entity.clone());
+        if let Some(id) = &self.id {
+            widgets.add_with_id(id.clone(), widget);
+        } else {
+            widgets.add(widget);
+        }
+
         let _normal_image = self
             .normal_image
-            .add_to_entity(entity, textures, entity_set)?;
+            .add_to_entity(entity, textures, entity_set, children)?;
         let hover_image = self
             .hover_image
-            .add_to_entity(entity, textures, entity_set)?;
+            .add_to_entity(entity, textures, entity_set, children)?;
         let press_image = self
             .press_image
-            .add_to_entity(entity, textures, entity_set)?;
+            .add_to_entity(entity, textures, entity_set, children)?;
 
-        let hover_sound = self.hover_sound.add_to_entity(entity, sounds, entity_set)?;
-        let press_sound = self.press_sound.add_to_entity(entity, sounds, entity_set)?;
+        let hover_sound = self
+            .hover_sound
+            .add_to_entity(entity, sounds, entity_set, children)?;
+        let press_sound = self
+            .press_sound
+            .add_to_entity(entity, sounds, entity_set, children)?;
         let release_sound = self
             .release_sound
-            .add_to_entity(entity, sounds, entity_set)?;
-
-        buttons.insert(entity, UiButton::new(self.normal_text_color))?;
+            .add_to_entity(entity, sounds, entity_set, children)?;
 
         let mut on_click_start = Vec::new();
         let mut on_click_stop = Vec::new();
@@ -537,15 +558,23 @@ where
 /// - `A`: `Format` used for loading sounds
 /// - `I`: `Format` used for loading `Texture`s
 /// - `F`: `Format` used for loading `FontAsset`
+/// - `W`: Type used for Widget ID for this widget and its children
 #[derive(Serialize, Deserialize, Clone)]
-pub enum UiWidget<A = AudioFormat, I = TextureFormat, F = FontFormat, C = NoCustomUi, G = ()>
-where
+pub enum UiWidget<
+    A = AudioFormat,
+    I = TextureFormat,
+    F = FontFormat,
+    C = NoCustomUi,
+    W = u32,
+    G = (),
+> where
     A: Format<Audio, Options = ()>,
     I: Format<Texture, Options = TextureMetadata>,
     F: Format<FontAsset, Options = ()>,
-    C: ToNativeWidget<A, I, F>,
+    C: ToNativeWidget<A, I, F, W>,
+    W: WidgetId,
 {
-    /// Container component
+    /// Container widget
     Container {
         /// Spatial information for the container
         transform: UiTransformBuilder<G>,
@@ -553,46 +582,47 @@ where
         #[serde(default = "default_container_image")]
         background: Option<UiImagePrefab<I>>,
         /// Child widgets
-        children: Vec<UiWidget<A, I, F, C>>,
+        children: Vec<UiWidget<A, I, F, C, W>>,
     },
-    /// Image component
+    /// Image widget
     Image {
         /// Spatial information
         transform: UiTransformBuilder<G>,
         /// Image
         image: UiImagePrefab<I>,
     },
-    /// Text component
-    Text {
+    /// Text widget
+    Label {
         /// Spatial information
         transform: UiTransformBuilder<G>,
         /// Text
         text: UiTextBuilder<F>,
     },
-    /// Button component
+    /// Button widget
     Button {
         /// Spatial information
         transform: UiTransformBuilder<G>,
         /// Button
-        button: UiButtonBuilder<A, I, F>,
+        button: UiButtonBuilder<A, I, F, W>,
     },
     /// Custom UI widget
     Custom(Box<C>),
 }
 
-impl<A, I, F, C, G> UiWidget<A, I, F, C, G>
+impl<A, I, F, C, W, G> UiWidget<A, I, F, C, W, G>
 where
     A: Format<Audio, Options = ()>,
     I: Format<Texture, Options = TextureMetadata>,
     F: Format<FontAsset, Options = ()>,
-    C: ToNativeWidget<A, I, F>,
+    C: ToNativeWidget<A, I, F, W>,
+    W: WidgetId,
 {
     /// Convenience function to access widgets `UiTransformBuilder`
     pub fn transform(&self) -> Option<&UiTransformBuilder<G>> {
         match self {
             UiWidget::Container { ref transform, .. } => Some(transform),
             UiWidget::Image { ref transform, .. } => Some(transform),
-            UiWidget::Text { ref transform, .. } => Some(transform),
+            UiWidget::Label { ref transform, .. } => Some(transform),
             UiWidget::Button { ref transform, .. } => Some(transform),
             UiWidget::Custom(_) => None,
         }
@@ -607,7 +637,7 @@ where
             UiWidget::Image {
                 ref mut transform, ..
             } => Some(transform),
-            UiWidget::Text {
+            UiWidget::Label {
                 ref mut transform, ..
             } => Some(transform),
             UiWidget::Button {
@@ -639,11 +669,12 @@ where
 }
 
 /// Create native `UiWidget` from custom UI
-pub trait ToNativeWidget<A = AudioFormat, I = TextureFormat, F = FontFormat>
+pub trait ToNativeWidget<A = AudioFormat, I = TextureFormat, F = FontFormat, W = u32>
 where
     A: Format<Audio, Options = ()>,
     I: Format<Texture, Options = TextureMetadata>,
     F: Format<FontAsset, Options = ()>,
+    W: WidgetId,
     Self: Sized,
 {
     /// Additional data used when loading UI prefab
@@ -655,24 +686,25 @@ where
     fn to_native_widget(
         self,
         parent_data: Self::PrefabData,
-    ) -> (UiWidget<A, I, F, Self>, Self::PrefabData);
+    ) -> (UiWidget<A, I, F, Self, W>, Self::PrefabData);
 }
 
 /// Type used when no custom ui is desired
 #[derive(Serialize, Deserialize)]
 pub enum NoCustomUi {}
 
-impl<A, I, F> ToNativeWidget<A, I, F> for NoCustomUi
+impl<A, I, F, W> ToNativeWidget<A, I, F, W> for NoCustomUi
 where
     A: Format<Audio, Options = ()>,
     I: Format<Texture, Options = TextureMetadata>,
     F: Format<FontAsset, Options = ()>,
+    W: WidgetId,
 {
     type PrefabData = ();
     fn to_native_widget(
         self,
         _: Self::PrefabData,
-    ) -> (UiWidget<A, I, F, NoCustomUi>, Self::PrefabData) {
+    ) -> (UiWidget<A, I, F, NoCustomUi, W>, Self::PrefabData) {
         // self can not exist
         unreachable!()
     }
@@ -690,12 +722,13 @@ type UiPrefabData<
     I = TextureFormat,
     F = FontFormat,
     D = <NoCustomUi as ToNativeWidget>::PrefabData,
+    W = u32,
     G = (),
 > = (
     Option<UiTransformBuilder<G>>,
     Option<UiImagePrefab<I>>,
     Option<UiTextBuilder<F>>,
-    Option<UiButtonBuilder<A, I, F>>,
+    Option<UiButtonBuilder<A, I, F, W>>,
     D,
 );
 
@@ -707,12 +740,14 @@ type UiPrefabData<
 /// - `I`: `Format` used for loading `Texture`s
 /// - `F`: `Format` used for loading `FontAsset`
 /// - `D`: `ToNativeWidget::PrefabData` data used by custom UI
+/// - `W`: Type used for Widget IDs
 pub type UiPrefab<
     A = AudioFormat,
     I = TextureFormat,
     F = FontFormat,
     D = <NoCustomUi as ToNativeWidget>::PrefabData,
-> = Prefab<UiPrefabData<A, I, F, D>>;
+    W = u32,
+> = Prefab<UiPrefabData<A, I, F, D, W>>;
 
 /// Ui format.
 ///
@@ -721,22 +756,23 @@ pub type UiPrefab<
 #[derivative(Clone(bound = ""), Debug(bound = ""), Default(bound = ""))]
 pub struct UiFormat<C>(PhantomData<C>);
 
-impl<A, I, F, C> SimpleFormat<UiPrefab<A, I, F, C::PrefabData>> for UiFormat<C>
+impl<A, I, F, C, W> SimpleFormat<UiPrefab<A, I, F, C::PrefabData, W>> for UiFormat<C>
 where
     A: Format<Audio, Options = ()> + Sync + DeserializeOwned,
     I: Format<Texture, Options = TextureMetadata> + Sync + DeserializeOwned + Clone,
     F: Format<FontAsset, Options = ()> + Sync + DeserializeOwned + Clone,
-    C: ToNativeWidget<A, I, F> + for<'de> serde::Deserialize<'de>,
+    C: ToNativeWidget<A, I, F, W> + for<'de> serde::Deserialize<'de>,
+    W: WidgetId + DeserializeOwned,
 {
     const NAME: &'static str = "Ui";
     type Options = ();
 
-    fn import(&self, bytes: Vec<u8>, _: ()) -> Result<UiPrefab<A, I, F, C::PrefabData>, Error> {
+    fn import(&self, bytes: Vec<u8>, _: ()) -> Result<UiPrefab<A, I, F, C::PrefabData, W>, Error> {
         use ron::de::Deserializer;
         use serde::Deserialize;
         let mut d = Deserializer::from_bytes(&bytes)
             .with_context(|_| format_err!("Failed deserializing Ron file"))?;
-        let root: UiWidget<A, I, F, C> = UiWidget::deserialize(&mut d)
+        let root: UiWidget<A, I, F, C, W> = UiWidget::deserialize(&mut d)
             .with_context(|_| format_err!("Failed parsing Ron file"))?;
         d.end()
             .with_context(|_| format_err!("Failed parsing Ron file"))?;
@@ -748,16 +784,17 @@ where
     }
 }
 
-fn walk_ui_tree<A, I, F, C>(
-    widget: UiWidget<A, I, F, C>,
+fn walk_ui_tree<A, I, F, C, W>(
+    widget: UiWidget<A, I, F, C, W>,
     current_index: usize,
-    prefab: &mut Prefab<UiPrefabData<A, I, F, C::PrefabData>>,
+    prefab: &mut Prefab<UiPrefabData<A, I, F, C::PrefabData, W>>,
     custom_data: C::PrefabData,
 ) where
     A: Format<Audio, Options = ()>,
     I: Format<Texture, Options = TextureMetadata> + Clone,
     F: Format<FontAsset, Options = ()> + Clone,
-    C: ToNativeWidget<A, I, F>,
+    C: ToNativeWidget<A, I, F, W>,
+    W: WidgetId,
 {
     match widget {
         UiWidget::Custom(custom) => {
@@ -772,7 +809,7 @@ fn walk_ui_tree<A, I, F, C>(
                 .set_data((Some(transform), Some(image), None, None, custom_data));
         }
 
-        UiWidget::Text { transform, text } => {
+        UiWidget::Label { transform, text } => {
             prefab
                 .entity(current_index)
                 .expect("Unreachable: `Prefab` entity should always be set when walking ui tree")
@@ -843,6 +880,7 @@ fn walk_ui_tree<A, I, F, C>(
 ///
 /// - `I`: `Format` used for loading `Texture`s
 /// - `F`: `Format` used for loading `FontAsset`
+/// - `W`: Type used for Widget IDs
 ///
 /// ### Example:
 ///
@@ -852,26 +890,28 @@ fn walk_ui_tree<A, I, F, C>(
 /// });
 /// ```
 #[derive(SystemData)]
-pub struct UiLoader<'a, A = AudioFormat, I = TextureFormat, F = FontFormat, C = NoCustomUi>
+pub struct UiLoader<'a, A = AudioFormat, I = TextureFormat, F = FontFormat, C = NoCustomUi, W = u32>
 where
     A: Format<Audio, Options = ()> + Sync,
     I: Format<Texture, Options = TextureMetadata> + Sync,
     F: Format<FontAsset, Options = ()> + Sync,
-    C: ToNativeWidget<A, I, F>,
+    C: ToNativeWidget<A, I, F, W>,
+    W: WidgetId,
 {
     loader: ReadExpect<'a, Loader>,
-    storage: Read<'a, AssetStorage<UiPrefab<A, I, F, C::PrefabData>>>,
+    storage: Read<'a, AssetStorage<UiPrefab<A, I, F, C::PrefabData, W>>>,
 }
 
-impl<'a, A, I, F, C> UiLoader<'a, A, I, F, C>
+impl<'a, A, I, F, C, W> UiLoader<'a, A, I, F, C, W>
 where
     A: Format<Audio, Options = ()> + Sync + DeserializeOwned,
     I: Format<Texture, Options = TextureMetadata> + Sync + DeserializeOwned + Clone,
     F: Format<FontAsset, Options = ()> + Sync + DeserializeOwned + Clone,
-    C: ToNativeWidget<A, I, F> + for<'de> serde::Deserialize<'de> + Send + Sync + 'static,
+    C: ToNativeWidget<A, I, F, W> + for<'de> serde::Deserialize<'de> + Send + Sync + 'static,
+    W: WidgetId + DeserializeOwned,
 {
     /// Load ui from disc
-    pub fn load<N, P>(&self, name: N, progress: P) -> Handle<UiPrefab<A, I, F, C::PrefabData>>
+    pub fn load<N, P>(&self, name: N, progress: P) -> Handle<UiPrefab<A, I, F, C::PrefabData, W>>
     where
         N: Into<String>,
         P: Progress,
@@ -891,6 +931,7 @@ where
 /// - `I`: `Format` used for loading `Texture`s
 /// - `F`: `Format` used for loading `FontAsset`
 /// - `C`: custom UI widget
+/// - `W`: Type used for Widget IDs
 ///
 /// ### Example:
 ///
@@ -900,24 +941,32 @@ where
 /// });
 /// ```
 #[derive(SystemData)]
-pub struct UiCreator<'a, A = AudioFormat, I = TextureFormat, F = FontFormat, C = NoCustomUi>
-where
+pub struct UiCreator<
+    'a,
+    A = AudioFormat,
+    I = TextureFormat,
+    F = FontFormat,
+    C = NoCustomUi,
+    W = u32,
+> where
     A: Format<Audio, Options = ()> + Sync,
     I: Format<Texture, Options = TextureMetadata> + Sync,
     F: Format<FontAsset, Options = ()> + Sync,
-    C: ToNativeWidget<A, I, F>,
+    C: ToNativeWidget<A, I, F, W>,
+    W: WidgetId,
 {
-    loader: UiLoader<'a, A, I, F, C>,
+    loader: UiLoader<'a, A, I, F, C, W>,
     entities: Entities<'a>,
-    handles: WriteStorage<'a, Handle<UiPrefab<A, I, F, C::PrefabData>>>,
+    handles: WriteStorage<'a, Handle<UiPrefab<A, I, F, C::PrefabData, W>>>,
 }
 
-impl<'a, A, I, F, C> UiCreator<'a, A, I, F, C>
+impl<'a, A, I, F, C, W> UiCreator<'a, A, I, F, C, W>
 where
     A: Format<Audio, Options = ()> + Sync + DeserializeOwned + Clone,
     I: Format<Texture, Options = TextureMetadata> + Sync + DeserializeOwned + Clone,
     F: Format<FontAsset, Options = ()> + Sync + DeserializeOwned + Clone,
-    C: ToNativeWidget<A, I, F> + for<'de> serde::Deserialize<'de> + Send + Sync + 'static,
+    C: ToNativeWidget<A, I, F, W> + for<'de> serde::Deserialize<'de> + Send + Sync + 'static,
+    W: WidgetId + DeserializeOwned,
 {
     /// Create a UI.
     ///
@@ -954,7 +1003,8 @@ where
 /// - `I`: `Format` used for loading `Texture`s
 /// - `F`: `Format` used for loading `FontAsset`
 /// - `CD`: prefab data from custom UI, see `ToNativeWidget::PrefabData`
-pub type UiLoaderSystem<A, I, F, CD> = PrefabLoaderSystem<UiPrefabData<A, I, F, CD>>;
+/// - `W`: Type used for Widget IDs
+pub type UiLoaderSystem<A, I, F, CD, W> = PrefabLoaderSystem<UiPrefabData<A, I, F, CD, W>>;
 
 fn button_text_transform<G>(mut id: String) -> UiTransformBuilder<G> {
     id.push_str("_btn_txt");

--- a/amethyst_ui/src/widgets.rs
+++ b/amethyst_ui/src/widgets.rs
@@ -1,0 +1,208 @@
+use derivative::Derivative;
+use rand::{self, distributions::Alphanumeric, Rng};
+use std::{
+    collections::{
+        hash_map::{Keys, Values, ValuesMut},
+        HashMap,
+    },
+    fmt::Display,
+    hash::Hash,
+    ops::Index,
+};
+
+/// A widget is an object that keeps track of all components and entities
+/// that make up an element of the user interface. Using the widget_components!
+/// macro, it's possible to generate methods that let you easily retrieve
+/// all components for a widget, and basically annotate which components the
+/// widget will definitely or maybe contain.
+/// Widgets are stored in their respective `Widgets` resource and referred to
+/// by their associated Id type. A widget will generally only contain fields
+/// for the entity Ids it consist of.
+pub trait Widget {}
+
+/// A WidgetId is the type by which the different widgets of a type will be
+/// differentiated when you create and retrieve them. Generally you'll want something
+/// here that can generate a random id with a low chance of collision, since
+/// auto generation will be used whenever you don't explicitly don't provide an
+/// id to widget builders.
+/// It's possible to use something like a bare enum as a WidgetId, but be aware
+/// that whenever you're not supplying a WidgetId, you'll probably overwrite an
+/// existing widget that had the same default id.
+pub trait WidgetId: Clone + PartialEq + Eq + Hash + Send + Sync + Display + 'static {
+    /// Generate a new widget id. This function can optionally be passed the last ID
+    /// that was generated, to make sequential ids possible.
+    fn generate(last: &Option<Self>) -> Self;
+}
+
+impl WidgetId for u32 {
+    fn generate(last: &Option<Self>) -> Self {
+        last.map(|last| last + 1).unwrap_or(0)
+    }
+}
+
+impl WidgetId for u64 {
+    fn generate(last: &Option<Self>) -> Self {
+        last.map(|last| last + 1).unwrap_or(0)
+    }
+}
+
+impl WidgetId for String {
+    fn generate(_: &Option<Self>) -> Self {
+        rand::thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(16)
+            .collect()
+    }
+}
+
+/// Widgets is an alias for a HashMap containing widgets mapped by their
+/// respective Id type. It's meant to be used as a resource for every widget type.
+#[derive(Derivative)]
+#[derivative(Default(bound = ""))]
+pub struct Widgets<T: Widget, I: WidgetId = u32> {
+    items: HashMap<I, T>,
+    last_key: Option<I>,
+}
+
+impl<T, I> Widgets<T, I>
+where
+    T: Widget,
+    I: WidgetId,
+{
+    /// Adds a widget to the map and returns the ID that was created
+    /// for it.
+    pub fn add(&mut self, widget: T) -> I {
+        let id = I::generate(&self.last_key);
+        self.items.insert(id.clone(), widget);
+        id
+    }
+
+    /// Adds a widget with a specified ID. If a widget with the given
+    /// ID already existed, the replaced widget will be returned.
+    pub fn add_with_id(&mut self, id: I, widget: T) -> Option<T> {
+        self.items.insert(id, widget)
+    }
+
+    /// Retrieves a widget by its ID.
+    pub fn get(&self, id: I) -> Option<&T> {
+        self.items.get(&id)
+    }
+
+    /// Mutably retrieves a widget by its ID.
+    pub fn get_mut(&mut self, id: I) -> Option<&mut T> {
+        self.items.get_mut(&id)
+    }
+
+    /// Provides an iterator over all widgets.
+    pub fn widgets(&self) -> Values<'_, I, T> {
+        self.items.values()
+    }
+
+    /// Provides a mutable iterator over all widgets.
+    pub fn widgets_mut(&mut self) -> ValuesMut<'_, I, T> {
+        self.items.values_mut()
+    }
+
+    /// Provides an iterator over all IDs included in the resource.
+    pub fn ids(&self) -> Keys<'_, I, T> {
+        self.items.keys()
+    }
+}
+
+impl<T, I> Index<I> for Widgets<T, I>
+where
+    T: Widget,
+    I: WidgetId,
+{
+    type Output = T;
+    fn index(&self, id: I) -> &Self::Output {
+        &self.items[&id]
+    }
+}
+
+/// Helper macro used inside `widget_components`
+#[macro_export]
+macro_rules! define_widget_component_fn_impl {
+    ( (has $t:ty as $name:ident on $entity:ident) ) => {
+        $crate::paste::item! {
+            /// Get a reference to the $t component for this widget.
+            pub fn [<get_ $name>]<'a>(
+                &self,
+                storage: &'a amethyst_core::ecs::prelude::ReadStorage<'a, $t>
+            ) -> &'a $t {
+                // TODO: Better error message
+                storage.get(self.$entity)
+                    .expect("Component should exist on entity")
+            }
+        }
+
+        $crate::paste::item! {
+            /// Get a mutable reference to the $t component for this widget.
+            pub fn [<get_ $name _mut>]<'a>(
+                &self,
+                storage: &'a mut amethyst_core::ecs::prelude::WriteStorage<'a, $t>
+            ) -> &'a mut $t {
+                // TODO: Better error message
+                storage.get_mut(self.$entity)
+                    .expect("Component should exist on entity")
+            }
+        }
+    };
+
+    ( (maybe_has $t:ty as $name:ident on $entity:ident) ) => {
+        $crate::paste::item! {
+            /// Get a reference to the $t component for this widget if it exists,
+            /// `None` otherwise.
+            pub fn [<get_ $name _maybe>]<'a>(
+                &self,
+                storage: &'a amethyst_core::ecs::prelude::ReadStorage<'a, $t>
+            ) -> Option<&'a $t> {
+                storage.get(self.$entity)
+            }
+        }
+
+        $crate::paste::item! {
+            /// Get a mutable reference to the $t component for this widget
+            /// if it exists, `None` otherwise.
+            pub fn [<get_ $name _mut_maybe>]<'a>(
+                &self,
+                storage: &'a mut amethyst_core::ecs::prelude::WriteStorage<'a, $t>
+            ) -> Option<&'a mut $t> {
+                storage.get_mut(self.$entity)
+            }
+        }
+    };
+}
+
+/// This macro allows you to define what components can be attached to a widget,
+/// and will automatically generate getters for all components you specify.
+/// For each component, you are required to specify which entity handle the
+/// component will be attached to.
+#[macro_export]
+macro_rules! define_widget {
+    ($t:ident =>
+        entities: [$($field:tt),*]
+        components: [$($component:tt),*]
+    ) => {
+        /// A $t widget, containing references to its associated entities.
+        #[derive(Debug, Clone)]
+        pub struct $t {
+            $($field: $crate::Entity),*
+        }
+
+        impl $crate::Widget for $t {}
+
+        impl $t {
+            /// Create a new $t widget from its associated entities.
+            pub fn new(
+                $($field: $crate::Entity),*
+            ) -> Self {
+                Self {
+                    $($field),*
+                }
+            }
+
+            $($crate::define_widget_component_fn_impl!{ $component })*
+        }
+    };
+}

--- a/book/src/prefabs/prefabs_technical_explanation.md
+++ b/book/src/prefabs/prefabs_technical_explanation.md
@@ -83,9 +83,9 @@ impl<'a> PrefabData<'a> for Transform {
         entity: Entity,
         storage: &mut Self::SystemData,
         _: &[Entity],
+        _: &[Entity],
     ) -> Result<(), Error> {
-        storage.insert(entity, self.clone())?;
-        Ok(())
+        storage.insert(entity, self.clone()).map(|_| ())
     }
 }
 ```
@@ -149,6 +149,7 @@ where
         &self,
         entity: Entity,
         system_data: &mut Self::SystemData,
+        _: &[Entity],
         _: &[Entity],
     ) -> Result<Handle<A>, Error> {
         let handle = match *self {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@ it is attached to. ([#1282])
 * Add `add_removal_to_entity` function. ([#1445])
 * Add `position_from_screen` to `Camera`. Transforms position from screen space to camera space. ([#1442])
 * Add `SpriteScenePrefab`. Allows load sprites from a grid and add them to the `SpriteRenderer`. ([#1469])
+* Add `Widgets` resource. Allows keeping track of UI entities and their components and iterating over them. ([#1390])
 
 ### Changed
 
@@ -56,6 +57,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * `ProgressCounter#num_loading()` no longer includes failed assets. ([#1452])
 * `SpriteSheetFormat` field renamed from `spritesheet_*` to `texture_*`. ([#1469])
 * Add new `keep_aspect_ratio` field to `Stretch::XY`. ([#1480])
+* Renamed `Text` UI Prefab to `Label` in preparation for full widget integration in prefabs. ([#1390])
 
 ### Removed
 
@@ -105,6 +107,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1469]: https://github.com/amethyst/amethyst/pull/1469
 [#1481]: https://github.com/amethyst/amethyst/pull/1481
 [#1480]: https://github.com/amethyst/amethyst/pull/1480
+[#1390]: https://github.com/amethyst/amethyst/pull/1390
 
 ## [0.10.0] - 2018-12
 

--- a/examples/assets/ui/custom.ron
+++ b/examples/assets/ui/custom.ron
@@ -4,7 +4,7 @@ Custom(
         count: 11,
         x_move: 75.,
         y_move: -50.,
-        item: Text(
+        item: Label(
             transform: (
                 id: "paused",
                 anchor: TopLeft,

--- a/examples/assets/ui/example.ron
+++ b/examples/assets/ui/example.ron
@@ -71,7 +71,7 @@ Container(
                 image: Data(Rgba((0.09, 0.02, 0.25, 1.0), (channel: Srgb))),
             ),
             children: [
-                Text(
+                Label(
                     transform: (
                         id: "editable",
                         width: 500.,
@@ -142,7 +142,7 @@ Container(
                 normal_image: Data(Rgba((0.82, 0.83, 0.83, 1.0), (channel: Srgb))),
             )
         ),
-        Text(
+        Label(
             transform: (
                 id: "fps",
                 x: 100.,
@@ -162,7 +162,7 @@ Container(
         ),
 
         // Random text
-        Text(
+        Label(
             transform: (
                 id: "random_text",
                 x: 100.,
@@ -181,7 +181,7 @@ Container(
             )
         ),
 
-        Text(
+        Label(
             transform: (
                 id: "multiline",
                 x: -200.,
@@ -200,7 +200,7 @@ Container(
             )
         ),
 
-        Text(
+        Label(
             transform: (
                 id: "system_font",
                 x: 200.,
@@ -218,7 +218,7 @@ Container(
         ),
 
         // ------ Text Align Start ------
-        Text(
+        Label(
             transform: (
                 id: "TopLeft",
                 y: 180.0,
@@ -235,7 +235,7 @@ Container(
                 align: TopLeft, // ! relative to the transform specified, which only has a width of 800 and height of 175 !
             )
         ),
-        Text(
+        Label(
             transform: (
                 id: "Middle",
                 y: 0.0,
@@ -252,7 +252,7 @@ Container(
                 align: Middle,
             )
         ),
-        Text(
+        Label(
             transform: (
                 id: "BottomRight",
                 y: -180.0,

--- a/examples/assets/ui/fov.ron
+++ b/examples/assets/ui/fov.ron
@@ -11,7 +11,7 @@ Container(
     ),
     background: None,
     children: [
-        Text(
+        Label(
             transform: (
                 id: "screen_aspect",
                 anchor: TopLeft,
@@ -29,7 +29,7 @@ Container(
                 font: File("font/square.ttf", Ttf, ()),
             ),
         ),
-        Text(
+        Label(
             transform: (
                 id: "camera_aspect",
                 anchor: MiddleLeft,
@@ -47,7 +47,7 @@ Container(
                 font: File("font/square.ttf", Ttf, ()),
             ),
         ),
-        Text(
+        Label(
             transform: (
                 id: "camera_fov",
                 anchor: BottomLeft,

--- a/examples/assets/ui/fps.ron
+++ b/examples/assets/ui/fps.ron
@@ -1,5 +1,5 @@
 #![enable(implicit_some)]
-Text(
+Label(
     transform: (
         id: "fps_text",
         anchor: TopLeft,

--- a/examples/assets/ui/loading.ron
+++ b/examples/assets/ui/loading.ron
@@ -1,5 +1,5 @@
 #![enable(implicit_some)]
-Text(
+Label(
     transform: (
         id: "loading",
         anchor: Middle,

--- a/examples/assets/ui/paused.ron
+++ b/examples/assets/ui/paused.ron
@@ -1,5 +1,5 @@
 #![enable(implicit_some)]
-Text(
+Label(
     transform: (
         id: "paused",
         anchor: Middle,

--- a/examples/prefab_adapter/main.rs
+++ b/examples/prefab_adapter/main.rs
@@ -52,6 +52,7 @@ impl<'a> PrefabData<'a> for PositionPrefab {
         entity: Entity,
         positions: &mut Self::SystemData,
         _entities: &[Entity],
+        _children: &[Entity],
     ) -> Result<(), Error> {
         let position = match *self {
             PositionPrefab::Pos3f { x, y, z } => (x, y, z).into(),


### PR DESCRIPTION
This is up for preliminary review, as I'm still very unsure about the specific implementation.

Basically this aims to do the following:
* Implement structs for each widget type which contain all entities belonging to the widget, effectively "tracking" the parts of the widget,
* Provide a way to easily see which components a widget definitely or potentially has, and get each of them, as well as
* Have an easy way to compose widget from different entities with components.

As an example, I've implemented these things for `UiButton` for now, to see how viable my solutions are. Please see the `widgets.rs` module as well as the `button/mod.rs` file, I've added comments with explanations.

Here's what's still missing to complete this PR:
* [x] Fix a weird generic/lifetime error in the builders for `UiLabel` and `UiWidget`
* [x] Implement `Widget`/`WidgetId` support for prefabs
* [x] Implement custom derive for `WidgetId`
* [x] ~Add examples and documentation for using `Widgets`~