### PR TITLE
Adding support for AMETHYST_NUM_THREADS environment variable to control size of the threads pool used by thread_pool_builder.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@ it is attached to. ([#1282])
 * `AmethystApplication` takes in application name using `with_app_name(..)`. ([#1499])
 * Add `NetEvent::Reliable` variant. When added to NetConnection, these events will eventually reach the target. ([#1513])
 * "How To" guides for defining state-specific dispatchers. ([#1498])
+* Adding support for AMETHYST_NUM_THREADS environment variable to control size of the threads pool used by thread_pool_builder.
 * Add `Input` variant to `StateEvent`. ([#1478])
 * Support type parameters in `EventReader` derive. ([#1478])
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -134,6 +134,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1513]: https://github.com/amethyst/amethyst/pull/1513
 [#1509]: https://github.com/amethyst/amethyst/pull/1509
 [#1510]: https:://github.com/amethyst/amethyst/pull/1523/
+[#1524]: https://github.com/amethyst/amethyst/pull/1524
 
 ## [0.10.0] - 2018-12
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -512,9 +512,6 @@ where
                 .map(Arc::new)?;
         } else {
             pool = thread_pool_builder.build().map(Arc::new)?;
-        } else {
-            info!("Running Amethyst with fixed thread pool: {}", thread_count);
-            pool = thread_pool_builder.num_threads(thread_count).build().map(Arc::new)?;
         }
         world.add_resource(Loader::new(path.as_ref().to_owned(), pool.clone()));
         world.add_resource(pool);

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,6 +15,7 @@ use crate::{
     assets::{Loader, Source},
     callback_queue::CallbackQueue,
     core::{
+        ArcThreadPool,
         frame_limiter::{FrameLimiter, FrameRateLimitConfig, FrameRateLimitStrategy},
         shrev::{EventChannel, ReaderId},
         timing::{Stopwatch, Time},
@@ -30,7 +31,6 @@ use crate::{
     state_event::{StateEvent, StateEventReader},
     ui::UiEvent,
 };
-use amethyst_core::ArcThreadPool;
 
 /// `CoreApplication` is the application implementation for the game engine. This is fully generic
 /// over the state type and event type.

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,11 +15,10 @@ use crate::{
     assets::{Loader, Source},
     callback_queue::CallbackQueue,
     core::{
-        ArcThreadPool,
         frame_limiter::{FrameLimiter, FrameRateLimitConfig, FrameRateLimitStrategy},
         shrev::{EventChannel, ReaderId},
         timing::{Stopwatch, Time},
-        EventReader, Named,
+        ArcThreadPool, EventReader, Named,
     },
     ecs::{
         common::Errors,

--- a/src/app.rs
+++ b/src/app.rs
@@ -487,7 +487,7 @@ where
             info!("Rustc git commit: {}", hash);
         }
 
-        let _thread_count :usize = env::var("AMETHYST_NUM_THREADS")
+        let thread_count :usize = env::var("AMETHYST_NUM_THREADS")
             .as_ref()
             .map(String::as_str)
             .unwrap_or(&String::from("0"))
@@ -501,11 +501,11 @@ where
             register_thread_with_profiler();
         });
         let pool :ArcThreadPool;
-        if _thread_count == 0 {
+        if thread_count == 0 {
             pool = thread_pool_builder.build().map(Arc::new)?;
         } else {
-            info!("Running Amethyst with fixed thread pool: {}", _thread_count);
-            pool = thread_pool_builder.num_threads(_thread_count).build().map(Arc::new)?;
+            info!("Running Amethyst with fixed thread pool: {}", thread_count);
+            pool = thread_pool_builder.num_threads(thread_count).build().map(Arc::new)?;
         }
         world.add_resource(Loader::new(path.as_ref().to_owned(), pool.clone()));
         world.add_resource(pool);

--- a/src/app.rs
+++ b/src/app.rs
@@ -489,9 +489,9 @@ where
 
         let thread_count :usize = env::var("AMETHYST_NUM_THREADS")
             .as_ref()
-            .map(String::as_str)
-            .unwrap_or("0")
-            .parse().expect("AMETHYST_NUM_THREADS was provided but is not a valid number!");
+            .map(|s| s.as_str().parse()
+                    .expect("AMETHYST_NUM_THREADS was provided but is not a valid number!"))
+            .unwrap_or(0);
 
         let mut world = World::new();
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -490,7 +490,7 @@ where
         let thread_count :usize = env::var("AMETHYST_NUM_THREADS")
             .as_ref()
             .map(String::as_str)
-            .unwrap_or(&String::from("0"))
+            .unwrap_or("0")
             .parse().expect("AMETHYST_NUM_THREADS was provided but is not a valid number!");
 
         let mut world = World::new();


### PR DESCRIPTION
## Description

This change allows for an environmental variable in Amethyst to control thread pool size, instead of relying on the variable in rayon. This helps alleviate extreme CPU saturation when amethyst is run on a system with many cores.

## Modifications

- `ApplicationBuilder:new`

## PR Checklist

By placing an x in the boxes I certify that I have:

- [X] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [X] Updated the content of the book if this PR would make the book outdated.
- [X] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

PS. Not sure how to cover this best in unit tests, so any help in that department (and any other really, new-ish to RUST here) is highly appreciated and more than welcome :). Also couldn't run the 2nd cargo test due to error:
`Warning: can't set `merge_imports = true`, unstable features are only available in nightly channel.`
