### PR TITLE
Revert matrix reverse and fix pong examples rendering

### DIFF
--- a/amethyst_rendy/src/camera.rs
+++ b/amethyst_rendy/src/camera.rs
@@ -24,7 +24,7 @@ impl Orthographic {
         let mut matrix = Matrix4::<f32>::identity();
 
         matrix[(0, 0)] = 2.0 / (right - left);
-        matrix[(1, 1)] = -2.0 / (top - bottom);
+        matrix[(1, 1)] = 2.0 / (top - bottom);
         matrix[(2, 2)] = -1.0 / (z_far - z_near);
         matrix[(0, 3)] = -(right + left) / (right - left);
         matrix[(1, 3)] = -(top + bottom) / (top - bottom);
@@ -35,12 +35,12 @@ impl Orthographic {
 
     #[inline]
     pub fn top(&self) -> f32 {
-        -((1.0 - self.matrix[(1, 3)]) / self.matrix[(1, 1)])
+        (1.0 - self.matrix[(1, 3)]) / self.matrix[(1, 1)]
     }
 
     #[inline]
     pub fn bottom(&self) -> f32 {
-        -((-1.0 - self.matrix[(1, 3)]) / self.matrix[(1, 1)])
+        (-1.0 - self.matrix[(1, 3)]) / self.matrix[(1, 1)]
     }
 
     #[inline]
@@ -790,9 +790,9 @@ mod tests {
         assert_gt!(x_axis[0], 0.0);
         assert_gt!(x_axis[0] / x_axis[3], 0.0);
 
-        // Y should be negative
-        assert_lt!(y_axis[1], 0.0);
-        assert_lt!(y_axis[1] / y_axis[3], 0.0);
+        // Y should be Positive
+        assert_gt!(y_axis[1], 0.0);
+        assert_gt!(y_axis[1] / y_axis[3], 0.0);
 
         // Z should be in [0; w] resp. [0; 1]
         assert_ge!(z_axis[2], 0.0);

--- a/examples/pong/main.rs
+++ b/examples/pong/main.rs
@@ -223,7 +223,7 @@ impl GraphCreator<DefaultBackend> for ExampleGraph {
             window_kind,
             1,
             surface_format,
-            Some(ClearValue::Color([0.34, 0.36, 0.52, 1.0].into())),
+            Some(ClearValue::Color([0., 0., 0., 1.0].into())),
         );
 
         let depth = graph_builder.create_image(

--- a/examples/pong_tutorial_01/main.rs
+++ b/examples/pong_tutorial_01/main.rs
@@ -123,7 +123,7 @@ impl GraphCreator<DefaultBackend> for ExampleGraph {
             window_kind,
             1,
             surface_format,
-            Some(ClearValue::Color([0.34, 0.36, 0.52, 1.0].into())),
+            Some(ClearValue::Color([0., 0., 0., 1.0].into())),
         );
 
         let depth = graph_builder.create_image(

--- a/examples/pong_tutorial_02/main.rs
+++ b/examples/pong_tutorial_02/main.rs
@@ -120,7 +120,7 @@ impl GraphCreator<DefaultBackend> for ExampleGraph {
             window_kind,
             1,
             surface_format,
-            Some(ClearValue::Color([0.34, 0.36, 0.52, 1.0].into())),
+            Some(ClearValue::Color([0., 0., 0., 1.0].into())),
         );
 
         let depth = graph_builder.create_image(

--- a/examples/pong_tutorial_03/main.rs
+++ b/examples/pong_tutorial_03/main.rs
@@ -129,7 +129,7 @@ impl GraphCreator<DefaultBackend> for ExampleGraph {
             window_kind,
             1,
             surface_format,
-            Some(ClearValue::Color([0.34, 0.36, 0.52, 1.0].into())),
+            Some(ClearValue::Color([0., 0., 0., 1.0].into())),
         );
 
         let depth = graph_builder.create_image(

--- a/examples/pong_tutorial_04/main.rs
+++ b/examples/pong_tutorial_04/main.rs
@@ -135,7 +135,7 @@ impl GraphCreator<DefaultBackend> for ExampleGraph {
             window_kind,
             1,
             surface_format,
-            Some(ClearValue::Color([0.34, 0.36, 0.52, 1.0].into())),
+            Some(ClearValue::Color([0., 0., 0., 1.0].into())),
         );
 
         let depth = graph_builder.create_image(

--- a/examples/pong_tutorial_05/main.rs
+++ b/examples/pong_tutorial_05/main.rs
@@ -142,7 +142,7 @@ impl GraphCreator<DefaultBackend> for ExampleGraph {
             window_kind,
             1,
             surface_format,
-            Some(ClearValue::Color([0.34, 0.36, 0.52, 1.0].into())),
+            Some(ClearValue::Color([0., 0., 0., 1.0].into())),
         );
 
         let depth = graph_builder.create_image(


### PR DESCRIPTION
Revert matrix reverse and fix pong examples rendering

## Description

 matrix[(1, 1)] was changed to be its inverse, which flips what is passed to the camera. Where you would do
```
.with(Camera::from(Projection::orthographic(
         0.,
         ARENA_WIDTH,
         0.,
         ARENA_HEIGHT,
         0.1,
         2000.0,
)))
```

you now must either set ARENA_HEIGHT to be negative, or set the bottom to be ARENA_HEIGHT and reverse all x/y logic. There is a comment that specifically said it should be negative, but standard_2d still does
```
Projection::orthographic(
      -width / 2.0,
      width / 2.0,
      -height / 2.0,
      height / 2.0,
      0.1,
      2000.0,
)
```
which means you would have to pass it like `standard_2d(1000, -1000)` for it to work the way it was before. If this change was intentional, I can reverse it and just fix the examples to use a negative height, but I don't feel like that is obvious at first glance. Posted in discord and Azriel also preferred the old way.

## Modifications

- Orthographic::new sets y projection to go positive

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ ] Updated the content of the book if this PR would make the book outdated. <-- this will be done under a separate PR for updating books, this is just to get the examples correct
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
