### PR TITLE
Allow use of AnimationSetPrefab with Material and SpriteRender

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,6 +184,11 @@ name = "fly_camera"
 path = "examples/fly_camera/main.rs"
 
 [[example]]
+name = "sprite_animation"
+path = "examples/sprite_animation/main.rs"
+required-features = ["animation", "json"]
+
+[[example]]
 name = "sprites_ordered"
 path = "examples/sprites_ordered/main.rs"
 

--- a/amethyst_animation/src/material.rs
+++ b/amethyst_animation/src/material.rs
@@ -8,9 +8,11 @@ use crate::{AnimationSampling, ApplyData, BlendMethod};
 
 /// Sampler primitive for Material animations
 /// Note that material can only ever be animated with `Step`, or a panic will occur.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
 pub enum MaterialPrimitive {
     /// Dynamically altering the texture rendered
+    #[serde(skip)]
     Texture(Handle<Texture>),
     /// Dynamically altering the section of the texture rendered.
     Offset((f32, f32), (f32, f32)),

--- a/amethyst_animation/src/prefab.rs
+++ b/amethyst_animation/src/prefab.rs
@@ -126,6 +126,7 @@ where
 /// - `I`: Id type
 /// - `T`: The animatable `Component`
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
+#[serde(bound = "I: for<'a> Deserialize<'a> + Serialize")]
 pub struct AnimationSetPrefab<I, T>
 where
     T: AnimationSampling,
@@ -240,6 +241,7 @@ where
     I: Clone + Hash + Eq + Send + Sync + 'static,
 {
     /// Place an `AnimationSet` on the `Entity`
+    #[serde(bound = "I: for<'a> Deserialize<'a> + Serialize")]
     pub animation_set: Option<AnimationSetPrefab<I, T>>,
     /// Place an `AnimationHierarchy` on the `Entity`
     pub hierarchy: Option<AnimationHierarchyPrefab<T>>,

--- a/amethyst_animation/src/sprite.rs
+++ b/amethyst_animation/src/sprite.rs
@@ -9,9 +9,11 @@ use crate::{AnimationSampling, ApplyData, BlendMethod};
 
 /// Sampler primitive for SpriteRender animations
 /// Note that sprites can only ever be animated with `Step`, or a panic will occur.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
 pub enum SpriteRenderPrimitive {
     /// A spritesheet id
+    #[serde(skip)]
     SpriteSheet(Handle<SpriteSheet>),
     /// An index into a spritesheet
     SpriteIndex(usize),

--- a/amethyst_renderer/src/formats/mod.rs
+++ b/amethyst_renderer/src/formats/mod.rs
@@ -1,7 +1,7 @@
 //! Provides texture formats
 //!
 
-pub use self::{mesh::*, mtl::*, texture::*};
+pub use self::{mesh::*, mtl::*, sprite::*, texture::*};
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
@@ -13,6 +13,7 @@ use crate::{shape::InternalShape, Mesh, ShapePrefab, Texture};
 
 mod mesh;
 mod mtl;
+mod sprite;
 mod texture;
 
 /// Internal mesh loading

--- a/amethyst_renderer/src/formats/sprite.rs
+++ b/amethyst_renderer/src/formats/sprite.rs
@@ -1,0 +1,190 @@
+use ron::de::from_bytes as from_ron_bytes;
+use serde::{Deserialize, Serialize};
+
+use amethyst_assets::{AssetStorage, Handle, Loader, PrefabData, ProgressCounter, SimpleFormat};
+use amethyst_core::specs::prelude::{Entity, Read, ReadExpect, WriteStorage};
+use amethyst_error::Error;
+
+use crate::{error, Sprite, SpriteRender, SpriteSheet, Texture, TextureFormat, TexturePrefab};
+
+/// Structure acting as scaffolding for serde when loading a spritesheet file.
+/// Positions originate in the top-left corner (bitmap image convention).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SpritePosition {
+    /// Horizontal position of the sprite in the sprite sheet
+    pub x: u32,
+    /// Vertical position of the sprite in the sprite sheet
+    pub y: u32,
+    /// Width of the sprite
+    pub width: u32,
+    /// Height of the sprite
+    pub height: u32,
+    /// Number of pixels to shift the sprite to the left and down relative to the entity holding it
+    pub offsets: Option<[f32; 2]>,
+}
+
+/// Structure acting as scaffolding for serde when loading a spritesheet file.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SerializedSpriteSheet {
+    /// Width of the sprite sheet
+    pub spritesheet_width: u32,
+    /// Height of the sprite sheet
+    pub spritesheet_height: u32,
+    /// Description of the sprites
+    pub sprites: Vec<SpritePosition>,
+}
+
+/// Allows loading of sprite sheets in RON format.
+///
+/// This format allows to conveniently load a sprite sheet from a RON file.
+///
+/// Example:
+/// ```text,ignore
+/// (
+///     // Width of the sprite sheet
+///     spritesheet_width: 48.0,
+///     // Height of the sprite sheet
+///     spritesheet_height: 16.0,
+///     // List of sprites the sheet holds
+///     sprites: [
+///         (
+///             // Horizontal position of the sprite in the sprite sheet
+///             x: 0.0,
+///             // Vertical position of the sprite in the sprite sheet
+///             y: 0.0,
+///             // Width of the sprite
+///             width: 16.0,
+///             // Height of the sprite
+///             height: 16.0,
+///             // Number of pixels to shift the sprite to the left and down relative to the entity holding it when rendering
+///             offsets: (0.0, 0.0), // This is optional and defaults to (0.0, 0.0)
+///         ),
+///         (
+///             x: 16.0,
+///             y: 0.0,
+///             width: 32.0,
+///             height: 16.0,
+///         ),
+///     ],
+/// )
+/// ```
+///
+/// Such a spritesheet description can be loaded using a `Loader` by passing it the handle of the corresponding loaded texture.
+/// ```rust,no_run
+/// # use amethyst_assets::{Loader, AssetStorage};
+/// # use amethyst_renderer::{SpriteSheetFormat, SpriteSheet, Texture, PngFormat, TextureMetadata};
+/// #
+/// # fn load_sprite_sheet() {
+/// #   let world = amethyst_core::specs::World::new(); // Normally, you would use Amethyst's world
+/// #   let loader = world.read_resource::<Loader>();
+/// #   let spritesheet_storage = world.read_resource::<AssetStorage<SpriteSheet>>();
+/// #   let texture_storage = world.read_resource::<AssetStorage<Texture>>();
+/// let texture_handle = loader.load(
+///     "my_texture.png",
+///     PngFormat,
+///     TextureMetadata::srgb(),
+///     (),
+///     &texture_storage,
+/// );
+/// let spritesheet_handle = loader.load(
+///     "my_spritesheet.ron",
+///     SpriteSheetFormat,
+///     texture_handle,
+///     (),
+///     &spritesheet_storage,
+/// );
+/// # }
+/// ```
+#[derive(Clone, Deserialize, Serialize)]
+pub struct SpriteSheetFormat;
+
+impl SimpleFormat<SpriteSheet> for SpriteSheetFormat {
+    const NAME: &'static str = "SPRITE_SHEET";
+
+    type Options = Handle<Texture>;
+
+    fn import(&self, bytes: Vec<u8>, texture: Self::Options) -> Result<SpriteSheet, Error> {
+        let sheet: SerializedSpriteSheet =
+            from_ron_bytes(&bytes).map_err(|_| error::Error::LoadSpritesheetError)?;
+
+        let mut sprites: Vec<Sprite> = Vec::with_capacity(sheet.sprites.len());
+        for sp in sheet.sprites {
+            let sprite = Sprite::from_pixel_values(
+                sheet.spritesheet_width as u32,
+                sheet.spritesheet_height as u32,
+                sp.width as u32,
+                sp.height as u32,
+                sp.x as u32,
+                sp.y as u32,
+                sp.offsets.unwrap_or([0.0; 2]),
+            );
+            sprites.push(sprite);
+        }
+        Ok(SpriteSheet { texture, sprites })
+    }
+}
+
+/// `PrefabData` for loading `SpriteRender`
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SpriteRenderPrefab {
+    /// Spritesheet texture
+    pub texture: TexturePrefab<TextureFormat>,
+    /// Sprite coordinates on the texture
+    pub sprite_sheet: SerializedSpriteSheet,
+    /// Index of the sprite on the sprite sheet
+    pub sprite_number: usize,
+}
+
+impl<'a> PrefabData<'a> for SpriteRenderPrefab {
+    type SystemData = (
+        <TexturePrefab<TextureFormat> as PrefabData<'a>>::SystemData,
+        ReadExpect<'a, Loader>,
+        Read<'a, AssetStorage<SpriteSheet>>,
+        WriteStorage<'a, SpriteRender>,
+    );
+    type Result = ();
+
+    fn add_to_entity(
+        &self,
+        entity: Entity,
+        system_data: &mut Self::SystemData,
+        entities: &[Entity],
+    ) -> Result<(), Error> {
+        let (tex_data, loader, sheet_storage, render_storage) = system_data;
+
+        let mut sprites: Vec<Sprite> = Vec::with_capacity(self.sprite_sheet.sprites.len());
+        for sp in &self.sprite_sheet.sprites {
+            let sprite = Sprite::from_pixel_values(
+                self.sprite_sheet.spritesheet_width as u32,
+                self.sprite_sheet.spritesheet_height as u32,
+                sp.width as u32,
+                sp.height as u32,
+                sp.x as u32,
+                sp.y as u32,
+                sp.offsets.unwrap_or([0.0; 2]),
+            );
+            sprites.push(sprite);
+        }
+
+        let texture = self.texture.add_to_entity(entity, tex_data, entities)?;
+
+        let sheet = SpriteSheet { texture, sprites };
+        let sheet_handle = loader.load_from_data(sheet, (), sheet_storage);
+
+        let render = SpriteRender {
+            sprite_sheet: sheet_handle,
+            sprite_number: self.sprite_number,
+        };
+        render_storage.insert(entity, render)?;
+
+        Ok(())
+    }
+
+    fn load_sub_assets(
+        &mut self,
+        progress: &mut ProgressCounter,
+        (tex_data, _, _, _): &mut Self::SystemData,
+    ) -> Result<bool, Error> {
+        self.texture.load_sub_assets(progress, tex_data)
+    }
+}

--- a/amethyst_renderer/src/lib.rs
+++ b/amethyst_renderer/src/lib.rs
@@ -36,8 +36,8 @@ pub use crate::{
     formats::{
         build_mesh_with_combo, create_mesh_asset, create_texture_asset, BmpFormat,
         ComboMeshCreator, GraphicsPrefab, ImageData, JpgFormat, MaterialPrefab, MeshCreator,
-        MeshData, ObjFormat, PngFormat, TextureData, TextureFormat, TextureMetadata, TexturePrefab,
-        TgaFormat,
+        MeshData, ObjFormat, PngFormat, SpriteRenderPrefab, SpriteSheetFormat, TextureData,
+        TextureFormat, TextureMetadata, TexturePrefab, TgaFormat,
     },
     hidden::{Hidden, HiddenPropagate},
     hide_system::HideHierarchySystem,
@@ -64,10 +64,7 @@ pub use crate::{
         AnimatedComboMeshCreator, AnimatedVertexBufferCombination, JointIds, JointTransforms,
         JointTransformsPrefab, JointWeights,
     },
-    sprite::{
-        Flipped, Sprite, SpriteRender, SpriteSheet, SpriteSheetFormat, SpriteSheetHandle,
-        TextureCoordinates,
-    },
+    sprite::{Flipped, Sprite, SpriteRender, SpriteSheet, SpriteSheetHandle, TextureCoordinates},
     sprite_visibility::{SpriteVisibility, SpriteVisibilitySortingSystem},
     system::RenderSystem,
     tex::{

--- a/amethyst_renderer/src/sprite.rs
+++ b/amethyst_renderer/src/sprite.rs
@@ -1,11 +1,10 @@
-use ron::de::from_bytes as from_ron_bytes;
 use serde::{Deserialize, Serialize};
 
-use amethyst_assets::{Asset, Handle, ProcessingState, SimpleFormat};
+use amethyst_assets::{Asset, Handle, ProcessingState};
 use amethyst_core::specs::prelude::{Component, DenseVecStorage, VecStorage};
 use amethyst_error::Error;
 
-use crate::{error, Texture};
+use crate::Texture;
 
 /// An asset handle to sprite sheet metadata.
 pub type SpriteSheetHandle = Handle<SpriteSheet>;
@@ -199,123 +198,6 @@ pub struct SpriteRender {
 
 impl Component for SpriteRender {
     type Storage = VecStorage<Self>;
-}
-
-/// Structure acting as scaffolding for serde when loading a spritesheet file.
-/// Positions originate in the top-left corner (bitmap image convention).
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-struct SpritePosition {
-    /// Horizontal position of the sprite in the sprite sheet
-    pub x: u32,
-    /// Vertical position of the sprite in the sprite sheet
-    pub y: u32,
-    /// Width of the sprite
-    pub width: u32,
-    /// Height of the sprite
-    pub height: u32,
-    /// Number of pixels to shift the sprite to the left and down relative to the entity holding it
-    pub offsets: Option<[f32; 2]>,
-}
-
-/// Structure acting as scaffolding for serde when loading a spritesheet file.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-struct SerializedSpriteSheet {
-    /// Width of the sprite sheet
-    pub spritesheet_width: u32,
-    /// Height of the sprite sheet
-    pub spritesheet_height: u32,
-    /// Description of the sprites
-    pub sprites: Vec<SpritePosition>,
-}
-
-/// Allows loading of sprite sheets in RON format.
-///
-/// This format allows to conveniently load a sprite sheet from a RON file.
-///
-/// Example:
-/// ```text,ignore
-/// (
-///     // Width of the sprite sheet
-///     spritesheet_width: 48.0,
-///     // Height of the sprite sheet
-///     spritesheet_height: 16.0,
-///     // List of sprites the sheet holds
-///     sprites: [
-///         (
-///             // Horizontal position of the sprite in the sprite sheet
-///             x: 0.0,
-///             // Vertical position of the sprite in the sprite sheet
-///             y: 0.0,
-///             // Width of the sprite
-///             width: 16.0,
-///             // Height of the sprite
-///             height: 16.0,
-///             // Number of pixels to shift the sprite to the left and down relative to the entity holding it when rendering
-///             offsets: (0.0, 0.0), // This is optional and defaults to (0.0, 0.0)
-///         ),
-///         (
-///             x: 16.0,
-///             y: 0.0,
-///             width: 32.0,
-///             height: 16.0,
-///         ),
-///     ],
-/// )
-/// ```
-///
-/// Such a spritesheet description can be loaded using a `Loader` by passing it the handle of the corresponding loaded texture.
-/// ```rust,no_run
-/// # use amethyst_assets::{Loader, AssetStorage};
-/// # use amethyst_renderer::{SpriteSheetFormat, SpriteSheet, Texture, PngFormat, TextureMetadata};
-/// #
-/// # fn load_sprite_sheet() {
-/// #   let world = amethyst_core::specs::World::new(); // Normally, you would use Amethyst's world
-/// #   let loader = world.read_resource::<Loader>();
-/// #   let spritesheet_storage = world.read_resource::<AssetStorage<SpriteSheet>>();
-/// #   let texture_storage = world.read_resource::<AssetStorage<Texture>>();
-/// let texture_handle = loader.load(
-///     "my_texture.png",
-///     PngFormat,
-///     TextureMetadata::srgb(),
-///     (),
-///     &texture_storage,
-/// );
-/// let spritesheet_handle = loader.load(
-///     "my_spritesheet.ron",
-///     SpriteSheetFormat,
-///     texture_handle,
-///     (),
-///     &spritesheet_storage,
-/// );
-/// # }
-/// ```
-#[derive(Clone, Deserialize, Serialize)]
-pub struct SpriteSheetFormat;
-
-impl SimpleFormat<SpriteSheet> for SpriteSheetFormat {
-    const NAME: &'static str = "SPRITE_SHEET";
-
-    type Options = Handle<Texture>;
-
-    fn import(&self, bytes: Vec<u8>, texture: Self::Options) -> Result<SpriteSheet, Error> {
-        let sheet: SerializedSpriteSheet =
-            from_ron_bytes(&bytes).map_err(|_| error::Error::LoadSpritesheetError)?;
-
-        let mut sprites: Vec<Sprite> = Vec::with_capacity(sheet.sprites.len());
-        for sp in sheet.sprites {
-            let sprite = Sprite::from_pixel_values(
-                sheet.spritesheet_width as u32,
-                sheet.spritesheet_height as u32,
-                sp.width as u32,
-                sp.height as u32,
-                sp.x as u32,
-                sp.y as u32,
-                sp.offsets.unwrap_or([0.0; 2]),
-            );
-            sprites.push(sprite);
-        }
-        Ok(SpriteSheet { texture, sprites })
-    }
 }
 
 #[cfg(test)]

--- a/book/src/animation/definition.md
+++ b/book/src/animation/definition.md
@@ -6,8 +6,10 @@ Right now we do not have a tutorial for defining an animation from scratch, but 
 
 * [animation example][ex_ani]
 * [gltf example][ex_gltf]
+* [sprite animation example][ex_sprite]
 * [API docs][api]
 
 [ex_ani]: https://github.com/amethyst/amethyst/tree/master/examples/animation
 [ex_gltf]: https://github.com/amethyst/amethyst/tree/master/examples/gltf
+[ex_sprite]: https://github.com/amethyst/amethyst/tree/master/examples/sprite_animation
 [api]: https://docs.rs/amethyst_animation

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,8 @@ it is attached to. ([#1282])
 * `Default::default` now returns a pass with transparency enabled for all applicable passes. ([#1419])
 * Several passes had a function named `with_transparency` changed to accept a boolean. ([#1419])
 * `FrameRateLimitConfig` has a `new` constructor, and its fields are made public. ([#1436])
+* derive `Deserialize, Serialize` for `MaterialPrimitive` and `SpriteRenderPrimitive`, remove
+extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 
 ### Removed
 
@@ -76,6 +78,7 @@ it is attached to. ([#1282])
 [#1411]: https://github.com/amethyst/amethyst/pull/1411
 [#1412]: https://github.com/amethyst/amethyst/pull/1412
 [#1419]: https://github.com/amethyst/amethyst/pull/1419
+[#1435]: https://github.com/amethyst/amethyst/pull/1435
 
 ## [0.10.0] - 2018-12
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ it is attached to. ([#1282])
 * Add `loaded_icon` to `DisplayConfig` to set a window icon programatically ([#1405])
 * Added optional feature gates which will reduce compilation times when used. ([#1412])
 * Several passes got `with_transparency_settings` which changes the transparency settings for the pass. ([#1419])
+* Add `SpriteRenderPrefab`. ([#1435])
 
 ### Changed
 
@@ -42,7 +43,7 @@ it is attached to. ([#1282])
 * `Default::default` now returns a pass with transparency enabled for all applicable passes. ([#1419])
 * Several passes had a function named `with_transparency` changed to accept a boolean. ([#1419])
 * `FrameRateLimitConfig` has a `new` constructor, and its fields are made public. ([#1436])
-* derive `Deserialize, Serialize` for `MaterialPrimitive` and `SpriteRenderPrimitive`, remove
+* Derive `Deserialize, Serialize` for `MaterialPrimitive` and `SpriteRenderPrimitive`, remove
 extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 
 ### Removed

--- a/examples/assets/prefab/sprite_animation.json
+++ b/examples/assets/prefab/sprite_animation.json
@@ -1,0 +1,113 @@
+{
+    "entities": [
+        {
+            "data": [
+                {
+                    "translation": [
+                        200.0,
+                        37.5,
+                        0.0
+                    ]
+                },
+                {
+                    "texture": {
+                        "File": [
+                            "texture/bat.32x32.png",
+                            "Png",
+                            {
+                                "channel": "Srgb"
+                            }
+                        ]
+                    },
+                    "sprite_sheet": {
+                        "spritesheet_width": 192,
+                        "spritesheet_height": 64,
+                        "sprites": [
+                            {
+                                "x": 0,
+                                "y": 0,
+                                "width": 32,
+                                "height": 32
+                            },
+                            {
+                                "x": 32,
+                                "y": 0,
+                                "width": 32,
+                                "height": 32
+                            },
+                            {
+                                "x": 64,
+                                "y": 0,
+                                "width": 32,
+                                "height": 32
+                            },
+                            {
+                                "x": 96,
+                                "y": 0,
+                                "width": 32,
+                                "height": 32
+                            },
+                            {
+                                "x": 128,
+                                "y": 0,
+                                "width": 32,
+                                "height": 32
+                            },
+                            {
+                                "x": 160,
+                                "y": 0,
+                                "width": 32,
+                                "height": 32
+                            }
+                        ]
+                    },
+                    "sprite_number": 0
+                },
+                {
+                    "animations": [
+                        [
+                            "Fly",
+                            {
+                                "samplers": [
+                                    [
+                                        0,
+                                        "SpriteIndex",
+                                        {
+                                            "input": [
+                                                0.0,
+                                                0.5,
+                                                0.6,
+                                                0.7,
+                                                0.8,
+                                                0.9,
+                                                1.0,
+                                                1.1,
+                                                1.2,
+                                                1.3,
+                                                1.4
+                                            ],
+                                            "output": [
+                                                5,
+                                                4,
+                                                3,
+                                                2,
+                                                1,
+                                                0,
+                                                1,
+                                                2,
+                                                3,
+                                                4,
+                                                4
+                                            ],
+                                            "function": "Step"
+                                        }
+                                    ]
+                                ]
+                            }
+                        ]
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/examples/assets/prefab/sprite_animation.ron
+++ b/examples/assets/prefab/sprite_animation.ron
@@ -1,0 +1,65 @@
+#![enable(implicit_some)]
+Prefab(
+    entities: [
+        PrefabEntity(
+            data: MyPrefabData(
+                // Rendering position and orientation
+                transform: (
+                    translation: (200.0, 37.5, 0.0),
+                ),
+                // Information for rendering a sprite
+                sprite_render: (
+                    // TexturePrefab
+                    texture: File(
+                        "texture/bat.32x32.png",
+                        Png,
+                        TextureMetadata(channel: Srgb),
+                    ),
+                    // SpriteSheetLoader
+                    sprite_sheet: (
+                        // Size of texture
+                        spritesheet_width: 192,
+                        spritesheet_height: 64,
+                        sprites: [
+                            // Sprites with indexes from 0 to 5
+                            (x: 0,   y: 0, width: 32, height: 32),
+                            (x: 32,  y: 0, width: 32, height: 32),
+                            (x: 64,  y: 0, width: 32, height: 32),
+                            (x: 96,  y: 0, width: 32, height: 32),
+                            (x: 128, y: 0, width: 32, height: 32),
+                            (x: 160, y: 0, width: 32, height: 32),
+                        ]
+                    ),
+                    sprite_number: 0,
+                ),
+                // AnimationSetPrefab
+                animation_set: (
+                    animations: [
+                        (
+                            // AnimationId
+                            Fly,
+                            (
+                                samplers: [
+                                    (
+                                        0,
+                                        // Only SpriteIndex channel allowed for SpriteRender in AnimationSetPrefab
+                                        SpriteIndex,
+                                        (
+                                            // Time of key frames
+                                            input:  [0.0, 0.5, 0.6, 0.7, 0.8, 0.9,
+                                                     1.0, 1.1, 1.2, 1.3, 1.4],
+                                            // Sprite indexes from SpriteSheet for key frames
+                                            output: [5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 4],
+                                            // Sprites can only ever be animated with Step
+                                            function: Step,
+                                        ),
+                                    ),
+                                ],
+                            ),
+                        ),
+                    ],
+                ),
+            ),
+        ),
+    ],
+)

--- a/examples/sprite_animation/main.rs
+++ b/examples/sprite_animation/main.rs
@@ -1,0 +1,245 @@
+//! Demonstrates how to load and render sprites.
+//!
+//! Sprites are from <https://opengameart.org/content/bat-32x32>.
+
+use amethyst::{
+    animation::{
+        get_animation_set, AnimationBundle, AnimationCommand, AnimationSet, AnimationSetPrefab,
+        EndControl,
+    },
+    assets::{AssetStorage, JsonFormat, Loader, PrefabData, PrefabLoaderSystem, ProgressCounter},
+    config::Config,
+    core::transform::{Transform, TransformBundle},
+    derive::PrefabData,
+    ecs::{prelude::Entity, Read, ReadExpect, WriteStorage},
+    error::Error,
+    prelude::{Builder, World},
+    renderer::{
+        Camera, DisplayConfig, DrawFlat2D, Pipeline, Projection, RenderBundle, ScreenDimensions,
+        Sprite, SpriteRender, SpriteSheet, Stage, TextureFormat, TexturePrefab,
+    },
+    utils::application_root_dir,
+    Application, GameData, GameDataBuilder, SimpleState, SimpleTrans, StateData, Trans,
+};
+use amethyst_assets::PrefabLoader;
+use serde::{Deserialize, Serialize};
+
+/// Information about position of the sprite in the sprite sheet
+/// Positions originate in the top-left corner (bitmap image convention).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct SpritePosition {
+    /// Horizontal position of the sprite in the sprite sheet
+    pub x: u32,
+    /// Vertical position of the sprite in the sprite sheet
+    pub y: u32,
+    /// Width of the sprite
+    pub width: u32,
+    /// Height of the sprite
+    pub height: u32,
+    /// Number of pixels to shift the sprite to the left and down relative to the entity holding it
+    pub offsets: Option<[f32; 2]>,
+}
+
+/// Represent `amethyst_renderer::SpriteSheetFormat`
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct SpriteSheetLoader {
+    pub spritesheet_width: u32,
+    pub spritesheet_height: u32,
+    pub sprites: Vec<SpritePosition>,
+}
+
+/// `PrefabData` for loading `SpriteRender`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct SpriteRenderPrefab {
+    /// Spritesheet texture
+    pub texture: TexturePrefab<TextureFormat>,
+    /// Spritesheet
+    pub sprite_sheet: SpriteSheetLoader,
+    /// Index of the default sprite on the sprite sheet
+    pub sprite_number: usize,
+}
+
+impl<'a> PrefabData<'a> for SpriteRenderPrefab {
+    type SystemData = (
+        <TexturePrefab<TextureFormat> as PrefabData<'a>>::SystemData,
+        ReadExpect<'a, Loader>,
+        Read<'a, AssetStorage<SpriteSheet>>,
+        WriteStorage<'a, SpriteRender>,
+    );
+    type Result = ();
+
+    /// Add loaded SpriteRender to entity
+    fn add_to_entity(
+        &self,
+        entity: Entity,
+        (tex_data, loader, sheet_storage, render_storage): &mut Self::SystemData,
+        entities: &[Entity],
+    ) -> Result<(), Error> {
+        // Creates a Sprite from pixel values
+        let mut sprites: Vec<Sprite> = Vec::with_capacity(self.sprite_sheet.sprites.len());
+        for sp in &self.sprite_sheet.sprites {
+            let sprite = Sprite::from_pixel_values(
+                self.sprite_sheet.spritesheet_width as u32,
+                self.sprite_sheet.spritesheet_height as u32,
+                sp.width as u32,
+                sp.height as u32,
+                sp.x as u32,
+                sp.y as u32,
+                sp.offsets.unwrap_or([0.0; 2]),
+            );
+            sprites.push(sprite);
+        }
+
+        // Get texture handle from TexturePrefab
+        let texture = self.texture.add_to_entity(entity, tex_data, entities)?;
+
+        // Load SpriteSheet and get handle
+        let sheet = SpriteSheet { texture, sprites };
+        let sheet_handle = loader.load_from_data(sheet, (), sheet_storage);
+
+        // Add SpriteRender to entity
+        let render = SpriteRender {
+            sprite_sheet: sheet_handle,
+            sprite_number: self.sprite_number,
+        };
+        render_storage.insert(entity, render)?;
+
+        Ok(())
+    }
+
+    /// Load TexturePrefab
+    fn load_sub_assets(
+        &mut self,
+        progress: &mut ProgressCounter,
+        (tex_data, _, _, _): &mut Self::SystemData,
+    ) -> Result<bool, Error> {
+        self.texture.load_sub_assets(progress, tex_data)
+    }
+}
+
+/// Animation ids used in a AnimationSet
+#[derive(Eq, PartialOrd, PartialEq, Hash, Debug, Copy, Clone, Deserialize, Serialize)]
+enum AnimationId {
+    Fly,
+}
+
+/// Loading data for one entity
+#[derive(Debug, Clone, Serialize, Deserialize, PrefabData)]
+struct MyPrefabData {
+    /// Rendering position and orientation
+    transform: Transform,
+    /// Information for rendering a sprite
+    sprite_render: SpriteRenderPrefab,
+    /// Аll animations that can be run on the entity
+    animation_set: AnimationSetPrefab<AnimationId, SpriteRender>,
+}
+
+/// The main state
+#[derive(Default)]
+struct Example {
+    /// A progress tracker to check that assets are loaded
+    pub progress_counter: Option<ProgressCounter>,
+    /// Bat entity to start animation after loading
+    pub bat: Option<Entity>,
+}
+
+impl SimpleState for Example {
+    fn on_start(&mut self, data: StateData<'_, GameData<'_, '_>>) {
+        let StateData { world, .. } = data;
+        // Crates new progress counter
+        self.progress_counter = Some(Default::default());
+        // Starts asset loading
+        let prefab_handle = world.exec(|loader: PrefabLoader<'_, MyPrefabData>| {
+            loader.load(
+                // FIXME: deserialization of untagged enum in `ron` is buggy
+                "prefab/sprite_animation.json",
+                JsonFormat,
+                (),
+                self.progress_counter.as_mut().unwrap(),
+            )
+        });
+        // Creates a new entity with components from MyPrefabData
+        self.bat = Some(world.create_entity().with(prefab_handle).build());
+        // Creates a new camera
+        initialise_camera(world);
+    }
+
+    fn update(&mut self, data: &mut StateData<'_, GameData<'_, '_>>) -> SimpleTrans {
+        // Checks if we are still loading data
+        if let Some(ref progress_counter) = self.progress_counter {
+            // Checks progress
+            if progress_counter.is_complete() {
+                let StateData { world, .. } = data;
+                // Gets the Fly animation from AnimationSet
+                let animation = world
+                    .read_storage::<AnimationSet<AnimationId, SpriteRender>>()
+                    .get(self.bat.unwrap())
+                    .and_then(|s| s.get(&AnimationId::Fly).cloned())
+                    .unwrap();
+                // Creates a new AnimationControlSet for bat entity
+                let mut sets = world.write_storage();
+                let control_set =
+                    get_animation_set::<AnimationId, SpriteRender>(&mut sets, self.bat.unwrap())
+                        .unwrap();
+                // Adds the animation to AnimationControlSet and loops infinitely
+                control_set.add_animation(
+                    AnimationId::Fly,
+                    &animation,
+                    EndControl::Loop(None),
+                    1.0,
+                    AnimationCommand::Start,
+                );
+                // All data loaded
+                self.progress_counter = None;
+            }
+        }
+        Trans::None
+    }
+}
+
+fn initialise_camera(world: &mut World) {
+    let (width, height) = {
+        let dim = world.read_resource::<ScreenDimensions>();
+        (dim.width(), dim.height())
+    };
+
+    let mut camera_transform = Transform::default();
+    camera_transform.set_z(1.0);
+
+    world
+        .create_entity()
+        .with(camera_transform)
+        .with(Camera::from(Projection::orthographic(
+            0.0, width, 0.0, height,
+        )))
+        .build();
+}
+
+fn main() -> amethyst::Result<()> {
+    amethyst::start_logger(Default::default());
+
+    let app_root = application_root_dir()?;
+    let assets_directory = app_root.join("examples/assets/");
+    let display_conf_path = app_root.join("examples/sprite_animation/resources/display_config.ron");
+    let display_config = DisplayConfig::load(display_conf_path);
+
+    let pipe = Pipeline::build().with_stage(
+        Stage::with_backbuffer()
+            .clear_target([0.0, 0.0, 0.0, 1.0], 1.0)
+            .with_pass(DrawFlat2D::new()),
+    );
+
+    let game_data = GameDataBuilder::default()
+        .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[])
+        .with_bundle(TransformBundle::new())?
+        .with_bundle(AnimationBundle::<AnimationId, SpriteRender>::new(
+            "animation_control_system",
+            "sampler_interpolation_system",
+        ))?
+        .with_bundle(RenderBundle::new(pipe, Some(display_config)).with_sprite_sheet_processor())?;
+
+    let mut game = Application::new(assets_directory, Example::default(), game_data)?;
+    game.run();
+
+    Ok(())
+}

--- a/examples/sprite_animation/resources/display_config.ron
+++ b/examples/sprite_animation/resources/display_config.ron
@@ -1,0 +1,10 @@
+(
+  dimensions: Some((400, 75)),
+  max_dimensions: None,
+  min_dimensions: None,
+  fullscreen: false,
+  multisampling: 0,
+  title: "Sprite animation example",
+  visibility: true,
+  vsync: true,
+)


### PR DESCRIPTION
## Description
Currently, `AnimationSetPrefab` can only be used with `Transform` animation, but we can allow to declare animations that do not use `Handle` in their `Primitives`.

## Additions
- `SpriteRenderPrefab`
- `sprite_animation` example

## Modifications
- derive `Deserialize, Serialize` for `MaterialPrimitive`
- derive `Deserialize, Serialize` for `SpriteRenderPrimitive`
- remove extra bounds from `AnimatablePrefab` and `AnimationSetPrefab`
- move `SpritePosition`, `SerializedSpriteSheet` and `SpriteSheetFormat` to `formats/sprite.rs`
- pub `SpritePosition` and `SerializedSpriteSheet`

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
