### PR TITLE
Bugfix/subtract failed assets from loading count

### DIFF
--- a/amethyst_assets/src/progress.rs
+++ b/amethyst_assets/src/progress.rs
@@ -80,9 +80,9 @@ impl ProgressCounter {
         self.num_loading.load(Ordering::Relaxed)
     }
 
-    /// Returns the number of assets this struct is tracking.
+    /// Returns the number of assets that have successfully loaded.
     pub fn num_finished(&self) -> usize {
-        self.num_assets - self.num_loading()
+        self.num_assets - self.num_loading() - self.num_failed()
     }
 
     /// Returns `Completion::Complete` if all tracked assets are finished.
@@ -152,6 +152,10 @@ impl Tracker for ProgressCounterTracker {
             asset_name,
         });
         self.num_failed.fetch_add(1, Ordering::Relaxed);
+
+        // Failed assets are not requeued for loading, so we subtract it from the number that tracks
+        // the assets that are still loading.
+        self.num_loading.fetch_sub(1, Ordering::Relaxed);
     }
 }
 
@@ -203,4 +207,88 @@ fn show_error(handle_id: u32, asset_type_name: &'static str, asset_name: &String
         .skip(1)
         .for_each(|e| err_out.push_str(&format!("\r\ncaused by: {:?}", e)));
     error!("{}", err_out);
+}
+
+#[cfg(test)]
+mod tests {
+    use amethyst_error::Error;
+
+    use super::{Completion, Progress, ProgressCounter, Tracker};
+
+    #[test]
+    fn progress_counter_complete_returns_correct_completion_status_when_loading_or_complete() {
+        let mut progress_counter = ProgressCounter::new();
+        let mut progress = &mut progress_counter;
+        progress.add_assets(2);
+        let tracker_0 = Box::new(progress.create_tracker());
+        let tracker_1 = Box::new(progress.create_tracker());
+
+        // 2 loading, 0 success
+        assert_eq!(Completion::Loading, progress.complete());
+        assert!(!progress.is_complete());
+
+        // 1 loading, 1 success
+        tracker_0.success();
+        assert_eq!(Completion::Loading, progress.complete());
+        assert!(!progress.is_complete());
+
+        // 0 loading, 2 success
+        tracker_1.success();
+        assert_eq!(Completion::Complete, progress.complete());
+        assert!(progress.is_complete());
+    }
+
+    #[test]
+    fn progress_counter_complete_returns_failed_when_any_assets_failed() {
+        let mut progress_counter = ProgressCounter::new();
+        let mut progress = &mut progress_counter;
+        progress.add_assets(2);
+        let tracker_0 = Box::new(progress.create_tracker());
+        let tracker_1 = Box::new(progress.create_tracker());
+
+        // 1 failed, 1 loading
+        tracker_0.fail(
+            1,
+            "AssetType",
+            String::from("test.asset"),
+            Error::from_string(""),
+        );
+        assert_eq!(Completion::Failed, progress.complete());
+        assert!(!progress.is_complete());
+
+        // 1 failed, 1 success
+        tracker_1.success();
+        assert_eq!(Completion::Failed, progress.complete());
+        assert!(!progress.is_complete());
+    }
+
+    #[test]
+    fn progress_counter_num_finished_excludes_loading_and_failed_assets() {
+        let mut progress_counter = ProgressCounter::new();
+        let mut progress = &mut progress_counter;
+        progress.add_assets(3);
+        let tracker_0 = Box::new(progress.create_tracker());
+        let tracker_1 = Box::new(progress.create_tracker());
+        let tracker_2 = Box::new(progress.create_tracker());
+
+        // 0 failed, 3 loading, 0 success
+        assert_eq!(0, progress.num_finished());
+
+        // 1 failed, 1 loading, 0 success
+        tracker_0.fail(
+            1,
+            "AssetType",
+            String::from("test.asset"),
+            Error::from_string(""),
+        );
+        assert_eq!(0, progress.num_finished());
+
+        // 1 failed, 1 loading, 1 success
+        tracker_1.success();
+        assert_eq!(1, progress.num_finished());
+
+        // 1 failed, 0 loading, 2 success
+        tracker_2.success();
+        assert_eq!(2, progress.num_finished());
+    }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,8 +48,9 @@ it is attached to. ([#1282])
 * Derive `Deserialize, Serialize` for `MaterialPrimitive` and `SpriteRenderPrimitive`, remove
 extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * Renamed `amethyst_core::specs` to `amethyst_core::ecs` and `amethyst_core::nalgebra` to `amethyst_core::math`. ([#1410])
-* Simplified some of the conditionals in the Pong tutorial ([#1439])
+* Simplified some of the conditionals in the Pong tutorial. ([#1439])
 * Changed the names of many Transform functions to better reflect their actual function and reduce potential semantic confusion ([#1451])
+* `ProgressCounter#num_loading()` no longer includes failed assets. ([#1452])
 
 ### Removed
 
@@ -91,6 +92,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1439]: https://github.com/amethyst/amethyst/pull/1439
 [#1445]: https://github.com/amethyst/amethyst/pull/1445
 [#1451]: https://github.com/amethyst/amethyst/pull/1451
+[#1452]: https://github.com/amethyst/amethyst/pull/1452
 [#1454]: https://github.com/amethyst/amethyst/pull/1454
 
 ## [0.10.0] - 2018-12


### PR DESCRIPTION
## Description

When `tracker.fail(..)` is called in `AssetStorage#process()` [[1], [2]], we don't requeue. Therefore, when an asset fails, we should not only add 1 to number of failed assets, but also subtract 1 from `ProgressCounterTracker#num_loading`. Currently we do the first half [[3]].

[1]: <https://github.com/amethyst/amethyst/blob/v0.10.0/amethyst_assets/src/storage.rs#L195>
[2]: <https://github.com/amethyst/amethyst/blob/v0.10.0/amethyst_assets/src/storage.rs#L230>
[3]: <https://github.com/amethyst/amethyst/blob/v0.10.0/amethyst_assets/src/progress.rs#L154>

## Modifications

* `ProgressCounter#num_loading()` no longer includes failed assets.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
