### PR TITLE
Change panic to a silent failure in UI layout Hierarchy handling

### DIFF
--- a/amethyst_ui/src/layout.rs
+++ b/amethyst_ui/src/layout.rs
@@ -214,12 +214,10 @@ impl<'a> System<'a> for UiTransformSystem {
         for entity in hierarchy.all() {
             {
                 let self_dirty = self_transform_modified.contains(entity.id());
-                let parent_entity = parents
-                    .get(*entity)
-                    .expect(
-                        "Unreachable: All entities in `ParentHierarchy` should also be in `Parent`",
-                    )
-                    .entity;
+                let parent_entity = match parents.get(*entity) {
+                    Some(p) => p.entity,
+                    None => continue, // Skip this entity iteration, as its dirty
+                };
                 let parent_dirty = self_transform_modified.contains(parent_entity.id());
                 if parent_dirty || self_dirty || screen_resized {
                     let parent_transform_copy = transforms.get(parent_entity).cloned();


### PR DESCRIPTION
## Description

Remove unreachable panic due to some circumstances that allow for a parent component to be removed but still reside in ParentHierarchy temporarily. Fixes panic in #1550. 

In the current integration with specs-hierarchy and the crate itself, we incorrectly assume parents and children prevent this circumstance to actually arise where a parent does not exist as a Parent component but is still in the Hierarchy. This can actually happen multiple ways, existing permanently or for at least a frame. Most obvious case is deleting the "Parent" component from a parent entity will cause this panic to occur during the same frame until the hierarchy is updated. 

This just removes the panic occurring because of this incorrect assumption here for now, and skips that entity for processing here. 

This edge case should be resolved later in a separate PR which will be with #1549

## Modifications

- Changes a panic to just skip this loop iteration.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
