### PR TITLE
renderer: Unify name of fragment output color to "out_color"

### DIFF
--- a/amethyst_renderer/src/pass/debug_lines/interleaved.rs
+++ b/amethyst_renderer/src/pass/debug_lines/interleaved.rs
@@ -96,7 +96,7 @@ where
         builder.with_raw_global("camera_position");
         builder.with_raw_global("line_width");
         builder.with_primitive_type(Primitive::PointList);
-        builder.with_output("color", Some(DepthMode::LessEqualWrite));
+        builder.with_output("out_color", Some(DepthMode::LessEqualWrite));
 
         builder.build()
     }

--- a/amethyst_renderer/src/pass/flat/interleaved.rs
+++ b/amethyst_renderer/src/pass/flat/interleaved.rs
@@ -123,8 +123,10 @@ where
             .with_raw_vertex_buffer(V::QUERIED_ATTRIBUTES, V::size() as ElemStride, 0);
         setup_textures(&mut builder, &TEXTURES);
         match self.transparency {
-            Some((mask, blend, depth)) => builder.with_blended_output("color", mask, blend, depth),
-            None => builder.with_output("color", Some(DepthMode::LessEqualWrite)),
+            Some((mask, blend, depth)) => {
+                builder.with_blended_output("out_color", mask, blend, depth)
+            }
+            None => builder.with_output("out_color", Some(DepthMode::LessEqualWrite)),
         };
         builder.build()
     }

--- a/amethyst_renderer/src/pass/flat/separate.rs
+++ b/amethyst_renderer/src/pass/flat/separate.rs
@@ -146,8 +146,10 @@ impl Pass for DrawFlatSeparate {
         );
         setup_textures(&mut builder, &TEXTURES);
         match self.transparency {
-            Some((mask, blend, depth)) => builder.with_blended_output("color", mask, blend, depth),
-            None => builder.with_output("color", Some(DepthMode::LessEqualWrite)),
+            Some((mask, blend, depth)) => {
+                builder.with_blended_output("out_color", mask, blend, depth)
+            }
+            None => builder.with_output("out_color", Some(DepthMode::LessEqualWrite)),
         };
         builder.build()
     }

--- a/amethyst_renderer/src/pass/flat2d/interleaved.rs
+++ b/amethyst_renderer/src/pass/flat2d/interleaved.rs
@@ -124,8 +124,10 @@ impl Pass for DrawFlat2D {
             .with_raw_vertex_buffer(Self::attributes(), SpriteInstance::size() as ElemStride, 1);
         setup_textures(&mut builder, &TEXTURES);
         match self.transparency {
-            Some((mask, blend, depth)) => builder.with_blended_output("color", mask, blend, depth),
-            None => builder.with_output("color", Some(DepthMode::LessEqualWrite)),
+            Some((mask, blend, depth)) => {
+                builder.with_blended_output("out_color", mask, blend, depth)
+            }
+            None => builder.with_output("out_color", Some(DepthMode::LessEqualWrite)),
         };
         builder.build()
     }

--- a/amethyst_renderer/src/pass/pbm/interleaved.rs
+++ b/amethyst_renderer/src/pass/pbm/interleaved.rs
@@ -123,8 +123,10 @@ where
         setup_light_buffers(&mut builder);
         setup_textures(&mut builder, &TEXTURES);
         match self.transparency {
-            Some((mask, blend, depth)) => builder.with_blended_output("color", mask, blend, depth),
-            None => builder.with_output("color", Some(DepthMode::LessEqualWrite)),
+            Some((mask, blend, depth)) => {
+                builder.with_blended_output("out_color", mask, blend, depth)
+            }
+            None => builder.with_output("out_color", Some(DepthMode::LessEqualWrite)),
         };
         builder.build()
     }

