### PR TITLE
Adding the global thread pool to the state specific dispatcher examples

### DIFF
--- a/book/src/controlling_system_execution/state-specific_dispatcher.md
+++ b/book/src/controlling_system_execution/state-specific_dispatcher.md
@@ -85,7 +85,7 @@ impl<'a, 'b> SimpleState for CustomState<'a, 'b> {
 }
 ```
 
-By default the dispatcher will create it's own pool of worker threads to execute states in but Amethyst's main dispatcher already has a thread pool setup and configured. Normally you'll want to reuse that. The global pool is available as a resource so we pull it from the world and attach the dispatcher to it with `.with_pool()`.
+By default the dispatcher will create its own pool of worker threads to execute systems in but Amethyst's main dispatcher already has a thread pool setup and configured. As reusing it is more efficient, we pull the global pool from the world and attach the dispatcher to it with `.with_pool()`.
 
 The `CustomState` requires two annotations (`'a` and `'b`) to satisfy the lifetimes of the `Dispatcher`. Now that we have our `Dispatcher` we need to ensure that it is executed. We do this in the `State`s `update` method.
 

--- a/book/src/controlling_system_execution/state-specific_dispatcher.md
+++ b/book/src/controlling_system_execution/state-specific_dispatcher.md
@@ -85,7 +85,7 @@ impl<'a, 'b> SimpleState for CustomState<'a, 'b> {
 }
 ```
 
-By default the dispatcher will create its own pool of worker threads to execute systems in but Amethyst's main dispatcher already has a thread pool setup and configured. As reusing it is more efficient, we pull the global pool from the world and attach the dispatcher to it with `.with_pool()`.
+By default, the dispatcher will create its own pool of worker threads to execute systems in, but Amethyst's main dispatcher already has a thread pool setup and configured. As reusing it is more efficient, we pull the global pool from the world and attach the dispatcher to it with `.with_pool()`.
 
 The `CustomState` requires two annotations (`'a` and `'b`) to satisfy the lifetimes of the `Dispatcher`. Now that we have our `Dispatcher` we need to ensure that it is executed. We do this in the `State`s `update` method.
 

--- a/book/src/controlling_system_execution/state-specific_dispatcher.md
+++ b/book/src/controlling_system_execution/state-specific_dispatcher.md
@@ -48,7 +48,7 @@ PongSystemsBundle::default()
     .expect("Failed to register PongSystemsBundle");
 ```
 
-The `DispatcherBuilder` can be initialized and populated wherever desired, be it inside the `State` or in an external location. However, the `Dispatcher` needs to modify the `World`s resources in order to initialize the resources used by its `System`s. Normally you will also want the `Dispatcher` to share the global thread pool which much be retrieved from the `World`. Therefore, we need to defer building the `Dispatcher` until we can access the `World`. This is commonly done in the `State`s `on_start` method. To showcase how this is done, we'll create a `SimpleState` with a `dispatcher` field and a `on_start` method that builds the `Dispatcher`.
+The `DispatcherBuilder` can be initialized and populated wherever desired, be it inside the `State` or in an external location. However, the `Dispatcher` needs to modify the `World`s resources in order to initialize the resources used by its `System`s. Therefore, we need to defer building the `Dispatcher` until we can access the `World`. This is commonly done in the `State`s `on_start` method. To showcase how this is done, we'll create a `SimpleState` with a `dispatcher` field and a `on_start` method that builds the `Dispatcher`.
 
 ```rust,edition2018,no_run,noplaypen
 # external crate amethyst;
@@ -84,6 +84,8 @@ impl<'a, 'b> SimpleState for CustomState<'a, 'b> {
     }
 }
 ```
+
+By default the dispatcher will create it's own pool of worker threads to execute states in but Amethyst's main dispatcher already has a thread pool setup and configured. Normally you'll want to reuse that. The global pool is available as a resource so we pull it from the world and attach the dispatcher to it with `.with_pool()`.
 
 The `CustomState` requires two annotations (`'a` and `'b`) to satisfy the lifetimes of the `Dispatcher`. Now that we have our `Dispatcher` we need to ensure that it is executed. We do this in the `State`s `update` method.
 


### PR DESCRIPTION
## Description

This extends the state specific dispatcher example in the book to include attaching the new dispatcher to the global thread pool rather than letting it create a new pool of its own. This seems to me like a sensible default.

The motivation for this change is that after I followed this example I couldn't use the thread profiler any more and, not being very familiar with specs, it took some digging to figure out why.

## Additions

n/a

## Removals

n/a

## Modifications

Adjusted one example in the book to have a better default behavior

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Ran `cargo test --all` locally if this modified any rs files.
- [ ] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
