### PR TITLE
fix #780, make frame_limit::do_sleep calculate how long to sleep instead of sleep(0) in a loop

### DIFF
--- a/amethyst_core/src/frame_limiter.rs
+++ b/amethyst_core/src/frame_limiter.rs
@@ -225,8 +225,13 @@ impl FrameLimiter {
 
     fn do_sleep(&self, stop_on_remaining: Duration) {
         let frame_duration = self.frame_duration - stop_on_remaining;
-        while Instant::now() - self.last_call < frame_duration {
-            sleep(ZERO);
+        loop {
+            let elapsed = Instant::now() - self.last_call;
+            if elapsed >= frame_duration {
+                break;
+            } else {
+                sleep(frame_duration - elapsed);
+            }
         }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@ it is attached to. ([#1282])
 
 ### Changed
 
+* Make `frame_limiter::do_sleep` calculate the amount of time to sleep instead of calling `sleep(0)` ([#780])
 * Make `application_root_dir` return a `Result<Path>` instead of a `String` ([#1213])
 * Remove unnecessary texture coordinates offset in `Sprite::from_pixel_values` ([#1267])
 * Changed `ActiveCamera` to have the `Option` inside. ([#1280])

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -58,6 +58,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * Set width and height of Pong Paddles ([#1363])
 * Fix omission in `PosNormTangTex` documentation. ([#1371])
 
+[#780]: https://github.com/amethyst/amethyst/pull/780
 [#1114]: https://github.com/amethyst/amethyst/pull/1114
 [#1213]: https://github.com/amethyst/amethyst/pull/1213
 [#1237]: https://github.com/amethyst/amethyst/pull/1237

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,7 +29,7 @@ it is attached to. ([#1282])
 
 ### Changed
 
-* Make `frame_limiter::do_sleep` calculate the amount of time to sleep instead of calling `sleep(0)` ([#780])
+* Make `frame_limiter::do_sleep` calculate the amount of time to sleep instead of calling `sleep(0)` ([#1446])
 * Make `application_root_dir` return a `Result<Path>` instead of a `String` ([#1213])
 * Remove unnecessary texture coordinates offset in `Sprite::from_pixel_values` ([#1267])
 * Changed `ActiveCamera` to have the `Option` inside. ([#1280])
@@ -58,7 +58,6 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * Set width and height of Pong Paddles ([#1363])
 * Fix omission in `PosNormTangTex` documentation. ([#1371])
 
-[#780]: https://github.com/amethyst/amethyst/pull/780
 [#1114]: https://github.com/amethyst/amethyst/pull/1114
 [#1213]: https://github.com/amethyst/amethyst/pull/1213
 [#1237]: https://github.com/amethyst/amethyst/pull/1237
@@ -86,6 +85,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1424]: https://github.com/amethyst/amethyst/pull/1424
 [#1435]: https://github.com/amethyst/amethyst/pull/1435
 [#1439]: https://github.com/amethyst/amethyst/pull/1439
+[#1446]: https://github.com/amethyst/amethyst/pull/1446
 
 ## [0.10.0] - 2018-12
 


### PR DESCRIPTION
## Description

This fixes PR #780, tested on linux. Passing 0 to sleep just results in busy waiting, instead we should calculate the amount of time we want to wait, and pass that to sleep.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x ] Ran `cargo test --all` locally if this modified any rs files.
- [x ] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x ] Updated the content of the book if this PR would make the book outdated.
- [x ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x ] Added unit tests for new APIs if any were added in this PR.
- [x ] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
