### PR TITLE
Work around false positive warning

### DIFF
--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -417,6 +417,7 @@ mod tests {
 
         BACKTRACE_STATUS.store(2, atomic::Ordering::Relaxed);
 
+        #[allow(warnings)]
         #[inline(never)]
         #[no_mangle]
         fn a_really_unique_name_42() -> Error {


### PR DESCRIPTION
Due to a regression in the Rust nightly compiler, `no_mangle` is incorrectly detected as "unused attribute".

## Description

Adds `allow(warnings)` to the symbol.
