### PR TITLE
Updated gfx_glyph version now that the performance fix has been released

### DIFF
--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -25,8 +25,7 @@ derive-new = "0.5.6"
 fnv = "1"
 gfx = { version = "0.17", features = ["serialize"] }
 
-# Remove once the patched version of gfx_glyph is published.
-gfx_glyph = { git = "https://github.com/alexheretic/glyph-brush", rev = "64f0c7e4269c8cebcb5456965a8e45c934f17fa6" }
+gfx_glyph = "0.13.3"
 
 glsl-layout = { version = "0.1.1", features = ["gfx"] }
 hibitset = { version = "0.5.1", features = ["parallel"] }


### PR DESCRIPTION
## Description

Updated gfx_glyph version now that the performance fix has been released.

I had left a todo while waiting for it to release.

## PR Checklist
I ran cargo run --example ui
