### PR TITLE
Fix remaining code of book/controlling_system_execution

### DIFF
--- a/book/src/controlling_system_execution/pausable_systems.md
+++ b/book/src/controlling_system_execution/pausable_systems.md
@@ -23,14 +23,26 @@ impl Default for CurrentState {
 We'll use this `enum` `Resource` to control whether or not our `System` is running. Next we'll register our `System` and set it as pausable.
 
 ```rust,edition2018,no_run,noplaypen
-# external crate amethyst;
+# extern crate amethyst;
 #
 # use amethyst::{
 #     ecs::prelude::*,
 #     prelude::*,
 # };
 # 
-# struct MovementSystem;
+# #[derive(PartialEq)]
+# pub enum CurrentState {
+#     Running,
+#     Paused,
+# }
+# 
+# impl Default for CurrentState {
+#     fn default() -> Self {
+#         CurrentState::Paused
+#     }
+# }
+#
+# #[derive(Default)] struct MovementSystem;
 # 
 # impl<'a> System<'a> for MovementSystem {
 #   type SystemData = ();
@@ -47,7 +59,7 @@ dispatcher.add(
 
 `pausable(CurrentState::Running)` creates a wrapper around our `System` that controls its execution depending on the `CurrentState` `Resource` registered with the `World`. As long as the value of the `Resource` is set to `CurrentState::Running`, the `System` is executed.
 
-To register the `Resource` or change its value, we can use the following line:
+To register the `Resource` or change its value, we can use the following code:
 
 ```rust,edition2018,no_run,noplaypen
 # extern crate amethyst;
@@ -64,13 +76,19 @@ To register the `Resource` or change its value, we can use the following line:
 #     }
 # }
 # 
-# struct GameplayState;
-# 
-# impl SimpleState for GameplayState {
-#     fn update(&mut self, data: &mut StateData<'_, GameData<'_, '_>>) -> SimpleTrans {
-*data.world.write_resource::<CurrentState>() = CurrentState::Paused;
-#     }
-# }
+struct GameplayState;
+
+impl SimpleState for GameplayState {
+    fn update(&mut self, data: &mut StateData<'_, GameData<'_, '_>>) -> SimpleTrans {
+#       let my_condition = true;
+        if (my_condition) {
+            *data.world.write_resource::<CurrentState>() = CurrentState::Paused;
+        }
+        
+        Trans::None
+    }
+}
 ```
 
-However, this cannot be done inside the pausable `System` itself. A pausable `System` can only access its pause `Resource` with immutable `Read` and cannot modify the value, thus the `System` cannot decide on its own if it should run on not. This has to be done from a different location. 
+However, this cannot be done inside the pausable `System` itself. A pausable `System` can only access its pause `Resource` with immutable `Read` and cannot modify the value, thus the `System` cannot decide on its own if it should run on not. This has to be done from a different location.
+ 

--- a/book/src/controlling_system_execution/state-specific_dispatcher.md
+++ b/book/src/controlling_system_execution/state-specific_dispatcher.md
@@ -5,7 +5,7 @@ This guide explains how to define a state-specific `Dispatcher` whose `System`s 
 First of all we required a `DispatcherBuilder`. The `DispatcherBuilder` handles the actual creation of the `Dispatcher` and the assignment of `System`s to our `Dispatcher`. 
 
 ```rust,edition2018,no_run,noplaypen
-# external crate amethyst;
+# extern crate amethyst;
 #
 # use amethyst::{
 #     ecs::prelude::*,
@@ -18,13 +18,16 @@ let mut dispatcher_builder = DispatcherBuilder::new();
 To add `System`s to the `DispatcherBuilder` we use a similar syntax to the one we used to add `System`s to `GameData`.
 
 ```rust,edition2018,no_run,noplaypen
-# external crate amethyst;
+# extern crate amethyst;
 #
 # use amethyst::{
 #     ecs::prelude::*,
 #     prelude::*,
 # };
-# 
+#
+# struct MoveBallsSystem; struct MovePaddlesSystem;
+# impl<'a> System<'a> for MoveBallsSystem { type SystemData = (); fn run(&mut self, _: ()) {} }
+# impl<'a> System<'a> for MovePaddlesSystem { type SystemData = (); fn run(&mut self, _: ()) {} }
 let mut dispatcher_builder = DispatcherBuilder::new();
 
 dispatcher_builder.add(MoveBallsSystem, "move_balls_system", &[]);
@@ -34,13 +37,19 @@ dispatcher_builder.add(MovePaddlesSystem, "move_paddles_system", &[]);
 Alternatively we can add `Bundle`s of `System`s to our `DispatcherBuilder` directly.
 
 ```rust,edition2018,no_run,noplaypen
-# external crate amethyst;
+# extern crate amethyst;
 #
 # use amethyst::{
+#     core::bundle::SystemBundle,
 #     ecs::prelude::*,
 #     prelude::*,
 # };
-# 
+# #[derive(Default)] struct PongSystemsBundle;
+# impl<'a, 'b> SystemBundle<'a, 'b> for PongSystemsBundle {
+#     fn build(self, _: &mut DispatcherBuilder<'a, 'b>) -> Result<(), amethyst::Error> {
+#         Ok(())
+#     }
+# }
 let mut dispatcher_builder = DispatcherBuilder::new();
 
 PongSystemsBundle::default()
@@ -51,14 +60,18 @@ PongSystemsBundle::default()
 The `DispatcherBuilder` can be initialized and populated wherever desired, be it inside the `State` or in an external location. However, the `Dispatcher` needs to modify the `World`s resources in order to initialize the resources used by its `System`s. Therefore, we need to defer building the `Dispatcher` until we can access the `World`. This is commonly done in the `State`s `on_start` method. To showcase how this is done, we'll create a `SimpleState` with a `dispatcher` field and a `on_start` method that builds the `Dispatcher`.
 
 ```rust,edition2018,no_run,noplaypen
-# external crate amethyst;
+# extern crate amethyst;
 #
 # use amethyst::{
 #     ecs::prelude::*,
 #     prelude::*,
 #     core::ArcThreadPool,
 # };
-# 
+#
+# struct MoveBallsSystem; struct MovePaddlesSystem;
+# impl<'a> System<'a> for MoveBallsSystem { type SystemData = (); fn run(&mut self, _: ()) {} }
+# impl<'a> System<'a> for MovePaddlesSystem { type SystemData = (); fn run(&mut self, _: ()) {} }
+#
 #[derive(Default)]
 pub struct CustomState<'a, 'b> {
     /// The `State` specific `Dispatcher`, containing `System`s only relevant for this `State`.
@@ -90,7 +103,7 @@ By default, the dispatcher will create its own pool of worker threads to execute
 The `CustomState` requires two annotations (`'a` and `'b`) to satisfy the lifetimes of the `Dispatcher`. Now that we have our `Dispatcher` we need to ensure that it is executed. We do this in the `State`s `update` method.
 
 ```rust,edition2018,no_run,noplaypen
-# external crate amethyst;
+# extern crate amethyst;
 #
 # use amethyst::{
 #     ecs::prelude::*,
@@ -102,6 +115,9 @@ The `CustomState` requires two annotations (`'a` and `'b`) to satisfy the lifeti
 #     /// The `State` specific `Dispatcher`, containing `System`s only relevant for this `State`.
 #     dispatcher: Option<Dispatcher<'a, 'b>>,
 # }
+# struct MoveBallsSystem; struct MovePaddlesSystem;
+# impl<'a> System<'a> for MoveBallsSystem { type SystemData = (); fn run(&mut self, _: ()) {} }
+# impl<'a> System<'a> for MovePaddlesSystem { type SystemData = (); fn run(&mut self, _: ()) {} }
 # 
 impl<'a, 'b> SimpleState for CustomState<'a, 'b> {
     fn on_start(&mut self, data: StateData<'_, GameData<'_, '_>>) {


### PR DESCRIPTION
## Description

Fixed the remaining code of the `controlling_system_execution` chapter to pass the `mdbook test`.

cc #1647 

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Ran `cargo test --all` locally if this modified any rs files.
- [ ] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
