### PR TITLE
Premultiply alpha when loading textures

### DIFF
--- a/amethyst_rendy/src/formats/texture.rs
+++ b/amethyst_rendy/src/formats/texture.rs
@@ -45,6 +45,7 @@ impl Default for ImageFormat {
                 anisotropic: Anisotropic::Off,
             },
             generate_mips: false,
+            premultiply_alpha: true,
         })
     }
 }

--- a/amethyst_rendy/src/pass/base_3d.rs
+++ b/amethyst_rendy/src/pass/base_3d.rs
@@ -741,7 +741,7 @@ fn build_pipelines<B: Backend, T: Base3DPassDef<B>>(
         .with_blend_targets(vec![pso::ColorBlendDesc(
             pso::ColorMask::ALL,
             if transparent {
-                pso::BlendState::ALPHA
+                pso::BlendState::PREMULTIPLIED_ALPHA
             } else {
                 pso::BlendState::Off
             },

--- a/amethyst_rendy/src/pass/flat2d.rs
+++ b/amethyst_rendy/src/pass/flat2d.rs
@@ -434,7 +434,7 @@ fn build_sprite_pipeline<B: Backend>(
                 .with_blend_targets(vec![pso::ColorBlendDesc(
                     pso::ColorMask::ALL,
                     if transparent {
-                        pso::BlendState::ALPHA
+                        pso::BlendState::PREMULTIPLIED_ALPHA
                     } else {
                         pso::BlendState::Off
                     },


### PR DESCRIPTION
## Description

Makes the TextureData loader premultiply image alpha when loading. This is desirable in most cases 
 as it can prevent many common sorts of image artifacts resulting from texture filtering pixels that are meant to be transparent (see http://www.adriancourreges.com/blog/2017/05/09/beware-of-transparent-pixels/).

This change relies on https://github.com/amethyst/rendy/pull/143, to test it you must change `amethyst_rendy` Cargo.toml to point to that branch for now.

## Additions

- Adds `premultiply_alpha` field to `TexturePrefab`

## PR Checklist

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- n/a Updated the content of the book if this PR would make the book outdated.
- n/a Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- n/a Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
