### PR TITLE
Maintenance/improve amethyst test failure message

### DIFF
--- a/amethyst_test/src/amethyst_application.rs
+++ b/amethyst_test/src/amethyst_application.rs
@@ -940,17 +940,16 @@ mod test {
 
     #[test]
     #[cfg(feature = "graphics")]
-    fn render_base_application_can_load_sprite_render_animations() {
+    fn render_base_application_can_load_sprite_render_animations() -> Result<(), Error> {
         use crate::SpriteRenderAnimationFixture;
 
-        assert!(AmethystApplication::render_base(
+        AmethystApplication::render_base(
             "render_base_application_can_load_sprite_render_animations",
-            false
+            false,
         )
         .with_effect(SpriteRenderAnimationFixture::effect)
         .with_assertion(SpriteRenderAnimationFixture::assertion)
         .run()
-        .is_ok());
     }
 
     #[test]

--- a/amethyst_test/src/amethyst_application.rs
+++ b/amethyst_test/src/amethyst_application.rs
@@ -733,35 +733,30 @@ mod test {
     use crate::{EffectReturn, FunctionState, PopState};
 
     #[test]
-    fn bundle_build_is_ok() {
-        assert!(AmethystApplication::blank()
-            .with_bundle(BundleZero)
-            .run()
-            .is_ok());
+    fn bundle_build_is_ok() -> Result<(), Error> {
+        AmethystApplication::blank().with_bundle(BundleZero).run()
     }
 
     #[test]
-    fn load_multiple_bundles() {
-        assert!(AmethystApplication::blank()
+    fn load_multiple_bundles() -> Result<(), Error> {
+        AmethystApplication::blank()
             .with_bundle(BundleZero)
             .with_bundle(BundleOne)
             .run()
-            .is_ok());
     }
 
     #[test]
-    fn assertion_when_resource_is_added_succeeds() {
+    fn assertion_when_resource_is_added_succeeds() -> Result<(), Error> {
         let assertion_fn = |world: &mut World| {
             world.read_resource::<ApplicationResource>();
             world.read_resource::<ApplicationResourceNonDefault>();
         };
 
-        assert!(AmethystApplication::blank()
+        AmethystApplication::blank()
             .with_bundle(BundleZero)
             .with_bundle(BundleOne)
             .with_assertion(assertion_fn)
             .run()
-            .is_ok());
     }
 
     #[test]
@@ -780,7 +775,7 @@ mod test {
     }
 
     #[test]
-    fn assertion_switch_with_loading_state_with_add_resource_succeeds() {
+    fn assertion_switch_with_loading_state_with_add_resource_succeeds() -> Result<(), Error> {
         let state_fns = || {
             let assertion_fn = |world: &mut World| {
                 world.read_resource::<LoadResource>();
@@ -791,14 +786,11 @@ mod test {
             LoadingState::new(assertion_state)
         };
 
-        assert!(AmethystApplication::blank()
-            .with_state(state_fns)
-            .run()
-            .is_ok());
+        AmethystApplication::blank().with_state(state_fns).run()
     }
 
     #[test]
-    fn assertion_push_with_loading_state_with_add_resource_succeeds() {
+    fn assertion_push_with_loading_state_with_add_resource_succeeds() -> Result<(), Error> {
         // Alternative to embedding the `FunctionState` is to switch to a `PopState` but still
         // provide the assertion function
         let state_fns = || LoadingState::new(PopState);
@@ -806,11 +798,10 @@ mod test {
             world.read_resource::<LoadResource>();
         };
 
-        assert!(AmethystApplication::blank()
+        AmethystApplication::blank()
             .with_state(state_fns)
             .with_assertion(assertion_fn)
             .run()
-            .is_ok());
     }
 
     #[test]
@@ -848,7 +839,7 @@ mod test {
     }
 
     #[test]
-    fn game_data_must_update_before_assertion() {
+    fn game_data_must_update_before_assertion() -> Result<(), Error> {
         let effect_fn = |world: &mut World| {
             let handles = vec![
                 AssetZeroLoader::load(world, AssetZero(10)).unwrap(),
@@ -865,16 +856,15 @@ mod test {
             assert_eq!(Some(&AssetZero(20)), store.get(&asset_zero_handles[1]));
         };
 
-        assert!(AmethystApplication::blank()
+        AmethystApplication::blank()
             .with_bundle(BundleAsset)
             .with_effect(effect_fn)
             .with_assertion(assertion_fn)
             .run()
-            .is_ok());
     }
 
     #[test]
-    fn execution_order_is_setup_state_effect_assertion() {
+    fn execution_order_is_setup_state_effect_assertion() -> Result<(), Error> {
         struct Setup;
         let setup_fns = |world: &mut World| world.add_resource(Setup);
         let state_fns = || {
@@ -897,18 +887,17 @@ mod test {
             assert_eq!(Some(&AssetZero(10)), store.get(&asset_zero_handles[0]));
         };
 
-        assert!(AmethystApplication::blank()
+        AmethystApplication::blank()
             .with_bundle(BundleAsset)
             .with_setup(setup_fns)
             .with_state(state_fns)
             .with_effect(effect_fn)
             .with_assertion(assertion_fn)
             .run()
-            .is_ok());
     }
 
     #[test]
-    fn base_application_can_load_ui() {
+    fn base_application_can_load_ui() -> Result<(), Error> {
         let assertion_fn = |world: &mut World| {
             // Next line would panic if `UiBundle` wasn't added.
             world.read_resource::<AssetStorage<FontAsset>>();
@@ -917,25 +906,23 @@ mod test {
             world.read_resource::<ScreenDimensions>();
         };
 
-        assert!(AmethystApplication::ui_base::<String, String>()
+        AmethystApplication::ui_base::<String, String>()
             .with_assertion(assertion_fn)
             .run()
-            .is_ok());
     }
 
     #[test]
     #[cfg(feature = "graphics")]
-    fn render_base_application_can_load_material_animations() {
+    fn render_base_application_can_load_material_animations() -> Result<(), Error> {
         use crate::MaterialAnimationFixture;
 
-        assert!(AmethystApplication::render_base(
+        AmethystApplication::render_base(
             "render_base_application_can_load_material_animations",
-            false
+            false,
         )
         .with_effect(MaterialAnimationFixture::effect)
         .with_assertion(MaterialAnimationFixture::assertion)
         .run()
-        .is_ok());
     }
 
     #[test]
@@ -953,7 +940,7 @@ mod test {
     }
 
     #[test]
-    fn with_system_runs_system_every_tick() {
+    fn with_system_runs_system_every_tick() -> Result<(), Error> {
         let effect_fn = |world: &mut World| {
             let entity = world.create_entity().with(ComponentZero(0)).build();
 
@@ -971,13 +958,12 @@ mod test {
             component_zero.0
         };
 
-        assert!(AmethystApplication::blank()
+        AmethystApplication::blank()
             .with_system(SystemEffect, "system_effect", &[])
             .with_effect(effect_fn)
             .with_assertion(|world| assert_eq!(1, get_component_zero_value(world)))
             .with_assertion(|world| assert_eq!(2, get_component_zero_value(world)))
             .run()
-            .is_ok());
     }
 
     #[test]
@@ -988,7 +974,7 @@ mod test {
     }
 
     #[test]
-    fn with_system_single_runs_system_once() {
+    fn with_system_single_runs_system_once() -> Result<(), Error> {
         let assertion_fn = |world: &mut World| {
             let entity = world.read_resource::<EffectReturn<Entity>>().0.clone();
 
@@ -1001,7 +987,7 @@ mod test {
             assert_eq!(1, component_zero.0);
         };
 
-        assert!(AmethystApplication::blank()
+        AmethystApplication::blank()
             .with_setup(|world| {
                 world.register::<ComponentZero>();
 
@@ -1012,15 +998,14 @@ mod test {
             .with_assertion(assertion_fn)
             .with_assertion(assertion_fn)
             .run()
-            .is_ok());
     }
 
     // Double usage tests
     // If the second call panics, then the setup functions were not executed in the right order.
 
     #[test]
-    fn with_setup_invoked_twice_should_run_in_specified_order() {
-        assert!(AmethystApplication::blank()
+    fn with_setup_invoked_twice_should_run_in_specified_order() -> Result<(), Error> {
+        AmethystApplication::blank()
             .with_setup(|world| {
                 world.add_resource(ApplicationResource);
             })
@@ -1028,12 +1013,11 @@ mod test {
                 world.read_resource::<ApplicationResource>();
             })
             .run()
-            .is_ok());
     }
 
     #[test]
-    fn with_effect_invoked_twice_should_run_in_the_specified_order() {
-        assert!(AmethystApplication::blank()
+    fn with_effect_invoked_twice_should_run_in_the_specified_order() -> Result<(), Error> {
+        AmethystApplication::blank()
             .with_effect(|world| {
                 world.add_resource(ApplicationResource);
             })
@@ -1041,12 +1025,11 @@ mod test {
                 world.read_resource::<ApplicationResource>();
             })
             .run()
-            .is_ok());
     }
 
     #[test]
-    fn with_assertion_invoked_twice_should_run_in_the_specified_order() {
-        assert!(AmethystApplication::blank()
+    fn with_assertion_invoked_twice_should_run_in_the_specified_order() -> Result<(), Error> {
+        AmethystApplication::blank()
             .with_assertion(|world| {
                 world.add_resource(ApplicationResource);
             })
@@ -1054,44 +1037,48 @@ mod test {
                 world.read_resource::<ApplicationResource>();
             })
             .run()
-            .is_ok());
     }
 
     #[test]
-    fn with_state_invoked_twice_should_run_in_the_specified_order() {
-        assert!(AmethystApplication::blank()
-            .with_state(|| FunctionState::new(|world| {
-                world.add_resource(ApplicationResource);
-            }))
-            .with_state(|| FunctionState::new(|world| {
-                world.read_resource::<ApplicationResource>();
-            }))
+    fn with_state_invoked_twice_should_run_in_the_specified_order() -> Result<(), Error> {
+        AmethystApplication::blank()
+            .with_state(|| {
+                FunctionState::new(|world| {
+                    world.add_resource(ApplicationResource);
+                })
+            })
+            .with_state(|| {
+                FunctionState::new(|world| {
+                    world.read_resource::<ApplicationResource>();
+                })
+            })
             .run()
-            .is_ok());
     }
 
     #[test]
-    fn setup_can_be_invoked_after_with_state() {
-        assert!(AmethystApplication::blank()
-            .with_state(|| FunctionState::new(|world| {
-                world.add_resource(ApplicationResource);
-            }))
+    fn setup_can_be_invoked_after_with_state() -> Result<(), Error> {
+        AmethystApplication::blank()
+            .with_state(|| {
+                FunctionState::new(|world| {
+                    world.add_resource(ApplicationResource);
+                })
+            })
             .with_setup(|world| {
                 world.read_resource::<ApplicationResource>();
             })
             .run()
-            .is_ok());
     }
 
     #[test]
-    fn with_state_invoked_after_with_resource_should_work() {
-        assert!(AmethystApplication::blank()
+    fn with_state_invoked_after_with_resource_should_work() -> Result<(), Error> {
+        AmethystApplication::blank()
             .with_resource(ApplicationResource)
-            .with_state(|| FunctionState::new(|world| {
-                world.read_resource::<ApplicationResource>();
-            }))
+            .with_state(|| {
+                FunctionState::new(|world| {
+                    world.read_resource::<ApplicationResource>();
+                })
+            })
             .run()
-            .is_ok());
     }
 
     // === Resources === //

--- a/book/src/testing.md
+++ b/book/src/testing.md
@@ -46,16 +46,13 @@ The following shows a simple example of testing a `State`. More examples are in 
 # }
 #
 #[test]
-fn loading_state_adds_load_resource() {
-    assert!(
-        AmethystApplication::blank()
-            .with_state(|| LoadingState::new())
-            .with_assertion(|world| {
-                world.read_resource::<LoadResource>();
-            })
-            .run()
-            .is_ok()
-    );
+fn loading_state_adds_load_resource() -> Result<(), Error> {
+    AmethystApplication::blank()
+        .with_state(|| LoadingState::new())
+        .with_assertion(|world| {
+            world.read_resource::<LoadResource>();
+        })
+        .run()
 }
 ```
 
@@ -120,22 +117,20 @@ fn test_name() {
 }
 ```
 
-Finally, call `.run()` to run the application. This returns `amethyst::Result<()>`, so you can
-wrap it in an `assert!(..);`:
+Finally, call `.run()` to run the application. This returns `amethyst::Result<()>`, so we return that as part of the function:
 
 ```rust,edition2018,no_run,noplaypen
+# extern crate amethyst;
 # extern crate amethyst_test;
 #
+# use amethyst::Error;
 # use amethyst_test::prelude::*;
 #
 #[test]
-fn test_name() {
+fn test_name() -> Result<(), Error> {
     let visibility = false; // Whether the window should be shown
-    assert!(
-        AmethystApplication::render_base("test_name", visibility)
-            // ...
-            .run()
-            .is_ok()
-    );
+    AmethystApplication::render_base("test_name", visibility)
+        // ...
+        .run()
 }
 ```

--- a/book/src/testing/test_examples.md
+++ b/book/src/testing/test_examples.md
@@ -8,10 +8,10 @@
 #
 # use amethyst_test::prelude::*;
 # use amethyst::{
-#     error::Error,
 #     core::bundle::SystemBundle,
 #     ecs::prelude::*,
 #     prelude::*,
+#     Error,
 # };
 #
 # #[derive(Debug)]
@@ -43,17 +43,14 @@ impl<'a, 'b> SystemBundle<'a, 'b> for MyBundle {
 }
 
 // #[test]
-fn bundle_registers_system_with_resource() {
-    assert!(
-        AmethystApplication::blank()
-            .with_bundle(MyBundle)
-            .with_assertion(|world| {
-                // The next line would panic if the resource wasn't added.
-                world.read_resource::<ApplicationResource>();
-            })
-            .run()
-            .is_ok()
-    );
+fn bundle_registers_system_with_resource() -> Result<(), Error> {
+    AmethystApplication::blank()
+        .with_bundle(MyBundle)
+        .with_assertion(|world| {
+            // The next line would panic if the resource wasn't added.
+            world.read_resource::<ApplicationResource>();
+        })
+        .run()
 }
 #
 # fn main() {
@@ -71,6 +68,7 @@ fn bundle_registers_system_with_resource() {
 # use amethyst::{
 #     ecs::prelude::*,
 #     prelude::*,
+#     Error,
 # };
 #
 struct MyComponent(pub i32);
@@ -91,28 +89,25 @@ impl<'s> System<'s> for MySystem {
 }
 
 // #[test]
-fn system_increases_component_value_by_one() {
-    assert!(
-        AmethystApplication::blank()
-            .with_system(MySystem, "my_system", &[])
-            .with_effect(|world| {
-                let entity = world.create_entity().with(MyComponent(0)).build();
-                world.add_resource(EffectReturn(entity));
-            })
-            .with_assertion(|world| {
-                let entity = world.read_resource::<EffectReturn<Entity>>().0.clone();
+fn system_increases_component_value_by_one() -> Result<(), Error> {
+    AmethystApplication::blank()
+        .with_system(MySystem, "my_system", &[])
+        .with_effect(|world| {
+            let entity = world.create_entity().with(MyComponent(0)).build();
+            world.add_resource(EffectReturn(entity));
+        })
+        .with_assertion(|world| {
+            let entity = world.read_resource::<EffectReturn<Entity>>().0.clone();
 
-                let my_component_storage = world.read_storage::<MyComponent>();
-                let my_component = my_component_storage
-                    .get(entity)
-                    .expect("Entity should have a `MyComponent` component.");
+            let my_component_storage = world.read_storage::<MyComponent>();
+            let my_component = my_component_storage
+                .get(entity)
+                .expect("Entity should have a `MyComponent` component.");
 
-                // If the system ran, the value in the `MyComponent` should be 1.
-                assert_eq!(1, my_component.0);
-            })
-            .run()
-            .is_ok()
-    );
+            // If the system ran, the value in the `MyComponent` should be 1.
+            assert_eq!(1, my_component.0);
+        })
+        .run()
 }
 #
 # fn main() {
@@ -132,6 +127,7 @@ This is useful when your system must run *after* some setup has been done, for e
 # use amethyst::{
 #     ecs::prelude::*,
 #     prelude::*,
+#     Error,
 # };
 #
 // !Default
@@ -149,22 +145,19 @@ impl<'s> System<'s> for MySystem {
 }
 
 // #[test]
-fn system_increases_resource_value_by_one() {
-    assert!(
-        AmethystApplication::blank()
-            .with_setup(|world| {
-                world.add_resource(MyResource(0));
-            })
-            .with_system_single(MySystem, "my_system", &[])
-            .with_assertion(|world| {
-                let my_resource = world.read_resource::<MyResource>();
+fn system_increases_resource_value_by_one() -> Result<(), Error> {
+    AmethystApplication::blank()
+        .with_setup(|world| {
+            world.add_resource(MyResource(0));
+        })
+        .with_system_single(MySystem, "my_system", &[])
+        .with_assertion(|world| {
+            let my_resource = world.read_resource::<MyResource>();
 
-                // If the system ran, the value in the `MyResource` should be 1.
-                assert_eq!(1, my_resource.0);
-            })
-            .run()
-            .is_ok()
-    );
+            // If the system ran, the value in the `MyResource` should be 1.
+            assert_eq!(1, my_resource.0);
+        })
+        .run()
 }
 #
 # fn main() {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ it is attached to. ([#1282])
 * Add `position_from_screen` to `Camera`. Transforms position from screen space to camera space. ([#1442])
 * Add `SpriteScenePrefab`. Allows load sprites from a grid and add them to the `SpriteRenderer`. ([#1469])
 * Add `Widgets` resource. Allows keeping track of UI entities and their components and iterating over them. ([#1390])
+* `AmethystApplication` takes in application name using `with_app_name(..)`. ([#1499])
 
 ### Changed
 
@@ -58,6 +59,8 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * `SpriteSheetFormat` field renamed from `spritesheet_*` to `texture_*`. ([#1469])
 * Add new `keep_aspect_ratio` field to `Stretch::XY`. ([#1480])
 * Renamed `Text` UI Prefab to `Label` in preparation for full widget integration in prefabs. ([#1390])
+* `amethyst_test` includes the application name of a failing test. ([#1499])
+* `amethyst_test` returns the panic message of a failed execution. ([#1499])
 
 ### Removed
 
@@ -88,6 +91,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1371]: https://github.com/amethyst/amethyst/pull/1371
 [#1373]: https://github.com/amethyst/amethyst/pull/1373
 [#1388]: https://github.com/amethyst/amethyst/pull/1388
+[#1390]: https://github.com/amethyst/amethyst/pull/1390
 [#1397]: https://github.com/amethyst/amethyst/pull/1397
 [#1404]: https://github.com/amethyst/amethyst/pull/1404
 [#1408]: https://github.com/amethyst/amethyst/pull/1408
@@ -108,7 +112,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1469]: https://github.com/amethyst/amethyst/pull/1469
 [#1481]: https://github.com/amethyst/amethyst/pull/1481
 [#1480]: https://github.com/amethyst/amethyst/pull/1480
-[#1390]: https://github.com/amethyst/amethyst/pull/1390
+[#1499]: https://github.com/amethyst/amethyst/pull/1499
 [#1501]: https://github.com/amethyst/amethyst/pull/1501
 
 ## [0.10.0] - 2018-12


### PR DESCRIPTION
## Description

* Better error messages:

    Instead of:

    ```
    thread '<unnamed>' panicked at 'Failed to run Amethyst application: Any'
    ```

    We get:

    ```
    Error: Error { inner: Inner { source: None, backtrace: None, error: StringError("rarara") } }
    thread 'amethyst_application::test::render_base_application_can_load_sprite_render_animations' panicked at 'assertion failed: `(left == right)`
      left: `1`,
     right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', src\libtest\lib.rs:335:5
    ```

* When you have 5 tests, and test 2 fails, tests 3, 4 and 5 still run instead of all failing with a mutex `PoisionedError`.

## Additions

* `AmethystApplication` takes in application name using `with_app_name(..)`.

## Modifications

* `amethyst_test` includes the application name of a failing test.
* `amethyst_test` returns the panic message of a failed execution.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
