### PR TITLE
Use paddle constants to avoid paddle size bug

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-05.md
+++ b/book/src/pong-tutorial/pong-tutorial-05.md
@@ -317,8 +317,8 @@ use amethyst::{
 #     fn new(side: Side) -> Paddle {
 #         Paddle {
 #             side: side,
-#             width: 1.0,
-#             height: 1.0,
+#             width: PADDLE_WIDTH,
+#             height: PADDLE_HEIGHT,
 #         }
 #     }
 # }


### PR DESCRIPTION
## Description

Fix the last remaining paddle size bug in the pong example, where the paddle's bounding box is initialized as smaller than its sprite.  I encountered this bug today while following the `latest` release of the book, but it looks like someone has mostly cleaned up `master` since then.

## Modifications

- Replace 1.0 width/height for paddle with defined constants.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [X] Ran `cargo test --all` locally if this modified any rs files.
- [ ] Ran `cargo +stable fmt --all` locally if this modified any rs files. **Rustup claims the required package does not exist for x86_64-pc-windows-msvc.  Also, I did not modify formatting**
- [X] Updated the content of the book if this PR would make the book outdated.
- [X] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [X] Added unit tests for new APIs if any were added in this PR.
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
