### PR TITLE
Allow NetConnection to send reliable OR unreliable events

### DIFF
--- a/amethyst_network/src/lib.rs
+++ b/amethyst_network/src/lib.rs
@@ -28,6 +28,30 @@ mod network_socket;
 mod server;
 mod test;
 
+/// Each event type is either reliable or unreliable:
+/// Reliable events always reach their destination,
+/// Unreliable events may be lost
+/// For Amethyst-defined events, whether it's reliable is specified in this function,
+/// Otherwise, it's specified by the use of NetEvent::Reliable vs NetEvent::Unreliable
+fn is_reliable<T>(event: NetEvent<T>) -> bool {
+	use NetEvent as NE;
+	match event {
+		// I specify them all explicitly so the typechecker can save
+		// us from the mistake of specifying a builtin that SHOULD be
+		// unreliable, but is assumed to be unreliable like all the rest
+		| NE::Connect {..}
+		| NE::Connected {..}
+		| NE::ConnectionRefused {..}
+		| NE::Disconnect {..}
+		| NE::Disconnected {..}
+		| NE::TextMessage {..}
+		| NE::Reliable(_)
+		=> true,
+		| NE::Unreliable(_)
+		=> false,
+	}
+}
+
 /// Sends an event to the target NetConnection using the provided network Socket.
 /// The socket has to be bound.
 pub fn send_event<T>(event: NetEvent<T>, addr: SocketAddr, sender: &SyncSender<ServerSocketEvent>)
