### PR TITLE
Updating book to rendy API changes

### DIFF
--- a/book/src/controlling_system_execution/custom_game_data.md
+++ b/book/src/controlling_system_execution/custom_game_data.md
@@ -124,8 +124,7 @@ our `Application`, but first we should create some `State`s.
 #
 # use amethyst::ecs::prelude::{Dispatcher, World};
 # use amethyst::prelude::{State, StateData, StateEvent, Trans};
-# use amethyst::input::{is_close_requested, is_key_down};
-# use amethyst::renderer::VirtualKeyCode;
+# use amethyst::input::{is_close_requested, is_key_down, VirtualKeyCode};
 #
 # pub struct CustomGameData<'a, 'b> {
 #     core_dispatcher: Dispatcher<'a, 'b>,

--- a/book/src/controlling_system_execution/pausable_systems.md
+++ b/book/src/controlling_system_execution/pausable_systems.md
@@ -22,7 +22,22 @@ impl Default for CurrentState {
 
 We'll use this `enum` `Resource` to control whether or not our `System` is running. Next we'll register our `System` and set it as pausable.
 
-```rust,no_run,noplaypen
+```rust,edition2018,no_run,noplaypen
+# external crate amethyst;
+#
+# use amethyst::{
+#     ecs::prelude::*,
+#     prelude::*,
+# };
+# 
+# struct MovementSystem;
+# 
+# impl<'a> System<'a> for MovementSystem {
+#   type SystemData = ();
+#
+#   fn run(&mut self, data: Self::SystemData) {}
+# }
+# let mut dispatcher = DispatcherBuilder::new();
 dispatcher.add(
     MovementSystem::default().pausable(CurrentState::Running),
     "movement_system",
@@ -34,8 +49,28 @@ dispatcher.add(
 
 To register the `Resource` or change its value, we can use the following line:
 
-```rust,no_run,noplaypen
+```rust,edition2018,no_run,noplaypen
+# extern crate amethyst;
+# use amethyst::prelude::*;
+# #[derive(PartialEq)]
+# pub enum CurrentState {
+#    Running,
+#    Paused,
+# }
+# 
+# impl Default for CurrentState {
+#     fn default() -> Self {
+#         CurrentState::Paused
+#     }
+# }
+# 
+# struct GameplayState;
+# 
+# impl SimpleState for GameplayState {
+#     fn update(&mut self, data: &mut StateData<'_, GameData<'_, '_>>) -> SimpleTrans {
 *data.world.write_resource::<CurrentState>() = CurrentState::Paused;
+#     }
+# }
 ```
 
 However, this cannot be done inside the pausable `System` itself. A pausable `System` can only access its pause `Resource` with immutable `Read` and cannot modify the value, thus the `System` cannot decide on its own if it should run on not. This has to be done from a different location. 


### PR DESCRIPTION
## Description

Updating the unit tests in the book to comply with API changes.

#1647

## Additions

Nothing.

## Removals

Nothing.

## Modifications

Nothing.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ n/a] Ran `cargo test --all` locally if this modified any rs files.
- [ n/a] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ n/a] Updated the content of the book if this PR would make the book outdated.
- [ n/a] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ n/a] Added unit tests for new APIs if any were added in this PR.
- [ x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
