### PR TITLE
Downgraded `shred` version to `0.7` in `amethyst_network`.

### DIFF
--- a/amethyst_network/Cargo.toml
+++ b/amethyst_network/Cargo.toml
@@ -25,7 +25,7 @@ amethyst_core = { path = "../amethyst_core", version = "0.5" }
 amethyst_error = { path = "../amethyst_error", version = "0.1.0" }
 serde = { version = "1", features = ["derive"] }
 shrev = "1.0"
-shred = "0.8.0"
+shred = "0.7"
 bincode = "1.0"
 log = "0.4.6"
 uuid = { version = "0.7.1", features = ["v4","serde"] }


### PR DESCRIPTION
## Description

Downgrade `shrev` dependency in `amethyst_network` to `0.7`. This keeps it in line with all other crates' dependencies.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- **n/a** Ran `cargo +stable fmt --all` locally if this modified any rs files.
- **n/a** Updated the content of the book if this PR would make the book outdated.
- **n/a** Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
