### PR TITLE
Update ron dependency to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ thread_profiler = { version = "0.3", optional = true }
 derive-new = "0.5"
 env_logger = "0.6.1"
 genmesh = "0.6"
-ron = "0.4.2"
+ron = "0.5"
 specs-derive = "0.4"
 
 [build-dependencies]

--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -34,7 +34,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", optional = true }
 shred = { version = "0.7" }
 shred-derive = { version = "0.5" }
-ron = "0.4.2"
+ron = "0.5"
 thread_profiler = { version = "0.3", optional = true }
 err-derive = "0.1"
 

--- a/amethyst_config/Cargo.toml
+++ b/amethyst_config/Cargo.toml
@@ -17,7 +17,7 @@ appveyor = { repository = "amethyst/amethyst" }
 travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
-ron = "0.4"
+ron = "0.5"
 serde = "1.0"
 log = "0.4.6"
 

--- a/amethyst_renderer/Cargo.toml
+++ b/amethyst_renderer/Cargo.toml
@@ -44,7 +44,7 @@ hibitset = { version = "0.5.1", features = ["parallel"] }
 image = "0.20"
 log = "0.4.6"
 rayon = "1.0.2"
-ron = "0.4"
+ron = "0.5"
 serde = { version = "1", features = ["derive"] }
 shred-derive = "0.5"
 shred = "0.7"

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -29,7 +29,7 @@ gfx_glyph = "0.13.3"
 
 glsl-layout = { version = "0.1.1", features = ["gfx"] }
 hibitset = { version = "0.5.1", features = ["parallel"] }
-ron = "0.4"
+ron = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 shred-derive = "0.5"
 shred = "0.7"


### PR DESCRIPTION
## Description

Update the `ron` dependency from `0.4` to `0.5`.

Ron 0.5.1 seems to better handle untagged enums, among other things.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
