### PR TITLE
Make generated UI entity fields `pub`.

### DIFF
--- a/amethyst_ui/src/button/builder.rs
+++ b/amethyst_ui/src/button/builder.rs
@@ -260,7 +260,7 @@ impl<'a, G: PartialEq + Send + Sync + 'static, I: WidgetId> UiButtonBuilder<G, I
     pub fn build(mut self, mut res: UiButtonBuilderResources<'a, G, I>) -> (I, UiButton) {
         let image_entity = res.entities.create();
         let text_entity = res.entities.create();
-        let widget = UiButton::new(image_entity, text_entity);
+        let widget = UiButton::new(text_entity, image_entity);
 
         let id = {
             let widget = widget.clone();

--- a/amethyst_ui/src/widgets.rs
+++ b/amethyst_ui/src/widgets.rs
@@ -187,7 +187,10 @@ macro_rules! define_widget {
         /// A $t widget, containing references to its associated entities.
         #[derive(Debug, Clone)]
         pub struct $t {
-            $($field: $crate::Entity),*
+            $(
+                /// `$field` Entity
+                pub $field: $crate::Entity
+            ),*
         }
 
         impl $crate::Widget for $t {}


### PR DESCRIPTION
## Description

Expose `Entity` fields created by the `define_widget!` macro.

See #1531 for details.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- **n/a** Updated the content of the book if this PR would make the book outdated.
- **n/a** Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
