### PR TITLE
Fix xcb deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Additionally, make sure you have EGL installed. Since the package depends on you
 ### Debian/Ubuntu
 
 ```
-$ sudo apt install pkg-config libasound2-dev libx11-xcb-dev libssl-dev cmake libfreetype6-dev libexpat1-dev libxcb1-dev
+$ sudo apt install pkg-config libasound2-dev libssl-dev cmake libfreetype6-dev libexpat1-dev libxcb-composite0-dev
 ```
 
 ### Fedora


### PR DESCRIPTION
## Description

Fix the deps list on the readme for ubuntu

## Additions

- None

## Removals

- None

## Modifications

- None

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Ran `cargo test --all` locally if this modified any rs files.
- [ ] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
