### PR TITLE
Remove unnecessary string allocs

### DIFF
--- a/amethyst_derive/src/event_reader.rs
+++ b/amethyst_derive/src/event_reader.rs
@@ -30,8 +30,9 @@ pub fn impl_event_reader(ast: &DeriveInput) -> TokenStream {
         };
     }
 
-    let reader_name = reader_name.expect(&format!(
-        r#"
+    let reader_name = reader_name.unwrap_or_else(|| {
+        panic!(
+            r#"
 #[derive(EventReader)] requested for {}, but #[reader(SomeEventReader)] attribute is missing
 
 Example usage:
@@ -42,8 +43,9 @@ pub enum SomeEvent {{
     Two(Event2),
 }}
 "#,
-        event_name
-    ));
+            event_name
+        )
+    });
 
     let tys = collect_field_types(&ast.data);
     let tys = &tys;

--- a/amethyst_renderer/src/blink.rs
+++ b/amethyst_renderer/src/blink.rs
@@ -61,10 +61,9 @@ impl<'a> System<'a> for BlinkSystem {
             let on = blink.timer < blink.delay / 2.0;
 
             match (on, hiddens.contains(entity)) {
-                (true, false) => hiddens.insert(entity, Hidden).expect(&format!(
-                    "Failed to insert Hidden component for {:?}",
-                    entity
-                )),
+                (true, false) => hiddens.insert(entity, Hidden).unwrap_or_else(|_| {
+                    panic!("Failed to insert Hidden component for {:?}", entity)
+                }),
                 (false, true) => hiddens.remove(entity),
                 _ => None,
             };


### PR DESCRIPTION
## Description

`.expect(format!(...))` is a pattern shown to have adverse performance impacts due to string allocations that are only used on a cold path. This PR removes those string allocations and retains the error messages.

## Additions

- None

## Removals

- None

## Modifications

- Slight performance improvement

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ ] **N/A** Updated the content of the book if this PR would make the book outdated.
- [ ] **N/A** Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] **N/A** Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
