### PR TITLE
[Rendy] Change camera back to global matrix

### DIFF
--- a/amethyst_core/src/transform/components/transform.rs
+++ b/amethyst_core/src/transform/components/transform.rs
@@ -855,7 +855,7 @@ mod tests {
                 &Vector3::new(-1.0, 1.0, 2.0),
                 &Vector3::new(1.0, 0.0, 0.0),
             )
-                .unwrap(),
+            .unwrap(),
         );
 
         assert_ulps_eq!(

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -35,7 +35,7 @@ approx = "0.3.2"
 [dev-dependencies]
 rayon = "1.0.2"
 more-asserts = "0.2.1"
-bencher = "0.1.5"
+criterion = "0.2.11"
 
 [features]
 dx12 = ["rendy/dx12"]
@@ -45,3 +45,7 @@ profiler = [ "thread_profiler/thread_profiler", "rendy/profiler" ]
 nightly = [ "amethyst_core/nightly", "shred/nightly" ]
 no-slow-safety-checks = ["rendy/no-slow-safety-checks"]
 shader-compiler =  ["rendy/shader-compiler"]
+
+[[bench]]
+name = "camera"
+harness = false

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -35,6 +35,7 @@ approx = "0.3.2"
 [dev-dependencies]
 rayon = "1.0.2"
 more-asserts = "0.2.1"
+bencher = "0.1.5"
 
 [features]
 dx12 = ["rendy/dx12"]

--- a/amethyst_rendy/benches/camera.rs
+++ b/amethyst_rendy/benches/camera.rs
@@ -1,0 +1,59 @@
+use amethyst_core::{
+    components::Transform,
+    math::{convert, Matrix4, Translation3, UnitQuaternion},
+};
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+// Our world-space is +Y Up, +X Right and -Z Away
+// Current render target is +Y Down, +X Right and +Z Away
+fn setup() -> Transform {
+    // Setup common inputs for most of the tests.
+    //
+    // Sets up a test camera is positioned at (0,0,3) in world space.
+    // A camera without rotation is pointing in the (0,0,-1) direction.
+    Transform::new(
+        Translation3::new(0.0, 0.0, 3.0),
+        // Apply _no_ rotation
+        UnitQuaternion::identity(),
+        [1.0, 1.0, 1.0].into(),
+    )
+}
+
+pub fn transform_global_view_matrix_1000(b: &mut Criterion) {
+    let transform = setup();
+
+    b.bench_function("transform_global_view_matrix_1000", move |b| {
+        b.iter(|| {
+            for _ in 0..1000 {
+                let _: [[f32; 4]; 4] =
+                    convert::<_, Matrix4<f32>>(transform.global_view_matrix()).into();
+            }
+        });
+    });
+}
+
+pub fn manual_inverse_global_matrix_1000(b: &mut Criterion) {
+    let transform = setup();
+
+    b.bench_function("manual_inverse_global_matrix_1000", move |b| {
+        b.iter(|| {
+            for _ in 0..1000 {
+                let _: [[f32; 4]; 4] = convert::<_, Matrix4<f32>>(
+                    transform
+                        .global_matrix()
+                        .try_inverse()
+                        .expect("Unable to get inverse of camera transform"),
+                )
+                .into();
+            }
+        });
+    });
+}
+
+criterion_group!(
+    cameras,
+    transform_global_view_matrix_1000,
+    manual_inverse_global_matrix_1000,
+);
+criterion_main!(cameras);

--- a/amethyst_rendy/src/camera.rs
+++ b/amethyst_rendy/src/camera.rs
@@ -925,4 +925,55 @@ mod tests {
     fn orthographic_project_cube_off_centered_rotated() {
         unimplemented!()
     }
+
+    #[cfg(not(feature = "nightly"))]
+    #[bench]
+    pub fn transform_global_view_matrix_1000(b: &mut bencher::Bencher) {
+        do_transform_global_view_matrix_1000(b)
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    pub fn transform_global_view_matrix_1000(b: &mut test::Bencher) {
+        do_transform_global_view_matrix_1000(b)
+    }
+
+    pub fn do_transform_global_view_matrix_1000<T>(b: T) {
+        let (transform, _, _) = setup();
+
+        b.iter(|| {
+            for _ in 0..1000 {
+                let _: [[f32; 4]; 4] =
+                    convert::<_, Matrix4<f32>>(transform.global_view_matrix()).into();
+            }
+        });
+    }
+
+    #[cfg(not(feature = "nightly"))]
+    #[bench]
+    pub fn manual_inverse_global_matrix_1000(b: &mut bencher::Bencher) {
+        do_manual_inverse_global_matrix_1000(b)
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    pub fn manual_inverse_global_matrix_1000(b: &mut test::Bencher) {
+        do_manual_inverse_global_matrix_1000(b)
+    }
+
+    pub fn do_manual_inverse_global_matrix_1000<T>(b: T) {
+        let (transform, _, _) = setup();
+
+        b.iter(|| {
+            for _ in 0..1000 {
+                let _: [[f32; 4]; 4] = convert::<_, Matrix4<f32>>(
+                    transform
+                        .global_matrix()
+                        .try_inverse()
+                        .expect("Unable to get inverse of camera transform"),
+                )
+                .into();
+            }
+        });
+    }
 }

--- a/amethyst_rendy/src/camera.rs
+++ b/amethyst_rendy/src/camera.rs
@@ -925,35 +925,4 @@ mod tests {
     fn orthographic_project_cube_off_centered_rotated() {
         unimplemented!()
     }
-
-    #[cfg(not(feature = "nightly"))]
-    #[bench]
-    pub fn transform_global_view_matrix_1000(b: &mut bencher::Bencher) {
-        let (transform, _, _) = setup();
-
-        b.iter(|| {
-            for _ in 0..1000 {
-                let _: [[f32; 4]; 4] =
-                    convert::<_, Matrix4<f32>>(transform.global_view_matrix()).into();
-            }
-        });
-    }
-
-    #[cfg(not(feature = "nightly"))]
-    #[bench]
-    pub fn manual_inverse_global_matrix_1000(b: &mut bencher::Bencher) {
-        let (transform, _, _) = setup();
-
-        b.iter(|| {
-            for _ in 0..1000 {
-                let _: [[f32; 4]; 4] = convert::<_, Matrix4<f32>>(
-                    transform
-                        .global_matrix()
-                        .try_inverse()
-                        .expect("Unable to get inverse of camera transform"),
-                )
-                    .into();
-            }
-        });
-    }
 }

--- a/amethyst_rendy/src/camera.rs
+++ b/amethyst_rendy/src/camera.rs
@@ -929,16 +929,6 @@ mod tests {
     #[cfg(not(feature = "nightly"))]
     #[bench]
     pub fn transform_global_view_matrix_1000(b: &mut bencher::Bencher) {
-        do_transform_global_view_matrix_1000(b)
-    }
-
-    #[cfg(feature = "nightly")]
-    #[bench]
-    pub fn transform_global_view_matrix_1000(b: &mut test::Bencher) {
-        do_transform_global_view_matrix_1000(b)
-    }
-
-    pub fn do_transform_global_view_matrix_1000<T>(b: T) {
         let (transform, _, _) = setup();
 
         b.iter(|| {
@@ -952,16 +942,6 @@ mod tests {
     #[cfg(not(feature = "nightly"))]
     #[bench]
     pub fn manual_inverse_global_matrix_1000(b: &mut bencher::Bencher) {
-        do_manual_inverse_global_matrix_1000(b)
-    }
-
-    #[cfg(feature = "nightly")]
-    #[bench]
-    pub fn manual_inverse_global_matrix_1000(b: &mut test::Bencher) {
-        do_manual_inverse_global_matrix_1000(b)
-    }
-
-    pub fn do_manual_inverse_global_matrix_1000<T>(b: T) {
         let (transform, _, _) = setup();
 
         b.iter(|| {
@@ -972,7 +952,7 @@ mod tests {
                         .try_inverse()
                         .expect("Unable to get inverse of camera transform"),
                 )
-                .into();
+                    .into();
             }
         });
     }

--- a/amethyst_rendy/src/submodules/gather.rs
+++ b/amethyst_rendy/src/submodules/gather.rs
@@ -54,7 +54,7 @@ impl CameraGatherer {
             convert::<_, Vector3<f32>>(transform.global_matrix().column(3).xyz()).into_pod();
 
         let proj: [[f32; 4]; 4] = (*camera.as_matrix()).into();
-        let view: [[f32; 4]; 4] = convert::<_, Matrix4<f32>>(transform.view_matrix()).into();
+        let view: [[f32; 4]; 4] = convert::<_, Matrix4<f32>>(transform.global_view_matrix()).into();
 
         let projview = pod::ViewArgs {
             proj: proj.into(),


### PR DESCRIPTION
## Description

This is a re-open of #1633

Credit for this solution goes to @termhn . I just implemented it and did the benchmarking.

This changes the camera gatherer to use global_view_matrix(), a solution by @termhn. This fixes the fact we are using the wrong matrix currently (view_matrix), and also adds some optimization to prevent the full matrix inverse calculations we were doing previous (the last fix).

`test camera::tests::manual_inverse_global_matrix_1000 ... bench:     366,152 ns/iter (+/- 107,849)
test camera::tests::transform_global_view_matrix_1000 ... bench:      39,855 ns/iter (+/- 1,148)`

## Modifications

- Swaps camera::gather to global_view_matrix() 

## Additions

- Transform::global_view_matrix()
- New bencher unit tests added for camera gathering. The results between the two solutions

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
