### PR TITLE
quick and dirty pivot

### DIFF
--- a/amethyst_ui/src/button/builder.rs
+++ b/amethyst_ui/src/button/builder.rs
@@ -325,6 +325,7 @@ impl<'a, G: PartialEq + Send + Sync + 'static, I: WidgetId> UiButtonBuilder<G, I
                 UiTransform::new(
                     format!("{}_btn", id),
                     self.anchor,
+                    Anchor::Middle,
                     self.x,
                     self.y,
                     self.z,
@@ -359,6 +360,7 @@ impl<'a, G: PartialEq + Send + Sync + 'static, I: WidgetId> UiButtonBuilder<G, I
                 text_entity,
                 UiTransform::new(
                     format!("{}_btn_text", id),
+                    Anchor::Middle,
                     Anchor::Middle,
                     0.,
                     0.,

--- a/amethyst_ui/src/label.rs
+++ b/amethyst_ui/src/label.rs
@@ -188,6 +188,7 @@ where
                 UiTransform::new(
                     format!("{}_label", id),
                     self.anchor,
+                    Anchor::Middle,
                     self.x,
                     self.y,
                     self.z,

--- a/amethyst_ui/src/layout.rs
+++ b/amethyst_ui/src/layout.rs
@@ -289,6 +289,9 @@ impl<'a> System<'a> for UiTransformSystem {
                                 transform.height * parent_transform_copy.pixel_height;
                         }
                     }
+                    let pivot_norm = transform.pivot.norm_offset();
+                    transform.pixel_x += transform.pixel_width * -pivot_norm.0;
+                    transform.pixel_y += transform.pixel_height * -pivot_norm.1;
                 }
             }
             // Populate the modifications we just did.
@@ -374,5 +377,8 @@ where
                 transform.pixel_height = transform.height * screen_dim.height();
             }
         }
+        let pivot_norm = transform.pivot.norm_offset();
+        transform.pixel_x += transform.pixel_width * -pivot_norm.0;
+        transform.pixel_y += transform.pixel_height * -pivot_norm.1;
     }
 }

