### PR TITLE
Bugfix/prefab data derive tuple suffix

### DIFF
--- a/amethyst_derive/src/prefab_data.rs
+++ b/amethyst_derive/src/prefab_data.rs
@@ -1,4 +1,4 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{Literal, TokenStream};
 use quote::quote;
 use syn::{Attribute, Data, DeriveInput, Generics, Ident, Meta, NestedMeta, Type};
 
@@ -48,14 +48,15 @@ fn impl_prefab_data_aggregate(ast: &DeriveInput) -> TokenStream {
         }
     });
     let adds = (0..data.len()).map(|n| {
+        let tuple_index = Literal::usize_unsuffixed(n);
         let (_, name, is_component) = &data[n];
         if *is_component {
             quote! {
-                system_data.#n.insert(entity, self.#name.clone())?;
+                system_data.#tuple_index.insert(entity, self.#name.clone())?;
             }
         } else {
             quote! {
-                self.#name.add_to_entity(entity, &mut system_data.#n, entities)?;
+                self.#name.add_to_entity(entity, &mut system_data.#tuple_index, entities)?;
             }
         }
     });
@@ -64,8 +65,9 @@ fn impl_prefab_data_aggregate(ast: &DeriveInput) -> TokenStream {
         if *is_component {
             None
         } else {
+            let tuple_index = Literal::usize_unsuffixed(n);
             Some(quote! {
-                if self.#name.load_sub_assets(progress, &mut system_data.#n)? {
+                if self.#name.load_sub_assets(progress, &mut system_data.#tuple_index)? {
                     ret = true;
                 }
             })

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -67,7 +67,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * Set width and height of Pong Paddles ([#1363])
 * Fix omission in `PosNormTangTex` documentation. ([#1371])
 * Fix division by zero in vertex data building ([#1481])
-* Fix tuple index generation on `PrefabData` proc macro for newer versions of Rust. ([#1501])
+* Fix tuple index generation on `PrefabData` and `EventReader` proc macros. ([#1501])
 
 [#1114]: https://github.com/amethyst/amethyst/pull/1114
 [#1213]: https://github.com/amethyst/amethyst/pull/1213

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -67,6 +67,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * Set width and height of Pong Paddles ([#1363])
 * Fix omission in `PosNormTangTex` documentation. ([#1371])
 * Fix division by zero in vertex data building ([#1481])
+* Fix tuple index generation on `PrefabData` proc macro for newer versions of Rust. ([#1501])
 
 [#1114]: https://github.com/amethyst/amethyst/pull/1114
 [#1213]: https://github.com/amethyst/amethyst/pull/1213
@@ -105,6 +106,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1469]: https://github.com/amethyst/amethyst/pull/1469
 [#1481]: https://github.com/amethyst/amethyst/pull/1481
 [#1480]: https://github.com/amethyst/amethyst/pull/1480
+[#1501]: https://github.com/amethyst/amethyst/pull/1501
 
 ## [0.10.0] - 2018-12
 


### PR DESCRIPTION
## Description

Fixes #1492. Use `proc_macro2::Literal::usize_unsuffixed` in `PrefabData` quoted tokens.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
