### PR TITLE
[Rendy] Change DynamicVertex to a generic type for index buffers

### DIFF
--- a/amethyst_rendy/src/pass/debug_lines.rs
+++ b/amethyst_rendy/src/pass/debug_lines.rs
@@ -2,7 +2,7 @@ use crate::{
     debug_drawing::{DebugLine, DebugLines, DebugLinesComponent, DebugLinesParams},
     pipeline::{PipelineDescBuilder, PipelinesBuilder},
     pod::ViewArgs,
-    submodules::{gather::CameraGatherer, DynamicUniform, DynamicVertex},
+    submodules::{gather::CameraGatherer, DynamicUniform, DynamicVertexBuffer},
     types::Backend,
     util,
 };
@@ -59,7 +59,7 @@ impl<B: Backend> RenderGroupDesc<B, Resources> for DrawDebugLinesDesc {
 
         let env = DynamicUniform::new(factory, pso::ShaderStageFlags::VERTEX)?;
         let args = DynamicUniform::new(factory, pso::ShaderStageFlags::VERTEX)?;
-        let vertex = DynamicVertex::new();
+        let vertex = DynamicVertexBuffer::new();
 
         let (pipeline, pipeline_layout) = build_lines_pipeline(
             factory,
@@ -89,7 +89,7 @@ pub struct DrawDebugLines<B: Backend> {
     pipeline_layout: B::PipelineLayout,
     env: DynamicUniform<B, ViewArgs>,
     args: DynamicUniform<B, DebugLinesArgs>,
-    vertex: DynamicVertex<B, DebugLine>,
+    vertex: DynamicVertexBuffer<B, DebugLine>,
     framebuffer_width: f32,
     framebuffer_height: f32,
     lines: Vec<DebugLine>,
@@ -172,7 +172,7 @@ impl<B: Backend> RenderGroup<B, Resources> for DrawDebugLines<B> {
         encoder.bind_graphics_pipeline(&self.pipeline);
         self.env.bind(index, layout, 0, &mut encoder);
         self.args.bind(index, layout, 1, &mut encoder);
-        self.vertex.bind(index, 0, &mut encoder);
+        self.vertex.bind(index, 0, 0, &mut encoder);
         encoder.draw(0..4, 0..self.lines.len() as u32);
     }
 

--- a/amethyst_rendy/src/pass/flat2d.rs
+++ b/amethyst_rendy/src/pass/flat2d.rs
@@ -4,7 +4,7 @@ use crate::{
     pod::SpriteArgs,
     sprite::{SpriteRender, SpriteSheet},
     sprite_visibility::SpriteVisibility,
-    submodules::{DynamicVertex, FlatEnvironmentSub, TextureId, TextureSub},
+    submodules::{DynamicVertexBuffer, FlatEnvironmentSub, TextureId, TextureSub},
     types::{Backend, Texture},
     util,
 };
@@ -60,7 +60,7 @@ impl<B: Backend> RenderGroupDesc<B, Resources> for DrawFlat2DDesc {
 
         let env = FlatEnvironmentSub::new(factory)?;
         let textures = TextureSub::new(factory)?;
-        let vertex = DynamicVertex::new();
+        let vertex = DynamicVertexBuffer::new();
 
         let (pipeline, pipeline_layout) = build_sprite_pipeline(
             factory,
@@ -88,7 +88,7 @@ pub struct DrawFlat2D<B: Backend> {
     pipeline_layout: B::PipelineLayout,
     env: FlatEnvironmentSub<B>,
     textures: TextureSub<B>,
-    vertex: DynamicVertex<B, SpriteArgs>,
+    vertex: DynamicVertexBuffer<B, SpriteArgs>,
     sprites: OneLevelBatch<TextureId, SpriteArgs>,
 }
 
@@ -213,7 +213,7 @@ impl<B: Backend> RenderGroup<B, Resources> for DrawFlat2D<B> {
         let layout = &self.pipeline_layout;
         encoder.bind_graphics_pipeline(&self.pipeline);
         self.env.bind(index, layout, 0, &mut encoder);
-        self.vertex.bind(index, 0, &mut encoder);
+        self.vertex.bind(index, 0, 0, &mut encoder);
         for (&tex, range) in self.sprites.iter() {
             if self.textures.loaded(tex) {
                 self.textures.bind(layout, 1, tex, &mut encoder);
@@ -261,7 +261,7 @@ impl<B: Backend> RenderGroupDesc<B, Resources> for DrawFlat2DTransparentDesc {
 
         let env = FlatEnvironmentSub::new(factory)?;
         let textures = TextureSub::new(factory)?;
-        let vertex = DynamicVertex::new();
+        let vertex = DynamicVertexBuffer::new();
 
         let (pipeline, pipeline_layout) = build_sprite_pipeline(
             factory,
@@ -290,7 +290,7 @@ pub struct DrawFlat2DTransparent<B: Backend> {
     pipeline_layout: B::PipelineLayout,
     env: FlatEnvironmentSub<B>,
     textures: TextureSub<B>,
-    vertex: DynamicVertex<B, SpriteArgs>,
+    vertex: DynamicVertexBuffer<B, SpriteArgs>,
     sprites: OrderedOneLevelBatch<TextureId, SpriteArgs>,
     change: util::ChangeDetection,
 }
@@ -383,7 +383,7 @@ impl<B: Backend> RenderGroup<B, Resources> for DrawFlat2DTransparent<B> {
         let layout = &self.pipeline_layout;
         encoder.bind_graphics_pipeline(&self.pipeline);
         self.env.bind(index, layout, 0, &mut encoder);
-        self.vertex.bind(index, 0, &mut encoder);
+        self.vertex.bind(index, 0, 0, &mut encoder);
         for (&tex, range) in self.sprites.iter() {
             if self.textures.loaded(tex) {
                 self.textures.bind(layout, 1, tex, &mut encoder);

--- a/amethyst_rendy/src/submodules/texture.rs
+++ b/amethyst_rendy/src/submodules/texture.rs
@@ -29,7 +29,7 @@ enum TextureState<B: Backend> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct TextureId(pub u32);
+pub struct TextureId(u32);
 
 #[derive(Debug)]
 pub struct TextureSub<B: Backend> {

--- a/amethyst_rendy/src/submodules/texture.rs
+++ b/amethyst_rendy/src/submodules/texture.rs
@@ -29,7 +29,7 @@ enum TextureState<B: Backend> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct TextureId(u32);
+pub struct TextureId(pub u32);
 
 #[derive(Debug)]
 pub struct TextureSub<B: Backend> {

--- a/amethyst_rendy/src/submodules/vertex.rs
+++ b/amethyst_rendy/src/submodules/vertex.rs
@@ -45,9 +45,12 @@ pub trait VertexDataBufferType<B: Backend> {
 }
 
 impl<B: Backend, T: 'static> VertexDataBufferType<B> for VertexData<T> {
+    #[inline]
     fn usage() -> hal::buffer::Usage {
         hal::buffer::Usage::VERTEX
     }
+
+    #[inline]
     fn bind(
         binding_id: u32,
         encoder: &mut RenderPassEncoder<'_, B>,
@@ -64,10 +67,12 @@ impl<B: Backend, T: 'static> VertexDataBufferType<B> for VertexData<T> {
 }
 
 impl<B: Backend, T: 'static> VertexDataBufferType<B> for IndexData<T> {
+    #[inline]
     fn usage() -> hal::buffer::Usage {
         hal::buffer::Usage::INDEX
     }
 
+    #[inline]
     fn bind(
         _: u32,
         encoder: &mut RenderPassEncoder<'_, B>,

--- a/amethyst_rendy/src/submodules/vertex.rs
+++ b/amethyst_rendy/src/submodules/vertex.rs
@@ -109,7 +109,7 @@ pub struct DynamicVertexData<B: Backend, V: VertexDataBufferType, T: 'static> {
 }
 
 impl<B: Backend, V: VertexDataBufferType, T: 'static> DynamicVertexData<B, V, T> {
-    /// Creates an empty, 0-frame `DynamicVertexData`
+    /// Creates a new `DynamicVertexData`
     pub fn new() -> Self {
         Self {
             per_image: Vec::new(),
@@ -199,13 +199,13 @@ impl<B: Backend> DynamicVertexData<B, IndexData<B, u32>, u32> {
 /// implementation also leverages the [VertexDataBufferType] trait type for statically dispatching
 /// the appropriate binding and allocation functions, preventing hot-path branching.
 #[derive(Debug)]
-pub struct PerImageDynamicVertexData<B: Backend, V: VertexDataBufferType> {
+struct PerImageDynamicVertexData<B: Backend, V: VertexDataBufferType> {
     buffer: Option<Escape<Buffer<B>>>,
     marker: PhantomData<V>,
 }
 
 impl<B: Backend, V: VertexDataBufferType> PerImageDynamicVertexData<B, V> {
-    /// Creates an empty, 0-frame `DynamicVertexData`
+    /// Creates a new 'PerImageDynamicVertexData'
     fn new() -> Self {
         Self {
             buffer: None,

--- a/amethyst_rendy/src/submodules/vertex.rs
+++ b/amethyst_rendy/src/submodules/vertex.rs
@@ -66,7 +66,7 @@ impl<B: Backend, T: 'static> VertexDataBufferType<B> for VertexData<T> {
     }
 }
 
-impl<B: Backend, T: 'static> VertexDataBufferType<B> for IndexData<T> {
+impl<B: Backend> VertexDataBufferType<B> for IndexData<u16> {
     #[inline]
     fn usage() -> hal::buffer::Usage {
         hal::buffer::Usage::INDEX
@@ -81,6 +81,28 @@ impl<B: Backend, T: 'static> VertexDataBufferType<B> for IndexData<T> {
     ) -> bool {
         if let Some(buffer) = buffer.as_ref() {
             encoder.bind_index_buffer(buffer.raw(), offset, hal::IndexType::U16);
+            return true;
+        }
+
+        false
+    }
+}
+
+impl<B: Backend> VertexDataBufferType<B> for IndexData<u32> {
+    #[inline]
+    fn usage() -> hal::buffer::Usage {
+        hal::buffer::Usage::INDEX
+    }
+
+    #[inline]
+    fn bind(
+        _: u32,
+        encoder: &mut RenderPassEncoder<'_, B>,
+        buffer: &Option<Escape<Buffer<B>>>,
+        offset: u64,
+    ) -> bool {
+        if let Some(buffer) = buffer.as_ref() {
+            encoder.bind_index_buffer(buffer.raw(), offset, hal::IndexType::U32);
             return true;
         }
 

--- a/amethyst_ui/src/pass.rs
+++ b/amethyst_ui/src/pass.rs
@@ -30,7 +30,7 @@ use amethyst_rendy::{
     },
     resources::Tint,
     simple_shader_set,
-    submodules::{DynamicUniform, DynamicVertex, TextureId, TextureSub},
+    submodules::{DynamicUniform, DynamicVertexBuffer, TextureId, TextureSub},
     types::{Backend, Texture},
     ChangeDetection,
 };
@@ -108,7 +108,7 @@ impl<B: Backend> RenderGroupDesc<B, Resources> for DrawUiDesc {
     ) -> Result<Box<dyn RenderGroup<B, Resources>>, failure::Error> {
         let env = DynamicUniform::new(factory, pso::ShaderStageFlags::VERTEX)?;
         let textures = TextureSub::new(factory)?;
-        let vertex = DynamicVertex::new();
+        let vertex = DynamicVertexBuffer::new();
 
         let (pipeline, pipeline_layout) = build_ui_pipeline(
             factory,
@@ -147,7 +147,7 @@ pub struct DrawUi<B: Backend> {
     pipeline_layout: B::PipelineLayout,
     env: DynamicUniform<B, UiViewArgs>,
     textures: TextureSub<B>,
-    vertex: DynamicVertex<B, UiArgs>,
+    vertex: DynamicVertexBuffer<B, UiArgs>,
     batches: OrderedOneLevelBatch<TextureId, UiArgs>,
     change: ChangeDetection,
     cached_draw_order: CachedDrawOrder,
@@ -396,7 +396,7 @@ impl<B: Backend> RenderGroup<B, Resources> for DrawUi<B> {
             let layout = &self.pipeline_layout;
             encoder.bind_graphics_pipeline(&self.pipeline);
             self.env.bind(index, &self.pipeline_layout, 0, &mut encoder);
-            self.vertex.bind(index, 0, &mut encoder);
+            self.vertex.bind(index, 0, 0, &mut encoder);
             for (&tex, range) in self.batches.iter() {
                 self.textures.bind(layout, 1, tex, &mut encoder);
                 encoder.draw(0..4, range);


### PR DESCRIPTION
## Description

The current implementation of `DynamicBuffer` is hard-coded to only create vertex buffers, and has some offsets hard coded. This implementation makes this instead generic `DynamicVertexData` (and `DynamicVertexBuffer` / `DynamicIndexBuffer`), which statically dispatches to the appropriate `bind` function of the rendy encoder based on its type parameter. This lets us dispatch for the correct usage at compile time without any hotpath overhead. 

## Additions

- Adds the generic parameters and other associated data in submodules::vertex

## Modifications

- Changes the struct tuple inner of amethyst_rendy::submodules::texture::TextureSub to public.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