@@ -37,12 +61,12 @@ where
     let ser = serialize(&event);
     match ser {
         Ok(s) => {
-            let slice = s.as_slice();
-            // send an unreliable `Packet` from laminar which is basically just a bare UDP packet.
-            match sender.send(ServerSocketEvent::Packet(Packet::unreliable(
-                addr,
-                slice.to_owned(),
-            ))) {
+            let p = if is_reliable(event) {
+	            Packet::unreliable(addr, s)
+            } else {
+	            Packet::reliable_unordered(addr, s)
+            };
+            match sender.send(ServerSocketEvent::Packet(p)) {
                 Ok(_qty) => {}
                 Err(e) => error!("Failed to send data to network socket: {}", e),
             }

--- a/amethyst_network/src/lib.rs
+++ b/amethyst_network/src/lib.rs
@@ -34,22 +34,20 @@ mod test;
 /// For Amethyst-defined events, whether it's reliable is specified in this function,
 /// Otherwise, it's specified by the use of NetEvent::Reliable vs NetEvent::Unreliable
 fn is_reliable<T>(event: NetEvent<T>) -> bool {
-	use NetEvent as NE;
-	match event {
-		// I specify them all explicitly so the typechecker can save
-		// us from the mistake of specifying a builtin that SHOULD be
-		// unreliable, but is assumed to be unreliable like all the rest
-		| NE::Connect {..}
-		| NE::Connected {..}
-		| NE::ConnectionRefused {..}
-		| NE::Disconnect {..}
-		| NE::Disconnected {..}
-		| NE::TextMessage {..}
-		| NE::Reliable(_)
-		=> true,
-		| NE::Unreliable(_)
-		=> false,
-	}
+    use NetEvent as NE;
+    match event {
+        // I specify them all explicitly so the typechecker can save
+        // us from the mistake of specifying a builtin that SHOULD be
+        // unreliable, but is assumed to be unreliable like all the rest
+        NE::Connect { .. }
+        | NE::Connected { .. }
+        | NE::ConnectionRefused { .. }
+        | NE::Disconnect { .. }
+        | NE::Disconnected { .. }
+        | NE::TextMessage { .. }
+        | NE::Reliable(_) => true,
+        NE::Unreliable(_) => false,
+    }
 }
 
 /// Sends an event to the target NetConnection using the provided network Socket.
@@ -62,9 +60,9 @@ where
     match ser {
         Ok(s) => {
             let p = if is_reliable(event) {
-	            Packet::unreliable(addr, s)
+                Packet::unreliable(addr, s)
             } else {
-	            Packet::reliable_unordered(addr, s)
+                Packet::reliable_unordered(addr, s)
             };
             match sender.send(ServerSocketEvent::Packet(p)) {
                 Ok(_qty) => {}

--- a/amethyst_network/src/net_event.rs
+++ b/amethyst_network/src/net_event.rs
@@ -54,25 +54,25 @@ impl<T> NetEvent<T> {
             _ => None,
         }
     }
-	/// Each event type is either reliable or unreliable:
-	/// Reliable events always reach their destination,
-	/// Unreliable events may be lost
-	/// For Amethyst-defined events, whether it's reliable is specified in this function,
-	/// Otherwise, it's specified by the use of NetEvent::Reliable vs NetEvent::Unreliable
-	pub fn is_reliable(&self) -> bool {
-	    use NetEvent as NE;
-	    match self {
-	        // I specify them all explicitly so the typechecker can save
-	        // us from the mistake of specifying a builtin that SHOULD be
-	        // unreliable, but is assumed to be unreliable like all the rest
-	        NE::Connect { .. }
-	        | NE::Connected { .. }
-	        | NE::ConnectionRefused { .. }
-	        | NE::Disconnect { .. }
-	        | NE::Disconnected { .. }
-	        | NE::TextMessage { .. }
-	        | NE::Reliable(_) => true,
-	        NE::Unreliable(_) => false,
-	    }
-	}
+    /// Each event type is either reliable or unreliable:
+    /// Reliable events always reach their destination,
+    /// Unreliable events may be lost
+    /// For Amethyst-defined events, whether it's reliable is specified in this function,
+    /// Otherwise, it's specified by the use of NetEvent::Reliable vs NetEvent::Unreliable
+    pub fn is_reliable(&self) -> bool {
+        use NetEvent as NE;
+        match self {
+            // I specify them all explicitly so the typechecker can save
+            // us from the mistake of specifying a builtin that SHOULD be
+            // unreliable, but is assumed to be unreliable like all the rest
+            NE::Connect { .. }
+            | NE::Connected { .. }
+            | NE::ConnectionRefused { .. }
+            | NE::Disconnect { .. }
+            | NE::Disconnected { .. }
+            | NE::TextMessage { .. }
+            | NE::Reliable(_) => true,
+            NE::Unreliable(_) => false,
+        }
+    }
 }

--- a/amethyst_network/src/net_event.rs
+++ b/amethyst_network/src/net_event.rs
@@ -54,4 +54,25 @@ impl<T> NetEvent<T> {
             _ => None,
         }
     }
+	/// Each event type is either reliable or unreliable:
+	/// Reliable events always reach their destination,
+	/// Unreliable events may be lost
+	/// For Amethyst-defined events, whether it's reliable is specified in this function,
+	/// Otherwise, it's specified by the use of NetEvent::Reliable vs NetEvent::Unreliable
+	pub fn is_reliable(&self) -> bool {
+	    use NetEvent as NE;
+	    match self {
+	        // I specify them all explicitly so the typechecker can save
+	        // us from the mistake of specifying a builtin that SHOULD be
+	        // unreliable, but is assumed to be unreliable like all the rest
+	        NE::Connect { .. }
+	        | NE::Connected { .. }
+	        | NE::ConnectionRefused { .. }
+	        | NE::Disconnect { .. }
+	        | NE::Disconnected { .. }
+	        | NE::TextMessage { .. }
+	        | NE::Reliable(_) => true,
+	        NE::Unreliable(_) => false,
+	    }
+	}
 }

--- a/amethyst_network/src/net_event.rs
+++ b/amethyst_network/src/net_event.rs
@@ -39,17 +39,21 @@ pub enum NetEvent<T> {
         /// The message.
         msg: String,
     },
-    /// A user-defined type containing more network event types.
-    Custom(T),
+    /// There are two user-defined types containing more network event types:
+    /// Reliable events will keep sending until the target confirms receipt
+    Reliable(T),
+    /// Unreliable events will send a bare packet, whether lost or not
+    Unreliable(T),
 }
 
 impl<T> NetEvent<T> {
     /// Tries to convert a NetEvent to a custom event type.
     pub fn custom(&self) -> Option<&T> {
-        if let NetEvent::Custom(ref t) = self {
-            Some(&t)
-        } else {
-            None
-        }
+	    match self {
+		    | NetEvent::Reliable(ref t)
+		    | NetEvent::Unreliable(ref t)
+		    => Some(&t),
+		    _ => None,
+	    }
     }
 }

--- a/amethyst_network/src/net_event.rs
+++ b/amethyst_network/src/net_event.rs
@@ -50,9 +50,7 @@ impl<T> NetEvent<T> {
     /// Tries to convert a NetEvent to a custom event type.
     pub fn custom(&self) -> Option<&T> {
         match self {
-            | NetEvent::Reliable(ref t)
-            | NetEvent::Unreliable(ref t)
-            => Some(&t),
+            NetEvent::Reliable(ref t) | NetEvent::Unreliable(ref t) => Some(&t),
             _ => None,
         }
     }

--- a/amethyst_network/src/net_event.rs
+++ b/amethyst_network/src/net_event.rs
@@ -49,11 +49,11 @@ pub enum NetEvent<T> {
 impl<T> NetEvent<T> {
     /// Tries to convert a NetEvent to a custom event type.
     pub fn custom(&self) -> Option<&T> {
-	    match self {
-		    | NetEvent::Reliable(ref t)
-		    | NetEvent::Unreliable(ref t)
-		    => Some(&t),
-		    _ => None,
-	    }
+        match self {
+            | NetEvent::Reliable(ref t)
+            | NetEvent::Unreliable(ref t)
+            => Some(&t),
+            _ => None,
+        }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@ it is attached to. ([#1282])
 * Add `SpriteScenePrefab`. Allows load sprites from a grid and add them to the `SpriteRenderer`. ([#1469])
 * Add `Widgets` resource. Allows keeping track of UI entities and their components and iterating over them. ([#1390])
 * `AmethystApplication` takes in application name using `with_app_name(..)`. ([#1499])
+* Add `NetEvent::Reliable` variant. When added to NetConnection, these events will eventually reach the target. ([#???])
 
 ### Changed
 
@@ -61,6 +62,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * Renamed `Text` UI Prefab to `Label` in preparation for full widget integration in prefabs. ([#1390])
 * `amethyst_test` includes the application name of a failing test. ([#1499])
 * `amethyst_test` returns the panic message of a failed execution. ([#1499])
+* Rename `NetEvent::Custom` variant to `NetEvent::Unreliable`. ([#???])
 
 ### Removed
 


### PR DESCRIPTION
## Description

`NetEvent::Custom` was split into `NetEvent::Reliable` and `NetEvent::Unreliable`, and based on that when laminar packets are made reliability is chosen

Also, when doing so, I realized that Connect, Disconnect, etc are sent unreliably when (due to the possibility of packet loss) they really should be reliable, so that's changed as well.

## Additions

- NetEvent::Reliable(T)

## Modifications

- NetEvent::Custom(T) renamed to NetEvent::Unreliable(T)
- All current builtin NetEvent types are sent reliably

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new APIs if any were added in this PR.
No unit tests in this crate in the first place tbh
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
