### PR TITLE
Use stderr to print message to user.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,7 @@
 use dirs::home_dir;
 use std::{
     fs::{create_dir_all, read_to_string, remove_file, File},
-    io::{stdin, stdout, Write},
+    io::{stderr, stdin, Write},
     path::Path,
 };
 use vergen::{self, ConstantsFlags};
@@ -53,8 +53,8 @@ fn check_sentry_allowed(amethyst_home: &Path) -> Option<bool> {
 }
 
 fn ask_user_data_collection() -> bool {
-    print!("May we collect anonymous panic data and usage statistics to help improve Amethyst? No personal information is collected or stored. [Y/n]: ");
-    stdout().flush().expect("Failed to flush stdout");
+    eprint!("May we collect anonymous panic data and usage statistics to help improve Amethyst? No personal information is collected or stored. [Y/n]: ");
+    stderr().flush().expect("Failed to flush stdout");
 
     let mut s = String::new();
     stdin()


### PR DESCRIPTION
This doesn't actually show up in the console, but printing to stdout
pollutes the stream that cargo reads from.

Issue #1588

## Description

Attempt to eliminate a source of error in #1588.

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- **n/a** Updated the content of the book if this PR would make the book outdated.
- **n/a** Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
