### PR TITLE
Don't take Bindings as mut when retrieving axis

### DIFF
--- a/amethyst_input/src/bindings.rs
+++ b/amethyst_input/src/bindings.rs
@@ -180,7 +180,7 @@ where
     }
 
     /// Returns a reference to an axis.
-    pub fn axis<A: Hash + Eq + ?Sized>(&mut self, id: &A) -> Option<&Axis>
+    pub fn axis<A: Hash + Eq + ?Sized>(&self, id: &A) -> Option<&Axis>
     where
         AX: Borrow<A>,
     {


### PR DESCRIPTION
I see no reason this needs to be &mut self.

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
