### PR TITLE
Update pong-tutorial-02.md

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -22,6 +22,16 @@ of how Amethyst works, especially if you're new to ECS.
 
 Let's create a new file called `pong.rs` to hold our core game logic. We can
 move the `Pong` struct over here, and the `impl SimpleState for Pong` block as well.
+
+```rust,ignore
+extern crate amethyst;
+use amethyst::prelude::*;
+
+pub struct Pong;
+
+impl SimpleState for Pong {}
+```
+
 Then, in `main.rs` declare it as a module and import it:
 
 ```rust,ignore


### PR DESCRIPTION
## Description

Simple update to make it clear that the Pong struct needs to be made public and that Amethyst imports must exist in the new file as well.

## Additions

None

## Removals

None

## Modifications

None

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
