### PR TITLE
Added Migration Documentation for Transform API for 0.11

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -57,4 +57,5 @@
     * [Adding Paddle Configs](./appendices/a_config_files/paddle_configs.md)
 * [Appendix B: Migration Notes](./appendices/b_migration_notes.md)
     * [`cgmath` to `nalgebra`](./appendices/b_migration_notes/cgmath_to_nalgebra.md)
+    * [`Transform` API Changes](./appendices/b_migration_notes/transform_api_changes.md)
 * [Appendix C: Feature Gates](./appendices/c_feature_gates.md)

--- a/book/src/appendices/b_migration_notes.md
+++ b/book/src/appendices/b_migration_notes.md
@@ -3,5 +3,4 @@
 At times Amethyst goes through non-trivial changes which may impose additional effort to upgrade. This section contains migration notes to reduce this effort.
 
 * [0.9 to 0.10](b_migration_notes/cgmath_to_nalgebra.html): `cgmath` to `nalgebra` migration
-
 * [0.10 to 0.11](b_migration_notes/transform_api_changes.html): Changes in the `Transform` API

--- a/book/src/appendices/b_migration_notes.md
+++ b/book/src/appendices/b_migration_notes.md
@@ -3,3 +3,5 @@
 At times Amethyst goes through non-trivial changes which may impose additional effort to upgrade. This section contains migration notes to reduce this effort.
 
 * [0.9 to 0.10](b_migration_notes/cgmath_to_nalgebra.html): `cgmath` to `nalgebra` migration
+
+* [0.10 to 0.11](b_migration_notes/transform_api_changes.html): Changes in the `Transform` API

--- a/book/src/appendices/b_migration_notes/transform_api_changes.md
+++ b/book/src/appendices/b_migration_notes/transform_api_changes.md
@@ -4,17 +4,16 @@ The names of several `Transform` methods have been changed in order to better re
 
 ## Summary
 
-
-* `Float` type has been added.
-* `GlobalTransform` has been removed.
-* `set` methods have been renamed using `set_translation`
-* `local` methods have been renamed using `append`
+* `Float` type has been added to wrap `f32` or `f64` for `Transform` coordinates.
+* `GlobalTransform` has been removed, and merged into `Transform`.
+* `set_*` translation methods have been renamed to `set_translation_*`
+* `*_local` transforms have been renamed to `append_*`.
+* `*_global` transforms have been renamed to `prepend_*`.
 * `pitch`, `yaw`, and `roll` methods now use x, y, and z axis respectively.
-* `global` methods have been renamed using `prepend`
-* `set_position` has been renamed `set_translation`
-* 2D helper aliases have been added
-* `set_rotation` methods have been added
-* `euler_angles` has been added
+* `set_position` has been renamed `set_translation`.
+* Method aliases for 2D rotation have have been added.
+* `set_rotation` methods have been added.
+* `euler_angles` method has been added.
 
 ## `Float` Type
 
@@ -22,154 +21,127 @@ A wrapper type around `f32` and `f64`. It is used to hide the actual type being 
 
 ## Renamed Transform Methods (Breaking Changes)
 
-### `set(x|y|z)` to `set_translation(x|y|z)`
+* `set(x|y|z)` to `set_translation(x|y|z)`
 
-```patch
--transform.set_x(0.2);
-+transform.set_translation_x(0.2);
-```
+    ```patch
+    -transform.set_x(0.2);
+    +transform.set_translation_x(0.2);
 
-```patch
--transform.set_y(7.1);
-+transform.set_translation_y(7.1);
-```
+    -transform.set_y(7.1);
+    +transform.set_translation_y(7.1);
 
-```patch
--transform.set_z(2.4);
-+transform.set_translation_z(2.4);
-```
+    -transform.set_z(2.4);
+    +transform.set_translation_z(2.4);
 
-```patch
--transform.set_xyz(0.2, 1.0, 0.8);
-+transform.set_translation_xyz(0.2, 1.0, 0.8);
-```
+    -transform.set_xyz(0.2, 1.0, 0.8);
+    +transform.set_translation_xyz(0.2, 1.0, 0.8);
+    ```
 
-### `_local` to `append_`
+* `_local` to `append_`
 
