### PR TITLE
Maintenance/additional derives for audio source

### DIFF
--- a/amethyst_audio/src/source.rs
+++ b/amethyst_audio/src/source.rs
@@ -10,7 +10,7 @@ use crate::formats::AudioData;
 pub type SourceHandle = Handle<Source>;
 
 /// A loaded audio file
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Source {
     /// The bytes of this audio source.
     pub bytes: Vec<u8>,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,7 @@ it is attached to. ([#1282])
 * Adding support for AMETHYST_NUM_THREADS environment variable to control size of the threads pool used by thread_pool_builder.
 * Add `Input` variant to `StateEvent`. ([#1478])
 * Support type parameters in `EventReader` derive. ([#1478])
+* Derive `Debug`, `PartialEq`, `Eq` for `Source`. ([#1591])
 * Added `events` example which demonstrates working even reader and writer in action. ([#1538])
 
 ### Changed
@@ -147,6 +148,8 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1539]: https://github.com/amethyst/amethyst/pull/1543
 [#1571]: https://github.com/amethyst/amethyst/pull/1571
 [#1584]: https://github.com/amethyst/amethyst/pull/1584
+[#1591]: https://github.com/amethyst/amethyst/pull/1591
+
 ## [0.10.0] - 2018-12
 
 ### Added


### PR DESCRIPTION
## Description

Derive `Debug`, `PartialEq`, `Eq` for `amethyst::audio::Source`.

## Additions

- Derive `Debug`, `PartialEq`, `Eq` for `Source`.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
