### PR TITLE
Fix bad default in lod_range

### DIFF
--- a/amethyst_rendy/src/formats/texture.rs
+++ b/amethyst_rendy/src/formats/texture.rs
@@ -38,7 +38,7 @@ impl Default for ImageFormat {
                 lod_bias: 0.0.into(),
                 lod_range: std::ops::Range {
                     start: 0.0.into(),
-                    end: 8000.0.into(),
+                    end: 1000.0.into(),
                 },
                 comparison: None,
                 border: PackedColor(0),


### PR DESCRIPTION
## Description

Creating a default ImageFormat resulted in lod_range having an end of -1536 rather than the expected 8000. This is because when gfx_hal::image::Lod converts an f32 it multiplies it by 8 and converts it to i16 which overflowed.

The behavior of Lod seems strange to me so maybe this is really a gfx bug but I'm not sure.

## Additions
n/a

## Removals
n/a

## Modifications

n/a

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
