### PR TITLE
Improve documentation for logger env variables

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -130,8 +130,18 @@ impl Logger {
 ///
 /// Configuration of the logger can also be controlled via environment variables:
 /// * AMETHYST_LOG_STDOUT - determines the output to the terminal
+///     * "no" / "off" disables logging to stdout
+///     * "plain" / "yes" enables logging to stdout
+///     * "colored" enables logging and makes it colored
 /// * AMETHYST_LOG_LEVEL_FILTER - sets the log level
+///     * "off" disables all logging
+///     * "error" enables only error logging
+///     * "warn" only errors and warnings are emitted
+///     * "info" only error, warning and info messages
+///     * "debug" everything except trace
+///     * "trace" everything
 /// * AMETHYST_LOG_FILE_PATH - if set, enables logging to the file at the path
+///     * the value is expected to be a path to the logging file
 pub fn start_logger(config: LoggerConfig) {
     Logger::from_config(config).start();
 }
@@ -139,8 +149,8 @@ pub fn start_logger(config: LoggerConfig) {
 fn env_var_override(config: &mut LoggerConfig) {
     if let Ok(var) = env::var("AMETHYST_LOG_STDOUT") {
         match var.to_lowercase().as_ref() {
-            "off" => config.stdout = StdoutLog::Off,
-            "plain" => config.stdout = StdoutLog::Plain,
+            "off" | "no" => config.stdout = StdoutLog::Off,
+            "plain" | "yes" => config.stdout = StdoutLog::Plain,
             "colored" => config.stdout = StdoutLog::Colored,
             _ => {}
         }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -178,3 +178,21 @@ fn colored_stdout(color_config: fern::colors::ColoredLevelConfig) -> fern::Dispa
             ))
         })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    #[test]
+    fn check_stdout_override() {
+        let mut config = LoggerConfig::default();
+        assert_eq!(config.stdout, StdoutLog::Colored);
+
+        env::set_var("AMETHYST_LOG_STDOUT", "pLaIn");
+        env_var_override(&mut config);
+        env::remove_var("AMETHYST_LOG_STDOUT");
+
+        assert_eq!(config.stdout, StdoutLog::Plain);
+    }
+}

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -130,9 +130,9 @@ impl Logger {
 ///
 /// Configuration of the logger can also be controlled via environment variables:
 /// * AMETHYST_LOG_STDOUT - determines the output to the terminal
-///     * "no" / "off" disables logging to stdout
-///     * "plain" / "yes" enables logging to stdout
-///     * "colored" enables logging and makes it colored
+///     * "no" / "off" / "0" disables logging to stdout
+///     * "plain" / "yes" / "1" enables logging to stdout
+///     * "colored" / "2" enables logging and makes it colored
 /// * AMETHYST_LOG_LEVEL_FILTER - sets the log level
 ///     * "off" disables all logging
 ///     * "error" enables only error logging
@@ -149,9 +149,9 @@ pub fn start_logger(config: LoggerConfig) {
 fn env_var_override(config: &mut LoggerConfig) {
     if let Ok(var) = env::var("AMETHYST_LOG_STDOUT") {
         match var.to_lowercase().as_ref() {
-            "off" | "no" => config.stdout = StdoutLog::Off,
-            "plain" | "yes" => config.stdout = StdoutLog::Plain,
-            "colored" => config.stdout = StdoutLog::Colored,
+            "off" | "no" | "0" => config.stdout = StdoutLog::Off,
+            "plain" | "yes" | "1" => config.stdout = StdoutLog::Plain,
+            "colored" | "2" => config.stdout = StdoutLog::Colored,
             _ => {}
         }
     }


### PR DESCRIPTION
## Description

Improves docs & allows more values as described in #1316.

Fixes #1316

## Additions

* Add "yes" / "no" to allowed values
* Document allowed values
* Add test for env var override of `LoggerConfig`

## Removals

## Modifications

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] ~~Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.~~
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
