### PR TITLE
Rework transform function names and documentation

### DIFF
--- a/amethyst_animation/src/transform.rs
+++ b/amethyst_animation/src/transform.rs
@@ -36,7 +36,7 @@ impl AnimationSampling for Transform {
 
         match (channel, *data) {
             (&Translation, Vec3(ref d)) => {
-                self.set_xyz(d[0], d[1], d[2]);
+                self.set_translation_xyz(d[0], d[1], d[2]);
             }
             (&Rotation, Vec4(ref d)) => {
                 *self.rotation_mut() = Unit::new_normalize(Quaternion::new(d[0], d[1], d[2], d[3]));

--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -169,7 +169,7 @@ where
                 if let Event::DeviceEvent { ref event, .. } = *event {
                     if let DeviceEvent::MouseMotion { delta: (x, y) } = *event {
                         for (transform, _) in (&mut transform, &tag).join() {
-                            transform.prepend_rotation_x_axis(
+                            transform.append_rotation_x_axis(
                                 (-y as f32 * self.sensitivity_y).to_radians(),
                             );
                             transform.prepend_rotation_y_axis(

--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -76,7 +76,7 @@ where
 
         if let Some(dir) = Unit::try_new(Vector3::new(x, y, z), 1.0e-6) {
             for (transform, _) in (&mut transform, &tag).join() {
-                transform.move_along_local(dir, time.delta_seconds() * self.speed);
+                transform.append_translation_along(dir, time.delta_seconds() * self.speed);
             }
         }
     }
@@ -169,8 +169,12 @@ where
                 if let Event::DeviceEvent { ref event, .. } = *event {
                     if let DeviceEvent::MouseMotion { delta: (x, y) } = *event {
                         for (transform, _) in (&mut transform, &tag).join() {
-                            transform.pitch_local((-y as f32 * self.sensitivity_y).to_radians());
-                            transform.yaw_global((-x as f32 * self.sensitivity_x).to_radians());
+                            transform.prepend_rotation_x_axis(
+                                (-y as f32 * self.sensitivity_y).to_radians(),
+                            );
+                            transform.prepend_rotation_y_axis(
+                                (-x as f32 * self.sensitivity_x).to_radians(),
+                            );
                         }
                     }
                 }

--- a/amethyst_core/src/transform/components/local_transform.rs
+++ b/amethyst_core/src/transform/components/local_transform.rs
@@ -150,36 +150,43 @@ impl Transform {
         &mut self.iso
     }
 
-    /// Move relatively to its current position.
+    /// Move relatively to its current position, but the parent's (or
+    /// global, if no parent exists) orientation.
     #[inline]
-    pub fn move_global(&mut self, translation: Vector3<f32>) -> &mut Self {
+    pub fn prepend_translation(&mut self, translation: Vector3<f32>) -> &mut Self {
         self.iso.translation.vector += translation;
         self
     }
 
     /// Move relatively to its current position and orientation.
     ///
-    /// Equivalent to rotating the translation before applying.
+    /// Equivalent to rotating the translation by the transform's current
+    /// rotation before applying.
     #[inline]
-    pub fn move_local(&mut self, translation: Vector3<f32>) -> &mut Self {
+    pub fn append_translation(&mut self, translation: Vector3<f32>) -> &mut Self {
         self.iso.translation.vector += self.iso.rotation * translation;
         self
     }
 
-    /// Move a distance along an axis.
-    ///
-    /// It will not move in the case where the axis is zero, for any distance.
+    /// Move a distance along an axis relative to the parent's orientation
+    /// (or the global orientation if no parent exists).
     #[inline]
-    pub fn move_along_global(&mut self, direction: Unit<Vector3<f32>>, distance: f32) -> &mut Self {
+    pub fn prepend_translation_along(
+        &mut self,
+        direction: Unit<Vector3<f32>>,
+        distance: f32,
+    ) -> &mut Self {
         self.iso.translation.vector += direction.as_ref() * distance;
         self
     }
 
-    /// Move a distance along an axis.
-    ///
-    /// It will not move in the case where the axis is zero, for any distance.
+    /// Move a distance along an axis relative to the local orientation.
     #[inline]
-    pub fn move_along_local(&mut self, direction: Unit<Vector3<f32>>, distance: f32) -> &mut Self {
+    pub fn append_translation_along(
+        &mut self,
+        direction: Unit<Vector3<f32>>,
+        distance: f32,
+    ) -> &mut Self {
         self.iso.translation.vector += self.iso.rotation * direction.as_ref() * distance;
         self
     }
@@ -188,149 +195,225 @@ impl Transform {
     #[inline]
     pub fn move_forward(&mut self, amount: f32) -> &mut Self {
         // sign is reversed because z comes towards us
-        self.move_local(Vector3::new(0.0, 0.0, -amount))
+        self.append_translation(Vector3::new(0.0, 0.0, -amount))
     }
 
     /// Move backward relative to current position and orientation.
     #[inline]
     pub fn move_backward(&mut self, amount: f32) -> &mut Self {
-        self.move_local(Vector3::new(0.0, 0.0, amount))
+        self.append_translation(Vector3::new(0.0, 0.0, amount))
     }
 
     /// Move right relative to current position and orientation.
     #[inline]
     pub fn move_right(&mut self, amount: f32) -> &mut Self {
-        self.move_local(Vector3::new(amount, 0.0, 0.0))
+        self.append_translation(Vector3::new(amount, 0.0, 0.0))
     }
 
     /// Move left relative to current position and orientation.
     #[inline]
     pub fn move_left(&mut self, amount: f32) -> &mut Self {
-        self.move_local(Vector3::new(-amount, 0.0, 0.0))
+        self.append_translation(Vector3::new(-amount, 0.0, 0.0))
     }
 
     /// Move up relative to current position and orientation.
     #[inline]
     pub fn move_up(&mut self, amount: f32) -> &mut Self {
-        self.move_local(Vector3::new(0.0, amount, 0.0))
+        self.append_translation(Vector3::new(0.0, amount, 0.0))
     }
 
     /// Move down relative to current position and orientation.
     #[inline]
     pub fn move_down(&mut self, amount: f32) -> &mut Self {
-        self.move_local(Vector3::new(0.0, -amount, 0.0))
+        self.append_translation(Vector3::new(0.0, -amount, 0.0))
     }
 
     /// Adds the specified amount to the translation vector's x component.
+    /// i.e. move relative to the parent's (or global, if no parent exists)
+    /// x axis.
     #[inline]
-    pub fn translate_x(&mut self, amount: f32) -> &mut Self {
+    pub fn prepend_translation_x(&mut self, amount: f32) -> &mut Self {
         self.iso.translation.vector.x += amount;
         self
     }
 
     /// Adds the specified amount to the translation vector's y component.
+    /// i.e. move relative to the parent's (or global, if no parent exists)
+    /// y axis.
     #[inline]
-    pub fn translate_y(&mut self, amount: f32) -> &mut Self {
+    pub fn prepend_translation_y(&mut self, amount: f32) -> &mut Self {
         self.iso.translation.vector.y += amount;
         self
     }
 
     /// Adds the specified amount to the translation vector's z component.
+    /// i.e. move relative to the parent's (or global, if no parent exists)
+    /// z axis.
     #[inline]
-    pub fn translate_z(&mut self, amount: f32) -> &mut Self {
+    pub fn prepend_translation_z(&mut self, amount: f32) -> &mut Self {
         self.iso.translation.vector.z += amount;
         self
     }
 
     /// Sets the translation vector's x component to the specified value.
     #[inline]
-    pub fn set_x(&mut self, value: f32) -> &mut Self {
+    pub fn set_translation_x(&mut self, value: f32) -> &mut Self {
         self.iso.translation.vector.x = value;
         self
     }
 
     /// Sets the translation vector's y component to the specified value.
     #[inline]
-    pub fn set_y(&mut self, value: f32) -> &mut Self {
+    pub fn set_translation_y(&mut self, value: f32) -> &mut Self {
         self.iso.translation.vector.y = value;
         self
     }
 
     /// Sets the translation vector's z component to the specified value.
     #[inline]
-    pub fn set_z(&mut self, value: f32) -> &mut Self {
+    pub fn set_translation_z(&mut self, value: f32) -> &mut Self {
         self.iso.translation.vector.z = value;
         self
     }
 
-    /// Pitch relatively to the world. `angle` is specified in radians.
+    /// Premultiply a rotation about the x axis, i.e. perform a rotation about
+    /// the parent's x axis (or the global x axis if no parent exists).
+    ///
+    /// `delta_angle` is specified in radians.
     #[inline]
-    pub fn pitch_global(&mut self, angle: f32) -> &mut Self {
-        self.rotate_global(Vector3::x_axis(), angle)
+    pub fn prepend_rotation_x_axis(&mut self, delta_angle: f32) -> &mut Self {
+        self.prepend_rotation(Vector3::x_axis(), delta_angle)
     }
 
-    /// Pitch relatively to its own rotation. `angle` is specified in radians.
+    /// Postmultiply a rotation about the x axis, i.e. perform a rotation about
+    /// the *local* x-axis, including any prior rotations that have been performed.
+    ///
+    /// `delta_angle` is specified in radians.
     #[inline]
-    pub fn pitch_local(&mut self, angle: f32) -> &mut Self {
-        self.rotate_local(Vector3::x_axis(), angle)
+    pub fn append_rotation_x_axis(&mut self, delta_angle: f32) -> &mut Self {
+        self.append_rotation(Vector3::x_axis(), delta_angle)
     }
 
-    /// Yaw relatively to the world. `angle` is specified in radians.
+    /// Set the rotation about the parent's x axis (or the global x axis
+    /// if no parent exists). This will *clear any other rotations that have
+    /// previously been performed*!
+    ///
+    /// `angle` is specified in radians.
     #[inline]
-    pub fn yaw_global(&mut self, angle: f32) -> &mut Self {
-        self.rotate_global(Vector3::y_axis(), angle)
+    pub fn set_rotation_x_axis(&mut self, angle: f32) -> &mut Self {
+        self.set_rotation_euler(angle, 0.0, 0.0)
     }
 
-    /// Yaw relatively to its own rotation. `angle` is specified in radians.
+    /// Premultiply a rotation about the y axis, i.e. perform a rotation about
+    /// the parent's y axis (or the global y axis if no parent exists).
+    ///
+    /// `delta_angle` is specified in radians.
     #[inline]
-    pub fn yaw_local(&mut self, angle: f32) -> &mut Self {
-        self.rotate_local(Vector3::y_axis(), angle)
+    pub fn prepend_rotation_y_axis(&mut self, delta_angle: f32) -> &mut Self {
+        self.prepend_rotation(Vector3::y_axis(), delta_angle)
     }
 
-    /// Roll relatively to the world. `angle` is specified in radians.
+    /// Postmultiply a rotation about the y axis, i.e. perform a rotation about
+    /// the *local* y-axis, including any prior rotations that have been performed.
+    ///
+    /// `delta_angle` is specified in radians.
     #[inline]
-    pub fn roll_global(&mut self, angle: f32) -> &mut Self {
-        self.rotate_global(-Vector3::z_axis(), angle)
+    pub fn append_rotation_y_axis(&mut self, delta_angle: f32) -> &mut Self {
+        self.append_rotation(Vector3::y_axis(), delta_angle)
     }
 
-    /// Roll relatively to its own rotation. `angle` is specified in radians.
+    /// Set the rotation about the parent's y axis (or the global y axis
+    /// if no parent exists). This will *clear any other rotations that have
+    /// previously been performed*!
+    ///
+    /// `angle` is specified in radians.
     #[inline]
-    pub fn roll_local(&mut self, angle: f32) -> &mut Self {
-        self.rotate_local(-Vector3::z_axis(), angle)
+    pub fn set_rotation_y_axis(&mut self, angle: f32) -> &mut Self {
+        self.set_rotation_euler(0.0, angle, 0.0)
     }
 
-    /// Rotate relatively to the world. `angle` is specified in radians.
+    /// Premultiply a rotation about the z axis, i.e. perform a rotation about
+    /// the parent's z axis (or the global z axis if no parent exists).
+    ///
+    /// `delta_angle` is specified in radians.
     #[inline]
-    pub fn rotate_global(&mut self, axis: Unit<Vector3<f32>>, angle: f32) -> &mut Self {
-        let q = UnitQuaternion::from_axis_angle(&axis, angle);
+    pub fn prepend_rotation_z_axis(&mut self, delta_angle: f32) -> &mut Self {
+        self.prepend_rotation(-Vector3::z_axis(), delta_angle)
+    }
+
+    /// Postmultiply a rotation about the z axis, i.e. perform a rotation about
+    /// the *local* z-axis, including any prior rotations that have been performed.
+    ///
+    /// `delta_angle` is specified in radians.
+    #[inline]
+    pub fn append_rotation_z_axis(&mut self, delta_angle: f32) -> &mut Self {
+        self.append_rotation(-Vector3::z_axis(), delta_angle)
+    }
+
+    /// Set the rotation about the parent's z axis (or the global z axis
+    /// if no parent exists). This will *clear any other rotations that have
+    /// previously been performed*!
+    ///
+    /// `angle` is specified in radians.
+    #[inline]
+    pub fn set_rotation_z_axis(&mut self, angle: f32) -> &mut Self {
+        self.set_rotation_euler(0.0, 0.0, angle)
+    }
+
+    /// Perform a rotation about the axis perpendicular to X and Y,
+    /// i.e. the most common way to rotate an object in a 2d game.
+    ///
+    /// `delta_angle` is specified in radians.
+    #[inline]
+    pub fn rotate_2d(&mut self, delta_angle: f32) -> &mut Self {
+        self.prepend_rotation_z_axis(delta_angle)
+    }
+
+    /// Set the rotation about the axis perpendicular to X and Y,
+    /// i.e. the most common way to rotate an object in a 2d game.
+    ///
+    /// `angle` is specified in radians.
+    #[inline]
+    pub fn set_rotation_2d(&mut self, angle: f32) -> &mut Self {
+        self.set_rotation_euler(0.0, 0.0, angle)
+    }
+
+    /// Premultiply a rotation, i.e. rotate relatively to the parent's orientation
+    /// (or the global orientation if no parent exists), about a specified axis.
+    ///
+    /// `delta_angle` is specified in radians.
+    #[inline]
+    pub fn prepend_rotation(&mut self, axis: Unit<Vector3<f32>>, delta_angle: f32) -> &mut Self {
+        let q = UnitQuaternion::from_axis_angle(&axis, delta_angle);
         self.iso.rotation = q * self.iso.rotation;
         self
     }
 
-    /// Rotate relatively to the current orientation. `angle` is specified in radians.
+    /// Postmultiply a rotation, i.e. rotate relatively to the local orientation (the
+    /// currently applied rotations), about a specified axis.
+    ///
+    /// `delta_angle` is specified in radians.
     #[inline]
-    pub fn rotate_local(&mut self, axis: Unit<Vector3<f32>>, angle: f32) -> &mut Self {
-        self.iso.rotation *= UnitQuaternion::from_axis_angle(&axis, angle);
+    pub fn append_rotation(&mut self, axis: Unit<Vector3<f32>>, delta_angle: f32) -> &mut Self {
+        self.iso.rotation *= UnitQuaternion::from_axis_angle(&axis, delta_angle);
         self
     }
 
     /// Set the position.
-    pub fn set_position(&mut self, position: Vector3<f32>) -> &mut Self {
+    pub fn set_translation(&mut self, position: Vector3<f32>) -> &mut Self {
         self.iso.translation.vector = position;
         self
     }
 
     /// Adds the specified amounts to the translation vector.
-    pub fn translate_xyz(&mut self, x: f32, y: f32, z: f32) -> &mut Self {
-        self.translate_x(x);
-        self.translate_y(y);
-        self.translate_z(z);
+    pub fn append_translation_xyz(&mut self, x: f32, y: f32, z: f32) -> &mut Self {
+        self.append_translation(Vector3::new(x, y, z));
         self
     }
 
     /// Sets the specified values of the translation vector.
-    pub fn set_xyz(&mut self, x: f32, y: f32, z: f32) -> &mut Self {
-        self.set_position(Vector3::new(x, y, z))
+    pub fn set_translation_xyz(&mut self, x: f32, y: f32, z: f32) -> &mut Self {
+        self.set_translation(Vector3::new(x, y, z))
     }
 
     /// Sets the rotation of the transform.
@@ -347,15 +430,30 @@ impl Transform {
         self
     }
 
-    /// Set the rotation using Euler x, y, z.
+    /// Set the rotation using x, y, z Euler axes.
     ///
-    /// All angles are specified in radians. Euler order is roll → pitch → yaw.
+    /// All angles are specified in radians. Euler order is x → y → z.
     ///
     /// # Arguments
     ///
-    ///  - x - The angle to apply around the x axis. Also known as the roll.
-    ///  - y - The angle to apply around the y axis. Also known as the pitch.
-    ///  - z - The angle to apply around the z axis. Also known as the yaw.
+    ///  - x - The angle to apply around the x axis.
+    ///  - y - The angle to apply around the y axis.
+    ///  - z - The angle to apply around the z axis.
+    ///
+    /// # Note on Euler angle semantics and `nalgebra`
+    ///
+    /// `nalgebra` has a few methods related to Euler angles, and they use
+    /// roll, pitch, and yaw as arguments instead of x, y, and z axes specifically.
+    /// Yaw has the semantic meaning of rotation about the "up" axis, roll about the
+    /// "forward axis", and pitch about the "right" axis respectively. However, `nalgebra`
+    /// assumes a +Z = up coordinate system for its roll, pitch, and yaw semantics, while
+    /// Amethyst uses a +Y = up coordinate system. Therefore, the `nalgebra` Euler angle
+    /// methods are slightly confusing to use in concert with Amethyst, and so we've
+    /// provided our own with semantics that match the rest of Amethyst. If you do end up
+    /// using `nalgebra`'s `euler_angles` or `from_euler_angles` methods, be aware that
+    /// 'roll' in that context will mean rotation about the x axis, 'pitch' will mean
+    /// rotation about the y axis, and 'yaw' will mean rotation about the z axis.
+    ///
     /// ```
     /// # use amethyst_core::transform::components::Transform;
     /// let mut transform = Transform::default();
@@ -367,6 +465,27 @@ impl Transform {
     pub fn set_rotation_euler(&mut self, x: f32, y: f32, z: f32) -> &mut Self {
         self.iso.rotation = UnitQuaternion::from_euler_angles(x, y, z);
         self
+    }
+
+    /// Get the Euler angles of the current rotation. Returns
+    /// in a tuple of the form (x, y, z), where `x`, `y`, and `z`
+    /// are the current rotation about that axis in radians.
+    ///
+    /// # Note on Euler angle semantics and `nalgebra`
+    ///
+    /// `nalgebra` has a few methods related to Euler angles, and they use
+    /// roll, pitch, and yaw as arguments instead of x, y, and z axes specifically.
+    /// Yaw has the semantic meaning of rotation about the "up" axis, roll about the
+    /// "forward axis", and pitch about the "right" axis respectively. However, `nalgebra`
+    /// assumes a +Z = up coordinate system for its roll, pitch, and yaw semantics, while
+    /// Amethyst uses a +Y = up coordinate system. Therefore, the `nalgebra` Euler angle
+    /// methods are slightly confusing to use in concert with Amethyst, and so we've
+    /// provided our own with semantics that match the rest of Amethyst. If you do end up
+    /// using `nalgebra`'s `euler_angles` or `from_euler_angles` methods, be aware that
+    /// 'roll' in that context will mean rotation about the x axis, 'pitch' will mean
+    /// rotation about the y axis, and 'yaw' will mean rotation about the z axis.
+    pub fn euler_angles(&self) -> (f32, f32, f32) {
+        self.iso.rotation.euler_angles()
     }
 
     /// Concatenates another transform onto `self`.
@@ -568,7 +687,7 @@ mod tests {
     fn test_mul() {
         // For the condition to hold both scales must be uniform
         let mut first = Transform::default();
-        first.set_xyz(20., 10., -3.);
+        first.set_translation_xyz(20., 10., -3.);
         first.set_scale(2., 2., 2.);
         first.set_rotation(
             UnitQuaternion::rotation_between(&Vector3::new(-1., 1., 2.), &Vector3::new(1., 0., 0.))
@@ -576,7 +695,7 @@ mod tests {
         );
 
         let mut second = Transform::default();
-        second.set_xyz(2., 1., -3.);
+        second.set_translation_xyz(2., 1., -3.);
         second.set_scale(1., 1., 1.);
         second.set_rotation(
             UnitQuaternion::rotation_between(&Vector3::new(7., -1., 3.), &Vector3::new(2., 1., 1.))
@@ -597,7 +716,7 @@ mod tests {
     #[test]
     fn test_view_matrix() {
         let mut transform = Transform::default();
-        transform.set_xyz(5.0, 70.1, 43.7);
+        transform.set_translation_xyz(5.0, 70.1, 43.7);
         transform.set_scale(1.0, 5.0, 8.9);
         transform.set_rotation(
             UnitQuaternion::rotation_between(&Vector3::new(-1., 1., 2.), &Vector3::new(1., 0., 0.))

--- a/amethyst_core/src/transform/components/local_transform.rs
+++ b/amethyst_core/src/transform/components/local_transform.rs
@@ -152,6 +152,11 @@ impl Transform {
 
     /// Move relatively to its current position, but the parent's (or
     /// global, if no parent exists) orientation.
+    ///
+    /// For example, if the object is rotated 45 degrees about its Y axis,
+    /// then you *prepend* a translation along the Z axis, it will still
+    /// move along the parent's Z axis rather than its local Z axis (which
+    /// is rotated 45 degrees).
     #[inline]
     pub fn prepend_translation(&mut self, translation: Vector3<f32>) -> &mut Self {
         self.iso.translation.vector += translation;
@@ -159,6 +164,11 @@ impl Transform {
     }
 
     /// Move relatively to its current position and orientation.
+    ///
+    /// For example, if the object is rotated 45 degrees about its Y axis,
+    /// then you append a translation along the Z axis, that Z axis is now
+    /// rotated 45 degrees, and so the appended translation will go along that
+    /// rotated Z axis.
     ///
     /// Equivalent to rotating the translation by the transform's current
     /// rotation before applying.
@@ -170,6 +180,11 @@ impl Transform {
 
     /// Move a distance along an axis relative to the parent's orientation
     /// (or the global orientation if no parent exists).
+    ///
+    /// For example, if the object is rotated 45 degrees about its Y axis,
+    /// then you *prepend* a translation along the Z axis, it will still
+    /// move along the parent's Z axis rather than its local Z axis (which
+    /// is rotated 45 degrees).
     #[inline]
     pub fn prepend_translation_along(
         &mut self,

--- a/amethyst_core/src/transform/systems.rs
+++ b/amethyst_core/src/transform/systems.rs
@@ -157,7 +157,7 @@ mod tests {
     #[test]
     fn transform_matrix() {
         let mut transform = Transform::default();
-        transform.set_xyz(5.0, 2.0, -0.5);
+        transform.set_translation_xyz(5.0, 2.0, -0.5);
         transform.set_rotation(Unit::new_normalize(Quaternion::new(1.0, 0.0, 0.0, 0.0)));
         transform.set_scale(2.0, 2.0, 2.0);
 
@@ -232,7 +232,7 @@ mod tests {
         let (mut world, mut hs, mut system) = transform_world();
 
         let mut local = Transform::default();
-        local.set_xyz(5.0, 5.0, 5.0);
+        local.set_translation_xyz(5.0, 5.0, 5.0);
         local.set_rotation(Unit::new_normalize(Quaternion::new(1.0, 0.5, 0.5, 0.0)));
 
         let e1 = world
@@ -260,7 +260,7 @@ mod tests {
         let (mut world, mut hs, mut system) = transform_world();
 
         let mut local1 = Transform::default();
-        local1.set_xyz(5.0, 5.0, 5.0);
+        local1.set_translation_xyz(5.0, 5.0, 5.0);
         local1.set_rotation(Unit::new_normalize(Quaternion::new(1.0, 0.5, 0.5, 0.0)));
 
         let e1 = world
@@ -270,7 +270,7 @@ mod tests {
             .build();
 
         let mut local2 = Transform::default();
-        local2.set_xyz(5.0, 5.0, 5.0);
+        local2.set_translation_xyz(5.0, 5.0, 5.0);
         local2.set_rotation(Unit::new_normalize(Quaternion::new(1.0, 0.5, 0.5, 0.0)));
 
         let e2 = world
@@ -281,7 +281,7 @@ mod tests {
             .build();
 
         let mut local3 = Transform::default();
-        local3.set_xyz(5.0, 5.0, 5.0);
+        local3.set_translation_xyz(5.0, 5.0, 5.0);
         local3.set_rotation(Unit::new_normalize(Quaternion::new(1.0, 0.5, 0.5, 0.0)));
 
         let e3 = world
@@ -328,7 +328,7 @@ mod tests {
         let (mut world, mut hs, mut system) = transform_world();
 
         let mut local3 = Transform::default();
-        local3.set_xyz(5.0, 5.0, 5.0);
+        local3.set_translation_xyz(5.0, 5.0, 5.0);
         local3.set_rotation(Unit::new_normalize(Quaternion::new(1.0, 0.5, 0.5, 0.0)));
 
         let e3 = world
@@ -338,7 +338,7 @@ mod tests {
             .build();
 
         let mut local2 = Transform::default();
-        local2.set_xyz(5.0, 5.0, 5.0);
+        local2.set_translation_xyz(5.0, 5.0, 5.0);
         local2.set_rotation(Unit::new_normalize(Quaternion::new(1.0, 0.5, 0.5, 0.0)));
 
         let e2 = world
@@ -348,7 +348,7 @@ mod tests {
             .build();
 
         let mut local1 = Transform::default();
-        local1.set_xyz(5.0, 5.0, 5.0);
+        local1.set_translation_xyz(5.0, 5.0, 5.0);
         local1.set_rotation(Unit::new_normalize(Quaternion::new(1.0, 0.5, 0.5, 0.0)));
 
         let e1 = world
@@ -401,7 +401,7 @@ mod tests {
 
         let mut local = Transform::default();
         // Release the indeterminate forms!
-        local.set_xyz(0.0 / 0.0, 0.0 / 0.0, 0.0 / 0.0);
+        local.set_translation_xyz(0.0 / 0.0, 0.0 / 0.0, 0.0 / 0.0);
 
         world
             .create_entity()
@@ -421,7 +421,7 @@ mod tests {
 
         let mut local = Transform::default();
         // Release the indeterminate forms!
-        local.set_xyz(1.0 / 0.0, 1.0 / 0.0, 1.0 / 0.0);
+        local.set_translation_xyz(1.0 / 0.0, 1.0 / 0.0, 1.0 / 0.0);
         world
             .create_entity()
             .with(local.clone())

--- a/book/src/appendices/b_migration_notes/cgmath_to_nalgebra.md
+++ b/book/src/appendices/b_migration_notes/cgmath_to_nalgebra.md
@@ -55,7 +55,7 @@ We will not list the names of every type with the same simple name, but will try
         -transform.translation = Vector3::new(5.0, 2.0, -0.5);
         -transform.scale = Vector3::new(2.0, 2.0, 2.0);
         -transform.rotation = Quaternion::new(1.0, 0.0, 0.0, 0.0);
-        +transform.set_xyz(5.0, 2.0, -0.5);
+        +transform.set_translation_xyz(5.0, 2.0, -0.5);
         +transform.set_scale(2.0, 2.0, 2.0);
         +transform.set_rotation(Unit::new_normalize(Quaternion::new(1.0, 0.0, 0.0, 0.0)));
 
@@ -67,12 +67,12 @@ We will not list the names of every type with the same simple name, but will try
         +transform_0.translation() - transform_1.translation()
 
         -transform.translation[0] = x;
-        +transform.set_x(position.x);
+        +transform.set_translation_x(position.x);
 
         -translation.x += 0.1;
         -translation.y -= 0.1;
-        +transform.translate_x(0.1);
-        +transform.translate_y(-0.1);
+        +transform.prepend_translation_x(0.1);
+        +transform.prepend_translation_y(-0.1);
         // or
         +transform.translation_mut().x += 0.1;
         +transform.translation_mut().y -= 0.1;
@@ -81,7 +81,7 @@ We will not list the names of every type with the same simple name, but will try
         +let ball_x = transform.translation().x;
 
         -transform.set_position(Vector3::new(6.0, 6.0, -6.0));
-        +transform.set_xyz(6.0, 6.0, -6.0);
+        +transform.set_translation_xyz(6.0, 6.0, -6.0);
         // or
         *transform.translation_mut() = Vector3::new(6.0, 6.0, -6.0);
 
@@ -99,7 +99,9 @@ We will not list the names of every type with the same simple name, but will try
         -use amethyst::core::cgmath::Deg;
         -
         -transform.set_rotation(Deg(75.96), Deg(0.0), Deg(0.0));
-        +transform.rotate_local(Vector3::x_axis(), 1.3257521);
+        +transform.set_rotation_x_axis(1.3257521);
+        // or
+        +transform.set_rotation_euler(1.3257521, 0.0, 0.0);
 
         // Scaling
         -transform.scale = Vector3::new(1.0, 1.0, 1.0);

--- a/book/src/concepts/system.md
+++ b/book/src/concepts/system.md
@@ -78,7 +78,7 @@ impl<'a> System<'a> for WalkPlayerUp {
     type SystemData = WriteStorage<'a, Transform>;
 
     fn run(&mut self, mut transforms: Self::SystemData) {
-        transforms.get_mut(self.player).unwrap().translate_y(0.1);
+        transforms.get_mut(self.player).unwrap().prepend_translation_y(0.1);
     }
 }
 ```
@@ -123,7 +123,7 @@ impl<'a> System<'a> for MakeObjectsFall {
     fn run(&mut self, (mut transforms, falling): Self::SystemData) {
         for (mut transform, _) in (&mut transforms, &falling).join() {
             if transform.translation().y > 0.0 {
-                transform.translate_y(-0.1);
+                transform.prepend_translation_y(-0.1);
             }
         }
     }
@@ -161,7 +161,7 @@ impl<'a> System<'a> for NotFallingObjects {
     fn run(&mut self, (mut transforms, falling): Self::SystemData) {
         for (mut transform, _) in (&mut transforms, !&falling).join() {
             // If they don't fall, why not make them go up!
-            transform.translate_y(0.1);
+            transform.prepend_translation_y(0.1);
         }
     }
 }
@@ -251,7 +251,7 @@ impl<'a> System<'a> for MakeObjectsFall {
     fn run(&mut self, (entities, mut transforms, falling): Self::SystemData) {
         for (e, mut transform, _) in (&*entities, &mut transforms, &falling).join() {
             if transform.translation().y > 0.0 {
-                transform.translate_y(-0.1);
+                transform.prepend_translation_y(-0.1);
             } else {
                 entities.delete(e);
             }

--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -101,7 +101,7 @@ the entire arena. Let's do it in a new function `initialise_camera`!
 # use amethyst::core::Transform;
 fn initialise_camera(world: &mut World) {
     let mut transform = Transform::default();
-    transform.set_z(1.0);
+    transform.set_translation_z(1.0);
     world
         .create_entity()
         .with(Camera::from(Projection::orthographic(
@@ -255,8 +255,8 @@ fn initialise_paddles(world: &mut World) {
 
     // Correctly position the paddles.
     let y = ARENA_HEIGHT / 2.0;
-    left_transform.set_xyz(PADDLE_WIDTH * 0.5, y, 0.0);
-    right_transform.set_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
+    left_transform.set_translation_xyz(PADDLE_WIDTH * 0.5, y, 0.0);
+    right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Create a left plank entity.
     world

--- a/book/src/pong-tutorial/pong-tutorial-03.md
+++ b/book/src/pong-tutorial/pong-tutorial-03.md
@@ -273,7 +273,7 @@ component of the transform's translation.
       };
       if let Some(mv_amount) = movement {
         let scaled_amount = 1.2 * mv_amount as f32;
-        transform.translate_y(scaled_amount);
+        transform.prepend_translation_y(scaled_amount);
       }
     }
   }
@@ -334,7 +334,7 @@ Our run function should now look something like this:
       if let Some(mv_amount) = movement {
         let scaled_amount = 1.2 * mv_amount as f32;
         let paddle_y = transform.translation().y;
-        transform.set_y(
+        transform.set_translation_y(
             (paddle_y + scaled_amount)
                 .min(ARENA_HEIGHT - PADDLE_HEIGHT * 0.5)
                 .max(PADDLE_HEIGHT * 0.5),

--- a/book/src/pong-tutorial/pong-tutorial-04.md
+++ b/book/src/pong-tutorial/pong-tutorial-04.md
@@ -68,7 +68,7 @@ Then let's add a `initialise_ball` function the same way we wrote the
 fn initialise_ball(world: &mut World, sprite_sheet_handle: SpriteSheetHandle) {
     // Create the translation.
     let mut local_transform = Transform::default();
-    local_transform.set_xyz(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
+    local_transform.set_translation_xyz(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
 
     // Assign the sprite for the ball
     let sprite_render = SpriteRender {
@@ -175,8 +175,8 @@ impl<'s> System<'s> for MoveBallsSystem {
     fn run(&mut self, (balls, mut locals, time): Self::SystemData) {
         // Move every ball according to its speed, and the time passed.
         for (ball, local) in (&balls, &mut locals).join() {
-            local.translate_x(ball.velocity[0] * time.delta_seconds());
-            local.translate_y(ball.velocity[1] * time.delta_seconds());
+            local.prepend_translation_x(ball.velocity[0] * time.delta_seconds());
+            local.prepend_translation_y(ball.velocity[1] * time.delta_seconds());
         }
     }
 }

--- a/book/src/pong-tutorial/pong-tutorial-05.md
+++ b/book/src/pong-tutorial/pong-tutorial-05.md
@@ -74,7 +74,7 @@ impl<'s> System<'s> for WinnerSystem {
 
             if did_hit {
                 ball.velocity[0] = -ball.velocity[0]; // Reverse Direction
-                transform.set_x(ARENA_WIDTH / 2.0); // Reset Position
+                transform.set_translation_x(ARENA_WIDTH / 2.0); // Reset Position
             }
         }
     }
@@ -382,7 +382,7 @@ pub struct ScoreText {
 # /// Initialise the camera.
 # fn initialise_camera(world: &mut World) {
 #     let mut transform = Transform::default();
-#     transform.set_z(1.0);
+#     transform.set_translation_z(1.0);
 #     world
 #         .create_entity()
 #         .with(Camera::from(Projection::orthographic(
@@ -401,8 +401,8 @@ pub struct ScoreText {
 # 
 #     // Correctly position the paddles.
 #     let y = ARENA_HEIGHT / 2.0;
-#     left_transform.set_xyz(PADDLE_WIDTH * 0.5, y, 0.0);
-#     right_transform.set_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
+#     left_transform.set_translation_xyz(PADDLE_WIDTH * 0.5, y, 0.0);
+#     right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 # 
 #     // Assign the sprites for the paddles
 #     let sprite_render = SpriteRender {
@@ -432,7 +432,7 @@ pub struct ScoreText {
 # fn initialise_ball(world: &mut World, sprite_sheet_handle: SpriteSheetHandle) {
 #     // Create the translation.
 #     let mut local_transform = Transform::default();
-#     local_transform.set_xyz(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
+#     local_transform.set_translation_xyz(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
 # 
 #     // Assign the sprite for the ball
 #     let sprite_render = SpriteRender {
@@ -584,7 +584,7 @@ impl SimpleState for Pong {
 # /// Initialise the camera.
 # fn initialise_camera(world: &mut World) {
 #     let mut transform = Transform::default();
-#     transform.set_z(1.0);
+#     transform.set_translation_z(1.0);
 #     world
 #         .create_entity()
 #         .with(Camera::from(Projection::orthographic(
@@ -603,8 +603,8 @@ impl SimpleState for Pong {
 # 
 #     // Correctly position the paddles.
 #     let y = ARENA_HEIGHT / 2.0;
-#     left_transform.set_xyz(PADDLE_WIDTH * 0.5, y, 0.0);
-#     right_transform.set_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
+#     left_transform.set_translation_xyz(PADDLE_WIDTH * 0.5, y, 0.0);
+#     right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 # 
 #     // Assign the sprites for the paddles
 #     let sprite_render = SpriteRender {
@@ -634,7 +634,7 @@ impl SimpleState for Pong {
 # fn initialise_ball(world: &mut World, sprite_sheet_handle: SpriteSheetHandle) {
 #     // Create the translation.
 #     let mut local_transform = Transform::default();
-#     local_transform.set_xyz(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
+#     local_transform.set_translation_xyz(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
 # 
 #     // Assign the sprite for the ball
 #     let sprite_render = SpriteRender {
@@ -819,7 +819,7 @@ impl<'s> System<'s> for WinnerSystem {
 
             if did_hit {
 #                 ball.velocity[0] = -ball.velocity[0]; // Reverse Direction
-#                 transform.set_x(ARENA_WIDTH / 2.0); // Reset Position
+#                 transform.set_translation_x(ARENA_WIDTH / 2.0); // Reset Position
                 // --snip--
 
                 // Print the score board.

--- a/book/src/sprites/display_the_texture.md
+++ b/book/src/sprites/display_the_texture.md
@@ -30,8 +30,8 @@ use amethyst::renderer::{Flipped, PngFormat, Texture, TextureMetadata, TextureHa
 fn init_image(world: &mut World, texture_handle: &TextureHandle) {
     // Add a transform component to give the image a position
     let mut transform = Transform::default();
-    transform.set_x(0.0);
-    transform.set_y(0.0);
+    transform.set_translation_x(0.0);
+    transform.set_translation_y(0.0);
 
     world
         .create_entity()

--- a/book/src/sprites/orthographic_camera.md
+++ b/book/src/sprites/orthographic_camera.md
@@ -34,7 +34,7 @@ impl ExampleState {
         // Translate the camera to Z coordinate 10.0, and it looks back toward
         // the origin with depth 20.0
         let mut transform = Transform::default();
-        transform.set_xyz(0., 0., 10.);
+        transform.set_translation_xyz(0., 0., 10.);
 
         let camera = world
             .create_entity()

--- a/book/src/sprites/sprite_render_component.md
+++ b/book/src/sprites/sprite_render_component.md
@@ -114,7 +114,7 @@ impl ExampleState {
 
         // Move the sprite to the middle of the window
         let mut sprite_transform = Transform::default();
-        sprite_transform.set_xyz(width / 2., height / 2., 0.);
+        sprite_transform.set_translation_xyz(width / 2., height / 2., 0.);
 
         let sprite_render = SpriteRender {
             sprite_sheet: sprite_sheet_handle,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,6 +49,7 @@ it is attached to. ([#1282])
 extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * Renamed `amethyst_core::specs` to `amethyst_core::ecs` and `amethyst_core::nalgebra` to `amethyst_core::math`. ([#1410])
 * Simplified some of the conditionals in the Pong tutorial ([#1439])
+* Changed the names of many Transform functions to better reflect their actual function and reduce potential semantic confusion ([#1451])
 
 ### Removed
 
@@ -88,6 +89,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1410]: https://github.com/amethyst/amethyst/pull/1410
 [#1439]: https://github.com/amethyst/amethyst/pull/1439
 [#1445]: https://github.com/amethyst/amethyst/pull/1445
+[#1451]: https://github.com/amethyst/amethyst/pull/1451
 
 ## [0.10.0] - 2018-12
 

--- a/examples/appendix_a/pong.rs
+++ b/examples/appendix_a/pong.rs
@@ -42,7 +42,7 @@ fn initialise_camera(world: &mut World) {
     };
 
     let mut transform = Transform::default();
-    transform.set_z(1.0);
+    transform.set_translation_z(1.0);
     world
         .create_entity()
         .with(Camera::from(Projection::orthographic(
@@ -108,8 +108,8 @@ fn initialise_paddles(world: &mut World) {
 
     let left_y = (arena_height - left_height) / 2.0;
     let right_y = (arena_height - right_height) / 2.0;
-    left_transform.set_xyz(0.0, left_y, 0.0);
-    right_transform.set_xyz(arena_width - right_width, right_y, 0.0);
+    left_transform.set_translation_xyz(0.0, left_y, 0.0);
+    right_transform.set_translation_xyz(arena_width - right_width, right_y, 0.0);
 
     let left_mesh = create_mesh(
         world,
@@ -170,7 +170,7 @@ fn initialise_balls(world: &mut World) {
     let mesh = create_mesh(world, generate_circle_vertices(radius, 16));
     let material = create_colour_material(world, colour);
     let mut local_transform = Transform::default();
-    local_transform.set_xyz(arena_width / 2.0, arena_height / 2.0, 0.0);
+    local_transform.set_translation_xyz(arena_width / 2.0, arena_height / 2.0, 0.0);
 
     world
         .create_entity()

--- a/examples/appendix_a/systems/move_balls.rs
+++ b/examples/appendix_a/systems/move_balls.rs
@@ -18,8 +18,8 @@ impl<'s> System<'s> for MoveBallsSystem {
     fn run(&mut self, (mut balls, mut locals, time): Self::SystemData) {
         // Move every ball according to its speed, and the time passed.
         for (ball, local) in (&mut balls, &mut locals).join() {
-            local.translate_x(ball.velocity[0] * time.delta_seconds());
-            local.translate_y(ball.velocity[1] * time.delta_seconds());
+            local.prepend_translation_x(ball.velocity[0] * time.delta_seconds());
+            local.prepend_translation_y(ball.velocity[1] * time.delta_seconds());
         }
     }
 }

--- a/examples/appendix_a/systems/paddle.rs
+++ b/examples/appendix_a/systems/paddle.rs
@@ -29,11 +29,14 @@ impl<'s> System<'s> for PaddleSystem {
             };
 
             if let Some(movement) = opt_movement {
-                transform.translate_y(paddle.velocity * time.delta_seconds() * movement as f32);
+                transform.prepend_translation_y(
+                    paddle.velocity * time.delta_seconds() * movement as f32,
+                );
 
                 // We make sure the paddle remains in the arena.
                 let paddle_y = transform.translation().y;
-                transform.set_y(paddle_y.max(0.0).min(arena_config.height - paddle.height));
+                transform
+                    .set_translation_y(paddle_y.max(0.0).min(arena_config.height - paddle.height));
             }
         }
     }

--- a/examples/appendix_a/systems/winner.rs
+++ b/examples/appendix_a/systems/winner.rs
@@ -63,7 +63,7 @@ impl<'s> System<'s> for WinnerSystem {
             if did_hit {
                 // Reset the ball.
                 ball.velocity[0] = -ball.velocity[0];
-                transform.set_x(arena_config.width / 2.0);
+                transform.set_translation_x(arena_config.width / 2.0);
 
                 // Print the score board.
                 println!(

--- a/examples/asset_loading/main.rs
+++ b/examples/asset_loading/main.rs
@@ -87,7 +87,7 @@ impl SimpleState for AssetsExample {
         };
 
         let mut trans = Transform::default();
-        trans.set_xyz(-5.0, 0.0, 0.0);
+        trans.set_translation_xyz(-5.0, 0.0, 0.0);
         trans.set_scale(2.0, 2.0, 2.0);
         world
             .create_entity()
@@ -121,8 +121,8 @@ fn main() -> Result<(), Error> {
 
 fn initialise_camera(world: &mut World) {
     let mut transform = Transform::default();
-    transform.set_xyz(0.0, -20.0, 10.0);
-    transform.rotate_local(Vector3::x_axis(), 1.3257521);
+    transform.set_translation_xyz(0.0, -20.0, 10.0);
+    transform.prepend_rotation_x_axis(1.3257521);
 
     world
         .create_entity()
@@ -145,7 +145,7 @@ fn initialise_lights(world: &mut World) {
     .into();
 
     let mut transform = Transform::default();
-    transform.set_xyz(5.0, -20.0, 15.0);
+    transform.set_translation_xyz(5.0, -20.0, 15.0);
 
     // Add point light.
     world.create_entity().with(light).with(transform).build();

--- a/examples/custom_game_data/example_system.rs
+++ b/examples/custom_game_data/example_system.rs
@@ -59,7 +59,7 @@ impl<'a> System<'a> for ExampleSystem {
                     }
                 })
         {
-            transform.set_xyz(
+            transform.set_translation_xyz(
                 light_orbit_radius * state.light_angle.cos(),
                 light_orbit_radius * state.light_angle.sin(),
                 light_z,

--- a/examples/debug_lines/main.rs
+++ b/examples/debug_lines/main.rs
@@ -125,7 +125,7 @@ impl SimpleState for ExampleState {
 
         // Setup camera
         let mut local_transform = Transform::default();
-        local_transform.set_position([0.0, 0.5, 2.0].into());
+        local_transform.set_translation_xyz(0.0, 0.5, 2.0);
         data.world
             .create_entity()
             .with(FlyControlTag)

--- a/examples/material/main.rs
+++ b/examples/material/main.rs
@@ -2,7 +2,7 @@
 
 use amethyst::{
     assets::AssetLoaderSystemData,
-    core::{math::Vector3, Transform, TransformBundle},
+    core::{Transform, TransformBundle},
     prelude::*,
     renderer::*,
     utils::application_root_dir,
@@ -37,7 +37,7 @@ impl SimpleState for Example {
                 let metallic = 1.0f32 * (j as f32 / 4.0f32);
 
                 let mut pos = Transform::default();
-                pos.set_xyz(2.0f32 * (i - 2) as f32, 2.0f32 * (j - 2) as f32, 0.0);
+                pos.set_translation_xyz(2.0f32 * (i - 2) as f32, 2.0f32 * (j - 2) as f32, 0.0);
 
                 let metallic = [metallic, metallic, metallic, 1.0].into();
                 let roughness = [roughness, roughness, roughness, 1.0].into();
@@ -75,7 +75,7 @@ impl SimpleState for Example {
         .into();
 
         let mut light1_transform = Transform::default();
-        light1_transform.set_xyz(6.0, 6.0, -6.0);
+        light1_transform.set_translation_xyz(6.0, 6.0, -6.0);
 
         let light2: Light = PointLight {
             intensity: 5.0,
@@ -85,7 +85,7 @@ impl SimpleState for Example {
         .into();
 
         let mut light2_transform = Transform::default();
-        light2_transform.set_xyz(6.0, -6.0, -6.0);
+        light2_transform.set_translation_xyz(6.0, -6.0, -6.0);
 
         world
             .create_entity()
@@ -102,8 +102,8 @@ impl SimpleState for Example {
         println!("Put camera");
 
         let mut transform = Transform::default();
-        transform.set_xyz(0.0, 0.0, -12.0);
-        transform.rotate_local(Vector3::y_axis(), std::f32::consts::PI);
+        transform.set_translation_xyz(0.0, 0.0, -12.0);
+        transform.prepend_rotation_y_axis(std::f32::consts::PI);
 
         world
             .create_entity()

--- a/examples/pong/pong.rs
+++ b/examples/pong/pong.rs
@@ -63,7 +63,7 @@ fn load_sprite_sheet(world: &mut World) -> SpriteSheetHandle {
 /// Initialise the camera.
 fn initialise_camera(world: &mut World) {
     let mut transform = Transform::default();
-    transform.set_z(1.0);
+    transform.set_translation_z(1.0);
     world
         .create_entity()
         .with(Camera::from(Projection::orthographic(
@@ -85,8 +85,8 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: SpriteSheetHandle)
 
     // Correctly position the paddles.
     let y = (ARENA_HEIGHT - PADDLE_HEIGHT) / 2.0;
-    left_transform.set_xyz(PADDLE_WIDTH * 0.5, y, 0.0);
-    right_transform.set_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
+    left_transform.set_translation_xyz(PADDLE_WIDTH * 0.5, y, 0.0);
+    right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Assign the sprites for the paddles
     let sprite_render = SpriteRender {
@@ -128,7 +128,7 @@ fn initialise_ball(world: &mut World, sprite_sheet_handle: SpriteSheetHandle) {
 
     // Create the translation.
     let mut local_transform = Transform::default();
-    local_transform.set_xyz(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
+    local_transform.set_translation_xyz(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
 
     // Assign the sprite for the ball
     let sprite_render = SpriteRender {

--- a/examples/pong/systems/move_balls.rs
+++ b/examples/pong/systems/move_balls.rs
@@ -18,8 +18,8 @@ impl<'s> System<'s> for MoveBallsSystem {
     fn run(&mut self, (balls, mut locals, time): Self::SystemData) {
         // Move every ball according to its speed, and the time passed.
         for (ball, local) in (&balls, &mut locals).join() {
-            local.translate_x(ball.velocity[0] * time.delta_seconds());
-            local.translate_y(ball.velocity[1] * time.delta_seconds());
+            local.prepend_translation_x(ball.velocity[0] * time.delta_seconds());
+            local.prepend_translation_y(ball.velocity[1] * time.delta_seconds());
         }
     }
 }

--- a/examples/pong/systems/paddle.rs
+++ b/examples/pong/systems/paddle.rs
@@ -30,11 +30,13 @@ impl<'s> System<'s> for PaddleSystem {
 
             if let Some(movement) = opt_movement {
                 use crate::ARENA_HEIGHT;
-                transform.translate_y(paddle.velocity * time.delta_seconds() * movement as f32);
+                transform.prepend_translation_y(
+                    paddle.velocity * time.delta_seconds() * movement as f32,
+                );
 
                 // We make sure the paddle remains in the arena.
                 let paddle_y = transform.translation().y;
-                transform.set_y(
+                transform.set_translation_y(
                     paddle_y
                         .max(paddle.height * 0.5)
                         .min(ARENA_HEIGHT - paddle.height * 0.5),

--- a/examples/pong/systems/winner.rs
+++ b/examples/pong/systems/winner.rs
@@ -65,7 +65,7 @@ impl<'s> System<'s> for WinnerSystem {
             if did_hit {
                 // Reset the ball.
                 ball.velocity[0] = -ball.velocity[0];
-                transform.set_x(ARENA_WIDTH / 2.0);
+                transform.set_translation_x(ARENA_WIDTH / 2.0);
 
                 // Print the score board.
                 println!(

--- a/examples/pong_tutorial_02/pong.rs
+++ b/examples/pong_tutorial_02/pong.rs
@@ -90,7 +90,7 @@ fn load_sprite_sheet(world: &mut World) -> SpriteSheetHandle {
 /// Initialise the camera.
 fn initialise_camera(world: &mut World) {
     let mut transform = Transform::default();
-    transform.set_xyz(0.0, 0.0, 1.0);
+    transform.set_translation_xyz(0.0, 0.0, 1.0);
 
     world
         .create_entity()
@@ -111,8 +111,8 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: SpriteSheetHandle)
 
     // Correctly position the paddles.
     let y = ARENA_HEIGHT / 2.0;
-    left_transform.set_xyz(PADDLE_WIDTH * 0.5, y, 0.0);
-    right_transform.set_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
+    left_transform.set_translation_xyz(PADDLE_WIDTH * 0.5, y, 0.0);
+    right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Assign the sprites for the paddles
     let sprite_render = SpriteRender {

--- a/examples/pong_tutorial_03/pong.rs
+++ b/examples/pong_tutorial_03/pong.rs
@@ -90,7 +90,7 @@ fn load_sprite_sheet(world: &mut World) -> SpriteSheetHandle {
 /// Initialise the camera.
 fn initialise_camera(world: &mut World) {
     let mut transform = Transform::default();
-    transform.set_xyz(0.0, 0.0, 1.0);
+    transform.set_translation_xyz(0.0, 0.0, 1.0);
 
     world
         .create_entity()
@@ -111,8 +111,8 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: SpriteSheetHandle)
 
     // Correctly position the paddles.
     let y = ARENA_HEIGHT / 2.0;
-    left_transform.set_xyz(PADDLE_WIDTH * 0.5, y, 0.0);
-    right_transform.set_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
+    left_transform.set_translation_xyz(PADDLE_WIDTH * 0.5, y, 0.0);
+    right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Assign the sprites for the paddles
     let sprite_render = SpriteRender {

--- a/examples/pong_tutorial_03/systems/paddle.rs
+++ b/examples/pong_tutorial_03/systems/paddle.rs
@@ -23,7 +23,7 @@ impl<'s> System<'s> for PaddleSystem {
             if let Some(mv_amount) = movement {
                 let scaled_amount = 1.2 * mv_amount as f32;
                 let paddle_y = transform.translation().y;
-                transform.set_y(
+                transform.set_translation_y(
                     (paddle_y + scaled_amount)
                         .min(ARENA_HEIGHT - PADDLE_HEIGHT * 0.5)
                         .max(PADDLE_HEIGHT * 0.5),

--- a/examples/pong_tutorial_04/pong.rs
+++ b/examples/pong_tutorial_04/pong.rs
@@ -102,7 +102,7 @@ fn load_sprite_sheet(world: &mut World) -> SpriteSheetHandle {
 /// Initialise the camera.
 fn initialise_camera(world: &mut World) {
     let mut transform = Transform::default();
-    transform.set_z(1.0);
+    transform.set_translation_z(1.0);
     world
         .create_entity()
         .with(Camera::from(Projection::orthographic(
@@ -122,8 +122,8 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: SpriteSheetHandle)
 
     // Correctly position the paddles.
     let y = ARENA_HEIGHT / 2.0;
-    left_transform.set_xyz(PADDLE_WIDTH * 0.5, y, 0.0);
-    right_transform.set_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
+    left_transform.set_translation_xyz(PADDLE_WIDTH * 0.5, y, 0.0);
+    right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Assign the sprites for the paddles
     let sprite_render = SpriteRender {
@@ -153,7 +153,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: SpriteSheetHandle)
 fn initialise_ball(world: &mut World, sprite_sheet_handle: SpriteSheetHandle) {
     // Create the translation.
     let mut local_transform = Transform::default();
-    local_transform.set_xyz(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
+    local_transform.set_translation_xyz(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
 
     // Assign the sprite for the ball
     let sprite_render = SpriteRender {

--- a/examples/pong_tutorial_04/systems/move_balls.rs
+++ b/examples/pong_tutorial_04/systems/move_balls.rs
@@ -17,8 +17,8 @@ impl<'s> System<'s> for MoveBallsSystem {
     fn run(&mut self, (balls, mut locals, time): Self::SystemData) {
         // Move every ball according to its speed, and the time passed.
         for (ball, local) in (&balls, &mut locals).join() {
-            local.translate_x(ball.velocity[0] * time.delta_seconds());
-            local.translate_y(ball.velocity[1] * time.delta_seconds());
+            local.prepend_translation_x(ball.velocity[0] * time.delta_seconds());
+            local.prepend_translation_y(ball.velocity[1] * time.delta_seconds());
         }
     }
 }

--- a/examples/pong_tutorial_04/systems/paddle.rs
+++ b/examples/pong_tutorial_04/systems/paddle.rs
@@ -23,7 +23,7 @@ impl<'s> System<'s> for PaddleSystem {
             if let Some(mv_amount) = movement {
                 let scaled_amount = 1.2 * mv_amount as f32;
                 let paddle_y = transform.translation().y;
-                transform.set_y(
+                transform.set_translation_y(
                     (paddle_y + scaled_amount)
                         .min(ARENA_HEIGHT - PADDLE_HEIGHT * 0.5)
                         .max(PADDLE_HEIGHT * 0.5),

--- a/examples/pong_tutorial_05/pong.rs
+++ b/examples/pong_tutorial_05/pong.rs
@@ -117,7 +117,7 @@ fn load_sprite_sheet(world: &mut World) -> SpriteSheetHandle {
 /// Initialise the camera.
 fn initialise_camera(world: &mut World) {
     let mut transform = Transform::default();
-    transform.set_z(1.0);
+    transform.set_translation_z(1.0);
     world
         .create_entity()
         .with(Camera::from(Projection::orthographic(
@@ -137,8 +137,8 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: SpriteSheetHandle)
 
     // Correctly position the paddles.
     let y = ARENA_HEIGHT / 2.0;
-    left_transform.set_xyz(PADDLE_WIDTH * 0.5, y, 0.0);
-    right_transform.set_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
+    left_transform.set_translation_xyz(PADDLE_WIDTH * 0.5, y, 0.0);
+    right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Assign the sprites for the paddles
     let sprite_render = SpriteRender {
@@ -168,7 +168,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: SpriteSheetHandle)
 fn initialise_ball(world: &mut World, sprite_sheet_handle: SpriteSheetHandle) {
     // Create the translation.
     let mut local_transform = Transform::default();
-    local_transform.set_xyz(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
+    local_transform.set_translation_xyz(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
 
     // Assign the sprite for the ball
     let sprite_render = SpriteRender {

--- a/examples/pong_tutorial_05/systems/move_balls.rs
+++ b/examples/pong_tutorial_05/systems/move_balls.rs
@@ -17,8 +17,8 @@ impl<'s> System<'s> for MoveBallsSystem {
     fn run(&mut self, (balls, mut locals, time): Self::SystemData) {
         // Move every ball according to its speed, and the time passed.
         for (ball, local) in (&balls, &mut locals).join() {
-            local.translate_x(ball.velocity[0] * time.delta_seconds());
-            local.translate_y(ball.velocity[1] * time.delta_seconds());
+            local.prepend_translation_x(ball.velocity[0] * time.delta_seconds());
+            local.prepend_translation_y(ball.velocity[1] * time.delta_seconds());
         }
     }
 }

--- a/examples/pong_tutorial_05/systems/paddle.rs
+++ b/examples/pong_tutorial_05/systems/paddle.rs
@@ -23,7 +23,7 @@ impl<'s> System<'s> for PaddleSystem {
             if let Some(mv_amount) = movement {
                 let scaled_amount = 1.2 * mv_amount as f32;
                 let paddle_y = transform.translation().y;
-                transform.set_y(
+                transform.set_translation_y(
                     (paddle_y + scaled_amount)
                         .min(ARENA_HEIGHT - PADDLE_HEIGHT * 0.5)
                         .max(PADDLE_HEIGHT * 0.5),

--- a/examples/pong_tutorial_05/systems/winner.rs
+++ b/examples/pong_tutorial_05/systems/winner.rs
@@ -47,7 +47,7 @@ impl<'s> System<'s> for WinnerSystem {
             if did_hit {
                 // Reset the ball.
                 ball.velocity[0] = -ball.velocity[0];
-                transform.set_x(ARENA_WIDTH / 2.0);
+                transform.set_translation_x(ARENA_WIDTH / 2.0);
 
                 // Print the score board.
                 println!(

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -265,7 +265,7 @@ impl<'a> System<'a> for ExampleSystem {
                     }
                 })
         {
-            transform.set_xyz(
+            transform.set_translation_xyz(
                 light_orbit_radius * state.light_angle.cos(),
                 light_orbit_radius * state.light_angle.sin(),
                 light_z,

--- a/examples/simple_image/main.rs
+++ b/examples/simple_image/main.rs
@@ -45,7 +45,7 @@ fn main() -> amethyst::Result<()> {
 
 fn init_camera(world: &mut World) {
     let mut transform = Transform::default();
-    transform.set_z(1.0);
+    transform.set_translation_z(1.0);
     world
         .create_entity()
         .with(Camera::from(Projection::orthographic(
@@ -57,8 +57,8 @@ fn init_camera(world: &mut World) {
 
 fn init_image(world: &mut World, texture: &TextureHandle) -> Entity {
     let mut transform = Transform::default();
-    transform.set_x(0.0);
-    transform.set_y(0.0);
+    transform.set_translation_x(0.0);
+    transform.set_translation_y(0.0);
 
     world
         .create_entity()

--- a/examples/sprite_animation/main.rs
+++ b/examples/sprite_animation/main.rs
@@ -109,7 +109,7 @@ fn initialise_camera(world: &mut World) {
     };
 
     let mut camera_transform = Transform::default();
-    camera_transform.set_z(1.0);
+    camera_transform.set_translation_z(1.0);
 
     world
         .create_entity()

--- a/examples/sprite_camera_follow/main.rs
+++ b/examples/sprite_camera_follow/main.rs
@@ -33,8 +33,8 @@ impl<'s> System<'s> for MovementSystem {
         let y_move = input.axis_value("entity_y").unwrap();
 
         for (_, transform) in (&players, &mut transforms).join() {
-            transform.translate_x(x_move as f32 * 5.0);
-            transform.translate_y(y_move as f32 * 5.0);
+            transform.prepend_translation_x(x_move as f32 * 5.0);
+            transform.prepend_translation_y(y_move as f32 * 5.0);
         }
     }
 }
@@ -65,7 +65,7 @@ fn load_sprite_sheet(world: &mut World, png_path: &str, ron_path: &str) -> Sprit
 // Initialize a background
 fn init_background_sprite(world: &mut World, sprite_sheet: &SpriteSheetHandle) -> Entity {
     let mut transform = Transform::default();
-    transform.set_z(-10.0);
+    transform.set_translation_z(-10.0);
     let sprite = SpriteRender {
         sprite_sheet: sprite_sheet.clone(),
         sprite_number: 0,
@@ -76,8 +76,7 @@ fn init_background_sprite(world: &mut World, sprite_sheet: &SpriteSheetHandle) -
 // Initialize a sprite as a reference point at a fixed location
 fn init_reference_sprite(world: &mut World, sprite_sheet: &SpriteSheetHandle) -> Entity {
     let mut transform = Transform::default();
-    transform.set_x(100.0);
-    transform.set_y(0.0);
+    transform.set_translation_xyz(100.0, 0.0, 0.0);
     let sprite = SpriteRender {
         sprite_sheet: sprite_sheet.clone(),
         sprite_number: 0,
@@ -93,9 +92,7 @@ fn init_reference_sprite(world: &mut World, sprite_sheet: &SpriteSheetHandle) ->
 // Initialize a sprite as a reference point using a screen position
 fn init_screen_reference_sprite(world: &mut World, sprite_sheet: &SpriteSheetHandle) -> Entity {
     let mut transform = Transform::default();
-    transform.set_x(60.0);
-    transform.set_y(10.0);
-    transform.set_z(-20.0);
+    transform.set_translation_xyz(60.0, 10.0, -20.0);
     let sprite = SpriteRender {
         sprite_sheet: sprite_sheet.clone(),
         sprite_number: 0,
@@ -111,8 +108,7 @@ fn init_screen_reference_sprite(world: &mut World, sprite_sheet: &SpriteSheetHan
 
 fn init_player(world: &mut World, sprite_sheet: &SpriteSheetHandle) -> Entity {
     let mut transform = Transform::default();
-    transform.set_x(0.0);
-    transform.set_y(0.0);
+    transform.set_translation_xyz(0.0, 0.0, 0.0);
     let sprite = SpriteRender {
         sprite_sheet: sprite_sheet.clone(),
         sprite_number: 1,
@@ -128,7 +124,7 @@ fn init_player(world: &mut World, sprite_sheet: &SpriteSheetHandle) -> Entity {
 
 fn init_camera(world: &mut World, parent: Entity) -> Entity {
     let mut transform = Transform::default();
-    transform.set_z(1.0);
+    transform.set_translation_z(1.0);
     world
         .create_entity()
         .with(Camera::from(Projection::orthographic(

--- a/examples/sprites_ordered/main.rs
+++ b/examples/sprites_ordered/main.rs
@@ -205,7 +205,7 @@ impl Example {
         };
 
         let mut camera_transform = Transform::default();
-        camera_transform.set_xyz(0.0, 0.0, self.camera_z);
+        camera_transform.set_translation_xyz(0.0, 0.0, self.camera_z);
 
         let camera = world
             .create_entity()
@@ -255,7 +255,7 @@ impl Example {
         };
         // This `Transform` moves the sprites to the middle of the window
         let mut common_transform = Transform::default();
-        common_transform.set_xyz(width / 2.0 - sprite_offset_x, height / 2.0, 0.0);
+        common_transform.set_translation_xyz(width / 2.0 - sprite_offset_x, height / 2.0, 0.0);
 
         self.draw_sprites(world, &common_transform);
     }
@@ -281,7 +281,11 @@ impl Example {
             } else {
                 i as f32
             };
-            sprite_transform.set_xyz((i * sprite_w) as f32 * SPRITE_SPACING_RATIO, z, z);
+            sprite_transform.set_translation_xyz(
+                (i * sprite_w) as f32 * SPRITE_SPACING_RATIO,
+                z,
+                z,
+            );
 
             // This combines multiple `Transform`ations.
             sprite_transform.concat(&common_transform);


### PR DESCRIPTION
## Description

Reworks the names and documentation of many Transform functions to better reflect their actual function and reduce potential semantic confusion. Also fixes #1450

## Additions

`Transform::rotate_2d` - Perform a rotation about the axis perpendicular to X and Y, i.e. the most common way to rotate an object in a 2d game.
`Transform::set_rotation_(x_axis|y_axis|z_axis|2d)` - Set the rotation about the specified axis of the parent. Clears any previous rotations done.
`Transform::euler_angles` - Get the Euler angles of the current rotation in `(x, y, z)`

## Removals

- List API removals here if any

## Modifications

Renames several functions and changes their documentation to reflect the pattern:

`Transform::prepend_(rotation|translation)[_some_axis]`, which is the equivalent of the previous "global" functions, or `Transform::append_(rotation|translation)[_some_axis]`, which is the equivalent of the previous "local" functions. This better reflects what is actually happening, as previously the functions named "global" were not actually doing a transformation with respect to the global coordinate system, just with respect to the parent entity's coordinate system.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
