### PR TITLE
Adds profiler to appropriate places in rendy

### DIFF
--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -7,13 +7,6 @@ description = "High-level rendering engine with multiple backends"
 keywords = ["game", "engine", "renderer", "3d", "amethyst"]
 categories = ["rendering", "rendering::engine"]
 
-[features]
-dx12 = ["rendy/dx12"]
-metal = ["rendy/metal"]
-vulkan = ["rendy/vulkan"]
-nightly = ["shred/nightly"]
-profiler = []
-
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.6" }
 amethyst_core = { path = "../amethyst_core", version = "0.5" }
@@ -32,8 +25,17 @@ rendy = { path = "../../rendy/rendy/", features = ["full", "empty", "serde-1"] }
 ron = "0.4"
 serde = { version = "1", features = ["serde_derive"] }
 shred = { version = "0.7"  }
-shred-derive = { version = "0.5" }  
+shred-derive = { version = "0.5" }
 fnv = "1"
 derivative = "1.0.2"
 smallvec = "0.6.9"
 num-traits = "0.2.6"
+
+thread_profiler = { version = "0.3", optional = true }
+
+[features]
+dx12 = ["rendy/dx12"]
+metal = ["rendy/metal"]
+vulkan = ["rendy/vulkan"]
+profiler = [ "thread_profiler/thread_profiler" ]
+nightly = [ "amethyst_core/nightly", "shred/nightly" ]

--- a/amethyst_rendy/src/batch.rs
+++ b/amethyst_rendy/src/batch.rs
@@ -7,6 +7,9 @@ use std::{
     ops::Range,
 };
 
+#[cfg(feature = "profiler")]
+use thread_profiler::profile_scope;
+
 pub trait GroupIterator<K, V>
 where
     Self: Iterator<Item = (K, V)> + Sized,
