### PR TITLE
Move transparent to default

### DIFF
--- a/amethyst_renderer/src/pass/flat/interleaved.rs
+++ b/amethyst_renderer/src/pass/flat/interleaved.rs
@@ -19,7 +19,7 @@ use crate::{
     hidden::{Hidden, HiddenPropagate},
     mesh::{Mesh, MeshHandle},
     mtl::{Material, MaterialDefaults},
-    pass::util::{draw_mesh, get_camera, setup_textures, VertexArgs},
+    pass::util::{default_transparency, draw_mesh, get_camera, setup_textures, VertexArgs},
     pipe::{
         pass::{Pass, PassData},
         DepthMode, Effect, NewEffect,
@@ -45,6 +45,7 @@ use super::*;
 #[derivative(Default(bound = "V: Query<(Position, TexCoord)>, Self: Pass"))]
 pub struct DrawFlat<V> {
     _pd: PhantomData<V>,
+    #[derivative(Default(value = "default_transparency()"))]
     transparency: Option<(ColorMask, Blend, Option<DepthMode>)>,
 }
 
@@ -58,8 +59,24 @@ where
         Default::default()
     }
 
-    /// Enable transparency
-    pub fn with_transparency(
+    /// Transparency is enabled by default.
+    /// If you pass false to this function transparency will be disabled.
+    ///
+    /// If you pass true and this was disabled previously default settings will be reinstated.
+    /// If you pass true and this was already enabled this will do nothing.
+    pub fn with_transparency(mut self, input: bool) -> Self {
+        if input {
+            if self.transparency.is_none() {
+                self.transparency = default_transparency();
+            }
+        } else {
+            self.transparency = None;
+        }
+        self
+    }
+
+    /// Set transparency settings to custom values.
+    pub fn with_transparency_settings(
         mut self,
         mask: ColorMask,
         blend: Blend,

--- a/amethyst_renderer/src/pass/flat/separate.rs
+++ b/amethyst_renderer/src/pass/flat/separate.rs
@@ -19,7 +19,7 @@ use crate::{
     mtl::{Material, MaterialDefaults},
     pass::{
         skinning::{create_skinning_effect, setup_skinning_buffers},
-        util::{draw_mesh, get_camera, setup_textures, VertexArgs},
+        util::{default_transparency, draw_mesh, get_camera, setup_textures, VertexArgs},
     },
     pipe::{
         pass::{Pass, PassData},
@@ -52,6 +52,7 @@ static ATTRIBUTES: [Attributes<'static>; 2] = [
 #[derivative(Default(bound = "Self: Pass"))]
 pub struct DrawFlatSeparate {
     skinning: bool,
+    #[derivative(Default(value = "default_transparency()"))]
     transparency: Option<(ColorMask, Blend, Option<DepthMode>)>,
 }
 
@@ -70,8 +71,24 @@ where
         self
     }
 
-    /// Enable transparency
-    pub fn with_transparency(
+    /// Transparency is enabled by default.
+    /// If you pass false to this function transparency will be disabled.
+    ///
+    /// If you pass true and this was disabled previously default settings will be reinstated.
+    /// If you pass true and this was already enabled this will do nothing.
+    pub fn with_transparency(mut self, input: bool) -> Self {
+        if input {
+            if self.transparency.is_none() {
+                self.transparency = default_transparency();
+            }
+        } else {
+            self.transparency = None;
+        }
+        self
+    }
+
+    /// Set transparency settings to custom values.
+    pub fn with_transparency_settings(
         mut self,
         mask: ColorMask,
         blend: Blend,

--- a/amethyst_renderer/src/pass/flat2d/interleaved.rs
+++ b/amethyst_renderer/src/pass/flat2d/interleaved.rs
@@ -18,7 +18,9 @@ use crate::{
     cam::{ActiveCamera, Camera},
     hidden::{Hidden, HiddenPropagate},
     mesh::MeshHandle,
-    pass::util::{add_texture, get_camera, set_view_args, setup_textures, ViewArgs},
+    pass::util::{
+        add_texture, default_transparency, get_camera, set_view_args, setup_textures, ViewArgs,
+    },
     pipe::{
         pass::{Pass, PassData},
         DepthMode, Effect, NewEffect,
@@ -37,6 +39,7 @@ use super::*;
 #[derive(Derivative, Clone, Debug)]
 #[derivative(Default(bound = "Self: Pass"))]
 pub struct DrawFlat2D {
+    #[derivative(Default(value = "default_transparency()"))]
     transparency: Option<(ColorMask, Blend, Option<DepthMode>)>,
     batch: TextureBatch,
 }
@@ -50,8 +53,24 @@ where
         Default::default()
     }
 
-    /// Enable transparency
-    pub fn with_transparency(
+    /// Transparency is enabled by default.
+    /// If you pass false to this function transparency will be disabled.
+    ///
+    /// If you pass true and this was disabled previously default settings will be reinstated.
+    /// If you pass true and this was already enabled this will do nothing.
+    pub fn with_transparency(mut self, input: bool) -> Self {
+        if input {
+            if self.transparency.is_none() {
+                self.transparency = default_transparency();
+            }
+        } else {
+            self.transparency = None;
+        }
+        self
+    }
+
+    /// Set transparency settings to custom values.
+    pub fn with_transparency_settings(
         mut self,
         mask: ColorMask,
         blend: Blend,

--- a/amethyst_renderer/src/pass/pbm/interleaved.rs
+++ b/amethyst_renderer/src/pass/pbm/interleaved.rs
@@ -21,7 +21,7 @@ use crate::{
     mtl::{Material, MaterialDefaults},
     pass::{
         shaded_util::{set_light_args, setup_light_buffers},
-        util::{draw_mesh, get_camera, setup_textures, setup_vertex_args},
+        util::{default_transparency, draw_mesh, get_camera, setup_textures, setup_vertex_args},
     },
     pipe::{
         pass::{Pass, PassData},
@@ -49,6 +49,7 @@ use super::*;
 #[derivative(Default(bound = "V: Query<(Position, Normal, Tangent, TexCoord)>"))]
 pub struct DrawPbm<V> {
     _pd: PhantomData<V>,
+    #[derivative(Default(value = "default_transparency()"))]
     transparency: Option<(ColorMask, Blend, Option<DepthMode>)>,
 }
 
@@ -61,8 +62,24 @@ where
         Default::default()
     }
 
-    /// Enable transparency
-    pub fn with_transparency(
+    /// Transparency is enabled by default.
+    /// If you pass false to this function transparency will be disabled.
+    ///
+    /// If you pass true and this was disabled previously default settings will be reinstated.
+    /// If you pass true and this was already enabled this will do nothing.
+    pub fn with_transparency(mut self, input: bool) -> Self {
+        if input {
+            if self.transparency.is_none() {
+                self.transparency = default_transparency();
+            }
+        } else {
+            self.transparency = None;
+        }
+        self
+    }
+
+    /// Set transparency settings to custom values.
+    pub fn with_transparency_settings(
         mut self,
         mask: ColorMask,
         blend: Blend,

--- a/amethyst_renderer/src/pass/pbm/separate.rs
+++ b/amethyst_renderer/src/pass/pbm/separate.rs
@@ -1,5 +1,6 @@
 //! Forward physically-based drawing pass.
 
+use derivative::Derivative;
 use gfx::pso::buffer::ElemStride;
 use gfx_core::state::{Blend, ColorMask};
 
@@ -22,7 +23,7 @@ use crate::{
     pass::{
         shaded_util::{set_light_args, setup_light_buffers},
         skinning::{create_skinning_effect, setup_skinning_buffers},
-        util::{draw_mesh, get_camera, setup_textures, setup_vertex_args},
+        util::{default_transparency, draw_mesh, get_camera, setup_textures, setup_vertex_args},
     },
     pipe::{
         pass::{Pass, PassData},
@@ -50,9 +51,11 @@ static ATTRIBUTES: [Attributes<'static>; 4] = [
 ///
 /// See the [crate level documentation](index.html) for information about interleaved and separate
 /// passes.
-#[derive(Default, Clone, Debug, PartialEq)]
+#[derive(Derivative, Clone, Debug, PartialEq)]
+#[derivative(Default)]
 pub struct DrawPbmSeparate {
     skinning: bool,
+    #[derivative(Default(value = "default_transparency()"))]
     transparency: Option<(ColorMask, Blend, Option<DepthMode>)>,
 }
 
@@ -68,8 +71,24 @@ impl DrawPbmSeparate {
         self
     }
 
-    /// Enable transparency
-    pub fn with_transparency(
+    /// Transparency is enabled by default.
+    /// If you pass false to this function transparency will be disabled.
+    ///
+    /// If you pass true and this was disabled previously default settings will be reinstated.
+    /// If you pass true and this was already enabled this will do nothing.
+    pub fn with_transparency(mut self, input: bool) -> Self {
+        if input {
+            if self.transparency.is_none() {
+                self.transparency = default_transparency();
+            }
+        } else {
+            self.transparency = None;
+        }
+        self
+    }
+
+    /// Set transparency settings to custom values.
+    pub fn with_transparency_settings(
         mut self,
         mask: ColorMask,
         blend: Blend,

--- a/amethyst_renderer/src/pass/shaded/interleaved.rs
+++ b/amethyst_renderer/src/pass/shaded/interleaved.rs
@@ -21,7 +21,7 @@ use crate::{
     mtl::{Material, MaterialDefaults},
     pass::{
         shaded_util::{set_light_args, setup_light_buffers},
-        util::{draw_mesh, get_camera, setup_textures, setup_vertex_args},
+        util::{default_transparency, draw_mesh, get_camera, setup_textures, setup_vertex_args},
     },
     pipe::{
         pass::{Pass, PassData},
@@ -49,6 +49,7 @@ use super::*;
 #[derivative(Default(bound = "V: Query<(Position, Normal, TexCoord)>"))]
 pub struct DrawShaded<V> {
     _pd: PhantomData<V>,
+    #[derivative(Default(value = "default_transparency()"))]
     transparency: Option<(ColorMask, Blend, Option<DepthMode>)>,
 }
 
@@ -61,8 +62,24 @@ where
         Default::default()
     }
 
-    /// Enable transparency
-    pub fn with_transparency(
+    /// Transparency is enabled by default.
+    /// If you pass false to this function transparency will be disabled.
+    ///
+    /// If you pass true and this was disabled previously default settings will be reinstated.
+    /// If you pass true and this was already enabled this will do nothing.
+    pub fn with_transparency(mut self, input: bool) -> Self {
+        if input {
+            if self.transparency.is_none() {
+                self.transparency = default_transparency();
+            }
+        } else {
+            self.transparency = None;
+        }
+        self
+    }
+
+    /// Set transparency settings to custom values.
+    pub fn with_transparency_settings(
         mut self,
         mask: ColorMask,
         blend: Blend,

--- a/amethyst_renderer/src/pass/util.rs
+++ b/amethyst_renderer/src/pass/util.rs
@@ -1,5 +1,6 @@
 use std::mem;
 
+use gfx_core::state::{Blend, ColorMask};
 use glsl_layout::*;
 use log::error;
 
@@ -18,7 +19,7 @@ use crate::{
     mesh::Mesh,
     mtl::{Material, MaterialDefaults, TextureOffset},
     pass::set_skinning_buffers,
-    pipe::{Effect, EffectBuilder},
+    pipe::{DepthMode, Effect, EffectBuilder},
     skinning::JointTransforms,
     tex::Texture,
     types::Encoder,
@@ -408,4 +409,12 @@ pub fn get_camera<'a>(
             cam.into_iter().zip(transform.into_iter()).next()
         })
         .or_else(|| (camera, global).join().next())
+}
+
+pub fn default_transparency() -> Option<(ColorMask, Blend, Option<DepthMode>)> {
+    Some((
+        ColorMask::all(),
+        crate::ALPHA,
+        Some(DepthMode::LessEqualWrite),
+    ))
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ it is attached to. ([#1282])
 * Add `icon` to `DisplayConfig` to set a window icon using a path to a file ([#1373])
 * Added setting to control gfx_device_gl logging level separately, and set it to Warn by default. ([#1404])
 * Add `loaded_icon` to `DisplayConfig` to set a window icon programatically ([#1405])
+* Several passes got `with_transparency_settings` which changes the transparency settings for the pass. ([#1419])
 
 ### Changed
 
@@ -37,6 +38,8 @@ it is attached to. ([#1282])
 * Remove unnecessary `mut` from `AnimationControlSet::has_animation` ([#1408])
 * Moved amethyst_gltf from development workspace to be like the other amethyst_* subcrates. ([#1411])
 * Re-exported amethyst_gltf by amethyst as amethyst::gltf. ([#1411])
+* `Default::default` now returns a pass with transparency enabled for all applicable passes. ([#1419])
+* Several passes had a function named `with_transparency` changed to accept a boolean. ([#1419])
 
 ### Removed
 
@@ -69,6 +72,7 @@ it is attached to. ([#1282])
 [#1408]: https://github.com/amethyst/amethyst/pull/1408
 [#1405]: https://github.com/amethyst/amethyst/pull/1405
 [#1411]: https://github.com/amethyst/amethyst/pull/1411
+[#1419]: https://github.com/amethyst/amethyst/pull/1419
 
 ## [0.10.0] - 2018-12
 

--- a/examples/gltf/main.rs
+++ b/examples/gltf/main.rs
@@ -186,13 +186,7 @@ fn main() -> Result<(), amethyst::Error> {
             "gltf_loader",
             &["scene_loader"], // This is important so that entity instantiation is performed in a single frame.
         )
-        .with_basic_renderer(
-            path,
-            DrawPbmSeparate::new()
-                .with_vertex_skinning()
-                .with_transparency(ColorMask::all(), ALPHA, Some(DepthMode::LessEqualWrite)),
-            false,
-        )?
+        .with_basic_renderer(path, DrawPbmSeparate::new().with_vertex_skinning(), false)?
         .with_bundle(
             AnimationBundle::<usize, Transform>::new("animation_control", "sampler_interpolation")
                 .with_dep(&["gltf_loader"]),

--- a/examples/simple_image/main.rs
+++ b/examples/simple_image/main.rs
@@ -4,8 +4,8 @@ use amethyst::{
     ecs::Entity,
     prelude::*,
     renderer::{
-        Camera, ColorMask, DepthMode, DisplayConfig, DrawFlat2D, Pipeline, PngFormat, Projection,
-        RenderBundle, Stage, Texture, TextureHandle, TextureMetadata, ALPHA,
+        Camera, DisplayConfig, DrawFlat2D, Pipeline, PngFormat, Projection, RenderBundle, Stage,
+        Texture, TextureHandle, TextureMetadata,
     },
     utils::application_root_dir,
 };
@@ -30,11 +30,7 @@ fn main() -> amethyst::Result<()> {
     let pipe = Pipeline::build().with_stage(
         Stage::with_backbuffer()
             .clear_target([0.1, 0.1, 0.1, 1.0], 1.0)
-            .with_pass(DrawFlat2D::new().with_transparency(
-                ColorMask::all(),
-                ALPHA,
-                Some(DepthMode::LessEqualWrite),
-            )),
+            .with_pass(DrawFlat2D::new()),
     );
 
     let game_data = GameDataBuilder::default()

--- a/examples/sprite_camera_follow/main.rs
+++ b/examples/sprite_camera_follow/main.rs
@@ -5,9 +5,9 @@ use amethyst::{
     input::{InputBundle, InputHandler},
     prelude::*,
     renderer::{
-        Camera, ColorMask, DepthMode, DisplayConfig, DrawFlat2D, Pipeline, PngFormat, Projection,
-        RenderBundle, SpriteRender, SpriteSheet, SpriteSheetFormat, SpriteSheetHandle, Stage,
-        Texture, TextureMetadata, Transparent, ALPHA,
+        Camera, DisplayConfig, DrawFlat2D, Pipeline, PngFormat, Projection, RenderBundle,
+        SpriteRender, SpriteSheet, SpriteSheetFormat, SpriteSheetHandle, Stage, Texture,
+        TextureMetadata, Transparent,
     },
     utils::application_root_dir,
 };
@@ -145,11 +145,7 @@ fn main() -> amethyst::Result<()> {
     let pipe = Pipeline::build().with_stage(
         Stage::with_backbuffer()
             .clear_target([0.1, 0.1, 0.1, 1.0], 1.0)
-            .with_pass(DrawFlat2D::new().with_transparency(
-                ColorMask::all(),
-                ALPHA,
-                Some(DepthMode::LessEqualWrite), // Tells the pipeline to respect sprite z-depth
-            )),
+            .with_pass(DrawFlat2D::new()),
     );
 
     let game_data = GameDataBuilder::default()

--- a/examples/sprites_ordered/main.rs
+++ b/examples/sprites_ordered/main.rs
@@ -17,9 +17,9 @@ use amethyst::{
     input::{get_key, is_close_requested, is_key_down},
     prelude::*,
     renderer::{
-        Camera, ColorMask, DepthMode, DisplayConfig, DrawFlat2D, ElementState, Hidden, Pipeline,
-        Projection, RenderBundle, ScreenDimensions, SpriteRender, SpriteSheet, SpriteSheetHandle,
-        Stage, Transparent, VirtualKeyCode, ALPHA,
+        Camera, DisplayConfig, DrawFlat2D, ElementState, Hidden, Pipeline, Projection,
+        RenderBundle, ScreenDimensions, SpriteRender, SpriteSheet, SpriteSheetHandle, Stage,
+        Transparent, VirtualKeyCode,
     },
     utils::application_root_dir,
 };
@@ -356,11 +356,7 @@ fn main() -> amethyst::Result<()> {
     let pipe = Pipeline::build().with_stage(
         Stage::with_backbuffer()
             .clear_target([0., 0., 0., 1.], 5.)
-            .with_pass(DrawFlat2D::new().with_transparency(
-                ColorMask::all(),
-                ALPHA,
-                Some(DepthMode::LessEqualWrite),
-            )),
+            .with_pass(DrawFlat2D::new()),
     );
 
     let assets_directory = app_root.join("examples/assets/");

--- a/tests/amethyst_test/src/amethyst_application.rs
+++ b/tests/amethyst_test/src/amethyst_application.rs
@@ -9,8 +9,8 @@ use amethyst::{
     input::InputBundle,
     prelude::*,
     renderer::{
-        ColorMask, DepthMode, DisplayConfig, DrawFlat2D, Material, Pipeline, PipelineBuilder,
-        RenderBundle, ScreenDimensions, SpriteRender, Stage, StageBuilder, ALPHA,
+        DisplayConfig, DrawFlat2D, Material, Pipeline, PipelineBuilder, RenderBundle,
+        ScreenDimensions, SpriteRender, Stage, StageBuilder,
     },
     shred::Resource,
     ui::{DrawUi, UiBundle},
@@ -656,11 +656,7 @@ where
         Pipeline::build().with_stage(
             Stage::with_backbuffer()
                 .clear_target([0., 0., 0., 0.], 0.)
-                .with_pass(DrawFlat2D::new().with_transparency(
-                    ColorMask::all(),
-                    ALPHA,
-                    Some(DepthMode::LessEqualWrite),
-                ))
+                .with_pass(DrawFlat2D::new())
                 .with_pass(DrawUi::new()),
         )
     }


### PR DESCRIPTION
## Description

Users seem to expect this to be the default, so we're going to make it the default.

## Additions

- Several passes got `disable_transparency` which disables transparency in the pass.
- Several passes got `with_transparency_settings` which changes the transparency settings for the pass.

## Removals

- Several passes had the method `with_transparency` removed as it is now the default.

## Modifications

- `Default::default` now returns a pass with transparency enabled for all applicable passes.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ ] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
