### PR TITLE
Fix gltf example rendering outside the viewport

### DIFF
--- a/examples/assets/prefab/puffy_scene.ron
+++ b/examples/assets/prefab/puffy_scene.ron
@@ -19,7 +19,10 @@ Prefab (
         (
             parent: 1,
             data: (
-                transform: (),
+                transform: (
+                    translation: (0.0, 0.0, 0.0),
+                    rotation: (0.0, 0.0, 1.0, 0.0),
+                ),
                 fly_tag: (),
             ),
         ),
@@ -27,7 +30,8 @@ Prefab (
             parent: 2,
             data: (
                 transform: (
-                    translation: (0., 0., 10.0),
+                    translation: (0.0, 0.0, 10.0),
+                    rotation: (0.0, 0.0, 1.0, 0.0),
                 ),
                 camera: Perspective((
                     aspect: 1.33333333333333333333,


### PR DESCRIPTION
## Description
Move the gltf model back in to view, in the gltf example.
Previously it was only rendering a black screen.

## PR Checklist
By placing an x in the boxes I certify that I have:
- [x ] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
