### PR TITLE
Add editable text events for input submission and modification.

### DIFF
--- a/amethyst_ui/src/event.rs
+++ b/amethyst_ui/src/event.rs
@@ -48,6 +48,10 @@ pub enum UiEventType {
         /// The entity on which the dragged object was dropped.
         dropped_on: Entity,
     },
+    /// When the value of an `Editable` Ui element has changed.
+    Change,
+    /// When an `Editable` Ui element has been committed.
+    Commit,
 }
 
 /// A ui event instance.

--- a/amethyst_ui/src/event.rs
+++ b/amethyst_ui/src/event.rs
@@ -48,10 +48,15 @@ pub enum UiEventType {
         /// The entity on which the dragged object was dropped.
         dropped_on: Entity,
     },
-    /// When the value of an `Editable` Ui element has changed.
-    Change,
-    /// When an `Editable` Ui element has been committed.
-    Commit,
+    /// When the value of a UiText element has been changed by user input.
+    ValueChange,
+    /// When the value of a UiText element has been committed either by 
+    /// losing focus on mobile or by pressing "Enter".
+    ValueCommit,
+    /// When an editable UiText element has gained focus.
+    Focus,
+    /// When an editable UiText element has lost focus.
+    Blur,
 }
 
 /// A ui event instance.

--- a/amethyst_ui/src/event.rs
+++ b/amethyst_ui/src/event.rs
@@ -50,8 +50,7 @@ pub enum UiEventType {
     },
     /// When the value of a UiText element has been changed by user input.
     ValueChange,
-    /// When the value of a UiText element has been committed either by 
-    /// losing focus on mobile or by pressing "Enter".
+    /// When the value of a UiText element has been committed by user action.
     ValueCommit,
     /// When an editable UiText element has gained focus.
     Focus,

--- a/amethyst_ui/src/selection.rs
+++ b/amethyst_ui/src/selection.rs
@@ -1,7 +1,7 @@
 use amethyst_core::{
     ecs::{
-        Component, DenseVecStorage, FlaggedStorage, Read, ReadStorage, ReaderId, Resources, System,
-        SystemData, WriteStorage,
+        Component, DenseVecStorage, Entities, FlaggedStorage, Join, Read, ReadStorage, ReaderId,
+        Resources, System, SystemData, Write, WriteStorage,
     },
     shrev::EventChannel,
 };
@@ -71,8 +71,13 @@ where
         Read<'a, EventChannel<Event>>,
         Read<'a, CachedSelectionOrder>,
         WriteStorage<'a, Selected>,
+        Write<'a, EventChannel<UiEvent>>,
+        Entities<'a>,
     );
