### PR TITLE
Docs/rendy migration guide

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -58,4 +58,5 @@
 * [Appendix B: Migration Notes](./appendices/b_migration_notes.md)
     * [`cgmath` to `nalgebra`](./appendices/b_migration_notes/cgmath_to_nalgebra.md)
     * [`Transform` API Changes](./appendices/b_migration_notes/transform_api_changes.md)
+    * [Rendy Migration](./appendices/b_migration_notes/rendy_migration.md)
 * [Appendix C: Feature Gates](./appendices/c_feature_gates.md)

--- a/book/src/appendices/b_migration_notes/rendy_migration.md
+++ b/book/src/appendices/b_migration_notes/rendy_migration.md
@@ -1,0 +1,239 @@
+# Rendy: Migration Guide
+
+## Audio
+
+* `AudioFormat` no longer exists, you have to use the lower level types -- `Mp3Format`, `WavFormat`, `OggFormat`, `FlacFormat`.
+
+## Assets
+
+* `SimpleFormat` trait has merged into `Format`.
+* `Options` associated type has been removed.
+* `NAME` associated constant is now a method call.
+* `Format<A>` type parameter now takes in `Format<D>`, where `D` is `A::Data`.
+* Implement `import_simple` instead of `import`.
+* `Loader#load` no longer takes in the `Options` parameter.
+
+## Input
+
+* `Bindings<String, String>` is now `Bindings<StringBindings>`.
+* `Bindings<AX, AC>` is now `Bindings<T>`, where `T` is a new type you must implement:
+
+    ```rust
+    pub struct ControlBindings;
+
+    impl BindingTypes for ControlBindings {
+        type Axis = PlayerAxisControl;
+        type Action = PlayerActionControl;
+    }
+    ```
+
+    Diff:
+
+    ```patch
+    -Bindings<PlayerAxisControl, PlayerActionControl>
+    +Bindings<ControlBindings>
+    ```
+
+* `InputBundle` type parameters:
+
+    ```patch
+    -InputBundle::<String, String>::new()
+    +InputBundle::<StringBindings>::new()
+    ```
+
+* `UiBundle` type parameters:
+
+    ```patch
+    +use amethyst::renderer::types::DefaultBackend;
+
+    -UiBundle::<String, String>::new()
+    +UiBundle::<DefaultBackend, StringBindings>::new()
+    ```
+
+## Window
+
+* `DisplayConfig`'s `fullscreen` field is now an `Option<MonitorIdent>`. `MonitorIdent` is `MonitorIdent(u16, String)`. What's that? Good question.
+* `WindowBundle` is now separate from `amethyst_renderer`.
+
+    ```rust
+    use amethyst::window::WindowBundle;
+
+    game_data.with_bundle(WindowBundle::from_config_file(display_config_path))?
+    ```
+
+## Renderer
+
+* `amethyst::renderer::VirtualKeyCode` is now `amethyst::input::VirtualKeyCode`
+* `amethyst::renderer::DisplayConfig` is now `amethyst::window::DisplayConfig`
+* `amethyst::renderer::WindowEvent` is now `amethyst::window::WindowEvent`
+* `amethyst::renderer::Event` is no longer re-exported. Use `winit::Event`
+* `amethyst::renderer::Transparent` is now under `amethyst::renderer::transparent::Transparent`.
+* `TextureHandle` type alias no longer exists, use `Handle<Texture>`.
+* `Flipped` component is removed. You can specify `flipped` during sprite loading, or mutating `Transform` at run time.
+* To load a texture in memory, you can't use `[0.; 4].into()` as the `TextureData` anymore. Use:
+
+    ```rust
+    use amethyst::{
+        assets::{AssetStorage, Handle, Loader, Prefab, PrefabLoader},
+        ecs::World,
+        renderer::{
+            loaders::load_from_srgba,
+            palette::Srgba,
+            types::TextureData,
+            Texture,
+        },
+    };
+
+    let loader = world.read_resource::<Loader>();
+    let texture_assets = world.read_resource::<AssetStorage<Texture>>();
+    let texture_builder = load_from_srgba(Srgba::new(0., 0., 0., 0.));
+    let texture_handle: Handle<Texture> =
+        loader.load_from_data(TextureData::from(texture_builder), (), &texture_assets);
+    ```
+
+* `RenderBundle` and `Pipeline` are gone, now you need to do something like this:
+
+    In `main.rs`:
+
+    ```rust
+    use amethyst::renderer::{types::DefaultBackend, RenderingSystem};
+
+    use crate::render_graph::RenderGraph;
+
+    mod render_graph;
+
+    let game_data = GameDataBuilder::default()
+        .with_bundle(WindowBundle::from_config(display_config))?
+        .with_thread_local(RenderingSystem::<DefaultBackend, _>::new(
+            RenderGraph::default(),
+        ))
+    ```
+
+    In `render_graph.rs`:
+
+    ```rust
+    use std::sync::Arc;
+
+    use amethyst::{
+        ecs::{ReadExpect, Resources, SystemData},
+        renderer::{
+            pass::{DrawFlat2DDesc, DrawFlat2DTransparentDesc},
+            rendy::{
+                factory::Factory,
+                graph::{
+                    present::PresentNode,
+                    render::{RenderGroupDesc, SubpassBuilder},
+                    GraphBuilder,
+                },
+                hal::{
+                    command::{ClearDepthStencil, ClearValue},
+                    format::Format,
+                    image::Kind,
+                },
+            },
+            types::DefaultBackend,
+            GraphCreator,
+        },
+        ui::DrawUiDesc,
+        window::{ScreenDimensions, Window},
+    };
+
+    #[derive(Default)]
+    pub struct RenderGraph {
+        dimensions: Option<ScreenDimensions>,
+        surface_format: Option<Format>,
+        dirty: bool,
+    }
+
+    impl GraphCreator<DefaultBackend> for RenderGraph {
+        fn rebuild(&mut self, res: &Resources) -> bool {
+            // Rebuild when dimensions change, but wait until at least two frames have the same.
+            let new_dimensions = res.try_fetch::<ScreenDimensions>();
+            use std::ops::Deref;
+            if self.dimensions.as_ref() != new_dimensions.as_ref().map(|d| d.deref()) {
+                self.dirty = true;
+                self.dimensions = new_dimensions.map(|d| d.clone());
+                return false;
+            }
+            return self.dirty;
+        }
+
+        fn builder(
+            &mut self,
+            factory: &mut Factory<DefaultBackend>,
+            res: &Resources,
+        ) -> GraphBuilder<DefaultBackend, Resources> {
+            self.dirty = false;
+
+            let window = <ReadExpect<'_, Arc<Window>>>::fetch(res);
+            let surface = factory.create_surface(&window);
+            // cache surface format to speed things up
+            let surface_format = *self
+                .surface_format
+                .get_or_insert_with(|| factory.get_surface_format(&surface));
+            let dimensions = self.dimensions.as_ref().unwrap();
+            let window_kind = Kind::D2(dimensions.width() as u32, dimensions.height() as u32, 1, 1);
+
+            let mut graph_builder = GraphBuilder::new();
+            let color = graph_builder.create_image(
+                window_kind,
+                1,
+                surface_format,
+                Some(ClearValue::Color([0.1, 0.1, 0.1, 1.0].into())),
+            );
+
+            let depth = graph_builder.create_image(
+                window_kind,
+                1,
+                Format::D32Sfloat,
+                Some(ClearValue::DepthStencil(ClearDepthStencil(1.0, 0))),
+            );
+
+            let sprite = graph_builder.add_node(
+                SubpassBuilder::new()
+                    .with_group(DrawFlat2DDesc::new().builder())
+                    .with_color(color)
+                    .with_depth_stencil(depth)
+                    .into_pass(),
+            );
+            let sprite_trans = graph_builder.add_node(
+                SubpassBuilder::new()
+                    .with_group(DrawFlat2DTransparentDesc::new().builder())
+                    .with_color(color)
+                    .with_depth_stencil(depth)
+                    .into_pass(),
+            );
+            let ui = graph_builder.add_node(
+                SubpassBuilder::new()
+                    .with_group(DrawUiDesc::new().builder())
+                    .with_color(color)
+                    .with_depth_stencil(depth)
+                    .into_pass(),
+            );
+
+            let _present = graph_builder.add_node(
+                PresentNode::builder(factory, surface, color)
+                    .with_dependency(sprite_trans)
+                    .with_dependency(sprite),
+            );
+
+            graph_builder
+        }
+    }
+
+    ```
+
+## Amethyst Test
+
+*Pending: <https://github.com/amethyst/amethyst/pull/1624>*
+
+* The `render_base` function has been changed:
+
+    ```rust
+    use amethyst_test::{AmethystApplication, RenderBaseAppExt};
+
+    AmethystApplication::render_base()
+        .with_app_name("you_test_name")
+    ```
+
+* `mark_render()` is renamed to `run_in_thread()`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -101,6 +101,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * Combined input axis/action generics into single type.
 * `Material` is now an asset. Must be turned into handle before putting on an entity.
 * Removed `Flipped` component. Use `flip_horizontal` and `flip_vertical` sprite property instead.
