### PR TITLE
Correct path to display_config.ron

### DIFF
--- a/examples/arc_ball_camera/main.rs
+++ b/examples/arc_ball_camera/main.rs
@@ -97,7 +97,7 @@ fn main() -> Result<(), Error> {
 
     let render_bundle = {
         let display_config = {
-            let path = app_root.join("{}/examples/arc_ball_camera/resources/display_config.ron");
+            let path = app_root.join("examples/arc_ball_camera/resources/display_config.ron");
             DisplayConfig::load(&path)
         };
         let pipe = Pipeline::build().with_stage(


### PR DESCRIPTION
## Description

This commit corrects the path display_config.ron in the arc_ball_camera example.