### PR TITLE
Allow setting a window icon programatically

### DIFF
--- a/amethyst_renderer/src/config.rs
+++ b/amethyst_renderer/src/config.rs
@@ -47,6 +47,10 @@ pub struct DisplayConfig {
     /// Path to window icon.
     pub icon: Option<String>,
 
+    /// Window icon. This must be set before render initialization and takes precedence over `icon`.
+    #[serde(skip)]
+    pub loaded_icon: Option<Icon>,
+
     /// Enables or disables vertical synchronization.
     pub vsync: bool,
 
@@ -85,6 +89,7 @@ impl Default for DisplayConfig {
             dimensions: Some((640, 480)),
             fullscreen: false,
             icon: None,
+            loaded_icon: None,
             max_dimensions: None,
             maximized: false,
             min_dimensions: None,
@@ -127,7 +132,9 @@ impl DisplayConfig {
             builder = builder.with_fullscreen(Some(monitor_id));
         }
 
-        if let Some(icon) = self.icon {
+        if self.loaded_icon.is_some() {
+            builder = builder.with_window_icon(self.loaded_icon);
+        } else if let Some(icon) = self.icon {
             builder = builder.with_window_icon(Icon::from_path(icon).ok());
         }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 it is attached to. ([#1282])
 * `AutoFov` and `AutoFovSystem` to adjust horizontal FOV to screen aspect ratio. ([#1281])
 * Add `icon` to `DisplayConfig` to set a window icon using a path to a file ([#1373])
+* Add `loaded_icon` to `DisplayConfig` to set a window icon programatically ([#1405])
 
 ### Changed
 
@@ -57,6 +58,7 @@ it is attached to. ([#1282])
 [#1371]: https://github.com/amethyst/amethyst/pull/1371
 [#1373]: https://github.com/amethyst/amethyst/pull/1373
 [#1397]: https://github.com/amethyst/amethyst/pull/1397
+[#1405]: https://github.com/amethyst/amethyst/pull/1405
 
 ## [0.10.0] - 2018-12
 

--- a/examples/custom_icon/main.rs
+++ b/examples/custom_icon/main.rs
@@ -1,0 +1,58 @@
+//! Opens an empty window.
+
+use amethyst::{
+    input::is_key_down,
+    prelude::*,
+    renderer::{DisplayConfig, DrawFlat, Pipeline, PosNormTex, RenderBundle, Stage},
+    utils::application_root_dir,
+    winit::{Icon, VirtualKeyCode},
+};
+
+struct Example;
+
+impl SimpleState for Example {
+    fn handle_event(
+        &mut self,
+        _: StateData<'_, GameData<'_, '_>>,
+        event: StateEvent,
+    ) -> SimpleTrans {
+        if let StateEvent::Window(event) = event {
+            if is_key_down(&event, VirtualKeyCode::Escape) {
+                Trans::Quit
+            } else {
+                Trans::None
+            }
+        } else {
+            Trans::None
+        }
+    }
+}
+
+fn main() -> amethyst::Result<()> {
+    amethyst::start_logger(Default::default());
+
+    let path = application_root_dir()?.join("examples/custom_icon/resources/display_config.ron");
+    let mut config = DisplayConfig::load(&path);
+    let mut icon = Vec::new();
+    for _ in 0..(128 * 128 / 4) {
+        icon.extend(vec![255, 0, 0, 255]);
+        icon.extend(vec![255, 0, 0, 255]);
+        icon.extend(vec![255, 0, 0, 255]);
+        icon.extend(vec![255, 0, 0, 255]);
+    }
+    config.loaded_icon = Some(Icon::from_rgba(icon, 128, 128).unwrap());
+
+    let pipe = Pipeline::build().with_stage(
+        Stage::with_backbuffer()
+            .clear_target([0.00196, 0.23726, 0.21765, 1.0], 1.0)
+            .with_pass(DrawFlat::<PosNormTex>::new()),
+    );
+
+    let game_data =
+        GameDataBuilder::default().with_bundle(RenderBundle::new(pipe, Some(config)))?;
+    let mut game = Application::new("./", Example, game_data)?;
+
+    game.run();
+
+    Ok(())
+}

--- a/examples/custom_icon/main.rs
+++ b/examples/custom_icon/main.rs
@@ -34,10 +34,7 @@ fn main() -> amethyst::Result<()> {
     let path = application_root_dir()?.join("examples/custom_icon/resources/display_config.ron");
     let mut config = DisplayConfig::load(&path);
     let mut icon = Vec::new();
-    for _ in 0..(128 * 128 / 4) {
-        icon.extend(vec![255, 0, 0, 255]);
-        icon.extend(vec![255, 0, 0, 255]);
-        icon.extend(vec![255, 0, 0, 255]);
+    for _ in 0..(128 * 128) {
         icon.extend(vec![255, 0, 0, 255]);
     }
     config.loaded_icon = Some(Icon::from_rgba(icon, 128, 128).unwrap());

--- a/examples/custom_icon/resources/display_config.ron
+++ b/examples/custom_icon/resources/display_config.ron
@@ -1,0 +1,10 @@
+(
+  title: "Custom icon example",
+  dimensions: None,
+  max_dimensions: None,
+  min_dimensions: None,
+  fullscreen: false,
+  multisampling: 0,
+  visibility: true,
+  vsync: true,
+)

--- a/tests/amethyst_test/src/amethyst_application.rs
+++ b/tests/amethyst_test/src/amethyst_application.rs
@@ -629,6 +629,7 @@ where
             dimensions: Some((SCREEN_WIDTH, SCREEN_HEIGHT)),
             min_dimensions: Some((SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2)),
             max_dimensions: None,
+            loaded_icon: None,
             icon: None,
             vsync: true,
             multisampling: 0, // Must be multiple of 2, use 0 to disable


### PR DESCRIPTION
## Description

Setting a window icon from a file path in the config file is already
allowed. Now the icon can be set from an image generated
programatically, for example in the new example a red square is painted.

![image](https://user-images.githubusercontent.com/223776/52505521-836f2c00-2bca-11e9-8a8e-9e3849b252d1.png)

## Additions

- Add `loaded_icon` to `DisplayConfig`. This property must be set programatically if wanted, cannot be set in a ron file.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ ] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
