### PR TITLE
Fix using SRGB for default texture data

### DIFF
--- a/amethyst_renderer/src/system.rs
+++ b/amethyst_renderer/src/system.rs
@@ -21,7 +21,7 @@ use amethyst_error::Error;
 
 use crate::{
     config::DisplayConfig,
-    formats::{create_mesh_asset, create_texture_asset},
+    formats::{create_mesh_asset, create_texture_asset, TextureData, TextureMetadata},
     mesh::Mesh,
     mtl::{Material, MaterialDefaults},
     pipe::{PipelineBuild, PipelineData, PolyPipeline},
@@ -223,13 +223,13 @@ fn create_default_mat(res: &mut Resources) -> Material {
 
     let loader = res.fetch::<Loader>();
 
-    let albedo = [0.5, 0.5, 0.5, 1.0].into();
-    let emission = [0.0; 4].into();
-    let normal = [0.5, 0.5, 1.0, 1.0].into();
-    let metallic = [0.0; 4].into();
-    let roughness = [0.5; 4].into();
-    let ambient_occlusion = [1.0; 4].into();
-    let caveat = [1.0; 4].into();
+    let albedo = TextureData::Rgba([0.5, 0.5, 0.5, 1.0], TextureMetadata::unorm());
+    let emission = TextureData::Rgba([0.0; 4], TextureMetadata::unorm());
+    let normal = TextureData::Rgba([0.5, 0.5, 1.0, 1.0], TextureMetadata::unorm());
+    let metallic = TextureData::Rgba([0.0; 4], TextureMetadata::unorm());
+    let roughness = TextureData::Rgba([0.5; 4], TextureMetadata::unorm());
+    let ambient_occlusion = TextureData::Rgba([1.0; 4], TextureMetadata::unorm());
+    let caveat = TextureData::Rgba([1.0; 4], TextureMetadata::unorm());
 
     let tex_storage = res.fetch();
 


### PR DESCRIPTION
## Description

`impl From<[f32; 4]> for TextureData` interprets texture in srgb and caused very weird normals.

cc #855.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.