### PR TITLE
Correct sprite sheet field names in prefab files.

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -461,8 +461,8 @@ are on the sheet. Let's create, right next to it, a file called
 
 ```text,ignore
 (
-    spritesheet_width: 8,
-    spritesheet_height: 16,
+    texture_width: 8,
+    texture_height: 16,
     sprites: [
         (
             x: 0,

--- a/book/src/sprites/define_the_sprite_sheet.md
+++ b/book/src/sprites/define_the_sprite_sheet.md
@@ -10,10 +10,10 @@ Here is an example of such a definition file:
 
 ```text,ignore
 (
-    // Width of the sprite sheet
-    spritesheet_width: 48,
-    // Height of the sprite sheet
-    spritesheet_height: 16,
+    // Width of the texture used by the sprite sheet
+    texture_width: 48,
+    // Height of the texture used by the sprite sheet
+    texture_height: 16,
     // List of sprites the sheet holds
     sprites: [
         (

--- a/examples/assets/texture/pong_spritesheet.ron
+++ b/examples/assets/texture/pong_spritesheet.ron
@@ -1,6 +1,6 @@
 (
-    spritesheet_width: 8,
-    spritesheet_height: 16,
+    texture_width: 8,
+    texture_height: 16,
     sprites: [
         (
             x: 0,

--- a/examples/sprite_camera_follow/resources/Background.ron
+++ b/examples/sprite_camera_follow/resources/Background.ron
@@ -1,6 +1,6 @@
 (
-  spritesheet_width: 512,
-  spritesheet_height: 512,
+  texture_width: 512,
+  texture_height: 512,
   sprites: [
     (
       x: 0,

--- a/examples/sprite_camera_follow/resources/Circle_Spritesheet.ron
+++ b/examples/sprite_camera_follow/resources/Circle_Spritesheet.ron
@@ -1,6 +1,6 @@
 (
-  spritesheet_width: 128,
-  spritesheet_height: 64,
+  texture_width: 128,
+  texture_height: 64,
   sprites: [
     (
       x: 0,


### PR DESCRIPTION
## Description

Fixed prefab files and documentation that used the old `spritesheet_width/height` sprite sheet prefab field names.

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Ran `cargo test --all` locally if this modified any rs files.
- **n/a** Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- **n/a** Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
