### PR TITLE
Update nalgebra version

### DIFF
--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -16,7 +16,7 @@ appveyor = { repository = "amethyst/amethyst" }
 travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
-nalgebra = { version = "0.16.7", features = ["serde-serialize", "mint"] }
+nalgebra = { version = "0.17", features = ["serde-serialize", "mint"] }
 approx = "0.3"
 amethyst_error = { path = "../amethyst_error", version = "0.1.0" }
 fnv = "1"

--- a/amethyst_core/src/transform/components/local_transform.rs
+++ b/amethyst_core/src/transform/components/local_transform.rs
@@ -84,7 +84,7 @@ impl Transform {
     #[inline]
     pub fn face_towards(&mut self, target: Vector3<f32>, up: Vector3<f32>) -> &mut Self {
         self.iso.rotation =
-            UnitQuaternion::new_observer_frame(&(self.iso.translation.vector - target), &up);
+            UnitQuaternion::face_towards(&(self.iso.translation.vector - target), &up);
         self
     }
 


### PR DESCRIPTION
This is necessary to use the new version of ncollide and nphysics.