--- a/amethyst_renderer/src/pass/pbm/separate.rs
+++ b/amethyst_renderer/src/pass/pbm/separate.rs
@@ -157,8 +157,10 @@ impl Pass for DrawPbmSeparate {
         setup_light_buffers(&mut builder);
         setup_textures(&mut builder, &TEXTURES);
         match self.transparency {
-            Some((mask, blend, depth)) => builder.with_blended_output("color", mask, blend, depth),
-            None => builder.with_output("color", Some(DepthMode::LessEqualWrite)),
+            Some((mask, blend, depth)) => {
+                builder.with_blended_output("out_color", mask, blend, depth)
+            }
+            None => builder.with_output("out_color", Some(DepthMode::LessEqualWrite)),
         };
         builder.build()
     }

--- a/amethyst_renderer/src/pass/shaded/interleaved.rs
+++ b/amethyst_renderer/src/pass/shaded/interleaved.rs
@@ -123,8 +123,10 @@ where
         setup_light_buffers(&mut builder);
         setup_textures(&mut builder, &TEXTURES);
         match self.transparency {
-            Some((mask, blend, depth)) => builder.with_blended_output("color", mask, blend, depth),
-            None => builder.with_output("color", Some(DepthMode::LessEqualWrite)),
+            Some((mask, blend, depth)) => {
+                builder.with_blended_output("out_color", mask, blend, depth)
+            }
+            None => builder.with_output("out_color", Some(DepthMode::LessEqualWrite)),
         };
         builder.build()
     }

--- a/amethyst_renderer/src/pass/shaded/separate.rs
+++ b/amethyst_renderer/src/pass/shaded/separate.rs
@@ -148,8 +148,10 @@ impl Pass for DrawShadedSeparate {
         setup_light_buffers(&mut builder);
         setup_textures(&mut builder, &TEXTURES);
         match self.transparency {
-            Some((mask, blend, depth)) => builder.with_blended_output("color", mask, blend, depth),
-            None => builder.with_output("color", Some(DepthMode::LessEqualWrite)),
+            Some((mask, blend, depth)) => {
+                builder.with_blended_output("out_color", mask, blend, depth)
+            }
+            None => builder.with_output("out_color", Some(DepthMode::LessEqualWrite)),
         };
         builder.build()
     }

--- a/amethyst_renderer/src/pass/shaders/fragment/flat.glsl
+++ b/amethyst_renderer/src/pass/shaders/fragment/flat.glsl
@@ -17,7 +17,7 @@ in VertexData {
     vec4 color;
 } vertex;
 
-out vec4 color;
+out vec4 out_color;
 
 float tex_coord(float coord, vec2 offset) {
     return offset.x + coord * (offset.y - offset.x);
@@ -28,5 +28,5 @@ vec2 tex_coords(vec2 coord, vec2 u, vec2 v) {
 }
 
 void main() {
-    color = texture(albedo, tex_coords(vertex.tex_coord, albedo_offset.u_offset, albedo_offset.v_offset)) * vertex.color;
+    out_color = texture(albedo, tex_coords(vertex.tex_coord, albedo_offset.u_offset, albedo_offset.v_offset)) * vertex.color;
 }

--- a/amethyst_renderer/src/pass/shaders/fragment/sprite.glsl
+++ b/amethyst_renderer/src/pass/shaders/fragment/sprite.glsl
@@ -9,8 +9,8 @@ in VertexData {
     vec4 color;
 } vertex;
 
-out vec4 color;
+out vec4 out_color;
 
 void main() {
-    color = texture(albedo, vertex.tex_uv) * vertex.color;
+    out_color = texture(albedo, vertex.tex_uv) * vertex.color;
 }

--- a/amethyst_renderer/src/pass/skybox/interleaved.rs
+++ b/amethyst_renderer/src/pass/skybox/interleaved.rs
@@ -70,7 +70,7 @@ impl Pass for DrawSkybox {
             .with_raw_global("camera_position")
             .with_raw_global("zenith_color")
             .with_raw_global("nadir_color")
-            .with_output("color", Some(DepthMode::LessEqualWrite))
+            .with_output("out_color", Some(DepthMode::LessEqualWrite))
             .build()
     }
 


### PR DESCRIPTION
## Description

Also fixes some shaders that don't match up with the passes (eg. physically based lighting). This effectively enables blending to work.

Please also check if I missed anything.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.