-    fn run(&mut self, (window_events, cached, mut selecteds): Self::SystemData) {
+    fn run(
+        &mut self,
+        (window_events, cached, mut selecteds, mut ui_events, entities): Self::SystemData,
+    ) {
         /*
         Add clicked elements + shift + ctrl status.
         If tab or shift-tab
@@ -115,6 +120,9 @@ where
                 if let Some(highest) = highest {
                     // If Some, an element was currently selected. We move the cursor to the next or previous element depending if Shift was pressed.
                     // Select Replace
+                    for (entity, _) in (&*entities, &selecteds).join() {
+                        ui_events.single_write(UiEvent::new(UiEventType::Blur, entity));
+                    }
                     selecteds.clear();
 
                     let target = if !modifiers.shift {
@@ -131,14 +139,19 @@ where
                         cached.cache.get(highest + 1).unwrap_or_else(|| cached.cache.first()
                         .expect("unreachable: A highest ui element was selected, but none exist in the cache."))
                     };
+
                     selecteds
                         .insert(target.1, Selected)
                         .expect("unreachable: We are inserting");
+
+                    ui_events.single_write(UiEvent::new(UiEventType::Focus, target.1));
                 } else if let Some(lowest) = cached.cache.first() {
                     // If None, nothing was selected. Try to take lowest if it exists.
                     selecteds
                         .insert(lowest.1, Selected)
                         .expect("unreachable: We are inserting");
+
+                    ui_events.single_write(UiEvent::new(UiEventType::Focus, lowest.1));
                 }
             }
         }
@@ -166,20 +179,23 @@ where
     AC: Hash + Eq + Clone + Send + Sync + 'static,
 {
     type SystemData = (
-        Read<'a, EventChannel<UiEvent>>,
+        Write<'a, EventChannel<UiEvent>>,
         Read<'a, CachedSelectionOrder>,
         WriteStorage<'a, Selected>,
         ReadStorage<'a, Selectable<G>>,
         Read<'a, InputHandler<AX, AC>>,
+        Entities<'a>,
     );
     fn run(
         &mut self,
-        (ui_events, cached, mut selecteds, selectables, input_handler): Self::SystemData,
+        (mut ui_events, cached, mut selecteds, selectables, input_handler, entities): Self::SystemData,
     ) {
         let shift = input_handler.key_is_down(VirtualKeyCode::LShift)
             || input_handler.key_is_down(VirtualKeyCode::RShift);
         let ctrl = input_handler.key_is_down(VirtualKeyCode::LControl)
             || input_handler.key_is_down(VirtualKeyCode::RControl);
+
+        let mut emitted: Vec<UiEvent> = Vec::new();
 
         // Add clicked elements to clicked buffer
         for ev in ui_events.read(self.ui_reader_id.as_mut().unwrap()) {
@@ -225,6 +241,9 @@ where
                                     .expect("unreachable: Entity has to be in the cache, otherwise it wouldn't have been added.");
 
                                 // When multi-selecting, you remove everything that was previously selected, and then add everything in the range.
+                                for (entity, _) in (&*entities, &selecteds).join() {
+                                    emitted.push(UiEvent::new(UiEventType::Blur, entity));
+                                }
                                 selecteds.clear();
 
                                 let min = cached_index_clicked.min(highest);
@@ -237,35 +256,51 @@ where
                                     selecteds
                                         .insert(target_entity.1, Selected)
                                         .expect("unreachable: We are inserting");
+
+                                    emitted.push(UiEvent::new(UiEventType::Focus, target_entity.1));
                                 }
                             } else if ctrl || auto_multi_select {
                                 // Select adding single element
                                 selecteds
                                     .insert(clicked, Selected)
                                     .expect("unreachable: We are inserting");
+
+                                emitted.push(UiEvent::new(UiEventType::Focus, clicked));
                             } else {
                                 // Select replace, because we don't want to be adding elements.
                                 selecteds.clear();
                                 selecteds
                                     .insert(clicked, Selected)
                                     .expect("unreachable: We are inserting");
+
+                                emitted.push(UiEvent::new(UiEventType::Focus, clicked));
                             }
                         } else {
+                            for (entity, _) in (&*entities, &selecteds).join() {
+                                emitted.push(UiEvent::new(UiEventType::Blur, entity));
+                            }
                             // Different multi select group than the latest one selected. Execute Select replace
                             selecteds.clear();
+
                             selecteds
                                 .insert(clicked, Selected)
                                 .expect("unreachable: We are inserting");
+
+                            emitted.push(UiEvent::new(UiEventType::Focus, clicked));
                         }
                     } else {
                         // Nothing was previously selected, let's just select single.
                         selecteds
                             .insert(clicked, Selected)
                             .expect("unreachable: We are inserting");
+
+                        emitted.push(UiEvent::new(UiEventType::Focus, clicked));
                     }
                 }
             }
         }
+
+        ui_events.iter_write(emitted.into_iter());
     }
     fn setup(&mut self, res: &mut Resources) {
         Self::SystemData::setup(res);

--- a/amethyst_ui/src/text_editing.rs
+++ b/amethyst_ui/src/text_editing.rs
@@ -6,9 +6,9 @@ use unicode_normalization::{char::is_combining_mark, UnicodeNormalization};
 use unicode_segmentation::UnicodeSegmentation;
 use winit::{ElementState, Event, KeyboardInput, ModifiersState, VirtualKeyCode, WindowEvent};
 
-use crate::{Selected, TextEditing, UiText};
+use crate::{Selected, TextEditing, UiText, UiEvent, UiEventType, LineMode};
 use amethyst_core::{
-    ecs::prelude::{Join, Read, ReadStorage, Resources, System, WriteStorage},
+    ecs::prelude::{Join, Read, Write, ReadStorage, Resources, System, WriteStorage, Entities},
     shrev::{EventChannel, ReaderId},
 };
 
@@ -32,13 +32,15 @@ impl TextEditingInputSystem {
 
 impl<'a> System<'a> for TextEditingInputSystem {
     type SystemData = (
+        Entities<'a>,
         WriteStorage<'a, UiText>,
         WriteStorage<'a, TextEditing>,
         ReadStorage<'a, Selected>,
         Read<'a, EventChannel<Event>>,
+        Write<'a, EventChannel<UiEvent>>,
     );
 
-    fn run(&mut self, (mut texts, mut editables, selecteds, events): Self::SystemData) {
+    fn run(&mut self, (entities, mut texts, mut editables, selecteds, events, mut edit_events): Self::SystemData) {
         for text in (&mut texts).join() {
             if (*text.text).chars().any(is_combining_mark) {
                 let normalized = text.text.nfd().collect::<String>();
@@ -52,8 +54,8 @@ impl<'a> System<'a> for TextEditingInputSystem {
                 .expect("`UiKeyboardSystem::setup` was not called before `UiKeyboardSystem::run`"),
         ) {
             // Process events for the focused text element
-            if let Some((ref mut focused_text, ref mut focused_edit, _)) =
-                (&mut texts, &mut editables, &selecteds).join().next()
+            if let Some((entity, ref mut focused_text, ref mut focused_edit, _)) =
+                (&*entities, &mut texts, &mut editables, &selecteds).join().next()
             {
                 match *event {
                     Event::WindowEvent {
@@ -78,6 +80,8 @@ impl<'a> System<'a> for TextEditingInputSystem {
                         if focused_text.text.graphemes(true).count() < focused_edit.max_length {
                             focused_text.text.insert(start_byte, input);
                             focused_edit.cursor_position += 1;
+
+                            edit_events.single_write(UiEvent::new(UiEventType::Change, entity));
                         }
                     }
                     Event::WindowEvent {
@@ -215,10 +219,11 @@ impl<'a> System<'a> for TextEditingInputSystem {
                             if ctrl_or_cmd(&modifiers) {
                                 let new_clip = extract_highlighted(focused_edit, focused_text);
                                 if !new_clip.is_empty() {
-                                    if let Err(e) = ClipboardProvider::new().and_then(
+                                    match ClipboardProvider::new().and_then(
                                         |mut ctx: ClipboardContext| ctx.set_contents(new_clip),
                                     ) {
-                                        error!("Error occured when cutting to clipboard: {:?}", e);
+                                        Ok(_) => edit_events.single_write(UiEvent::new(UiEventType::Change, entity)),
+                                        Err(e) => error!("Error occured when cutting to clipboard: {:?}", e)
                                     }
                                 }
                             }
@@ -258,11 +263,41 @@ impl<'a> System<'a> for TextEditingInputSystem {
                                         focused_text.text.insert_str(index, &contents);
                                         focused_edit.cursor_position +=
                                             contents.graphemes(true).count() as isize;
+
+
+                                        edit_events.single_write(UiEvent::new(UiEventType::Change, entity));
                                     }
                                     Err(e) => error!(
                                         "Error occured when pasting contents of clipboard: {:?}",
                                         e
                                     ),
+                                }
+                            }
+                        }
+                        VirtualKeyCode::Return | VirtualKeyCode::NumpadEnter => {
+                            info!("{:?}", focused_text);
+                            match focused_text.line_mode {
+                                LineMode::Single => {
+                                    edit_events.single_write(UiEvent::new(UiEventType::Commit, entity));
+                                }
+                                LineMode::Wrap => {
+                                    if modifiers.shift && focused_text.text.graphemes(true).count() < focused_edit.max_length {
+                                        let start_byte = focused_text
+                                            .text
+                                            .grapheme_indices(true)
+                                            .nth(focused_edit.cursor_position as usize)
+                                            .map(|i| i.0)
+                                            .unwrap_or_else(|| {
+                                                focused_text.text.len()
+                                            });
+
+                                        focused_text.text.insert(start_byte, '\n');
+                                        focused_edit.cursor_position += 1;
+
+                                        edit_events.single_write(UiEvent::new(UiEventType::Change, entity));
+                                    } else {
+                                        edit_events.single_write(UiEvent::new(UiEventType::Commit, entity));
+                                    }
                                 }
                             }
                         }

--- a/amethyst_ui/src/text_editing.rs
+++ b/amethyst_ui/src/text_editing.rs
@@ -8,7 +8,9 @@ use winit::{ElementState, Event, KeyboardInput, ModifiersState, VirtualKeyCode, 
 
 use crate::{LineMode, Selected, TextEditing, UiEvent, UiEventType, UiText};
 use amethyst_core::{
-    ecs::prelude::{Entity, Entities, Join, Read, ReadStorage, Resources, System, Write, WriteStorage},
+    ecs::prelude::{
+        Entities, Entity, Join, Read, ReadStorage, Resources, System, Write, WriteStorage,
+    },
     shrev::{EventChannel, ReaderId},
 };
 
@@ -27,7 +29,10 @@ pub struct TextEditingInputSystem {
 impl TextEditingInputSystem {
     /// Creates a new instance of this system
     pub fn new() -> Self {
-        Self { reader: None, last_selected: None }
+        Self {
+            reader: None,
+            last_selected: None,
+        }
     }
 }
 
@@ -63,19 +68,6 @@ impl<'a> System<'a> for TextEditingInputSystem {
                     .join()
                     .next()
             {
-                match self.last_selected {
-                    Some(last) => {
-                        if last != entity {
-                            edit_events.single_write(UiEvent::new(UiEventType::Blur, last));
-                            edit_events.single_write(UiEvent::new(UiEventType::Focus, entity));
-                        }
-                    }
-                    None => {
-                        edit_events.single_write(UiEvent::new(UiEventType::Focus, entity));
-                    }
-                }
-                self.last_selected = Some(entity);
-
                 match *event {
                     Event::WindowEvent {
                         event: WindowEvent::ReceivedCharacter(input),
@@ -100,7 +92,8 @@ impl<'a> System<'a> for TextEditingInputSystem {
                             focused_text.text.insert(start_byte, input);
                             focused_edit.cursor_position += 1;
 
-                            edit_events.single_write(UiEvent::new(UiEventType::ValueChange, entity));
+                            edit_events
+                                .single_write(UiEvent::new(UiEventType::ValueChange, entity));
                         }
                     }
                     Event::WindowEvent {
@@ -304,12 +297,16 @@ impl<'a> System<'a> for TextEditingInputSystem {
                         VirtualKeyCode::Return | VirtualKeyCode::NumpadEnter => {
                             match focused_text.line_mode {
                                 LineMode::Single => {
-                                    edit_events
-                                        .single_write(UiEvent::new(UiEventType::ValueCommit, entity));
+                                    edit_events.single_write(UiEvent::new(
+                                        UiEventType::ValueCommit,
+                                        entity,
+                                    ));
                                 }
                                 LineMode::Wrap => {
                                     if modifiers.shift {
-                                        if focused_text.text.graphemes(true).count() < focused_edit.max_length {
+                                        if focused_text.text.graphemes(true).count()
+                                            < focused_edit.max_length
+                                        {
                                             let start_byte = focused_text
                                                 .text
                                                 .grapheme_indices(true)

--- a/amethyst_ui/src/text_editing.rs
+++ b/amethyst_ui/src/text_editing.rs
@@ -8,9 +8,7 @@ use winit::{ElementState, Event, KeyboardInput, ModifiersState, VirtualKeyCode, 
 
 use crate::{LineMode, Selected, TextEditing, UiEvent, UiEventType, UiText};
 use amethyst_core::{
-    ecs::prelude::{
-        Entities, Entity, Join, Read, ReadStorage, Resources, System, Write, WriteStorage,
-    },
+    ecs::prelude::{Entities, Join, Read, ReadStorage, Resources, System, Write, WriteStorage},
     shrev::{EventChannel, ReaderId},
 };
 

--- a/amethyst_ui/src/text_editing.rs
+++ b/amethyst_ui/src/text_editing.rs
@@ -23,16 +23,12 @@ use amethyst_core::{
 pub struct TextEditingInputSystem {
     /// A reader for winit events.
     reader: Option<ReaderId<Event>>,
-    last_selected: Option<Entity>,
 }
 
 impl TextEditingInputSystem {
     /// Creates a new instance of this system
     pub fn new() -> Self {
-        Self {
-            reader: None,
-            last_selected: None,
-        }
+        Self { reader: None }
     }
 }
 
@@ -335,8 +331,6 @@ impl<'a> System<'a> for TextEditingInputSystem {
                     },
                     _ => {}
                 }
-            } else {
-                self.last_selected = None
             }
         }
     }


### PR DESCRIPTION
## Description

This PR extends the existing `UiEvent` definition to include two new events: `Change` and `Commit`.

The `Change` event is written whenever a focused, editable `UiText` component has its internal value modified through user action.

The `Commit` event is written when the system receives either the `Enter` or `NumPadEnter` virtual key codes. It is designed to indicate that the user has concluded their input and may want to move onto the next field, submit the form, etc.


## Modifications
- Created two new definitions in the `UiEventType` enumeration, `Change` and `Commit`.
- Added a new match arm in the `TextEditingInputSystem` to produce the new `Commit` event.
- Updated a number of alternate match arms in the same block to properly produce the new `Change` event. 
- Added the `Entity` resource to the system data for `TextEditingInputSystem` in support of the new targeted events. 

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
