### PR TITLE
Add functionality to keep the aspect ratio when stretching a UiTransform

### DIFF
--- a/amethyst_ui/src/button/builder.rs
+++ b/amethyst_ui/src/button/builder.rs
@@ -341,6 +341,7 @@ impl<G: PartialEq + Send + Sync + 'static> UiButtonBuilder<G> {
                     .with_stretch(Stretch::XY {
                         x_margin: 0.,
                         y_margin: 0.,
+                        keep_aspect_ratio: false,
                     }),
             )
             .expect("Unreachable: Inserting newly created entity");

--- a/amethyst_ui/src/layout.rs
+++ b/amethyst_ui/src/layout.rs
@@ -119,7 +119,7 @@ pub enum Stretch {
         x_margin: f32,
         /// The margin length for the height
         y_margin: f32,
-        /// Keep the aspect ratio
+        /// Keep the aspect ratio by adding more margin to one axis when necessary
         keep_aspect_ratio: bool,
     },
 }

--- a/amethyst_ui/src/layout.rs
+++ b/amethyst_ui/src/layout.rs
@@ -119,6 +119,8 @@ pub enum Stretch {
         x_margin: f32,
         /// The margin length for the height
         y_margin: f32,
+        /// Keep the aspect ratio
+        keep_aspect_ratio: bool,
     },
 }
 
@@ -246,10 +248,28 @@ impl<'a> System<'a> for UiTransformSystem {
                             transform.width,
                             parent_transform_copy.pixel_height - y_margin * 2.0,
                         ),
-                        Stretch::XY { x_margin, y_margin } => (
+                        Stretch::XY {
+                            keep_aspect_ratio: false,
+                            x_margin,
+                            y_margin,
+                        } => (
                             parent_transform_copy.pixel_width - x_margin * 2.0,
                             parent_transform_copy.pixel_height - y_margin * 2.0,
                         ),
+                        Stretch::XY {
+                            keep_aspect_ratio: true,
+                            x_margin,
+                            y_margin,
+                        } => {
+                            let scale = f32::min(
+                                (parent_transform_copy.pixel_width - x_margin * 2.0)
+                                    / transform.width,
+                                (parent_transform_copy.pixel_height - y_margin * 2.0)
+                                    / transform.height,
+                            );
+
+                            (transform.width * scale, transform.height * scale)
+                        }
                     };
                     transform.width = new_size.0;
                     transform.height = new_size.1;
@@ -319,10 +339,26 @@ where
             Stretch::NoStretch => (transform.width, transform.height),
             Stretch::X { x_margin } => (screen_dim.width() - x_margin * 2.0, transform.height),
             Stretch::Y { y_margin } => (transform.width, screen_dim.height() - y_margin * 2.0),
-            Stretch::XY { x_margin, y_margin } => (
+            Stretch::XY {
+                keep_aspect_ratio: false,
+                x_margin,
+                y_margin,
+            } => (
                 screen_dim.width() - x_margin * 2.0,
                 screen_dim.height() - y_margin * 2.0,
             ),
+            Stretch::XY {
+                keep_aspect_ratio: true,
+                x_margin,
+                y_margin,
+            } => {
+                let scale = f32::min(
+                    (screen_dim.width() - x_margin * 2.0) / transform.width,
+                    (screen_dim.height() - y_margin * 2.0) / transform.height,
+                );
+
+                (transform.width * scale, transform.height * scale)
+            }
         };
         transform.width = new_size.0;
         transform.height = new_size.1;

--- a/amethyst_ui/src/prefab.rs
+++ b/amethyst_ui/src/prefab.rs
@@ -965,6 +965,7 @@ fn button_text_transform<G>(mut id: String) -> UiTransformBuilder<G> {
         .with_stretch(Stretch::XY {
             x_margin: 0.,
             y_margin: 0.,
+            keep_aspect_ratio: false,
         })
         .transparent()
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -55,6 +55,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * Changed the names of many Transform functions to better reflect their actual function and reduce potential semantic confusion ([#1451])
 * `ProgressCounter#num_loading()` no longer includes failed assets. ([#1452])
 * `SpriteSheetFormat` field renamed from `spritesheet_*` to `texture_*`. ([#1469])
+* Add new `keep_aspect_ratio` field to `Stretch::XY`. ([#1480])
 
 ### Removed
 
@@ -103,6 +104,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1442]: https://github.com/amethyst/amethyst/pull/1442
 [#1469]: https://github.com/amethyst/amethyst/pull/1469
 [#1481]: https://github.com/amethyst/amethyst/pull/1481
+[#1480]: https://github.com/amethyst/amethyst/pull/1480
 
 ## [0.10.0] - 2018-12
 

--- a/examples/assets/ui/example.ron
+++ b/examples/assets/ui/example.ron
@@ -3,7 +3,7 @@ Container(
     transform: (
         id: "background",
         anchor: Middle,
-        stretch: XY( x_margin: 0., y_margin: 0.),
+        stretch: XY( x_margin: 0., y_margin: 0., keep_aspect_ratio: false),
         width: 20.,
         height: 20.,
     ),
@@ -31,7 +31,7 @@ Container(
                         width: 32.,
                         height: 32.,
                         anchor: Middle,
-                        stretch: XY( x_margin: 0., y_margin: 10.),
+                        stretch: XY( x_margin: 0., y_margin: 10., keep_aspect_ratio: false),
                     ),
                     image: (
                         image: Data(Rgba((0.18, 0.05, 0.85, 1.0), (channel: Srgb))),
@@ -78,7 +78,7 @@ Container(
                         height: 75.,
                         tab_order: 1,
                         anchor: Middle,
-                        stretch: XY(x_margin: 0., y_margin: 0.),
+                        stretch: XY(x_margin: 0., y_margin: 0., keep_aspect_ratio: false),
                         mouse_reactive: true,
                         selectable: 0,
                     ),


### PR DESCRIPTION
## Description

Makes it possible for `UiTransform`s to keep their aspect ratio when stretched to fit their parent. 
This is a breaking change, because it adds a new field to the `Stretch::XY` struct.

## Modifications

- Changed the `Stretch::XY` enum variant struct, adding a new `keep_aspect_ratio` field.
- Updated the `UiTransform` system to use this new field when stretching transforms.
- Updated all the places where `Stretch::XY` is instantiated, with this new field set to false.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new APIs if any were added in this PR. **Not sure how to add a test for this since it involves running a system with entities.**
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
