### PR TITLE
Add dependency from sprite_trans pass to sprite pass.

### DIFF
--- a/examples/sprites_ordered/main.rs
+++ b/examples/sprites_ordered/main.rs
@@ -473,6 +473,7 @@ impl GraphCreator<DefaultBackend> for ExampleGraph {
                 .with_group(DrawFlat2DTransparentDesc::new().builder())
                 .with_color(color)
                 .with_depth_stencil(depth)
+                .with_dependency(sprite)
                 .into_pass(),
         );
 


### PR DESCRIPTION
## Description

Added a dependency from `sprite_trans` node to `sprite` node in `sprites_ordered` example.

Based on [discord log](https://discordapp.com/channels/425678876929163284/493883465184575489/584996474681819149):

before:

![image](https://user-images.githubusercontent.com/2993230/58782968-f39b3500-8633-11e9-8398-6407ade8a030.png)

after:

![image](https://user-images.githubusercontent.com/2993230/58782938-e120fb80-8633-11e9-8322-c9777059c815.png)

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- **n/a** Updated the content of the book if this PR would make the book outdated.
- **n/a** Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
