### PR TITLE
nalgebra: 0.17 -> 0.18

### DIFF
--- a/amethyst_animation/src/util.rs
+++ b/amethyst_animation/src/util.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use amethyst_core::{
     ecs::prelude::{Entity, WriteStorage},
-    math::Real,
+    math::RealField,
 };
 
 use crate::resources::{AnimationControlSet, AnimationSampling};
@@ -37,7 +37,7 @@ where
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum SamplerPrimitive<S>
 where
-    S: Real,
+    S: RealField,
 {
     /// A single value
     Scalar(S),
@@ -51,7 +51,7 @@ where
 
 impl<S> From<[S; 2]> for SamplerPrimitive<S>
 where
-    S: Real,
+    S: RealField,
 {
     fn from(arr: [S; 2]) -> Self {
         SamplerPrimitive::Vec2(arr)
@@ -60,7 +60,7 @@ where
 
 impl<S> From<[S; 3]> for SamplerPrimitive<S>
 where
-    S: Real,
+    S: RealField,
 {
     fn from(arr: [S; 3]) -> Self {
         SamplerPrimitive::Vec3(arr)
@@ -69,7 +69,7 @@ where
 
 impl<S> From<[S; 4]> for SamplerPrimitive<S>
 where
-    S: Real,
+    S: RealField,
 {
     fn from(arr: [S; 4]) -> Self {
         SamplerPrimitive::Vec4(arr)
@@ -78,7 +78,7 @@ where
 
 impl<S> InterpolationPrimitive for SamplerPrimitive<S>
 where
-    S: Real + ToPrimitive + NumCast,
+    S: RealField + ToPrimitive + NumCast,
 {
     fn add(&self, other: &Self) -> Self {
         match (*self, *other) {
@@ -157,7 +157,7 @@ where
 
 fn mul_f32<T>(s: T, scalar: f32) -> T
 where
-    T: Real + ToPrimitive + NumCast,
+    T: RealField + ToPrimitive + NumCast,
 {
     NumCast::from(
         s.to_f32()

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -16,7 +16,7 @@ appveyor = { repository = "amethyst/amethyst" }
 travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
-nalgebra = { version = "0.17", features = ["serde-serialize", "mint"] }
+nalgebra = { version = "0.18", features = ["serde-serialize", "mint"] }
 approx = "0.3"
 amethyst_error = { path = "../amethyst_error", version = "0.1.0" }
 derive-new = "0.5"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -64,6 +64,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * `amethyst_test` returns the panic message of a failed execution. ([#1499])
 * Rename `NetEvent::Custom` variant to `NetEvent::Unreliable`. ([#1513])
 * Updated laminar to 0.2.0. ([#1502])
+* Updated nalgebra to 0.18.0. ([#1519])
 
 ### Removed
 


### PR DESCRIPTION
This is to ensure that identical versions are used if ncollide and
nphysics are used in addition to amethyst, which also use nalgebra.

This change is obviously a breaking change, since amethyst re-exports
nalgebra.

## PR Checklist

- [ ] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ ] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
