### PR TITLE
Bug/1595/segfault with multiple audio tests

### DIFF
--- a/amethyst_test/src/amethyst_application.rs
+++ b/amethyst_test/src/amethyst_application.rs
@@ -1122,6 +1122,7 @@ mod test {
     /// * Another sub-thread accesses the COM object through the same `lazy_static` variable.
     ///
     /// For more details, see <https://github.com/amethyst/amethyst/issues/1595>.
+    #[cfg(feature = "graphics")]
     mod audio_test {
         use amethyst::{
             assets::AssetStorage,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -85,10 +85,12 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * Add to fly_camera example code to release and capture back mouse input, and to show and hide cursor. ([#1582])
 
 ### Removed
+
 - Removed all `NetEvent's` because they were not used. ([#1539])
 - Removed filter logic, because it didn't do anything, will be added back in a later version (NetFilter, FilterConnected). ([#1539])
 
 ### Fixed
+
 * Optimize loading of wavefront obj mesh assets by getting rid of unnecessary allocations. ([#1454])
 * Fixed the "json" feature for amethyst_assets. ([#1302])
 * Fixed default system font loading to accept uppercase extension ("TTF"). ([#1328])
@@ -96,6 +98,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * Fix omission in `PosNormTangTex` documentation. ([#1371])
 * Fix division by zero in vertex data building ([#1481])
 * Fix tuple index generation on `PrefabData` and `EventReader` proc macros. ([#1501])
+* Avoid segmentation fault on Windows when using `AudioBundle` in `amethyst_test`. ([#1595], [#1599])
 
 [#1114]: https://github.com/amethyst/amethyst/pull/1114
 [#1213]: https://github.com/amethyst/amethyst/pull/1213
@@ -155,6 +158,8 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1584]: https://github.com/amethyst/amethyst/pull/1584
 [#1591]: https://github.com/amethyst/amethyst/pull/1591
 [#1582]: https://github.com/amethyst/amethyst/pull/1582
+[#1595]: https://github.com/amethyst/amethyst/issues/1595
+[#1599]: https://github.com/amethyst/amethyst/pull/1599
 
 ## [0.10.0] - 2018-12
 


### PR DESCRIPTION
## Description

Fixed a segmentation fault on Windows when multiple threads in `amethyst_test` share a COM object.

Closes #1595.

Before:

```
$ cargo test -p amethyst_test audio

running 4 tests
test amethyst_application::test::audio_test::audio_two ... ok
test amethyst_application::test::audio_test::audio_three ... ok
test amethyst_application::test::audio_test::audio_zero ... ok
error: test failed, to rerun pass '-p amethyst_test --lib'
Segmentation fault
```

After:

```bash
$ cargo test -p amethyst_test audio

running 4 tests
test amethyst_application::test::audio_test::audio_two ... ok
test amethyst_application::test::audio_test::audio_one ... ok
test amethyst_application::test::audio_test::audio_three ... ok
test amethyst_application::test::audio_test::audio_zero ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 20 filtered out
```


## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
