### PR TITLE
Fix reversed reliable / unreliable custom types

### DIFF
--- a/amethyst_network/src/lib.rs
+++ b/amethyst_network/src/lib.rs
@@ -39,9 +39,9 @@ where
     match ser {
         Ok(s) => {
             let p = if event.is_reliable() {
-                Packet::unreliable(addr, s)
-            } else {
                 Packet::reliable_unordered(addr, s)
+            } else {
+                Packet::unreliable(addr, s)
             };
 
             match sender.send(p) {


### PR DESCRIPTION
## Description

In my PR I accidentally had reliable / unreliable reversed in practice :/// lol

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [ ] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ ] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
