### PR TITLE
Fixed the "debug_lines" example not closing when escape key is pressed.

### DIFF
--- a/examples/debug_lines/main.rs
+++ b/examples/debug_lines/main.rs
@@ -8,7 +8,7 @@ use amethyst::{
         Time,
     },
     ecs::{Read, System, Write},
-    input::InputBundle,
+    input::{is_close_requested, is_key_down, InputBundle},
     prelude::*,
     renderer::*,
     utils::application_root_dir,
@@ -135,6 +135,22 @@ impl SimpleState for ExampleState {
             )))
             .with(local_transform)
             .build();
+    }
+
+    fn handle_event(
+        &mut self,
+        _: StateData<'_, GameData<'_, '_>>,
+        event: StateEvent,
+    ) -> SimpleTrans {
+        if let StateEvent::Window(event) = event {
+            if is_close_requested(&event) || is_key_down(&event, VirtualKeyCode::Escape) {
+                Trans::Quit
+            } else {
+                Trans::None
+            }
+        } else {
+            Trans::None
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Updated the "debug_lines" example so that the example closes when the escape key is pressed.

Fixes #1234

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
