### PR TITLE
Fix book links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ While the engine can be hard to use at times, we made a lot of [documentation][b
 
 If you don't understand a part of the documentation, please let us know. Join us on Discord or open an issue; we are always happy to help!
 
-[bkr]: https://www.amethyst.rs/book/latest/
-[bkm]: https://www.amethyst.rs/book/master/
+[bkr]: https://book.amethyst.rs/stable/
+[bkm]: https://book.amethyst.rs/master/
 [exr]: https://github.com/amethyst/amethyst/tree/v0.10.0/examples
 [exm]: https://github.com/amethyst/amethyst/tree/master/examples
 


### PR DESCRIPTION
## Description

Fixes the links to the book in the readme.

## Additions

- N/A

## Removals

- N/A

## Modifications

- N/A

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.