### PR TITLE
Allow user to control Ordering and reliability.

### DIFF
--- a/amethyst_network/Cargo.toml
+++ b/amethyst_network/Cargo.toml
@@ -25,7 +25,7 @@ amethyst_core = { path = "../amethyst_core", version = "0.5" }
 amethyst_error = { path = "../amethyst_error", version = "0.1.0" }
 serde = { version = "1", features = ["derive"] }
 shrev = "1.0"
-shred = "0.7"
+shred = "0.8.0"
 bincode = "1.0"
 log = "0.4.6"
 uuid = { version = "0.7.1", features = ["v4","serde"] }

--- a/amethyst_network/src/lib.rs
+++ b/amethyst_network/src/lib.rs
@@ -7,7 +7,7 @@ pub use crate::{
     connection::{ConnectionState, NetConnection, NetIdentity},
     error::Result,
     filter::{FilterConnected, NetFilter},
-    net_event::NetEvent,
+    net_event::{NetEvent, NetPacket},
     network_socket::NetSocketSystem,
     server::{Host, ServerConfig},
 };
@@ -31,7 +31,7 @@ mod test;
 
 /// Sends an event to the target NetConnection using the provided network Socket.
 /// The socket has to be bound.
-pub fn send_event<T>(event: NetEvent<T>, addr: SocketAddr, sender: &Sender<Packet>)
+pub fn send_event<T>(event: NetPacket<T>, addr: SocketAddr, sender: &Sender<Packet>)
 where
     T: Serialize,
 {
@@ -54,9 +54,9 @@ where
 }
 
 // Attempts to deserialize an event from the raw byte data.
-fn deserialize_event<T>(data: &[u8]) -> Result<NetEvent<T>>
+fn deserialize_event<T>(data: &[u8]) -> Result<NetPacket<T>>
 where
     T: DeserializeOwned,
 {
-    Ok(deserialize::<NetEvent<T>>(data)?)
+    Ok(deserialize::<NetPacket<T>>(data)?)
 }

--- a/amethyst_network/src/net_event.rs
+++ b/amethyst_network/src/net_event.rs
@@ -5,8 +5,7 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-/// The basic network events shipped with amethyst.
-// TODO: Add CreateEntity,RemoveEntity,UpdateEntity once specs 0.11 is released
+/// Network events which you can send or and receive from an endpoint.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum NetEvent<T> {
     /// Ask to connect to the server.
@@ -34,45 +33,223 @@ pub enum NetEvent<T> {
         /// The reason of the disconnection.
         reason: String,
     },
-    /// A simple text message event.
-    TextMessage {
-        /// The message.
-        msg: String,
-    },
-    /// There are two user-defined types containing more network event types:
-    /// Reliable events will keep sending until the target confirms receipt
-    Reliable(T),
-    /// Unreliable events will send a bare packet, whether lost or not
-    Unreliable(T),
+    /// Send a packet to all connected clients
+    Packet(NetPacket<T>),
 }
 