+* Added [Rendy migration guide][rendy_migration]. ([#1626])
 
 ### Removed
 
@@ -118,6 +119,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * Fix tuple index generation on `PrefabData` and `EventReader` proc macros. ([#1501])
 * Avoid segmentation fault on Windows when using `AudioBundle` in `amethyst_test`. ([#1595], [#1599])
 
+[rendy_migration]: https://book.amethyst.rs/master/appendices/b_migration_notes/rendy_migration.html
 [#1114]: https://github.com/amethyst/amethyst/pull/1114
 [#1213]: https://github.com/amethyst/amethyst/pull/1213
 [#1237]: https://github.com/amethyst/amethyst/pull/1237
@@ -178,6 +180,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1582]: https://github.com/amethyst/amethyst/pull/1582
 [#1595]: https://github.com/amethyst/amethyst/issues/1595
 [#1599]: https://github.com/amethyst/amethyst/pull/1599
+[#1626]: https://github.com/amethyst/amethyst/pull/1626
 [#1642]: https://github.com/amethyst/amethyst/pull/1642
 [#1683]: https://github.com/amethyst/amethyst/pull/1683
 


### PR DESCRIPTION
## Description

Added migration guide to switch from `gfx` to `rendy`.

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Ran `cargo test --all` locally if this modified any rs files.
- **n/a** Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