-```patch
--transform.move_local(Vector3::new(5.0, 2.0, 3.0));
-+transform.append_translation(Vector3::new(5.0, 2.0, 3.0));
-```
+    ```patch
+    -transform.move_local(Vector3::new(5.0, 2.0, 3.0));
+    +transform.append_translation(Vector3::new(5.0, 2.0, 3.0));
 
-```patch
--transform.move_along_local(Vector3::new(3.0, 2.0, 1.0), 4.0);
-+transform.append_translation_along(Vector3::new(3.0, 2.0, 1.0), 8.0);
-```
+    -transform.move_along_local(Vector3::new(3.0, 2.0, 1.0), 4.0);
+    +transform.append_translation_along(Vector3::new(3.0, 2.0, 1.0), 8.0);
 
-```patch
--transform.rotate_local(Vector3::new(2.0, 2.1, 3.0), 8.0);
-+transform.append_rotation(Vector3::new(2.0, 2.1, 3.0), 8.0);
-```
+    -transform.rotate_local(Vector3::new(2.0, 2.1, 3.0), 8.0);
+    +transform.append_rotation(Vector3::new(2.0, 2.1, 3.0), 8.0);
+    ```
 
-### `(pitch|yaw|roll)_local` to `append_rotation_(x|y|z)_axis`
+* `(pitch|yaw|roll)_local` to `append_rotation_(x|y|z)_axis`
 
-```patch
--transform.pitch_local(2.3);
-+transform.append_rotation_x_axis(2.3);
-```
+    ```patch
+    -transform.pitch_local(2.3);
+    +transform.append_rotation_x_axis(2.3);
 
-```patch
--transform.yaw_local(1.0);
-+transform.append_rotation_y_axis(1.0);
-```
+    -transform.yaw_local(1.0);
+    +transform.append_rotation_y_axis(1.0);
 
-```patch
--transform.roll_local(2.3);
-+transform.append_rotation_z_axis(4.6);
-```
+    -transform.roll_local(2.3);
+    +transform.append_rotation_z_axis(4.6);
+    ```
 
-### `_global` to `prepend_`
+* `_global` to `prepend_`
 
-```patch
--transform.move_global(Vector3::new(5.0, 2.0, 3.0));
-+transform.prepend_translation(Vector3::new(5.0, 2.0, 3.0));
-```
+    ```patch
+    -transform.move_global(Vector3::new(5.0, 2.0, 3.0));
+    +transform.prepend_translation(Vector3::new(5.0, 2.0, 3.0));
 
-```patch
--transform.move_along_global(Vector3::new(5.0, 2.0, 3.0));
-+transform.prepend_translation_along(Vector3::new(5.0, 2.0, 3.0));
-```
+    -transform.move_along_global(Vector3::new(5.0, 2.0, 3.0));
+    +transform.prepend_translation_along(Vector3::new(5.0, 2.0, 3.0));
 
-```patch
--transform.rotate_global(Vector3::new(0.2, 0.4, 0.6), 0.4);
-+transform.prepend_rotation(Vector3::new(0.2, 0.4, 0.6), 0.4);
-```
+    -transform.rotate_global(Vector3::new(0.2, 0.4, 0.6), 0.4);
+    +transform.prepend_rotation(Vector3::new(0.2, 0.4, 0.6), 0.4);
+    ```
 
-### `(pitch|yaw|roll)_global` to `append_rotation_(x|y|z)_axis`
+* `(pitch|yaw|roll)_global` to `append_rotation_(x|y|z)_axis`
 
-```patch
--transform.pitch_global(0.4);
-+transform.prepend_rotation_x_axis(0.4);
-```
+    ```patch
+    -transform.pitch_global(0.4);
+    +transform.prepend_rotation_x_axis(0.4);
 
-```patch
--transform.yaw_global(0.4);
-+transform.prepend_rotation_y_axis(0.4);
-```
+    -transform.yaw_global(0.4);
+    +transform.prepend_rotation_y_axis(0.4);
 
-```patch
--transform.roll_global(0.4);
-+transform.prepend_rotation_z_axis(0.4);
-```
+    -transform.roll_global(0.4);
+    +transform.prepend_rotation_z_axis(0.4);
+    ```
 
-### `translate_[xyz]` to `prepend_translation_[xyz]`
+* `translate_(x|y|z)` to `prepend_translation_(x|y|z)`
 