-impl<T> NetEvent<T> {
-    /// Tries to convert a NetEvent to a custom event type.
-    pub fn custom(&self) -> Option<&T> {
-        match self {
-            NetEvent::Reliable(ref t) | NetEvent::Unreliable(ref t) => Some(&t),
-            _ => None,
+/// Enum to specify how a packet should be arranged.
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialOrd, PartialEq, Eq)]
+enum OrderingGuarantee {
+    /// No arranging will be done.
+    None,
+    /// Packets will be arranged in sequence.
+    Sequenced(Option<u8>),
+    /// Packets will be arranged in order.
+    Ordered(Option<u8>),
+}
+
+/// Enum to specify how a packet should be delivered.
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialOrd, PartialEq, Eq)]
+enum DeliveryGuarantee {
+    /// Packet may or may not be delivered
+    Unreliable,
+    /// Packet will be delivered
+    Reliable,
+}
+
+impl From<laminar::OrderingGuarantee> for OrderingGuarantee {
+    fn from(ordering: laminar::OrderingGuarantee) -> Self {
+        match ordering {
+            laminar::OrderingGuarantee::None => OrderingGuarantee::None,
+            laminar::OrderingGuarantee::Sequenced(s) => OrderingGuarantee::Sequenced(s),
+            laminar::OrderingGuarantee::Ordered(o) => OrderingGuarantee::Ordered(o),
         }
     }
-    /// Each event type is either reliable or unreliable:
-    /// Reliable events always reach their destination,
-    /// Unreliable events may be lost
-    /// For Amethyst-defined events, whether it's reliable is specified in this function,
-    /// Otherwise, it's specified by the use of NetEvent::Reliable vs NetEvent::Unreliable
-    pub fn is_reliable(&self) -> bool {
-        use NetEvent as NE;
-        match self {
-            // I specify them all explicitly so the typechecker can save
-            // us from the mistake of specifying a builtin that SHOULD be
-            // unreliable, but is assumed to be unreliable like all the rest
-            NE::Connect { .. }
-            | NE::Connected { .. }
-            | NE::ConnectionRefused { .. }
-            | NE::Disconnect { .. }
-            | NE::Disconnected { .. }
-            | NE::TextMessage { .. }
-            | NE::Reliable(_) => true,
-            NE::Unreliable(_) => false,
+}
+
+impl From<laminar::DeliveryGuarantee> for DeliveryGuarantee {
+    fn from(delivery: laminar::DeliveryGuarantee) -> Self {
+        match delivery {
+            laminar::DeliveryGuarantee::Unreliable => DeliveryGuarantee::Unreliable,
+            laminar::DeliveryGuarantee::Reliable => DeliveryGuarantee::Reliable,
         }
+    }
+}
+
+/// Represents a packet which could have any serializable payload.
+///
+/// A packet could have reliability guarantees to specify how it should be delivered and processed.
+///
+/// | Reliability Type                 | Packet Drop | Packet Duplication | Packet Order  | Packet Fragmentation |Packet Delivery|
+/// | :-------------:                  | :-------------: | :-------------:    | :-------------:  | :-------------:  | :-------------:
+/// |       **Unreliable Unordered**   |       Yes       |       Yes          |      No          |      No          |       No
+/// |       **Unreliable Sequenced**   |       Yes       |      No            |      Sequenced   |      No          |       No
+/// |       **Reliable Unordered**     |       No        |      No            |      No          |      Yes         |       Yes
+/// |       **Reliable Ordered**       |       No        |      No            |      Ordered     |      Yes         |       Yes
+/// |       **Reliable Sequenced**     |       No        |      No            |      Sequenced     |      Yes       |       Yes
+///
+/// You are able to send packets with any the above guarantees.
+///
+/// For more information please have a look at: https://amethyst.github.io/laminar/docs/reliability/reliability.html
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NetPacket<T> {
+    ordering_guarantee: OrderingGuarantee,
+    delivery_guarantee: DeliveryGuarantee,
+    content: T,
+}
+
+impl<T> NetPacket<T> {
+    /// Create a new unreliable packet with the given content.
+    ///
+    /// Unreliable: Packets can be dropped, duplicated or arrive without order.
+    ///
+    /// **Details**
+    ///
+    /// | Packet Drop     | Packet Duplication | Packet Order     | Packet Fragmentation | Packet Delivery |
+    /// | :-------------: | :-------------:    | :-------------:  | :-------------:      | :-------------: |
+    /// |       Yes       |        Yes         |      No          |      No              |       No        |
+    ///
+    /// Basically just bare UDP. The packet may or may not be delivered.
+    pub fn unreliable(content: T) -> NetPacket<T> {
+        NetPacket {
+            ordering_guarantee: OrderingGuarantee::None,
+            delivery_guarantee: DeliveryGuarantee::Unreliable,
+            content,
+        }
+    }
+
+    /// Create a new unreliable sequenced packet with the given content.
+    ///
+    /// Unreliable Sequenced; Packets can be dropped, but could not be duplicated and arrive in sequence.
+    ///
+    /// *Details*
+    ///
+    /// | Packet Drop     | Packet Duplication | Packet Order     | Packet Fragmentation | Packet Delivery |
+    /// | :-------------: | :-------------:    | :-------------:  | :-------------:      | :-------------: |
+    /// |       Yes       |        Yes         |      Sequenced          |      No              |       No  |
+    ///
+    /// Basically just bare UDP, free to be dropped, but has some sequencing to it so that only the newest packets are kept.
+    pub fn unreliable_sequenced(content: T, stream_id: Option<u8>) -> NetPacket<T> {
+        NetPacket {
+            ordering_guarantee: OrderingGuarantee::Sequenced(stream_id),
+            delivery_guarantee: DeliveryGuarantee::Unreliable,
+            content,
+        }
+    }
+
+    /// Create a new packet with the given content.
+    /// Reliable; All packets will be sent and received, but without order.
+    ///
+    /// *Details*
+    ///
+    /// |   Packet Drop   | Packet Duplication | Packet Order     | Packet Fragmentation | Packet Delivery |
+    /// | :-------------: | :-------------:    | :-------------:  | :-------------:      | :-------------: |
+    /// |       No        |      No            |      No          |      Yes             |       Yes       |
+    ///
+    /// Basically this is almost TCP without ordering of packets.
+    pub fn reliable_unordered(content: T) -> NetPacket<T> {
+        NetPacket {
+            ordering_guarantee: OrderingGuarantee::None,
+            delivery_guarantee: DeliveryGuarantee::Reliable,
+            content,
+        }
+    }
+
+    /// Create a new packet with the given content and optional stream on which the ordering will be done.
+    ///
+    /// Reliable; All packets will be sent and received, with order.
+    ///
+    /// *Details*
+    ///
+    /// |   Packet Drop   | Packet Duplication | Packet Order     | Packet Fragmentation | Packet Delivery |
+    /// | :-------------: | :-------------:    | :-------------:  | :-------------:      | :-------------: |
+    /// |       No        |      No            |      Ordered     |      Yes             |       Yes       |
+    ///
+    /// Basically this is almost TCP-like with ordering of packets.
+    ///
+    /// # Remark
+    /// - When `stream_id` is specified as `None` the default stream will be used; if you are not sure what this is you can leave it at `None`.
+    pub fn reliable_ordered(content: T, stream_id: Option<u8>) -> NetPacket<T> {
+        NetPacket {
+            ordering_guarantee: OrderingGuarantee::Ordered(stream_id),
+            delivery_guarantee: DeliveryGuarantee::Reliable,
+            content,
+        }
+    }
+
+    /// Create a new packet with the given content and optional stream on which the sequencing will be done.
+    ///
+    /// Reliable; All packets will be sent and received, but arranged in sequence.
+    /// Which means that only the newest packets will be let through, older packets will be received but they won't get to the user.
+    ///
+    /// *Details*
+    ///
+    /// |   Packet Drop   | Packet Duplication | Packet Order     | Packet Fragmentation | Packet Delivery |
+    /// | :-------------: | :-------------:    | :-------------:  | :-------------:      | :-------------: |
+    /// |       Yes        |      No            |      Sequenced     |      Yes             |       Yes       |
+    ///
+    /// Basically this is almost TCP-like but then sequencing instead of ordering.
+    ///
+    /// # Remark
+    /// - When `stream_id` is specified as `None` the default stream will be used; if you are not sure what this is you can leave it at `None`.
+    pub fn reliable_sequenced(content: T, stream_id: Option<u8>) -> NetPacket<T> {
+        NetPacket {
+            ordering_guarantee: OrderingGuarantee::Sequenced(stream_id),
+            delivery_guarantee: DeliveryGuarantee::Reliable,
+            content,
+        }
+    }
+
+    /// Returns if this event is reliable.
+    ///
+    /// Each net event type is either reliable or unreliable.
+    /// Reliable events always reach their destination, unreliable events may be lost.
+    pub fn is_reliable(&self) -> bool {
+        self.delivery_guarantee == DeliveryGuarantee::Reliable
+    }
+
+    /// Returns if this event is unreliable.
+    ///
+    /// Each net event type is either reliable or unreliable.
+    /// Reliable events always reach their destination, unreliable events may be lost.
+    pub fn is_unreliable(&self) -> bool {
+        self.delivery_guarantee == DeliveryGuarantee::Unreliable
+    }
+
+    /// Returns whether this event is an ordered event.
+    pub fn is_ordered(&self) -> bool {
+        if let OrderingGuarantee::Ordered(_) = self.ordering_guarantee {
+            return true;
+        }
+        false
+    }
+
+    /// Returns whether this event is an sequenced event.
+    pub fn is_sequenced(&self) -> bool {
+        if let OrderingGuarantee::Sequenced(_) = self.ordering_guarantee {
+            return true;
+        }
+        false
+    }
+
+    /// Return if this event is neither ordered or sequenced.
+    pub fn is_unordered(&self) -> bool {
+        self.ordering_guarantee == OrderingGuarantee::None
+    }
+
+    /// Returns a immutable reference to the content.
+    pub fn content(&self) -> &T {
+        &self.content
+    }
+
+    /// Returns a immutable reference to the content.
+    pub fn content_mut(&mut self) -> &mut T {
+        &mut self.content
+    }
+}
+
+impl<T> From<NetPacket<T>> for NetEvent<T> {
+    fn from(packet: NetPacket<T>) -> Self {
+        NetEvent::Packet(packet)
     }
 }

--- a/amethyst_network/src/network_socket.rs
+++ b/amethyst_network/src/network_socket.rs
@@ -44,9 +44,9 @@ where
     /// The list of filters applied on the events received.
     pub filters: Vec<Box<dyn NetFilter<E>>>,
     // sender on which you can queue packets to send to some endpoint.
-    transport_sender: Sender<InternalSocketEvent<E>>,
+    event_sender: Sender<InternalSocketEvent<E>>,
     // receiver from which you can read received packets.
-    transport_receiver: Receiver<Packet>,
+    event_receiver: Receiver<laminar::SocketEvent>,
     config: ServerConfig,
 }
 
@@ -66,27 +66,31 @@ where
         let udp_send_handle = server.udp_send_handle();
         let udp_receive_handle = server.udp_receive_handle();
 
-        let server_sender = NetSocketSystem::<E>::start_sending(udp_send_handle);
-        let server_receiver = NetSocketSystem::<E>::start_receiving(udp_receive_handle);
+        let event_sender = NetSocketSystem::<E>::start_sending(udp_send_handle);
 
         Ok(NetSocketSystem {
             filters,
-            transport_sender: server_sender,
-            transport_receiver: server_receiver,
+            event_sender,
+            event_receiver: udp_receive_handle,
             config,
         })
     }
 
     /// Start a thread to send all queued packets.
     fn start_sending(sender: Sender<Packet>) -> Sender<InternalSocketEvent<E>> {
-        let (tx, send_queue) = crossbeam_channel::unbounded();
+        let (event_sender, event_receiver) = crossbeam_channel::unbounded();
 
         thread::spawn(move || loop {
-            for control_event in send_queue.try_iter() {
+            for control_event in event_receiver.try_iter() {
                 match control_event {
                     InternalSocketEvent::SendEvents { target, events } => {
                         for ev in events {
-                            send_event(ev, target, &sender);
+                            match ev {
+                                NetEvent::Packet(packet) => {
+                                    send_event(packet, target, &sender);
+                                }
+                                _ => { /* TODO, handle connect, disconnect etc. */ }
+                            }
                         }
                     }
                     InternalSocketEvent::Stop => {
@@ -96,28 +100,7 @@ where
             }
         });
 
-        tx
-    }
-
-    /// Starts a thread which receives incoming packets and sends them onto the 'Receiver' channel.
-    fn start_receiving(receiver: Receiver<SocketEvent>) -> Receiver<Packet> {
-        let (receive_queue, rx) = crossbeam_channel::unbounded();
-
-        thread::spawn(move || loop {
-            for event in receiver.iter() {
-                match event {
-                    SocketEvent::Packet(packet) => {
-                        if let Err(error) = receive_queue.send(packet.clone()) {
-                            error!("`NetworkSocketSystem` was dropped. Reason: {:?}", error);
-                            break;
-                        }
-                    }
-                    _ => error!("Event not supported"),
-                }
-            }
-        });
-
-        rx
+        event_sender
     }
 }
 
@@ -128,44 +111,49 @@ where
     type SystemData = (WriteStorage<'a, NetConnection<E>>);
 
     fn run(&mut self, mut net_connections: Self::SystemData) {
-        for net_connection in (&mut net_connections).join() {
-            let target = net_connection.target_addr;
-
-            if net_connection.state == ConnectionState::Connected
-                || net_connection.state == ConnectionState::Connecting
-            {
-                self.transport_sender
-                    .send(InternalSocketEvent::SendEvents {
-                        target,
-                        events: net_connection.send_buffer_early_read().cloned().collect(),
-                    })
-                    .expect("Unreachable: Channel will be alive until a stop event is sent");
-            } else if net_connection.state == ConnectionState::Disconnected {
-                self.transport_sender
-                    .send(InternalSocketEvent::Stop)
-                    .expect("Already sent a stop event to the channel");
+        for connection in (&mut net_connections).join() {
+            match connection.state {
+                ConnectionState::Connected | ConnectionState::Connecting => {
+                    self.event_sender
+                        .send(InternalSocketEvent::SendEvents {
+                            target: connection.target_addr,
+                            events: connection.send_buffer_early_read().cloned().collect(),
+                        })
+                        .expect("Unreachable: Channel will be alive until a stop event is sent");
+                }
+                ConnectionState::Disconnected => {
+                    self.event_sender
+                        .send(InternalSocketEvent::Stop)
+                        .expect("Already sent a stop event to the channel");
+                }
             }
         }
 
-        for (counter, raw_event) in self.transport_receiver.try_iter().enumerate() {
-            // Get the NetConnection from the source
-            for net_connection in (&mut net_connections).join() {
-                if net_connection.target_addr == raw_event.addr() {
+        for (counter, socket_event) in self.event_receiver.try_iter().enumerate() {
+            match socket_event {
+                SocketEvent::Packet(packet) => {
                     // Get the event
-                    match deserialize_event::<E>(raw_event.payload()) {
-                        Ok(ev) => {
-                            net_connection.receive_buffer.single_write(ev);
+                    match deserialize_event::<E>(packet.payload()) {
+                        Ok(event) => {
+                            // Get the NetConnection from the source
+                            for connection in (&mut net_connections).join() {
+                                if connection.target_addr == packet.addr() {
+                                    connection
+                                        .receive_buffer
+                                        .single_write(NetEvent::Packet(event.clone()));
+                                };
+                            }
                         }
                         Err(e) => error!(
                             "Failed to deserialize an incoming network event: {} From source: {:?}",
                             e,
-                            raw_event.addr()
+                            packet.addr()
                         ),
-                    }
-                } else {
-                    warn!("Received packet from unknown source");
+                    };
                 }
-            }
+                SocketEvent::Connect(_) => { /* TODO: Update connection status */ }
+                SocketEvent::Timeout(_) => { /* TODO: Update connection status */ }
+            };
 
             // this will prevent our system to be stuck in the iterator.
             // After 10000 packets we will continue and leave the other packets for the next run.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -66,6 +66,8 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * Rename `NetEvent::Custom` variant to `NetEvent::Unreliable`. ([#1513])
 * Updated laminar to 0.2.0. ([#1502])
 * Large binary files in examples are now tracked with `git-lfs`. ([#1509])
+* Allowed the user to arrange with laminar. ([#1510])
+* Removed `NetEvent::Custom` and added `NetEvent::Packet(NetPacket)` ([#1510])
 
 ### Removed
 
@@ -125,6 +127,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1502]: https://github.com/amethyst/amethyst/pull/1515
 [#1513]: https://github.com/amethyst/amethyst/pull/1513
 [#1509]: https://github.com/amethyst/amethyst/pull/1509
+[#1510]: https:://github.com/amethyst/amethyst/pull/1523/
 
 ## [0.10.0] - 2018-12
 


### PR DESCRIPTION
## Description

This PR implements the ordering and sequencing functionality from laminar into `amethyst_netework`. This required some API changes.

## Additions

- Added `NetEvent::Packet(NetPacket)` where `NetPacket` is a packet with different reliabilities. 
- OrderingGuarantee, same as the one we have in laminar, is needed so that we can implement `Serialize, Deserialize` for it. 
- DeliveryGuarantee, same as the one we have in laminar, is needed so that we can implement `Serialize, Deserialize` for it. 

## Removals

- Removed an UDP receiving thread
- Removed `NetEvent::Unreliable` and `NetEvent::Reliable`
- Removed `NetEvent::TextMessage` which is a `NetEvent::Packet()` now.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [  ] Ran `cargo test --all` locally if this modified any rs files.
- [X] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [X] Updated the content of the book if this PR would make the book outdated.
- [X] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
