### PR TITLE
Reduce logging verbosity

### DIFF
--- a/amethyst_utils/src/removal.rs
+++ b/amethyst_utils/src/removal.rs
@@ -1,7 +1,6 @@
 //! Provides utilities to remove large amounts of entities with a single command.
 
-use std::fmt::Debug;
-use std::ops::Deref;
+use std::{fmt::Debug, ops::Deref};
 
 use amethyst_assets::PrefabData;
 use amethyst_core::specs::{

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 it is attached to. ([#1282])
 * `AutoFov` and `AutoFovSystem` to adjust horizontal FOV to screen aspect ratio. ([#1281])
 * Add `icon` to `DisplayConfig` to set a window icon using a path to a file ([#1373])
-* Added setting to disable/enable gfx_device_gl logging, and set it disabled by default. ([#1404])
+* Added setting to control gfx_device_gl logging level separately, and set it to Warn by default. ([#1404])
 
 ### Changed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 it is attached to. ([#1282])
 * `AutoFov` and `AutoFovSystem` to adjust horizontal FOV to screen aspect ratio. ([#1281])
 * Add `icon` to `DisplayConfig` to set a window icon using a path to a file ([#1373])
+* Added setting to disable/enable gfx_device_gl logging, and set it disabled by default. ([#1404])
 
 ### Changed
 
@@ -30,6 +31,7 @@ it is attached to. ([#1282])
 * Convert everything to use err-derive and amethyst_error ([#1365])
 * Removed redundant code in `renderer.rs` ([#1375])
 * Changed argument types of `exec_removal` to allow use of both Read and Write Storages. ([#1397])
+* Changed default log level to Info. ([#1404])
 
 ### Removed
 
@@ -57,6 +59,7 @@ it is attached to. ([#1282])
 [#1371]: https://github.com/amethyst/amethyst/pull/1371
 [#1373]: https://github.com/amethyst/amethyst/pull/1373
 [#1397]: https://github.com/amethyst/amethyst/pull/1397
+[#1404]: https://github.com/amethyst/amethyst/pull/1404
 
 ## [0.10.0] - 2018-12
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -27,15 +27,18 @@ pub struct LoggerConfig {
     pub log_file: Option<PathBuf>,
     /// If set, allows the config values to be overriden via the corresponding environmental variables.
     pub allow_env_override: bool,
+    /// If false gfx_device_gl won't be logged.
+    pub log_gfx_device: bool,
 }
 
 impl Default for LoggerConfig {
     fn default() -> LoggerConfig {
         LoggerConfig {
             stdout: StdoutLog::Colored,
-            level_filter: LevelFilter::Debug,
+            level_filter: LevelFilter::Info,
             log_file: None,
             allow_env_override: true,
+            log_gfx_device: false,
         }
     }
 }
@@ -84,6 +87,12 @@ impl Logger {
                     .chain(colored_stdout(fern::colors::ColoredLevelConfig::new()))
             }
             StdoutLog::Off => {}
+        }
+
+        if !config.log_gfx_device {
+            logger.dispatch = logger
+                .dispatch
+                .filter(|m| !m.target().starts_with("gfx_device_gl"));
         }
 
         if let Some(path) = config.log_file {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -90,7 +90,9 @@ impl Logger {
         }
 
         if let Some(log_gfx_device_level) = config.log_gfx_device_level {
-            logger.dispatch = logger.dispatch.level_for("gfx_device_gl", log_gfx_device_level);
+            logger.dispatch = logger
+                .dispatch
+                .level_for("gfx_device_gl", log_gfx_device_level);
         }
 
         if let Some(path) = config.log_file {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -27,8 +27,8 @@ pub struct LoggerConfig {
     pub log_file: Option<PathBuf>,
     /// If set, allows the config values to be overriden via the corresponding environmental variables.
     pub allow_env_override: bool,
-    /// If false gfx_device_gl won't be logged.
-    pub log_gfx_device: bool,
+    /// Sets a different level for gfx_device_gl if Some
+    pub log_gfx_device_level: Option<LevelFilter>,
 }
 
 impl Default for LoggerConfig {
@@ -38,7 +38,7 @@ impl Default for LoggerConfig {
             level_filter: LevelFilter::Info,
             log_file: None,
             allow_env_override: true,
-            log_gfx_device: false,
+            log_gfx_device_level: Some(LevelFilter::Warn),
         }
     }
 }
@@ -89,10 +89,8 @@ impl Logger {
             StdoutLog::Off => {}
         }
 
-        if !config.log_gfx_device {
-            logger.dispatch = logger
-                .dispatch
-                .filter(|m| !m.target().starts_with("gfx_device_gl"));
+        if let Some(log_gfx_device_level) = config.log_gfx_device_level {
+            logger.dispatch = logger.dispatch.level_for("gfx_device_gl", log_gfx_device_level);
         }
 
         if let Some(path) = config.log_file {


### PR DESCRIPTION
## Description

Fixes #1403 

This crate raises the default log level to "info" and by default filters out info logs from the crate "gfx_device_gl" which is... quite verbose, to say the least.

## Additions

- Added LoggerConfig::log_gfx_device_level

## Removals

- None

## Modifications

- Set default log level to Info

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ ] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new APIs if any were added in this PR. (No great way to unit test as I'm not gfx_device_gl)
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
