### PR TITLE
Add mouse wheel axis

### DIFF
--- a/amethyst_input/src/axis.rs
+++ b/amethyst_input/src/axis.rs
@@ -26,4 +26,11 @@ pub enum Axis {
         /// linearly interpolate remaining ranges.
         dead_zone: f64,
     },
+    /// Represents the wheel on a PC mouse.
+    MouseWheel {
+        /// If this value is true then this axis is for the horizontal mouse wheel rather than the vertical mouse wheel.
+        ///
+        /// You almost always want this false.
+        horizontal: bool,
+    },
 }

--- a/amethyst_input/src/button.rs
+++ b/amethyst_input/src/button.rs
@@ -17,7 +17,7 @@ pub enum Button {
     /// Mouse buttons
     Mouse(MouseButton),
 
-    /// Mouse wheel
+    /// Mouse wheel (Do not use these with an emulated axis, instead use the MouseWheel axis.)
     MouseWheel(ScrollDirection),
 
     /// Controller buttons matching SDL controller model.

--- a/amethyst_input/src/system.rs
+++ b/amethyst_input/src/system.rs
@@ -45,6 +45,7 @@ impl<'a, T: BindingTypes> System<'a> for InputSystem<T> {
     );
 
     fn run(&mut self, (input, mut handler, mut output, screen_dimensions): Self::SystemData) {
+        handler.send_frame_begin();
         for event in input.read(
             &mut self
                 .reader

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,10 @@ it is attached to. ([#1282])
 * Added `events` example which demonstrates working even reader and writer in action. ([#1538])
 *  Implement builder like functionality for `AnimationSet` and `AnimationControlSet` ([#1568])
 * Add `get_mouse_button` and `is_mouse_button_down` utility functions to amethyst_input. ([#1582])
+- Add amethyst_input::Axis::MouseWheel ([#1642])
+- Add amethyst_input::BindingError::MouseWheelAlreadyBound ([#1642])
+- Add amethyst_input::InputHandler::send_frame_begin ([#1642])
+- Add amethyst_input::InputHandler::mouse_wheel_value ([#1642])
 
 ### Changed
 
@@ -172,6 +176,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1582]: https://github.com/amethyst/amethyst/pull/1582
 [#1595]: https://github.com/amethyst/amethyst/issues/1595
 [#1599]: https://github.com/amethyst/amethyst/pull/1599
+[#1642]: https://github.com/amethyst/amethyst/pull/1642
 
 ## [0.10.0] - 2018-12
 


### PR DESCRIPTION
## Description

Fixes #1627 .

This PR adds a new axis type dedicated to mouse wheel support. Using mouse wheels as buttons for an Emulated axis does not produce satisfactory results, so instead a mouse wheel axis is implemented.

## Additions

- Axis::MouseWheel
- BindingError::MouseWheelAlreadyBound
- InputHandler::send_frame_begin
- InputHandler::mouse_wheel_value

## Removals

- None

## Modifications

- Updated axis trait implementations to account for new axis
- Updated BindingError trait implementations to account for new error

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- N/A Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
