### PR TITLE
Moved gltf from dev-only workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ amethyst_core = { path = "amethyst_core", version = "0.5.0" }
 amethyst_error = { path = "amethyst_error", version = "0.1.0" }
 amethyst_controls = { path = "amethyst_controls", version = "0.4.0" }
 amethyst_derive = { path = "amethyst_derive", version = "0.3.0" }
+amethyst_gltf = { path = "amethyst_gltf", version = "0.5.0" }
 amethyst_network = { path = "amethyst_network", version = "0.3.0" }
 amethyst_locale = { path = "amethyst_locale", version = "0.4.0" }
 amethyst_renderer = { path = "amethyst_renderer", version = "0.10.0" }
@@ -84,7 +85,6 @@ serde = { version = "1.0", features = ["derive"] }
 thread_profiler = { version = "0.3", optional = true }
 
 [dev-dependencies]
-amethyst_gltf = { path = "amethyst_gltf", version = "0.5.0" }
 derive-new = "0.5"
 env_logger = "0.5.13"
 genmesh = "0.6"
@@ -248,6 +248,5 @@ path = "examples/auto_fov/main.rs"
 
 [workspace]
 members = [
-  "amethyst_gltf",
   "tests/amethyst_test"
 ]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,8 @@ it is attached to. ([#1282])
 * Changed argument types of `exec_removal` to allow use of both Read and Write Storages. ([#1397])
 * Changed default log level to Info. ([#1404])
 * Remove unnecessary `mut` from `AnimationControlSet::has_animation` ([#1408])
+* Moved amethyst_gltf from development workspace to be like the other amethyst_* subcrates. ([#1411])
+* Re-exported amethyst_gltf by amethyst as amethyst::gltf. ([#1411])
 
 ### Removed
 
@@ -66,6 +68,7 @@ it is attached to. ([#1282])
 [#1404]: https://github.com/amethyst/amethyst/pull/1404
 [#1408]: https://github.com/amethyst/amethyst/pull/1408
 [#1405]: https://github.com/amethyst/amethyst/pull/1405
+[#1411]: https://github.com/amethyst/amethyst/pull/1411
 
 ## [0.10.0] - 2018-12
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ pub use amethyst_controls as controls;
 pub use amethyst_core as core;
 pub use amethyst_derive as derive;
 pub use amethyst_error as error;
+pub use amethyst_gltf as gltf;
 pub use amethyst_input as input;
 pub use amethyst_locale as locale;
 pub use amethyst_network as network;


### PR DESCRIPTION
## Description

It was in a separated workspace to cut down on build times.
However, the way it was done was inconvenient, because you had to manually import it separately from the main amethyst crate in external projects. Also it had some crate syncing issues when using git-based dependencies during development and testing.

## Modifications

- Moved amethyst_gltf from development workspace to be like the other amethyst_* subcrates and re-exported by amethyst as amethyst::gltf.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [X] Ran `cargo test --all` locally if this modified any rs files.
- N/A Ran `cargo +stable fmt --all` locally if this modified any rs files.
- N/A Updated the content of the book if this PR would make the book outdated.
- [X] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- N/A Added unit tests for new APIs if any were added in this PR.
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