-```patch
--transform.translate_x(3.0);
-+transform.prepend_translation_x(3.0);
-```
+    ```patch
+    -transform.translate_x(3.0);
+    +transform.prepend_translation_x(3.0);
 
-```patch
--transform.translate_y(2.4);
-+transform.prepend_translation_y(2.4);
-```
+    -transform.translate_y(2.4);
+    +transform.prepend_translation_y(2.4);
 
+    -transform.translate_z(0.4);
+    +transform.prepend_translation_z(0.4);
 
-```patch
--transform.translate_z(0.4);
-+transform.prepend_translation_z(0.4);
-```
+    -transform.translate_xyz(0.4, 2.4, 3.2);
+    +transform.prepend_translation_xyz(0.4, 2.4, 3.2);
+    ```
 
-```patch
--transform.translate_xyz(0.4, 2.4, 3.2);
-+transform.prepend_translation_xyz(0.4, 2.4, 3.2);
-```
+* `set_position` to `set_translation`
 
-### `set_position` to `set_translation`
+    ```patch
+    -transform.set_position(Vector3::new(0.3, 0.2, 4.1));
+    +transform.set_translation(Vector3::new(0.3, 0.2, 4.1));
+    ```
 
-```patch
--transform.set_position(Vector3::new(0.3, 0.2, 4.1));
-+transform.set_translation(Vector3::new(0.3, 0.2, 4.1));
-```
 ## New Transform Methods
 
-### Set Rotation
+* Set Rotation
 
-Several new methods to set rotation have been added.
+    ```
+    transform.set_rotation(UnitQuaternion::identity());
+    transform.set_rotation_x_axis(0.4);
+    transform.set_rotation_y_axis(2.3);
+    transform.set_rotation_z_axis(1.0);
+    transform.set_rotation_euler(2.1, 3.4, 8.7);
+    ```
 
-```
-transform.set_rotation(UnitQuaternion::identity());
-transform.set_rotation_x_axis(0.4);
-transform.set_rotation_y_axis(2.3);
-transform.set_rotation_z_axis(1.0);
-transform.set_rotation_euler(2.1, 3.4, 8.7);
-```
+* 2D helper functions
 
-### 2D helper functions
+    - `rotate_2d`, an alias for `prepend_rotation_z_axis`
 
-`rotate_2d`, an alias for `prepend_rotation_z_axis`
-```
-transform.rotate_2d(5.0);
-```
-`set_rotation`, an alias for `set_rotation_z_axis`
-```
-transform.set_rotation_2d(4.7);
-```
+        ```
+        transform.rotate_2d(5.0);
+        ```
 
-### Euler
+    - `set_rotation_2d`, an alias for `set_rotation_z_axis`
 
-Get the Euler angles of a transform's rotation.
+        ```
+        transform.set_rotation_2d(4.7);
+        ```
 
-```
-let (x, y, z) = transform.euler_angles();
-```
+* Euler
+
+    - Get the Euler angles of a transform's rotation.
+
+        ```
+        let (x, y, z) = transform.euler_angles();
+        ```

--- a/book/src/appendices/b_migration_notes/transform_api_changes.md
+++ b/book/src/appendices/b_migration_notes/transform_api_changes.md
@@ -1,20 +1,26 @@
 # `Transform` API Changes
 
-The `Transform` API has been changed in order to be clearer and avoid potential naming conflicts in the future.
+The `Transform` API has been changed in order to better reflect their actual function and reduce potential semantic confusion. Many of these changes are breaking and old projects will have to be updated.
 
 ## Summary
 
+
+* `Float` type has been added.
 * `GlobalTransform` has been removed.
 * `set` methods have been renamed using `set_translation`
 * `local` methods have been renamed using `append`
 * `pitch`, `yaw`, and `roll` methods now use x, y, and z axis respectively.
 * `global` methods have been renamed using `prepend`
 * `set_position` has been renamed `set_translation`
-* 2d helper aliases have been added
+* 2D helper aliases have been added
 * `set_rotation` methods have been added
 * `euler_angles` has been added
 
 ## Breaking Changes
+
+### `Float` Type
+
+A wrapper type around f32 and f64. It is used to hide the actual type being used internally. Mostly used with the Transform type. The default type is f32 and you can switch to the f64 type by enabling the "float64" feature gate.
 
 ### `set(x|y|z)` to `set_translation(x|y|z)`
 
