### PR TITLE
Fix example due to rotations deserialization changes

### DIFF
--- a/examples/assets/prefab/auto_fov.ron
+++ b/examples/assets/prefab/auto_fov.ron
@@ -17,7 +17,7 @@ Prefab (
                 ),
                 transform: (
                     translation: (5.0, 5.0, 0.0),
-                    rotation: (0.5, 0.5, -0.5, -0.5),
+                    rotation: (0.5, -0.5, -0.5, 0.5),
                 ),
             ),
         ),
@@ -32,7 +32,7 @@ Prefab (
                 ),
                 transform: (
                     translation: (5.0, 5.0, 0.0),
-                    rotation: (0.5, 0.5, -0.5, -0.5),
+                    rotation: (0.5, -0.5, -0.5, 0.5),
                 ),
             ),
         ),
@@ -61,6 +61,7 @@ Prefab (
                 transform: (
                     translation: (-5.0, 5.0, 0.0),
                     scale: (2.0, 2.0, 2.0),
+                    rotation: (0.0, 0.0, 1.0, 0.0),
                 ),
             ),
         ),
@@ -88,6 +89,7 @@ Prefab (
                 ),
                 transform: (
                     scale: (10.0, 10.0, 10.0),
+                    rotation: (0.0, 0.0, 1.0, 0.0),
                 ),
             ),
         ),
@@ -118,7 +120,7 @@ Prefab (
             data: (
                 transform: Transform (
                     translation: (0.0, -20.0, 10.0),
-                    rotation: (0.7933533, 0.6087614, 0.0, 0.0),
+                    rotation: (0.6087614, 0.0, 0.0, 0.7933533),
                 ),
                 camera: Perspective((
                     aspect: 1.3,

--- a/examples/assets/prefab/example.ron
+++ b/examples/assets/prefab/example.ron
@@ -33,7 +33,7 @@ Prefab (
             data: (
                 transform: Transform (
                     translation: (0.0, -20.0, 10.0),
-                    rotation: (0.7882256, 0.6153864, 0.0, 0.0),
+                    rotation: (0.6153864, 0.0, 0.0, 0.7882256),
                 ),
                 camera: Perspective((
                     aspect: 1.0,

--- a/examples/assets/prefab/puffy_scene.ron
+++ b/examples/assets/prefab/puffy_scene.ron
@@ -41,7 +41,7 @@ Prefab (
             data: (
                 transform: (
                     translation: (6.0, 6.0, -6.0),
-                    rotation: (0.0, 0.0, 1.0, 0.0),
+                    rotation: (0.0, 1.0, 0.0, 0.0),
                 ),
                 light: (
                     light: Point((
@@ -55,7 +55,7 @@ Prefab (
             data: (
                 transform: (
                     translation: (0.0, 4.0, 4.0),
-                    rotation: (0.0, 0.0, 1.0, 0.0),
+                    rotation: (0.0, 1.0, 0.0, 0.0),
                 ),
                 light: (
                     light: Point((

--- a/examples/assets/prefab/renderable.ron
+++ b/examples/assets/prefab/renderable.ron
@@ -17,7 +17,7 @@ Prefab (
                 ),
                 transform: (
                     translation: (5.0, 5.0, 0.0),
-                    rotation: (0.5, 0.5, -0.5, -0.5),
+                    rotation: (0.5, -0.5, -0.5, 0.5),
                 ),
             ),
         ),
@@ -32,7 +32,7 @@ Prefab (
                 ),
                 transform: (
                     translation: (5.0, 5.0, 0.0),
-                    rotation: (0.5, 0.5, -0.5, -0.5),
+                    rotation: (0.5, -0.5, -0.5, 0.5),
                 ),
             ),
         ),
@@ -61,6 +61,7 @@ Prefab (
                 transform: (
                     translation: (-5.0, 5.0, 0.0),
                     scale: (2.0, 2.0, 2.0),
+                    rotation: (0, 0, 1, 0),
                 ),
             ),
         ),
@@ -88,6 +89,7 @@ Prefab (
                 ),
                 transform: (
                     scale: (10.0, 10.0, 10.0),
+                    rotation: (0, 0, 1, 0),
                 ),
             ),
         ),
@@ -117,7 +119,7 @@ Prefab (
             data: (
                 transform: Transform (
                     translation: (0.0, -20.0, 10.0),
-                    rotation: (0.7933533, 0.6087614, 0.0, 0.0),
+                    rotation: (0.6087614, 0.0, 0.0, 0.7933533),
                 ),
                 camera: Perspective((
                     aspect: 1.3,

--- a/examples/assets/prefab/sphere.ron
+++ b/examples/assets/prefab/sphere.ron
@@ -16,7 +16,7 @@ Prefab (
             data: (
                 transform: (
                     translation: (2.0, 2.0, -2.0),
-                    rotation: (0.0, 0.0, 1.0, 0.0),
+                    rotation: (0.0, 1.0, 0.0, 0.0),
                 ),
                 light: (
                     ambient_color: (Rgba(0.01, 0.01, 0.01, 1.0)),
@@ -32,7 +32,7 @@ Prefab (
             data: (
                 transform: (
                     translation: (0.0, 0.0, -4.0),
-                    rotation: (0.0, 0.0, 1.0, 0.0),
+                    rotation: (0.0, 1.0, 0.0, 0.0),
                 ),
                 camera: Perspective((
                     aspect: 1.3,

--- a/examples/assets/prefab/spotlights_scene.ron
+++ b/examples/assets/prefab/spotlights_scene.ron
@@ -11,7 +11,7 @@ Prefab (
                     ),
                 ),
                 transform: (
-                    rotation: (0.0, 0.0, 1.0, 0.0),
+                    rotation: (0.0, 1.0, 0.0, 0.0),
                     scale: (4.0, 2.0, 1.0),
                 ),
             ),
@@ -95,7 +95,7 @@ Prefab (
             data: (
                 transform: (
                     translation: (0.0, 0.0, -4.0),
-                    rotation: (0.0, 0.0, 1.0, 0.0),
+                    rotation: (0.0, 1.0, 0.0, 0.0),
                 ),
                 camera: Perspective((
                     aspect: 1.3,


### PR DESCRIPTION
## Description

Fix examples from rotations being moved left one place. Lights and objects were not appearing/upside down after #1564 

## Modifications

- Moved example rotations to the left, and had to add a few that assumed 1 at the end.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

## Screenshots After Changes
![prefab](https://user-images.githubusercontent.com/7254623/57189097-14e6f500-6ebf-11e9-979c-2d58c59d825b.png)

![spotlights](https://user-images.githubusercontent.com/7254623/57189104-20d2b700-6ebf-11e9-8545-a975df7c6b85.png)

![sphere](https://user-images.githubusercontent.com/7254623/57189102-1e705d00-6ebf-11e9-8b00-2af81f389d6b.png)

![renderable](https://user-images.githubusercontent.com/7254623/57189098-16b0b880-6ebf-11e9-8804-6aede7a32d52.png)

![auto_fov](https://user-images.githubusercontent.com/7254623/57189094-11536e00-6ebf-11e9-97d2-7c723fd5954e.png)
