### PR TITLE
Add initial roadmap

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,15 @@
+# Amethyst Roadmap 2019
+
+## Current Features:
+
+- 2D/3D Rendering
+- ECS
+- Audio
+- Basic physics
+- Basic Networking
+- Configuration management
+- Animation
+- Basic UI
+- Keyboard and Gamepad input
+- Asset loading
+- glTF support 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,6 +5,7 @@
 - 2D/3D Rendering
 - ECS
 - Audio
+- Asset loading
 - Basic physics
 - Basic Networking
 - Configuration management
@@ -13,6 +14,7 @@
 - Keyboard and Gamepad input
 - Asset loading
 - glTF support 
+- Testing utilities
 
 ## Planned Features
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,3 +13,15 @@
 - Keyboard and Gamepad input
 - Asset loading
 - glTF support 
+
+## Planned Features
+
+- Windows, macOS, Linux compatibility (in that order)
+- A scripting language
+- Basic UI library
+- An editor
+- Graphical capabilities on par with the most popular engines (shoot for Unity/Godot)
+- Pixel-perfect 2D capabilities (Godot-level quality)
+- Compatibility with PS4, Xbox One, Switch
+- Compatibility with iOS and Android
+- Server-Client Networking architecture


### PR DESCRIPTION
This is the first step in making our roadmap more public and easier to digest. This is related to #1380.

@amethyst/documentation-team @amethyst/engine-devs please take a look and suggest more items below in the comments. Any feedback is welcome.

Things left todo:

- [x] Verify all current features are listed
- [x] Add a `planned` features section