@@ -24,13 +30,13 @@ The `Transform` API has been changed in order to be clearer and avoid potential 
 ```
 
 ```patch
--transform.set_y(0.2);
-+transform.set_translation_y(0.2);
+-transform.set_y(7.1);
++transform.set_translation_y(7.1);
 ```
 
 ```patch
--transform.set_z(0.2);
-+transform.set_translation_z(0.2);
+-transform.set_z(2.4);
++transform.set_translation_z(2.4);
 ```
 
 ```patch
@@ -40,26 +46,26 @@ The `Transform` API has been changed in order to be clearer and avoid potential 
 
 ### `_local` to `append_`
 
-```diff
+```patch
 -transform.move_local(Vector3::new(5.0, 2.0, 3.0));
 +transform.append_translation(Vector3::new(5.0, 2.0, 3.0));
 ```
 
 ```patch
--transform.move_along_local();
-+transform.append_translation_along();
+-transform.move_along_local(Vector3::new(3.0, 2.0, 1.0), 4.0);
++transform.append_translation_along(Vector3::new(3.0, 2.0, 1.0), 8.0);
 ```
 
 ```patch
--transform.rotate_local();
-+transform.append_rotation();
+-transform.rotate_local(Vector3::new(2.0, 2.1, 3.0), 8.0);
++transform.append_rotation(Vector3::new(2.0, 2.1, 3.0), 8.0);
 ```
 
 ### `(pitch|yaw|roll)_local` to `append_rotation_(x|y|z)_axis`
 
 ```patch
--transform.pitch_local();
-+transform.append_rotation_x_axis();
+-transform.pitch_local(2.3);
++transform.append_rotation_x_axis(2.3);
 ```
 
 ```patch
@@ -147,19 +153,21 @@ transform.set_rotation_y_axis(2.3);
 transform.set_rotation_z_axis(1.0);
 ```
 
-### 2d helper functions
+### 2D helper functions
 
-Alias for `prepend_rotation_z_axis`
+`rotate_2d`, an alias for `prepend_rotation_z_axis`
 ```
 transform.rotate_2d(5.0);
 ```
-Alias for `set_rotation_z_axis`
+`set_rotation`, an alias for `set_rotation_z_axis`
 ```
 transform.set_rotation_2d(4.7);
 ```
 
 ### Euler
 
+Get the Euler angles of a transform's rotation.
+
 ```
-Vector3::new(transform.euler_angles());
+let (x, y, z) = transform.euler_angles();
 ```

--- a/book/src/appendices/b_migration_notes/transform_api_changes.md
+++ b/book/src/appendices/b_migration_notes/transform_api_changes.md
@@ -95,7 +95,7 @@ A wrapper type around `f32` and `f64`. It is used to hide the actual type being 
 +transform.prepend_rotation(Vector3::new(0.2, 0.4, 0.6), 0.4);
 ```
 
-### `(pitch|yaw|roll)_global` have changed to `append_rotation_(x|y|z)_axis`
+### `(pitch|yaw|roll)_global` to `append_rotation_(x|y|z)_axis`
 
 ```patch
 -pitch_global(0.4);
@@ -142,7 +142,6 @@ A wrapper type around `f32` and `f64`. It is used to hide the actual type being 
 +transform.set_translation(Vector3::new(0.3, 0.2, 4.1));
 ```
 ## New Transform Methods
-
 
 ### Set Rotation
 

--- a/book/src/appendices/b_migration_notes/transform_api_changes.md
+++ b/book/src/appendices/b_migration_notes/transform_api_changes.md
@@ -1,6 +1,6 @@
 # `Transform` API Changes
 
-The `Transform` API has been changed in order to better reflect their actual function and reduce potential semantic confusion. Many of these changes are breaking and old projects will have to be updated.
+The names of several `Transform` methods have been changed in order to better reflect their actual function and reduce potential semantic confusion. Many of these changes are breaking and old projects will have to be updated.
 
 ## Summary
 
@@ -16,11 +16,11 @@ The `Transform` API has been changed in order to better reflect their actual fun
 * `set_rotation` methods have been added
 * `euler_angles` has been added
 
-## Breaking Changes
+## `Float` Type
 
-### `Float` Type
+A wrapper type around `f32` and `f64`. It is used to hide the actual type being used internally. Mostly used with the Transform type. The default type is `f32` and you can switch to the `f64` type by enabling the "float64" feature gate.
 
