### PR TITLE
Update ObjFormat::simple_import for changes in rendy

### DIFF
--- a/amethyst_rendy/src/formats/mesh.rs
+++ b/amethyst_rendy/src/formats/mesh.rs
@@ -18,12 +18,19 @@ amethyst_assets::register_format_type!(MeshData);
 amethyst_assets::register_format!("OBJ", ObjFormat as MeshData);
 impl Format<MeshData> for ObjFormat {
     fn name(&self) -> &'static str {
-        "WAVEFRONT_OBJ"
+        "OBJ"
     }
 
     fn import_simple(&self, bytes: Vec<u8>) -> Result<MeshData, Error> {
         rendy::mesh::obj::load_from_obj(&bytes)
-            .map(|builder| builder.into())
+            .map(|objects| {
+                if objects.len() == 1 {
+                    let builder = objects[0].0.clone();
+                    builder.into()
+                } else {
+                    unimplemented!();
+                }
+            })
             .map_err(|e| e.compat().into())
     }
 }


### PR DESCRIPTION
## Description

If https://github.com/amethyst/rendy/pull/130 lands we need to limit the number of objects to 1 and ignore the material string for now.

## Modifications

- OBJ Loader uses only the first returned object. Support for multiple objects is unimplemented.

