### PR TITLE
Allows to refer to SpriteSheetPrefab by name. 

### DIFF
--- a/amethyst_renderer/src/sprite/prefab.rs
+++ b/amethyst_renderer/src/sprite/prefab.rs
@@ -181,6 +181,7 @@ impl SpriteSheetLoadedSet {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
 pub enum SpriteSheetReference {
     Index(usize),
     Name(String),

--- a/examples/assets/prefab/sprite_animation.ron
+++ b/examples/assets/prefab/sprite_animation.ron
@@ -41,10 +41,11 @@ Prefab(
                                 ],
                             )),
                         ],
+                        name: "bat",
                     ),
                     // SpriteRenderPrefab
                     render: (
-                        sheet: 0,
+                        sheet: Index(0),
                         sprite_number: 0,
                     ),
                     // Transform
@@ -87,7 +88,7 @@ Prefab(
                     render: (
                         // We have already added a SpriteSheet for the previous entity,
                         // now we can refer to it
-                        sheet: 0,
+                        sheet: Name("bat"),
                         sprite_number: 6,
                     ),
                     transform: (

--- a/examples/assets/prefab/sprite_animation.ron
+++ b/examples/assets/prefab/sprite_animation.ron
@@ -41,11 +41,12 @@ Prefab(
                                 ],
                             )),
                         ],
+                        // optional
                         name: "bat",
                     ),
                     // SpriteRenderPrefab
                     render: (
-                        sheet: Index(0),
+                        sheet: 0,
                         sprite_number: 0,
                     ),
                     // Transform
@@ -88,7 +89,7 @@ Prefab(
                     render: (
                         // We have already added a SpriteSheet for the previous entity,
                         // now we can refer to it
-                        sheet: Name("bat"),
+                        sheet: "bat", // or sheet: 0,
                         sprite_number: 6,
                     ),
                     transform: (


### PR DESCRIPTION
## Description

Allows to refer to SpriteSheetPrefab by name. This can be useful when you load prefabs from several files.

## Additions

- `name` field to `SpriteSheetPrefab::Sheet`

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
