### PR TITLE
Add Window centering and monitor size.

### DIFF
--- a/amethyst_renderer/src/config.rs
+++ b/amethyst_renderer/src/config.rs
@@ -15,6 +15,7 @@ use winit::{self, Icon, MonitorId, WindowAttributes, WindowBuilder};
 ///     max_dimensions: None,
 ///     min_dimensions: None,
 ///     fullscreen: false,
+///     centered_window: true,
 ///     multisampling: 0,
 ///     visibility: true,
 ///     vsync: true,
@@ -43,6 +44,9 @@ pub struct DisplayConfig {
 
     /// Maximum window dimensions, measured in pixels (px).
     pub max_dimensions: Option<(u32, u32)>,
+
+    /// Whether the window will be centered on the monitor by deafult.
+    pub centered_window: bool,
 
     /// Path to window icon.
     pub icon: Option<String>,
@@ -88,6 +92,7 @@ impl Default for DisplayConfig {
             decorations: true,
             dimensions: Some((640, 480)),
             fullscreen: false,
+            centered_window: true,
             icon: None,
             loaded_icon: None,
             max_dimensions: None,

--- a/amethyst_renderer/src/config.rs
+++ b/amethyst_renderer/src/config.rs
@@ -45,7 +45,7 @@ pub struct DisplayConfig {
     /// Maximum window dimensions, measured in pixels (px).
     pub max_dimensions: Option<(u32, u32)>,
 
-    /// Whether the window will be centered on the monitor by deafult.
+    /// Whether the window will be centered on the monitor by default.
     pub centered_window: bool,
 
     /// Path to window icon.

--- a/amethyst_renderer/src/renderer.rs
+++ b/amethyst_renderer/src/renderer.rs
@@ -212,6 +212,20 @@ impl RendererBuilder {
             .get_inner_size()
             .ok_or_else(|| format_err!("Unable to fetch window size, as the window went away."))?;
 
+        if self.config.centered_window && !self.config.fullscreen {
+            let windowsize = window.get_outer_size().ok_or_else(|| {
+                format_err!("Unable to fetch window outer size, as the window went away.")
+            })?;
+            let screen_size = window.get_current_monitor().get_dimensions();
+            window.set_position(
+                (
+                    ((screen_size.width * 0.5) - windowsize.width * 0.5) as f64,
+                    ((screen_size.height * 0.5) - windowsize.height * 0.5) as f64,
+                )
+                    .into(),
+            );
+        }
+
         let cached_hidpi_factor = window.get_hidpi_factor();
 
         let encoder = factory.create_command_buffer().into();

--- a/amethyst_renderer/src/resources.rs
+++ b/amethyst_renderer/src/resources.rs
@@ -68,10 +68,14 @@ impl WindowMessages {
 /// World resource that stores screen dimensions.
 #[derive(Debug)]
 pub struct ScreenDimensions {
-    /// Screen width in pixels (px).
+    /// Window width in pixels (px).
     pub(crate) w: f64,
-    /// Screen height in pixels (px).
+    /// Window height in pixels (px).
     pub(crate) h: f64,
+    /// Monitor width in pixels (px).
+    pub(crate) monitor_w: f64,
+    /// Monitor height in pixels (px).
+    pub(crate) monitor_h: f64,
     /// Width divided by height.
     aspect_ratio: f32,
     /// The ratio between the backing framebuffer resolution and the window size in screen pixels.
@@ -81,13 +85,15 @@ pub struct ScreenDimensions {
 }
 
 impl ScreenDimensions {
-    /// Creates a new screen dimensions object with the given width and height.
-    pub fn new(w: u32, h: u32, hidpi: f64) -> Self {
+    /// Creates a new screen dimensions object with the given width and height for the window and the monitor.
+    pub fn new(w: u32, h: u32, hidpi: f64, mw: u32, mh: u32) -> Self {
         ScreenDimensions {
             w: f64::from(w),
             h: f64::from(h),
             aspect_ratio: w as f32 / h as f32,
             hidpi,
+            monitor_w: f64::from(mw),
+            monitor_h: f64::from(mh),
             dirty: false,
         }
     }
@@ -100,6 +106,16 @@ impl ScreenDimensions {
     /// Returns the current height of the window.
     pub fn height(&self) -> f32 {
         self.h as f32
+    }
+
+    /// Returns the current width of the monitor that the window lives in.
+    pub fn monitor_width(&self) -> f32 {
+        self.monitor_w as f32
+    }
+
+    /// Returns the current height of the monitor that the window lives in.
+    pub fn monitor_height(&self) -> f32 {
+        self.monitor_h as f32
     }
 
     /// Returns the current aspect ratio of the window.

--- a/amethyst_renderer/src/system.rs
+++ b/amethyst_renderer/src/system.rs
@@ -124,6 +124,15 @@ where
         let width = screen_dimensions.w;
         let height = screen_dimensions.h;
 
+        let monitor_size = self
+            .renderer
+            .window()
+            .get_primary_monitor()
+            .get_dimensions();
+
+        screen_dimensions.monitor_w = monitor_size.width;
+        screen_dimensions.monitor_w = monitor_size.height;
+
         // Send resource size changes to the window
         if screen_dimensions.dirty {
             self.renderer
@@ -211,8 +220,18 @@ where
             .get_inner_size()
             .expect("Window closed during initialization!")
             .into();
+
+        let (monitor_w, monitor_h) = self
+            .renderer
+            .window()
+            .get_current_monitor()
+            .get_dimensions()
+            .into();
+
         let hidpi = self.renderer.window().get_hidpi_factor();
-        res.insert(ScreenDimensions::new(width, height, hidpi));
+        res.insert(ScreenDimensions::new(
+            width, height, hidpi, monitor_w, monitor_h,
+        ));
     }
 }
 

--- a/amethyst_renderer/src/system.rs
+++ b/amethyst_renderer/src/system.rs
@@ -131,7 +131,7 @@ where
             .get_dimensions();
 
         screen_dimensions.monitor_w = monitor_size.width;
-        screen_dimensions.monitor_w = monitor_size.height;
+        screen_dimensions.monitor_h = monitor_size.height;
 
         // Send resource size changes to the window
         if screen_dimensions.dirty {

--- a/amethyst_renderer/src/system.rs
+++ b/amethyst_renderer/src/system.rs
@@ -127,7 +127,7 @@ where
         let monitor_size = self
             .renderer
             .window()
-            .get_primary_monitor()
+            .get_current_monitor()
             .get_dimensions();
 
         screen_dimensions.monitor_w = monitor_size.width;

--- a/amethyst_test/src/amethyst_application.rs
+++ b/amethyst_test/src/amethyst_application.rs
@@ -57,6 +57,12 @@ type DefaultPipeline = PipelineBuilder<
 pub const SCREEN_WIDTH: u32 = 800;
 /// Screen height used in predefined display configuration.
 pub const SCREEN_HEIGHT: u32 = 600;
+
+/// Monitor width used in predefined display configuration.
+pub const MONITOR_WIDTH: u32 = 1280;
+/// Monitor height used in predefined display configuration.
+pub const MONITOR_HEIGHT: u32 = 800;
+
 /// The ratio between the backing framebuffer resolution and the window size in screen pixels.
 /// This is typically one for a normal display and two for a retina display.
 pub const HIDPI: f64 = 1.;
@@ -141,8 +147,8 @@ impl AmethystApplication<GameData<'static, 'static>, StateEvent, StateEventReade
                 SCREEN_WIDTH,
                 SCREEN_HEIGHT,
                 HIDPI,
-                1280,
-                800,
+                MONITOR_WIDTH,
+                MONITOR_HEIGHT,
             ))
     }
 

--- a/amethyst_test/src/amethyst_application.rs
+++ b/amethyst_test/src/amethyst_application.rs
@@ -137,7 +137,13 @@ impl AmethystApplication<GameData<'static, 'static>, StateEvent, StateEventReade
         AmethystApplication::blank()
             .with_bundle(TransformBundle::new())
             .with_ui_bundles::<AX, AC>()
-            .with_resource(ScreenDimensions::new(SCREEN_WIDTH, SCREEN_HEIGHT, HIDPI))
+            .with_resource(ScreenDimensions::new(
+                SCREEN_WIDTH,
+                SCREEN_HEIGHT,
+                HIDPI,
+                1280,
+                800,
+            ))
     }
 
     /// Returns an application with the Animation, Transform, and Render bundles.
@@ -682,6 +688,7 @@ where
             dimensions: Some((SCREEN_WIDTH, SCREEN_HEIGHT)),
             min_dimensions: Some((SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2)),
             max_dimensions: None,
+            centered_window: true,
             loaded_icon: None,
             icon: None,
             vsync: true,

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -28,3 +28,4 @@
 * White-Oak
 * Xaeroxe (Jacob Kiesel)
 * Telzhaak
+* mralve (Alve Larsson)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -139,6 +139,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1523]: https://github.com/amethyst/amethyst/pull/1523
 [#1524]: https://github.com/amethyst/amethyst/pull/1524
 [#1526]: https://github.com/amethyst/amethyst/pull/1526
+[#1539]: https://github.com/amethyst/amethyst/pull/1539
 
 ## [0.10.0] - 2018-12
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,8 +36,8 @@ it is attached to. ([#1282])
 * Adding support for AMETHYST_NUM_THREADS environment variable to control size of the threads pool used by thread_pool_builder.
 * Add `Input` variant to `StateEvent`. ([#1478])
 * Support type parameters in `EventReader` derive. ([#1478])
-* Added `monitor_width` and `monitor_height` in `ScreenDimensions`.
-* Added `centered_window` bool to `DisplayConfig` Windows will now be centered by deafult.
+* Added `monitor_width` and `monitor_height` in `ScreenDimensions`. ([#1539])
+* Added `centered_window` bool to `DisplayConfig` Windows will now be centered by deafult. ([#1539])
 
 ### Changed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,8 @@ it is attached to. ([#1282])
 * Adding support for AMETHYST_NUM_THREADS environment variable to control size of the threads pool used by thread_pool_builder.
 * Add `Input` variant to `StateEvent`. ([#1478])
 * Support type parameters in `EventReader` derive. ([#1478])
+* Added `monitor_width` and `monitor_height` in `ScreenDimensions`.
+* Added `centered_window` bool to `DisplayConfig` Windows will now be centered by deafult.
 
 ### Changed
 


### PR DESCRIPTION
## Description

Made so windows will now be centered on the current monitor by default.
Small fixes in ScreenDimensions docs to clarify.

## Additions

DisplayConfig - Added `centered_window` bool to be able to toggle the centering.
ScreenDimensions - Added monitor HEIGHT and WIDTH functions to get the current screens res.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
