### PR TITLE
Fixes typo: "abour" -> "about"

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-01.md
+++ b/book/src/pong-tutorial/pong-tutorial-01.md
@@ -113,7 +113,7 @@ In either case, open `display_config.ron` and change its contents to the followi
 > If you have never run into Rusty Object Notation before (or RON for short), 
 > it is a data storage format that mirrors Rust's syntax. Here, the
 > data represents the [`DisplayConfig`][displayconf] struct. If you want to
-> learn more abour the RON syntax, you can visit the [official repository][ron].
+> learn more about the RON syntax, you can visit the [official repository][ron].
 
 This will set the default window dimensions to 500 x 500, and make the title bar
 say "Pong!" instead of the sad, lowercase default of "pong".


### PR DESCRIPTION
## Description

Fixes a small typo in the pong-tutorial-01 page of the book.

## Additions

## Removals

## Modifications

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
