### PR TITLE
Feature/expose frame rate limit config constructor

### DIFF
--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -19,6 +19,7 @@ travis-ci = { repository = "amethyst/amethyst" }
 nalgebra = { version = "0.17", features = ["serde-serialize", "mint"] }
 approx = "0.3"
 amethyst_error = { path = "../amethyst_error", version = "0.1.0" }
+derive-new = "0.5"
 fnv = "1"
 hibitset = { version = "0.5.2", features = ["parallel"] }
 log = "0.4.6"

--- a/amethyst_core/src/frame_limiter.rs
+++ b/amethyst_core/src/frame_limiter.rs
@@ -72,6 +72,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use derive_new::new;
 use serde::{Deserialize, Serialize};
 
 const ZERO: Duration = Duration::from_millis(0);
@@ -122,10 +123,12 @@ impl Default for FrameRateLimitStrategy {
 ///
 /// [`FrameLimiter`]: ./struct.FrameLimiter.html
 /// [`Config`]: ../../amethyst_config/trait.Config.html
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, new)]
 pub struct FrameRateLimitConfig {
-    strategy: FrameRateLimitStrategy,
-    fps: u32,
+    /// Frame rate limiting strategy.
+    pub strategy: FrameRateLimitStrategy,
+    /// The FPS to limit the game loop execution.
+    pub fps: u32,
 }
 
 impl Default for FrameRateLimitConfig {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,7 @@ it is attached to. ([#1282])
 * Re-exported amethyst_gltf by amethyst as amethyst::gltf. ([#1411])
 * `Default::default` now returns a pass with transparency enabled for all applicable passes. ([#1419])
 * Several passes had a function named `with_transparency` changed to accept a boolean. ([#1419])
+* `FrameRateLimitConfig` has a `new` constructor, and its fields are made public. ([#1436])
 
 ### Removed
 


### PR DESCRIPTION
## Description

`FrameRateLimitConfig` has a `new` constructor, and its fields are made public, so that users can construct these as `const` fields.

## Modifications

* `FrameRateLimitConfig` has a `new` constructor, and its fields are made public, so that users can construct these as `const` fields.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