-A wrapper type around f32 and f64. It is used to hide the actual type being used internally. Mostly used with the Transform type. The default type is f32 and you can switch to the f64 type by enabling the "float64" feature gate.
+## Renamed Transform Methods (Breaking Changes)
 
 ### `set(x|y|z)` to `set_translation(x|y|z)`
 
@@ -141,10 +141,12 @@ A wrapper type around f32 and f64. It is used to hide the actual type being used
 -transform.set_position(Vector3::new(0.3, 0.2, 4.1));
 +transform.set_translation(Vector3::new(0.3, 0.2, 4.1));
 ```
-## New Additions
+## New Transform Methods
 
 
 ### Set Rotation
+
+Several new methods to set rotation have been added.
 
 ```
 transform.set_rotation(UnitQuaternion::identity());

--- a/book/src/appendices/b_migration_notes/transform_api_changes.md
+++ b/book/src/appendices/b_migration_notes/transform_api_changes.md
@@ -1,0 +1,165 @@
+# `Transform` API Changes
+
+The `Transform` API has been changed in order to be clearer and avoid potential naming conflicts in the future.
+
+## Summary
+
+* `GlobalTransform` has been removed.
+* `set` methods have been renamed using `set_translation`
+* `local` methods have been renamed using `append`
+* `pitch`, `yaw`, and `roll` methods now use x, y, and z axis respectively.
+* `global` methods have been renamed using `prepend`
+* `set_position` has been renamed `set_translation`
+* 2d helper aliases have been added
+* `set_rotation` methods have been added
+* `euler_angles` has been added
+
+## Breaking Changes
+
+### `set(x|y|z)` to `set_translation(x|y|z)`
+
+```patch
+-transform.set_x(0.2);
++transform.set_translation_x(0.2);
+```
+
+```patch
+-transform.set_y(0.2);
++transform.set_translation_y(0.2);
+```
+
+```patch
+-transform.set_z(0.2);
++transform.set_translation_z(0.2);
+```
+
+```patch
+-transform.set_xyz(0.2, 1.0, 0.8);
++transform.set_translation_xyz(0.2);
+```
+
+### `_local` to `append_`
+
+```diff
+-transform.move_local(Vector3::new(5.0, 2.0, 3.0));
++transform.append_translation(Vector3::new(5.0, 2.0, 3.0));
+```
+
+```patch
+-transform.move_along_local();
++transform.append_translation_along();
+```
+
+```patch
+-transform.rotate_local();
++transform.append_rotation();
+```
+
+### `(pitch|yaw|roll)_local` to `append_rotation_(x|y|z)_axis`
+
+```patch
+-transform.pitch_local();
++transform.append_rotation_x_axis();
+```
+
+```patch
+-transform.yaw_local(1.0);
++transform.append_rotation_y_axis(1.0);
+```
+
+```patch
+-transform.roll_local(2.3);
++transform.append_rotation_z_axis(4.6);
+```
+
+### `_global` to `prepend_`
+
+```patch
+-transform.move_global(Vector3::new(5.0, 2.0, 3.0));
++transform.prepend_translation(Vector3::new(5.0, 2.0, 3.0));
+```
+
+```patch
+-transform.move_along_global(Vector3::new(5.0, 2.0, 3.0));
++transform.prepend_translation_along(Vector3::new(5.0, 2.0, 3.0));
+```
+
+```patch
+-transform.rotate_global(Vector3::new(0.2, 0.4, 0.6), 0.4);
++transform.prepend_rotation(Vector3::new(0.2, 0.4, 0.6), 0.4);
+```
+
+### `(pitch|yaw|roll)_global` have changed to `append_rotation_(x|y|z)_axis`
+
+```patch
+-pitch_global(0.4);
++prepend_rotation_x_axis(0.4);
+```
+
+```patch
+-yaw_global(0.4);
++prepend_rotation_y_axis(0.4);
+```
+
+```patch
+-roll_global(0.4);
++prepend_rotation_z_axis(0.4);
+```
+
+### `translate_[xyz]` to `prepend_translation_[xyz]`
+
+```patch
+-translate_x(3.0);
++prepend_translation_x(3.0);
+```
+
+```patch
+-translate_y(2.4);
++prepend_translation_y(2.4);
+```
+
+
+```patch
+-translate_z(0.4);
++prepend_translation_z(0.4);
+```
+
+```patch
+-translate_xyz(0.4, 2.4, 3.2);
++prepend_translation_xyz(0.4, 2.4, 3.2);
+```
+
+### `set_position` to `set_translation`
+
+```patch
+-transform.set_position(Vector3::new(0.3, 0.2, 4.1));
++transform.set_translation(Vector3::new(0.3, 0.2, 4.1));
+```
+## New Additions
+
+
+### Set Rotation
+
+```
+transform.set_rotation(UnitQuaternion::identity());
+transform.set_rotation_x_axis(0.4);
+transform.set_rotation_y_axis(2.3);
+transform.set_rotation_z_axis(1.0);
+```
+
+### 2d helper functions
+
+Alias for `prepend_rotation_z_axis`
+```
+transform.rotate_2d(5.0);
+```
+Alias for `set_rotation_z_axis`
+```
+transform.set_rotation_2d(4.7);
+```
+
+### Euler
+
+```
+Vector3::new(transform.euler_angles());
+```

