### PR TITLE
Fix book/concepts example code

### DIFF
--- a/book/src/concepts/state.md
+++ b/book/src/concepts/state.md
@@ -134,8 +134,7 @@ Let's use handle_event to go to the `PausedState` and come back by pressing the 
 ```rust,edition2018,no_run,noplaypen
 extern crate amethyst;
 use amethyst::prelude::*;
-use amethyst::renderer::VirtualKeyCode;
-use amethyst::input::is_key_down;
+use amethyst::input::{VirtualKeyCode, is_key_down};
 
 struct GameplayState;
 struct PausedState;
@@ -183,9 +182,9 @@ To change the set of events that the state receives, you create a new event enum
 ```rust,edition2018,no_run,noplaypen
 # #[macro_use] extern crate amethyst;
 # use amethyst::prelude::*;
-# use amethyst::renderer::{VirtualKeyCode, Event};
 # use amethyst::ui::UiEvent;
-# use amethyst::input::is_key_down;
+# use amethyst::input::{VirtualKeyCode, is_key_down};
+# use amethyst::winit::Event;
 
 // These imports are required for the #[derive(EventReader)] code to build
 use amethyst::core::{

--- a/book/src/concepts/system.md
+++ b/book/src/concepts/system.md
@@ -105,7 +105,7 @@ Keep in mind that **the `join` method is only available by importing `amethyst::
 ```rust,edition2018,no_run,noplaypen
 # extern crate amethyst;
 # use amethyst::ecs::{System, ReadStorage, WriteStorage};
-# use amethyst::core::Transform;
+# use amethyst::core::{Float, Transform};
 # struct FallingObject;
 # impl amethyst::ecs::Component for FallingObject {
 #   type Storage = amethyst::ecs::DenseVecStorage<FallingObject>;
@@ -122,7 +122,7 @@ impl<'a> System<'a> for MakeObjectsFall {
 
     fn run(&mut self, (mut transforms, falling): Self::SystemData) {
         for (mut transform, _) in (&mut transforms, &falling).join() {
-            if transform.translation().y > 0.0 {
+            if transform.translation().y.as_f32() > 0.0 {
                 transform.prepend_translation_y(-0.1);
             }
         }
@@ -250,7 +250,7 @@ impl<'a> System<'a> for MakeObjectsFall {
 
     fn run(&mut self, (entities, mut transforms, falling): Self::SystemData) {
         for (e, mut transform, _) in (&*entities, &mut transforms, &falling).join() {
-            if transform.translation().y > 0.0 {
+            if transform.translation().y.as_f32() > 0.0 {
                 transform.prepend_translation_y(-0.1);
             } else {
                 entities.delete(e);
@@ -439,14 +439,14 @@ system:
 use amethyst::{
     prelude::*,
     ecs::{System, prelude::*},
-    input::InputHandler,
+    input::{InputHandler, StringBindings},
 };
 
 struct MyGameplaySystem;
 
 impl<'s> System<'s> for MyGameplaySystem {
     type SystemData = (
-        Read<'s, InputHandler<String, String>>,
+        Read<'s, InputHandler<StringBindings>>,
         Write<'s, Game>,
     );
 


### PR DESCRIPTION
## Description

Fixes code sampels in the concept book chapters to pass `mdbook test`. Note that there are still chapters to fix (notably Pong), this is just a first pass.

cc #1647 

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
