### PR TITLE
Fix logo image in docs to point to branding images

### DIFF
--- a/amethyst_config/src/lib.rs
+++ b/amethyst_config/src/lib.rs
@@ -1,7 +1,6 @@
 //! Loads RON files into a structure for easy / statically typed usage.
 
 #![crate_name = "amethyst_config"]
-#![doc(html_logo_url = "https://www.amethyst.rs/assets/amethyst.svg")]
 #![warn(missing_docs, rust_2018_idioms, rust_2018_compatibility)]
 
 use std::{

--- a/amethyst_renderer/src/lib.rs
+++ b/amethyst_renderer/src/lib.rs
@@ -24,7 +24,6 @@
 //! [gh]: https://github.com/amethyst/amethyst/tree/master/src/renderer
 //! [bk]: https://www.amethyst.rs/book/master/
 
-#![doc(html_logo_url = "https://www.amethyst.rs/assets/amethyst.svg")]
 #![warn(missing_docs, rust_2018_idioms, rust_2018_compatibility)]
 
 pub use crate::{

--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -1,6 +1,5 @@
 //! Provides components and systems to create an in game user interface.
 
-#![doc(html_logo_url = "https://www.amethyst.rs/assets/amethyst.svg")]
 #![warn(missing_docs, rust_2018_idioms, rust_2018_compatibility)]
 
 pub use self::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 //! }
 //! ```
 
-#![doc(html_logo_url = "https://www.amethyst.rs/assets/amethyst.svg")]
+#![doc(html_logo_url = "https://www.amethyst.rs/brand/logo-standard.svg")]
 #![warn(missing_docs, rust_2018_idioms, rust_2018_compatibility)]
 
 pub use amethyst_animation as animation;


### PR DESCRIPTION
## Description

The docs' logo image still pointed to the old Amethyst svg, which was removed in pull request https://github.com/amethyst/website/pull/90. This points the logo image to the new branding url.

## Additions

## Removals

## Modifications

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
