### PR TITLE
Measure code coverage using GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,3 +44,13 @@ run tests:
   only:
     - branches
     - merge_requests
+
+run kcov:
+  stage: test
+  image: docker:latest
+  services:
+    - docker:dind
+  script:
+    - docker --version
+    - ./scripts/kcov.sh
+    - curl -v -s https://codecov.io/bash | bash

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 # Amethyst
 
-[![Build Status][s1]][tc] [![Crates.io][s2]][ci] [![docs page][docs-badge]][docs] [![MIT/Apache][s3]][li] [![Join us on Discord][s4]][di] ![Lines of Code][s6]
+[![Build Status][s1]][tc] [![Crates.io][s2]][ci] [![docs page][docs-badge]][docs] [![MIT/Apache][s3]][li]
+[![Join us on Discord][s4]][di] ![Lines of Code][s6] [![Code coverage][s7]][cov]
 
 [s1]: https://travis-ci.org/amethyst/amethyst.svg?branch=master
 [s2]: https://img.shields.io/crates/v/amethyst.svg
@@ -11,10 +12,12 @@
 [s3]: https://img.shields.io/badge/license-MIT%2FApache-blue.svg
 [s4]: https://img.shields.io/discord/425678876929163284.svg?logo=discord
 [s6]: https://tokei.rs/b1/github/amethyst/amethyst?category=code
+[s7]: https://img.shields.io/codecov/c/gitlab/amethyst-engine/amethyst/master.svg
 [tc]: https://travis-ci.org/amethyst/amethyst/
 [ci]: https://crates.io/crates/amethyst/
 [li]: COPYING
 [di]: https://discord.gg/amethyst
+[cov]: https://codecov.io/gl/amethyst-engine/amethyst/branch/master
 
 ## What is Amethyst?
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,26 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+#  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "header, diff"
+  behavior: default
+  require_changes: no


### PR DESCRIPTION
Integrate GitLab CI + kcov + codecov.io

## Description

* Collect code coverage using `kcov`
* Upload coverage to codecov.io
* Use GitLab CI to do all the work
* Add badge to readme (not yet valid)

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
