### PR TITLE
[amethyst_rendy] Change projection matrix

### DIFF
--- a/amethyst_rendy/src/camera.rs
+++ b/amethyst_rendy/src/camera.rs
@@ -35,11 +35,10 @@ impl Projection {
         let znear = 0.1;
         let zfar = 2000.0;
         let mut proj = Perspective3::new(aspect, fov, znear, zfar).into_inner();
-        proj[(1,1)] = -proj[(1,1)];
+        proj[(1, 1)] = -proj[(1, 1)];
 
-        proj[(2,2)] = zfar / (znear - zfar);
-        proj[(2,3)] = (znear * zfar) / (znear - zfar);
-
+        proj[(2, 2)] = zfar / (znear - zfar);
+        proj[(2, 3)] = (znear * zfar) / (znear - zfar);
 
         Projection::Perspective(Perspective3::from_matrix_unchecked(proj))
     }

--- a/amethyst_rendy/src/camera.rs
+++ b/amethyst_rendy/src/camera.rs
@@ -32,7 +32,16 @@ impl Projection {
     /// Creates a perspective projection with the given aspect ratio and
     /// field-of-view. `fov` is specified in radians.
     pub fn perspective(aspect: f32, fov: f32) -> Projection {
-        Projection::Perspective(Perspective3::new(aspect, fov, 0.1, 2000.0))
+        let znear = 0.1;
+        let zfar = 2000.0;
+        let mut proj = Perspective3::new(aspect, fov, znear, zfar).into_inner();
+        proj[(1,1)] = -proj[(1,1)];
+
+        proj[(2,2)] = zfar / (znear - zfar);
+        proj[(2,3)] = (znear * zfar) / (znear - zfar);
+
+
+        Projection::Perspective(Perspective3::from_matrix_unchecked(proj))
     }
 }
 

--- a/amethyst_rendy/src/pass/util.rs
+++ b/amethyst_rendy/src/pass/util.rs
@@ -47,7 +47,6 @@ pub(crate) fn prepare_camera(
     let camera_position = (camera.1).0.column(3).xyz().into_pod();
 
     let mut proj: [[f32; 4]; 4] = camera.0.proj.into();
-    proj[1][1] *= -1.0;
 
     let view: [[f32; 4]; 4] = (*camera.1)
         .0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -56,6 +56,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * `ProgressCounter#num_loading()` no longer includes failed assets. ([#1452])
 * `SpriteSheetFormat` field renamed from `spritesheet_*` to `texture_*`. ([#1469])
 * Add new `keep_aspect_ratio` field to `Stretch::XY`. ([#1480])
+* `camera::Projection::perspective()` now returns a vulkan specific perspective matrix ([#1504])
 
 ### Removed
 
@@ -105,6 +106,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1469]: https://github.com/amethyst/amethyst/pull/1469
 [#1481]: https://github.com/amethyst/amethyst/pull/1481
 [#1480]: https://github.com/amethyst/amethyst/pull/1480
+[#1504]: https://github.com/amethyst/amethyst/pull/1504
 
 ## [0.10.0] - 2018-12
 


### PR DESCRIPTION
## Description

Vulkan uses a different screen coordinate system and depth buffer.
This PR changes the y axis to be inverted and the depth buffer to be in range [0,1] instead of the opengl range of [-1,1].

## Modifications

- `amtheyst_rendy::Projection::perspective` returns a modified `nalgebra::Projection::Perspective` for use with Vulkan.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ ] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