--- a/book/src/appendices/b_migration_notes/transform_api_changes.md
+++ b/book/src/appendices/b_migration_notes/transform_api_changes.md
@@ -98,41 +98,41 @@ A wrapper type around `f32` and `f64`. It is used to hide the actual type being 
 ### `(pitch|yaw|roll)_global` to `append_rotation_(x|y|z)_axis`
 
 ```patch
--pitch_global(0.4);
-+prepend_rotation_x_axis(0.4);
+-transform.pitch_global(0.4);
++transform.prepend_rotation_x_axis(0.4);
 ```
 
 ```patch
--yaw_global(0.4);
-+prepend_rotation_y_axis(0.4);
+-transform.yaw_global(0.4);
++transform.prepend_rotation_y_axis(0.4);
 ```
 
 ```patch
--roll_global(0.4);
-+prepend_rotation_z_axis(0.4);
+-transform.roll_global(0.4);
++transform.prepend_rotation_z_axis(0.4);
 ```
 
 ### `translate_[xyz]` to `prepend_translation_[xyz]`
 
 ```patch
--translate_x(3.0);
-+prepend_translation_x(3.0);
+-transform.translate_x(3.0);
++transform.prepend_translation_x(3.0);
 ```
 
 ```patch
--translate_y(2.4);
-+prepend_translation_y(2.4);
+-transform.translate_y(2.4);
++transform.prepend_translation_y(2.4);
 ```
 
 
 ```patch
--translate_z(0.4);
-+prepend_translation_z(0.4);
+-transform.translate_z(0.4);
++transform.prepend_translation_z(0.4);
 ```
 
 ```patch
--translate_xyz(0.4, 2.4, 3.2);
-+prepend_translation_xyz(0.4, 2.4, 3.2);
+-transform.translate_xyz(0.4, 2.4, 3.2);
++transform.prepend_translation_xyz(0.4, 2.4, 3.2);
 ```
 
 ### `set_position` to `set_translation`

--- a/book/src/appendices/b_migration_notes/transform_api_changes.md
+++ b/book/src/appendices/b_migration_notes/transform_api_changes.md
@@ -41,7 +41,7 @@ A wrapper type around f32 and f64. It is used to hide the actual type being used
 
 ```patch
 -transform.set_xyz(0.2, 1.0, 0.8);
-+transform.set_translation_xyz(0.2);
++transform.set_translation_xyz(0.2, 1.0, 0.8);
 ```
 
 ### `_local` to `append_`
@@ -151,6 +151,7 @@ transform.set_rotation(UnitQuaternion::identity());
 transform.set_rotation_x_axis(0.4);
 transform.set_rotation_y_axis(2.3);
 transform.set_rotation_z_axis(1.0);
+transform.set_rotation_euler(2.1, 3.4, 8.7);
 ```
 
 ### 2D helper functions


### PR DESCRIPTION
## Description

Added Migration Notes as discussed in #1561. They could probably use a once-over by someone who knows Amethyst, I'm new here.

## Additions
n/a

## Removals
n/a

## Modifications

Modified book with migration docs for Transform for 0.11

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Ran `cargo test --all` locally if this modified any rs files.
- [ ] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new APIs if any were added in this PR.
- [x ] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
