### PR TITLE
Correct euler angle argument names and documentation in Transform

### DIFF
--- a/amethyst_core/src/transform/components/local_transform.rs
+++ b/amethyst_core/src/transform/components/local_transform.rs
@@ -345,11 +345,11 @@ impl Transform {
         self
     }
 
-    /// Set the rotation using Euler roll, pitch, yaw. 
+    /// Set the rotation using Euler roll, pitch, yaw.
     ///
     /// Note that the *order* of arguments is different than you may be used
     /// to thinking about Euler angle transforms, and does not directly match
-    /// the customary x,y,z axis ordering.
+    /// the customary x, y, z axis ordering.
     ///
     /// All angles are specified in radians. Euler order is roll → pitch → yaw.
     ///

--- a/amethyst_core/src/transform/components/local_transform.rs
+++ b/amethyst_core/src/transform/components/local_transform.rs
@@ -345,15 +345,19 @@ impl Transform {
         self
     }
 
-    /// Set the rotation using Euler x, y, z.
+    /// Set the rotation using Euler roll, pitch, yaw. 
+    ///
+    /// Note that the *order* of arguments is different than you may be used
+    /// to thinking about Euler angle transforms, and does not directly match
+    /// the customary x,y,z axis ordering.
     ///
     /// All angles are specified in radians. Euler order is roll → pitch → yaw.
     ///
     /// # Arguments
     ///
-    ///  - x - The angle to apply around the x axis. Also known as the roll.
-    ///  - y - The angle to apply around the y axis. Also known as the pitch.
-    ///  - z - The angle to apply around the z axis. Also known as the yaw.
+    ///  - roll - The angle to apply around the Z axis. Also known as the roll.
+    ///  - pitch - The angle to apply around the X axis. Also known as the pitch.
+    ///  - yaw - The angle to apply around the Y axis. Also known as the yaw.
     /// ```
     /// # use amethyst_core::transform::components::Transform;
     /// let mut transform = Transform::default();
@@ -362,8 +366,8 @@ impl Transform {
     ///
     /// assert_eq!(transform.rotation().euler_angles().0, 1.0);
     /// ```
-    pub fn set_rotation_euler(&mut self, x: f32, y: f32, z: f32) -> &mut Self {
-        self.iso.rotation = UnitQuaternion::from_euler_angles(x, y, z);
+    pub fn set_rotation_euler(&mut self, roll: f32, pitch: f32, yaw: f32) -> &mut Self {
+        self.iso.rotation = UnitQuaternion::from_euler_angles(roll, pitch, yaw);
         self
     }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -56,6 +56,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * Fixed default system font loading to accept uppercase extension ("TTF"). ([#1328])
 * Set width and height of Pong Paddles ([#1363])
 * Fix omission in `PosNormTangTex` documentation. ([#1371])
+* Corrected the argument names and and documentation of `Transform::set_euler_angles`. Behavior is the same, only names changed ([#1449])
 
 [#1114]: https://github.com/amethyst/amethyst/pull/1114
 [#1213]: https://github.com/amethyst/amethyst/pull/1213
@@ -84,6 +85,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1424]: https://github.com/amethyst/amethyst/pull/1424
 [#1435]: https://github.com/amethyst/amethyst/pull/1435
 [#1439]: https://github.com/amethyst/amethyst/pull/1439
+[#1449]: https://github.com/amethyst/amethyst/pull/1449
 
 ## [0.10.0] - 2018-12
 


### PR DESCRIPTION
## Modifications

- Changes the `set_euler_angles` method to use `roll, pitch, yaw` arguments instead of `x, y, z` and correct the documentation to match. The old arguments and documentation was incorrect, as x =/= roll, y =/= pitch, z =/= yaw.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Ran `cargo test --all` locally if this modified any rs files.
- [ ] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ ] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
