### PR TITLE
fix: Display the syntax error when failing to parse sprite sheets

### DIFF
--- a/amethyst_renderer/src/error.rs
+++ b/amethyst_renderer/src/error.rs
@@ -14,7 +14,7 @@ pub(crate) enum Error {
     /// The window handle associated with the renderer has been destroyed.
     WindowDestroyed,
     /// Failed to parse a Spritesheet from RON.
-    LoadSpritesheetError,
+    LoadSpritesheetError(ron::de::Error),
     /// Failed to build texture.
     BuildTextureError,
     /// Unsupported texture size.
@@ -36,7 +36,7 @@ impl fmt::Display for Error {
             ProgramCreation => write!(fmt, "Program compilation failed"),
             PixelDataMismatch(ref e) => write!(fmt, "Pixel data and metadata do not match: {}", e),
             WindowDestroyed => write!(fmt, "Window has been destroyed"),
-            LoadSpritesheetError => write!(fmt, "Failed to parse SpriteSheet"),
+            LoadSpritesheetError(ref e) => write!(fmt, "Failed to parse SpriteSheet: {}", e),
             BuildTextureError => write!(fmt, "Failed to build texture"),
             UnsupportedTextureSize(w, h) => write!(
                 fmt,

--- a/amethyst_renderer/src/sprite/mod.rs
+++ b/amethyst_renderer/src/sprite/mod.rs
@@ -279,7 +279,7 @@ impl SimpleFormat<SpriteSheet> for SpriteSheetFormat {
 
     fn import(&self, bytes: Vec<u8>, texture: Self::Options) -> Result<SpriteSheet, Error> {
         let sprite_list: SpriteList =
-            from_ron_bytes(&bytes).map_err(|_| error::Error::LoadSpritesheetError)?;
+            from_ron_bytes(&bytes).map_err(|err| error::Error::LoadSpritesheetError(err))?;
 
         Ok(SpriteSheet {
             texture,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -69,9 +69,10 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * Rename `NetEvent::Custom` variant to `NetEvent::Unreliable`. ([#1513])
 * Updated laminar to 0.2.0. ([#1502])
 * Large binary files in examples are now tracked with `git-lfs`. ([#1509])
-* Allowed the user to arrange with laminar. ([#1510])
-* Removed `NetEvent::Custom` and added `NetEvent::Packet(NetPacket)` ([#1510])
+* Allowed the user to arrange with laminar. ([#1523])
+* Removed `NetEvent::Custom` and added `NetEvent::Packet(NetPacket)` ([#1523])
 * Fixed update is no longer frame rate dependent ([#1516])
+* Display the syntax error when failing to parse sprite sheets  ([#1526])
 
 
 ### Removed
@@ -133,8 +134,9 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1502]: https://github.com/amethyst/amethyst/pull/1515
 [#1513]: https://github.com/amethyst/amethyst/pull/1513
 [#1509]: https://github.com/amethyst/amethyst/pull/1509
-[#1510]: https:://github.com/amethyst/amethyst/pull/1523/
+[#1523]: https://github.com/amethyst/amethyst/pull/1523
 [#1524]: https://github.com/amethyst/amethyst/pull/1524
+[#1526]: https://github.com/amethyst/amethyst/pull/1526
 
 ## [0.10.0] - 2018-12
 


### PR DESCRIPTION
## Description

Displays the error generated by RON if a sprite sheet fails to parse. Makes it easier to figure out errors in spritesheets.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ ] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
