### PR TITLE
Store MeshData when loading objects

### DIFF
--- a/amethyst_assets/src/prefab/system.rs
+++ b/amethyst_assets/src/prefab/system.rs
@@ -69,7 +69,7 @@ where
         ) = data;
         let strategy = strategy.as_ref().map(Deref::deref);
         prefab_storage.process(
-            |mut d| {
+            |_, mut d| {
                 d.tag = Some(self.next_tag);
                 self.next_tag += 1;
                 if !d.loading() {

--- a/amethyst_assets/src/storage.rs
+++ b/amethyst_assets/src/storage.rs
@@ -135,7 +135,7 @@ impl<A: Asset> AssetStorage<A> {
         pool: &ThreadPool,
         strategy: Option<&HotReloadStrategy>,
     ) where
-        F: FnMut(A::Data) -> Result<ProcessingState<A>>,
+        F: FnMut(Handle<A>, A::Data) -> Result<ProcessingState<A>>,
     {
         self.process_custom_drop(f, |_| {}, frame_number, pool, strategy);
     }
@@ -151,7 +151,7 @@ impl<A: Asset> AssetStorage<A> {
         strategy: Option<&HotReloadStrategy>,
     ) where
         D: FnMut(A),
-        F: FnMut(A::Data) -> Result<ProcessingState<A>>,
+        F: FnMut(Handle<A>, A::Data) -> Result<ProcessingState<A>>,
     {
         {
             let requeue = self
@@ -174,7 +174,7 @@ impl<A: Asset> AssetStorage<A> {
                     } => {
                         let (asset, reload_obj) = match data
                             .map(|FormatValue { data, reload }| (data, reload))
-                            .and_then(|(d, rel)| f(d).map(|a| (a, rel)))
+                            .and_then(|(d, rel)| f(handle.clone(), d).map(|a| (a, rel)))
                             .chain_err(|| ErrorKind::Asset(name.clone()))
                         {
                             Ok((ProcessingState::Loaded(x), r)) => {
@@ -253,7 +253,7 @@ impl<A: Asset> AssetStorage<A> {
                     } => {
                         let (asset, reload_obj) = match data
                             .map(|FormatValue { data, reload }| (data, reload))
-                            .and_then(|(d, rel)| f(d).map(|a| (a, rel)))
+                            .and_then(|(d, rel)| f(handle.clone(), d).map(|a| (a, rel)))
                             .chain_err(|| ErrorKind::Asset(name.clone()))
                         {
                             Ok((ProcessingState::Loaded(x), r)) => (x, r),
@@ -446,7 +446,7 @@ where
         use std::ops::Deref;
 
         storage.process(
-            Into::into,
+            |_, h| Into::into(h),
             time.frame_number(),
             &**pool,
             strategy.as_ref().map(Deref::deref),

--- a/amethyst_renderer/src/formats/mesh.rs
+++ b/amethyst_renderer/src/formats/mesh.rs
@@ -196,7 +196,7 @@ fn from_data(obj_set: ObjSet) -> Vec<PosNormTex> {
 }
 
 /// Create mesh
-pub fn create_mesh_asset(data: MeshData, renderer: &mut Renderer) -> Result<ProcessingState<Mesh>> {
+pub fn create_mesh_asset(data: &MeshData, renderer: &mut Renderer) -> Result<ProcessingState<Mesh>> {
     let data = match data {
         MeshData::PosColor(ref vertices) => {
             let mb = MeshBuilder::new(vertices);
@@ -218,7 +218,7 @@ pub fn create_mesh_asset(data: MeshData, renderer: &mut Renderer) -> Result<Proc
             let mb = MeshBuilder::new(vertices);
             renderer.create_mesh(mb)
         }
-        MeshData::Creator(creator) => creator.build(renderer),
+        MeshData::Creator(creator) => creator.clone().build(renderer),
     };
 
     data.map(ProcessingState::Loaded)


### PR DESCRIPTION
I'm not sure if this is the right approach, but I'm opening the PR to get some feedback. I wanted to get the MeshData from a mesh obj file after loading it. gltf sees to have this implemented.