--- a/amethyst_ui/src/prefab.rs
+++ b/amethyst_ui/src/prefab.rs
@@ -54,6 +54,9 @@ pub struct UiTransformBuilder<G> {
     /// Indicates where the element sits, relative to the parent (or to the screen, if there is no parent)
     #[derivative(Default(value = "Anchor::Middle"))]
     pub anchor: Anchor,
+    /// Indicates where the element sits, relative to itself
+    #[derivative(Default(value = "Anchor::Middle"))]
+    pub pivot: Anchor,
     /// Allow mouse events on this UI element.
     pub mouse_reactive: bool,
     /// Hides an entity by adding a [`HiddenPropagate`](../amethyst_renderer/struct.HiddenPropagate.html) component
@@ -148,6 +151,7 @@ where
         let mut transform = UiTransform::new(
             self.id.clone(),
             self.anchor.clone(),
+            self.pivot.clone(),
             self.x,
             self.y,
             self.z,

--- a/amethyst_ui/src/transform.rs
+++ b/amethyst_ui/src/transform.rs
@@ -35,6 +35,8 @@ pub struct UiTransform {
     pub id: String,
     /// Indicates where the element sits, relative to the parent (or to the screen, if there is no parent)
     pub anchor: Anchor,
+    /// Indicates where the element sits, relative to itself
+    pub pivot: Anchor,
     /// If a child ui element needs to fill its parent this can be used to stretch it to the appropriate size.
     pub stretch: Stretch,
     /// X coordinate, 0 is the left edge of the screen. If scale_mode is set to pixel then the width of the
@@ -80,6 +82,7 @@ impl UiTransform {
     pub fn new(
         id: String,
         anchor: Anchor,
+        pivot: Anchor,
         x: f32,
         y: f32,
         z: f32,
@@ -89,6 +92,7 @@ impl UiTransform {
         UiTransform {
             id,
             anchor,
+            pivot,
             stretch: Stretch::NoStretch,
             local_x: x,
             local_y: y,
@@ -166,7 +170,16 @@ mod tests {
     use super::*;
     #[test]
     fn inside_local() {
-        let tr = UiTransform::new("".to_string(), Anchor::TopLeft, 0.0, 0.0, 0.0, 1.0, 1.0);
+        let tr = UiTransform::new(
+            "".to_string(),
+            Anchor::TopLeft,
+            Anchor::Middle,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            1.0,
+        );
         let pos = (-0.49, 0.20);
         assert!(tr.position_inside_local(pos.0, pos.1));
         let pos = (-1.49, 1.20);
@@ -175,7 +188,16 @@ mod tests {
 
     #[test]
     fn inside_global() {
-        let tr = UiTransform::new("".to_string(), Anchor::TopLeft, 0.0, 0.0, 0.0, 1.0, 1.0);
+        let tr = UiTransform::new(
+            "".to_string(),
+            Anchor::TopLeft,
+            Anchor::Middle,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            1.0,
+        );
         let pos = (-0.49, 0.20);
         assert!(tr.position_inside(pos.0, pos.1));
         let pos = (-1.49, 1.20);

--- a/book/src/pong-tutorial/pong-tutorial-05.md
+++ b/book/src/pong-tutorial/pong-tutorial-05.md
@@ -672,11 +672,11 @@ fn initialise_scoreboard(world: &mut World) {
         &world.read_resource(),
     );
     let p1_transform = UiTransform::new(
-        "P1".to_string(), Anchor::TopMiddle,
+        "P1".to_string(), Anchor::TopMiddle, Anchor::TopMiddle,
         -50., -50., 1., 200., 50.,
     );
     let p2_transform = UiTransform::new(
-        "P2".to_string(), Anchor::TopMiddle,
+        "P2".to_string(), Anchor::TopMiddle, Anchor::TopMiddle,
         50., -50., 1., 200., 50.,
     );
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -145,6 +145,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1526]: https://github.com/amethyst/amethyst/pull/1526
 [#1538]: https://github.com/amethyst/amethyst/pull/1538
 [#1539]: https://github.com/amethyst/amethyst/pull/1543
+[#1571]: https://github.com/amethyst/amethyst/pull/1571
 ## [0.10.0] - 2018-12
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -77,6 +77,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * Added generic parameter type to `Transform` to configure floating point precision. ([#1334])
 * `NetConnection` is automatically created when client starts sends data to server. ([#1539])
 * User will receive `NetEvent::Connected` on new connection and `NetEvent::Dissconnected` on disconnect. ([#1539])
+* Added a `pivot` field to `UiTransform`.
 
 ### Removed
 - Removed all `NetEvent's` because they were not used. ([#1539])

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -77,7 +77,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * Added generic parameter type to `Transform` to configure floating point precision. ([#1334])
 * `NetConnection` is automatically created when client starts sends data to server. ([#1539])
 * User will receive `NetEvent::Connected` on new connection and `NetEvent::Dissconnected` on disconnect. ([#1539])
-* Added a `pivot` field to `UiTransform`.
+* Added a `pivot` field to `UiTransform`. ([#1571])
 
 ### Removed
 - Removed all `NetEvent's` because they were not used. ([#1539])

--- a/examples/appendix_a/pong.rs
+++ b/examples/appendix_a/pong.rs
@@ -192,11 +192,27 @@ fn initialise_score(world: &mut World) {
         (),
         &world.read_resource(),
     );
-    let p1_transform =
-        UiTransform::new("P1".to_string(), Anchor::TopMiddle, -50., 50., 1., 55., 50.);
+    let p1_transform = UiTransform::new(
+        "P1".to_string(),
+        Anchor::TopMiddle,
+        Anchor::Middle,
+        -50.,
+        50.,
+        1.,
+        55.,
+        50.,
+    );
 
-    let p2_transform =
-        UiTransform::new("P2".to_string(), Anchor::TopMiddle, 50., 50., 1., 55., 50.);
+    let p2_transform = UiTransform::new(
+        "P2".to_string(),
+        Anchor::TopMiddle,
+        Anchor::Middle,
+        50.,
+        50.,
+        1.,
+        55.,
+        50.,
+    );
 
     let p1_score = world
         .create_entity()

--- a/examples/pong/pong.rs
+++ b/examples/pong/pong.rs
@@ -158,6 +158,7 @@ fn initialise_score(world: &mut World) {
     let p1_transform = UiTransform::new(
         "P1".to_string(),
         Anchor::TopMiddle,
+        Anchor::Middle,
         -50.,
         -50.,
         1.,
@@ -168,6 +169,7 @@ fn initialise_score(world: &mut World) {
     let p2_transform = UiTransform::new(
         "P2".to_string(),
         Anchor::TopMiddle,
+        Anchor::Middle,
         50.,
         -50.,
         1.,

--- a/examples/pong_tutorial_05/pong.rs
+++ b/examples/pong_tutorial_05/pong.rs
@@ -200,6 +200,7 @@ fn initialise_scoreboard(world: &mut World) {
     let p1_transform = UiTransform::new(
         "P1".to_string(),
         Anchor::TopMiddle,
+        Anchor::Middle,
         -50.,
         -50.,
         1.,
@@ -209,6 +210,7 @@ fn initialise_scoreboard(world: &mut World) {
     let p2_transform = UiTransform::new(
         "P2".to_string(),
         Anchor::TopMiddle,
+        Anchor::Middle,
         50.,
         -50.,
         1.,


### PR DESCRIPTION
## Description

Add a pivot field to UiTransform.

![](https://i.imgur.com/Ogmqkfi.gif)

## Modifications

`UiTransform::new` now accepts another `Anchor` as an argument

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
