### PR TITLE
Update wavefront_obj crate for faster obj asset loading

### DIFF
--- a/amethyst_renderer/Cargo.toml
+++ b/amethyst_renderer/Cargo.toml
@@ -48,7 +48,7 @@ ron = "0.4"
 serde = { version = "1", features = ["derive"] }
 shred-derive = "0.5"
 shred = "0.7"
-wavefront_obj = "5.1"
+wavefront_obj = "6.0"
 winit = { version = "0.18", features = ["serde", "icon_loading"] }
 
 thread_profiler = { version = "0.3", optional = true }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -55,6 +55,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 
 ### Fixed
 
+* Optimize loading of wavefront obj mesh assets by getting rid of unnecessary allocations. ([#1454])
 * Fixed the "json" feature for amethyst_assets. ([#1302])
 * Fixed default system font loading to accept uppercase extension ("TTF"). ([#1328])
 * Set width and height of Pong Paddles ([#1363])
@@ -90,6 +91,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1439]: https://github.com/amethyst/amethyst/pull/1439
 [#1445]: https://github.com/amethyst/amethyst/pull/1445
 [#1451]: https://github.com/amethyst/amethyst/pull/1451
+[#1454]: https://github.com/amethyst/amethyst/pull/1454
 
 ## [0.10.0] - 2018-12
 


### PR DESCRIPTION
## Description

This updates the `wavefront_obj` crate in order to include latest optimization changes from https://github.com/PistonDevelopers/wavefront_obj/pull/57

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [ ] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ ] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
