### PR TITLE
Add get mouse button fn input utils

### DIFF
--- a/amethyst_input/src/lib.rs
+++ b/amethyst_input/src/lib.rs
@@ -14,7 +14,10 @@ pub use self::{
     input_handler::InputHandler,
     scroll_direction::ScrollDirection,
     system::InputSystem,
-    util::{get_input_axis_simple, get_key, is_close_requested, is_key_down},
+    util::{
+        get_input_axis_simple, get_key, get_mouse_button, is_close_requested, is_key_down,
+        is_mouse_button_down,
+    },
 };
 
 use std::iter::Iterator;

--- a/amethyst_input/src/util.rs
+++ b/amethyst_input/src/util.rs
@@ -1,7 +1,7 @@
 use std::hash::Hash;
 
 use amethyst_core::math::{convert, RealField};
-use winit::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent};
+use winit::{ElementState, Event, KeyboardInput, MouseButton, VirtualKeyCode, WindowEvent};
 
 use crate::input_handler::InputHandler;
 
@@ -58,4 +58,26 @@ where
             .and_then(|ref n| input.axis_value(n))
             .unwrap_or(0.0),
     )
+}
+
+/// If this event was for manipulating a mouse button, this will return the `MouseButton`
+/// and the new state.
+pub fn get_mouse_button(event: &Event) -> Option<(MouseButton, ElementState)> {
+    match *event {
+        Event::WindowEvent { ref event, .. } => match *event {
+            WindowEvent::MouseInput { button, state, .. } => Some((button, state)),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Returns true if the event passed in is a mouse button down event for the
+/// provided `MouseButton`.
+pub fn is_mouse_button_down(event: &Event, button: MouseButton) -> bool {
+    if let Some((pressed_button, state)) = get_mouse_button(event) {
+        return pressed_button == button && state == ElementState::Pressed;
+    } else {
+        return false;
+    }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,7 @@ it is attached to. ([#1282])
 * Derive `Debug`, `PartialEq`, `Eq` for `Source`. ([#1591])
 * Added `events` example which demonstrates working even reader and writer in action. ([#1538])
 *  Implement builder like functionality for `AnimationSet` and `AnimationControlSet` ([#1568])
+* Add `get_mouse_button` and `is_mouse_button_down` utility functions to amethyst_input. ([#1582])
 
 ### Changed
 
@@ -80,6 +81,8 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * `NetConnection` is automatically created when client starts sends data to server. ([#1539])
 * User will receive `NetEvent::Connected` on new connection and `NetEvent::Disconnected` on disconnect. ([#1539])
 * Added a `pivot` field to `UiTransform`. ([#1571])
+* Fix fly_camera example initial camera and cube position. ([#1582])
+* Add to fly_camera example code to release and capture back mouse input, and to show and hide cursor. ([#1582])
 
 ### Removed
 - Removed all `NetEvent's` because they were not used. ([#1539])
@@ -151,6 +154,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1571]: https://github.com/amethyst/amethyst/pull/1571
 [#1584]: https://github.com/amethyst/amethyst/pull/1584
 [#1591]: https://github.com/amethyst/amethyst/pull/1591
+[#1582]: https://github.com/amethyst/amethyst/pull/1582
 
 ## [0.10.0] - 2018-12
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -72,7 +72,7 @@ Render a sphere using a physically based material.
 Animate a sphere using a custom built animation sampler sequence. Keybindings:
 
 * `Space` - start/pause/unpause the currentanimation(default is translational animation)
-* `D` - demonstrate deferred start, translate will run first, then rotate when translate ends, and last scale animation 
+* `D` - demonstrate deferred start, translate will run first, then rotate when translate ends, and last scale animation
         will start after rotation has run for 0.66s.
 * `T` - set translate to current animation
 * `R` - set rotate to current animation
@@ -81,7 +81,7 @@ Animate a sphere using a custom built animation sampler sequence. Keybindings:
 * `F` - run animation at full speed
 * `V` - run animation at no speed, use stepping keys for controlling the animation
 * `Right` - step to the next animation keyframe
-* `Left` - step to the previous animation keyframe 
+* `Left` - step to the previous animation keyframe
 
 ### Gltf
 
@@ -120,7 +120,7 @@ Demonstrates how to use custom `GameData`, with three different states: `Loading
 
 ### Fly Camera
 
-This example shows how to use the Fly Camera.
+This example shows how to use the Fly Camera, how to release and capture back user mouse input, and show and hide mouse cursor.
 
 ### Arc ball Camera
 

--- a/examples/assets/prefab/fly_camera.ron
+++ b/examples/assets/prefab/fly_camera.ron
@@ -15,13 +15,16 @@ Prefab (
                     ),
                 ),
                 transform: (
-                    translation: (0.0, 0.0, -5.0),
+                    translation: (0.0, 0.0, -4.0),
                 ),
             ),
         ),
         (
             data: (
-                transform: (),
+                transform: (
+                    translation: (0.0, 1.5, 0.0),
+                    rotation: (-0.13, 0.0, 0.0, 0.99),
+                ),
                 camera: Perspective((
                     aspect: 1.3,
                     fovy: 1.0471975512,

--- a/examples/fly_camera/main.rs
+++ b/examples/fly_camera/main.rs
@@ -2,11 +2,11 @@
 
 use amethyst::{
     assets::{PrefabLoader, PrefabLoaderSystem, RonFormat},
-    controls::FlyControlBundle,
+    controls::{FlyControlBundle, HideCursor},
     core::transform::TransformBundle,
-    input::InputBundle,
+    input::{is_key_down, is_mouse_button_down, InputBundle},
     prelude::*,
-    renderer::{DrawShaded, PosNormTex},
+    renderer::{DrawShaded, MouseButton, PosNormTex, VirtualKeyCode},
     utils::{application_root_dir, scene::BasicScenePrefab},
     Error,
 };
@@ -25,6 +25,24 @@ impl SimpleState for ExampleState {
             .named("Fly Camera Scene")
             .with(prefab_handle)
             .build();
+    }
+
+    fn handle_event(
+        &mut self,
+        data: StateData<'_, GameData<'_, '_>>,
+        event: StateEvent,
+    ) -> SimpleTrans {
+        let StateData { world, .. } = data;
+        if let StateEvent::Window(event) = &event {
+            if is_key_down(&event, VirtualKeyCode::Escape) {
+                let mut hide_cursor = world.write_resource::<HideCursor>();
+                hide_cursor.hide = false;
+            } else if is_mouse_button_down(&event, MouseButton::Left) {
+                let mut hide_cursor = world.write_resource::<HideCursor>();
+                hide_cursor.hide = true;
+            }
+        }
+        Trans::None
     }
 }
 


### PR DESCRIPTION
## Description

I found myself in need of functions to get mouse button state from `Event` instance in state `handle_event` function, so I wrote a couple. 
It also seemed to me that as they are analogous to `get_key` and `is_key_down` for keyboard key status, new functions should reside in the same file, so I placed it in amethyst_input/util.rs

Then I enhanced a bit fly_camera example to demonstrate how to capture and release mouse input and hide and show cursor. Here I made use of newly created functions.
It also turned out that fly_camera example behaves a bit odd, so I fixed this by providing explicit transform for it's prefab.

## Additions
`get_mouse_button` function to amethist_utlils
`is_mouse_button_pressed` function to amethist_utils

## Removals
None.

## Modifications
fly_camera example: add cursor show/hide, mouse input release/capture, also fix prefab so mouse lookout directions are not inverted, and camera looks at cube at the start.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