@@ -30,6 +33,9 @@ where
     where
         F: FnMut(K, &mut Vec<V>),
     {
+        #[cfg(feature = "profiler")]
+        profile_scope!("for_each_group");
+
         let mut block: Option<(K, Vec<V>)> = None;
 
         for (next_group_id, value) in self {
@@ -87,6 +93,9 @@ where
     }
 
     pub fn insert(&mut self, pk: PK, sk: SK, data: impl IntoIterator<Item = C::Item>) {
+        #[cfg(feature = "profiler")]
+        profile_scope!("twolevel_insert");
+
         let instance_data = data.into_iter().tap_count(&mut self.data_count);
 
         match self.map.entry(pk) {
@@ -149,6 +158,9 @@ where
     }
 
     pub fn insert(&mut self, pk: PK, sk: SK, data: impl IntoIterator<Item = D>) {
+        #[cfg(feature = "profiler")]
+        profile_scope!("ordered_twolevel_insert");
+
         let start = self.data_list.len() as u32;
         self.data_list.extend(data);
         let end = self.data_list.len() as u32;
@@ -219,6 +231,9 @@ where
     }
 
     pub fn insert(&mut self, pk: PK, data: impl IntoIterator<Item = D>) {
+        #[cfg(feature = "profiler")]
+        profile_scope!("onelevel_insert");
+
         let instance_data = data.into_iter();
 
         match self.map.entry(pk) {
@@ -276,6 +291,9 @@ where
     }
 
     pub fn insert(&mut self, pk: PK, data: impl IntoIterator<Item = D>) {
+        #[cfg(feature = "profiler")]
+        profile_scope!("ordered_onelevel_insert");
+
         let start = self.data_list.len() as u32;
         self.data_list.extend(data);
         let added_len = self.data_list.len() as u32 - start;

--- a/amethyst_rendy/src/sprite_visibility.rs
+++ b/amethyst_rendy/src/sprite_visibility.rs
@@ -11,6 +11,9 @@ use amethyst_core::{
 use hibitset::BitSet;
 use std::cmp::Ordering;
 
+#[cfg(feature = "profiler")]
+use thread_profiler::profile_scope;
+
 /// Resource for controlling what entities should be rendered, and whether to draw them ordered or
 /// not, which is useful for transparent surfaces.
 #[derive(Default)]
@@ -67,6 +70,9 @@ impl<'a> System<'a> for SpriteVisibilitySortingSystem {
         &mut self,
         (entities, mut visibility, hidden, hidden_prop, active, camera, transparent, global): Self::SystemData,
     ) {
+        #[cfg(feature = "profiler")]
+        profile_scope!("run");
+
         let origin = Point3::origin();
 
         // The camera position is used to determine culling, but the sprites are ordered based on

--- a/amethyst_rendy/src/submodules/environment.rs
+++ b/amethyst_rendy/src/submodules/environment.rs
@@ -17,6 +17,9 @@ use amethyst_core::{
 };
 use glsl_layout::*;
 
+#[cfg(feature = "profiler")]
+use thread_profiler::profile_scope;
+
 const MAX_POINT_LIGHTS: usize = 128;
 const MAX_DIR_LIGHTS: usize = 16;
 const MAX_SPOT_LIGHTS: usize = 128;
@@ -46,6 +49,9 @@ impl<B: Backend> EnvironmentSub<B> {
     }
 
     pub fn process(&mut self, factory: &Factory<B>, index: usize, res: &Resources) -> bool {
+        #[cfg(feature = "profiler")]
+        profile_scope!("process");
+
         let this_image = {
             while self.per_image.len() <= index {
                 self.per_image

--- a/amethyst_rendy/src/submodules/flat_environment.rs
+++ b/amethyst_rendy/src/submodules/flat_environment.rs
@@ -14,6 +14,9 @@ use crate::{
 };
 use amethyst_core::ecs::Resources;
 
+#[cfg(feature = "profiler")]
+use thread_profiler::profile_scope;
+
 #[derive(Debug)]
 pub struct FlatEnvironmentSub<B: Backend> {
     layout: RendyHandle<DescriptorSetLayout<B>>,
@@ -39,6 +42,9 @@ impl<B: Backend> FlatEnvironmentSub<B> {
     }
 
     pub fn process(&mut self, factory: &Factory<B>, index: usize, res: &Resources) {
+        #[cfg(feature = "profiler")]
+        profile_scope!("process");
+
         let this_image = {
             while self.per_image.len() <= index {
                 self.per_image

--- a/amethyst_rendy/src/submodules/gather.rs
+++ b/amethyst_rendy/src/submodules/gather.rs
@@ -9,6 +9,9 @@ use amethyst_core::{
 };
 use glsl_layout::*;
 
+#[cfg(feature = "profiler")]
+use thread_profiler::profile_scope;
+
 type Std140<T> = <T as AsStd140>::Std140;
 
 pub struct CameraGatherer {
@@ -18,6 +21,9 @@ pub struct CameraGatherer {
 
 impl CameraGatherer {
     pub fn gather(res: &Resources) -> Self {
+        #[cfg(feature = "profiler")]
+        profile_scope!("gather_cameras");
+
         let (active_camera, cameras, global_transforms) = <(
             Option<Read<'_, ActiveCamera>>,
             ReadStorage<'_, Camera>,

--- a/amethyst_rendy/src/submodules/material.rs
+++ b/amethyst_rendy/src/submodules/material.rs
@@ -17,6 +17,9 @@ use amethyst_assets::{AssetStorage, Handle};
 use amethyst_core::ecs::{Read, Resources, SystemData};
 use glsl_layout::*;
 
+#[cfg(feature = "profiler")]
+use thread_profiler::profile_scope;
+
 #[derive(Debug)]
 struct SlotAllocator {
     vaccants: Vec<u64>,
@@ -192,6 +195,9 @@ impl<B: Backend> MaterialSub<B> {
         res: &Resources,
         handle: &Handle<Material<B>>,
     ) -> Option<MaterialState<B>> {
+        #[cfg(feature = "profiler")]
+        profile_scope!("try_insert");
+
         use util::{desc_write, slice_as_bytes, texture_desc};
         let (mat_storage, tex_storage) = <(
             Read<'_, AssetStorage<Material<B>>>,
@@ -246,6 +252,9 @@ impl<B: Backend> MaterialSub<B> {
         res: &Resources,
         handle: &Handle<Material<B>>,
     ) -> Option<(MaterialId, bool)> {
+        #[cfg(feature = "profiler")]
+        profile_scope!("insert");
+
         let id = self.lookup.forward(handle.id());
         match self.materials.get_mut(id) {
             Some(MaterialState::Loaded { generation, .. }) => {

--- a/amethyst_rendy/src/submodules/skinning.rs
+++ b/amethyst_rendy/src/submodules/skinning.rs
@@ -11,6 +11,9 @@ use crate::{
 };
 use fnv::FnvHashMap;
 
+#[cfg(feature = "profiler")]
+use thread_profiler::profile_scope;
+
 #[derive(Debug)]
 pub struct SkinningSub<B: Backend> {
     layout: RendyHandle<DescriptorSetLayout<B>>,
@@ -53,6 +56,9 @@ impl<B: Backend> SkinningSub<B> {
     }
 
     pub fn insert(&mut self, joints: &JointTransforms) -> u32 {
+        #[cfg(feature = "profiler")]
+        profile_scope!("insert");
+
         let staging = &mut self.staging;
         *self
             .skin_offset_map

--- a/amethyst_rendy/src/submodules/texture.rs
+++ b/amethyst_rendy/src/submodules/texture.rs
@@ -11,6 +11,9 @@ use crate::{
 use amethyst_assets::{AssetStorage, Handle};
 use amethyst_core::ecs::{Read, Resources, SystemData};
 
+#[cfg(feature = "profiler")]
+use thread_profiler::profile_scope;
+
 #[derive(Debug)]
 enum TextureState<B: Backend> {
     Unloaded {
@@ -57,6 +60,9 @@ impl<B: Backend> TextureSub<B> {
         res: &Resources,
         handle: &Handle<Texture<B>>,
     ) -> Option<TextureState<B>> {
+        #[cfg(feature = "profiler")]
+        profile_scope!("try_insert");
+
         use util::{desc_write, texture_desc};
         let tex_storage = <(Read<'_, AssetStorage<Texture<B>>>)>::fetch(res);
 
@@ -78,6 +84,9 @@ impl<B: Backend> TextureSub<B> {
         res: &Resources,
         handle: &Handle<Texture<B>>,
     ) -> Option<(TextureId, bool)> {
+        #[cfg(feature = "profiler")]
+        profile_scope!("insert");
+
         let id = self.lookup.forward(handle.id());
         match self.textures.get_mut(id) {
             Some(TextureState::Loaded { .. }) => {

--- a/amethyst_rendy/src/system.rs
+++ b/amethyst_rendy/src/system.rs
@@ -26,6 +26,9 @@ use rendy::{
 };
 use std::sync::Arc;
 
+#[cfg(feature = "profiler")]
+use thread_profiler::profile_scope;
+
 pub trait GraphCreator<B: Backend> {
     /// Check if graph needs to be rebuilt.
     /// This function is evaluated every frame before running the graph.
@@ -150,6 +153,9 @@ where
     }
 
     fn rebuild_graph(&mut self, res: &Resources) {
+        #[cfg(feature = "profiler")]
+        profile_scope!("rebuild_graph");
+
         let mut factory = res.fetch_mut::<Factory<B>>();
 
         if let Some(graph) = self.graph.take() {

--- a/amethyst_rendy/src/util.rs
+++ b/amethyst_rendy/src/util.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "profiler")]
-use thread_profiler::profile_scope;
-
 use crate::types::Texture;
 use core::{
     hash::Hash,
@@ -18,6 +15,9 @@ use rendy::{
     mesh::VertexFormat,
     resource::{BufferInfo, Escape},
 };
+
+#[cfg(feature = "profiler")]
+use thread_profiler::profile_scope;
 
 #[inline]
 pub fn next_range<T: Add<Output = T> + Clone>(prev: &Range<T>, length: T) -> Range<T> {
@@ -41,6 +41,9 @@ pub fn ensure_buffer<B: Backend>(
     memory_usage: impl MemoryUsage,
     min_size: u64,
 ) -> Result<bool, failure::Error> {
+    #[cfg(feature = "profiler")]
+    profile_scope!("ensure_buffer");
+
     if buffer.as_ref().map(|b| b.size()).unwrap_or(0) < min_size {
         let new_size = min_size.next_power_of_two();
         let new_buffer = factory.create_buffer(

--- a/amethyst_rendy/src/visibility.rs
+++ b/amethyst_rendy/src/visibility.rs
@@ -14,6 +14,9 @@ use hibitset::BitSet;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 
+#[cfg(feature = "profiler")]
+use thread_profiler::profile_scope;
+
 /// Resource for controlling what entities should be rendered, and whether to draw them ordered or
 /// not, which is useful for transparent surfaces.
 #[derive(Default)]
@@ -102,6 +105,9 @@ impl<'a> System<'a> for VisibilitySortingSystem {
         &mut self,
         (entities, mut visibility, hidden, hidden_prop, active, camera, transparent, global, bound): Self::SystemData,
     ) {
+        #[cfg(feature = "profiler")]
+        profile_scope!("run");
+
         let origin = Point3::origin();
         let defcam = Camera::standard_2d();
         let identity = GlobalTransform::default();

--- a/src/app.rs
+++ b/src/app.rs
@@ -376,7 +376,10 @@ where
 }
 
 #[cfg(feature = "profiler")]
-impl<'a, T, E, R> Drop for CoreApplication<'a, T, E, R> {
+impl<'a, T, E, R> Drop for CoreApplication<'a, T, E, R>
+where
+    T: DataDispose,
+{
     fn drop(&mut self) {
         // TODO: Specify filename in config.
         use crate::utils::application_root_dir;


### PR DESCRIPTION


## Description

Fix profiler dispose trait condition. Also adds profiler to all current rendy hot paths, as well as heavily used functions to profile time in. 

## Additions

- Profile all the things

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.