### PR TITLE
Adding a register line in the creating entities section of the book

### DIFF
--- a/book/src/concepts/world.md
+++ b/book/src/concepts/world.md
@@ -74,6 +74,7 @@ Please note that **in order to use this syntax, you need to import the ``amethys
 # }
 # fn main() {
 #   let mut world = amethyst::ecs::World::new();
+#   world.register::<MyComponent>();
     use amethyst::prelude::Builder;
 
     let mut entity_builder = world.create_entity();

--- a/book/src/concepts/world.md
+++ b/book/src/concepts/world.md
@@ -74,7 +74,7 @@ Please note that **in order to use this syntax, you need to import the ``amethys
 # }
 # fn main() {
 #   let mut world = amethyst::ecs::World::new();
-#   world.register::<MyComponent>();
+    world.register::<MyComponent>();
     use amethyst::prelude::Builder;
 
     let mut entity_builder = world.create_entity();


### PR DESCRIPTION
## Description

The with() function used to create entities section of the book requires that the component is first registered which isn't done so in the book.

I'm new to programming and GitHub so please tell me if I am doing something incorrectly.

## Modifications

- added register line to the concepts\world\creating entities

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Ran `cargo test --all` locally if this modified any rs files.
- [ ] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [X] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new APIs if any were added in this PR.
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
