### PR TITLE
Adding events example based off the Events Channel page of the documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -288,3 +288,7 @@ path = "examples/simple_image/main.rs"
 [[example]]
 name = "auto_fov"
 path = "examples/auto_fov/main.rs"
+
+[[example]]
+name = "events"
+path = "examples/events/mains.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,4 +291,4 @@ path = "examples/auto_fov/main.rs"
 
 [[example]]
 name = "events"
-path = "examples/events/mains.rs"
+path = "examples/events/main.rs"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,7 +36,7 @@ it is attached to. ([#1282])
 * Adding support for AMETHYST_NUM_THREADS environment variable to control size of the threads pool used by thread_pool_builder.
 * Add `Input` variant to `StateEvent`. ([#1478])
 * Support type parameters in `EventReader` derive. ([#1478])
-* Added `events` example which demonstrates working even reader and writer in action. ([#])
+* Added `events` example which demonstrates working even reader and writer in action. ([#1538])
 
 ### Changed
 
@@ -138,6 +138,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1523]: https://github.com/amethyst/amethyst/pull/1523
 [#1524]: https://github.com/amethyst/amethyst/pull/1524
 [#1526]: https://github.com/amethyst/amethyst/pull/1526
+[#1538]: https://github.com/amethyst/amethyst/pull/1538
 
 ## [0.10.0] - 2018-12
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,7 @@ it is attached to. ([#1282])
 * Adding support for AMETHYST_NUM_THREADS environment variable to control size of the threads pool used by thread_pool_builder.
 * Add `Input` variant to `StateEvent`. ([#1478])
 * Support type parameters in `EventReader` derive. ([#1478])
+* Added `events` example which demonstrates working even reader and writer in action. ([#])
 
 ### Changed
 

--- a/examples/events/main.rs
+++ b/examples/events/main.rs
@@ -1,0 +1,97 @@
+extern crate amethyst;
+
+use amethyst::core::{
+    bundle::SystemBundle,
+    frame_limiter::FrameRateLimitStrategy,
+    shrev::{EventChannel, ReaderId},
+};
+use amethyst::{
+    ecs::{DispatcherBuilder, Read, Resources, System, SystemData, World, Write},
+    prelude::*,
+};
+
+use amethyst::Error;
+use core::result::Result;
+
+#[derive(Debug)]
+struct MyBundle;
+
+impl<'a, 'b> SystemBundle<'a, 'b> for MyBundle {
+    fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<(), Error> {
+        builder.add(SpammingSystem, "spamming_system", &[]);
+        builder.add(
+            ReceivingSystem {
+                reader: std::prelude::v1::Option::None,
+            },
+            "receiving_system",
+            &[],
+        );
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AppEvent {
+    data: i32,
+}
+
+#[derive(Debug)]
+pub enum MyEvent {
+    A,
+    B,
+    C,
+}
+
+struct GameplayState;
+
+struct SpammingSystem;
+
+impl<'a> System<'a> for SpammingSystem {
+    type SystemData = Write<'a, EventChannel<MyEvent>>;
+
+    fn run(&mut self, mut my_event_channel: Self::SystemData) {
+        my_event_channel.single_write(MyEvent::A);
+        println!("Sending A");
+        my_event_channel.single_write(MyEvent::B);
+        println!("Sending B");
+        my_event_channel.single_write(MyEvent::C);
+        println!("Sending C");
+    }
+}
+
+struct ReceivingSystem {
+    reader: Option<ReaderId<MyEvent>>,
+}
+
+impl<'a> System<'a> for ReceivingSystem {
+    type SystemData = Read<'a, EventChannel<MyEvent>>;
+
+    fn run(&mut self, my_event_channel: Self::SystemData) {
+        for event in my_event_channel.read(self.reader.as_mut().unwrap()) {
+            println!("Received an event: {:?}", event);
+        }
+    }
+
+    fn setup(&mut self, res: &mut Resources) {
+        Self::SystemData::setup(res);
+        self.reader = Some(res.fetch_mut::<EventChannel<MyEvent>>().register_reader());
+    }
+}
+
+impl SimpleState for GameplayState {}
+
+fn main() -> amethyst::Result<()> {
+    amethyst::start_logger(Default::default());
+
+    let mut world = World::new();
+    world.add_resource(EventChannel::<MyEvent>::new());
+
+    let game_data = GameDataBuilder::default().with_bundle(MyBundle)?;
+
+    let mut game = Application::build("./", GameplayState)?
+        .with_frame_limit(FrameRateLimitStrategy::Sleep, 1)
+        .build(game_data)?;
+
+    game.run();
+    Ok(())
+}

--- a/examples/events/main.rs
+++ b/examples/events/main.rs
@@ -21,7 +21,7 @@ impl<'a, 'b> SystemBundle<'a, 'b> for MyBundle {
         builder.add(SpammingSystem, "spamming_system", &[]);
         builder.add(
             ReceivingSystem {
-                reader: std::prelude::v1::Option::None,
+                reader: Option::None,
             },
             "receiving_system",
             &[],


### PR DESCRIPTION
## Description

A very simple PR that merely adds an example of a cli application that sends and receives events. I felt like a working demonstration helps a lot, especially as it also deals with creating a bundle, adding systems to it etc.

## Additions

- Examples/Events

## Removals


## Modifications


## PR Checklist

By placing an x in the boxes I certify that I have:

- [X] Ran `cargo test --all` locally if this modified any rs files.
- [X] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [X] Updated the content of the book if this PR would make the book outdated.
- [X] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [X] Added unit tests for new APIs if any were added in this PR.
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
