### PR TITLE
Fix some more clippy warnings

### DIFF
--- a/amethyst_animation/src/resources.rs
+++ b/amethyst_animation/src/resources.rs
@@ -219,7 +219,7 @@ where
 /// - `T`: the component type that the animation should be applied to
 ///
 /// [sampler]: struct.Sampler.html
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Animation<T>
 where
     T: AnimationSampling,

--- a/amethyst_animation/src/skinning/systems.rs
+++ b/amethyst_animation/src/skinning/systems.rs
@@ -14,6 +14,7 @@ use super::resources::*;
 /// System for performing vertex skinning.
 ///
 /// Needs to run after global transforms have been updated for the current frame.
+#[derive(Default)]
 pub struct VertexSkinningSystem {
     /// Also scratch space, used while determining which skins need to be updated.
     updated: BitSet,
@@ -25,11 +26,7 @@ pub struct VertexSkinningSystem {
 impl VertexSkinningSystem {
     /// Creates a new `VertexSkinningSystem`
     pub fn new() -> Self {
-        Self {
-            updated: BitSet::new(),
-            updated_skins: BitSet::new(),
-            updated_id: None,
-        }
+        Self::default()
     }
 }
 

--- a/amethyst_animation/src/systems/sampling.rs
+++ b/amethyst_animation/src/systems/sampling.rs
@@ -257,7 +257,7 @@ fn next_duration(last_frame: Duration, duration: Duration) -> (Duration, u32) {
 
 fn linear_blend<T>(
     channel: &T::Channel,
-    output: &Vec<(f32, T::Channel, T::Primitive)>,
+    output: &[(f32, T::Channel, T::Primitive)],
 ) -> Option<T::Primitive>
 where
     T: AnimationSampling,

--- a/amethyst_assets/src/prefab/impls.rs
+++ b/amethyst_assets/src/prefab/impls.rs
@@ -111,9 +111,7 @@ macro_rules! impl_data {
             ) -> Result<bool, Error> {
                 let mut ret = false;
                 $(
-                    if self.$i.load_sub_assets(progress, &mut system_data.$i)? {
-                        ret = true;
-                    }
+                    ret |= self.$i.load_sub_assets(progress, &mut system_data.$i)?;
                 )*
                 Ok(ret)
             }

--- a/amethyst_assets/src/prefab/mod.rs
+++ b/amethyst_assets/src/prefab/mod.rs
@@ -225,6 +225,11 @@ impl<T> Prefab<T> {
         self.entities.len()
     }
 
+    /// Returns `true` if the prefab contains no entities.
+    pub fn is_empty(&self) -> bool {
+        self.entities.is_empty()
+    }
+
     /// Create a new entity in the prefab, with no data and no parent
     pub fn new_entity(&mut self) -> usize {
         self.add(None, None)

--- a/amethyst_assets/src/prefab/system.rs
+++ b/amethyst_assets/src/prefab/system.rs
@@ -129,7 +129,7 @@ where
 
                         children
                             .entry(parent)
-                            .or_insert_with(|| vec![])
+                            .or_insert_with(Vec::new)
                             .push(new_entity);
                     }
                     tags.insert(

--- a/amethyst_assets/src/prefab/system.rs
+++ b/amethyst_assets/src/prefab/system.rs
@@ -129,8 +129,8 @@ where
 
                         children
                             .entry(parent)
-                            .or_insert(vec![])
-                            .push(new_entity.clone());
+                            .or_insert_with(|| vec![])
+                            .push(new_entity);
                     }
                     tags.insert(
                         new_entity,

--- a/amethyst_assets/src/progress.rs
+++ b/amethyst_assets/src/progress.rs
@@ -195,7 +195,7 @@ impl Tracker for () {
     }
 }
 
-fn show_error(handle_id: u32, asset_type_name: &'static str, asset_name: &String, error: &Error) {
+fn show_error(handle_id: u32, asset_type_name: &'static str, asset_name: &str, error: &Error) {
     let mut err_out = format!(
         "Error loading handle {}, {}, with name {}: {}",
         handle_id, asset_type_name, asset_name, error,

--- a/amethyst_assets/src/storage.rs
+++ b/amethyst_assets/src/storage.rs
@@ -185,12 +185,12 @@ impl<A: Asset> AssetStorage<A> {
 
     /// Check if given handle points to a valid asset in the storage.
     pub fn contains(&self, handle: &Handle<A>) -> bool {
-        return self.bitset.contains(handle.id());
+        self.bitset.contains(handle.id())
     }
 
     /// Check if given asset id points to a valid asset in the storage.
     pub fn contains_id(&self, id: u32) -> bool {
-        return self.bitset.contains(id);
+        self.bitset.contains(id)
     }
 
     /// Get an asset by it's handle id without checking the internal bitset.
@@ -498,6 +498,7 @@ impl<A: Asset> Drop for AssetStorage<A> {
 ///
 /// This system can only be used if the asset data implements
 /// `Into<Result<A, BoxedErr>>`.
+#[derive(Default)]
 pub struct Processor<A> {
     marker: PhantomData<A>,
 }

--- a/amethyst_controls/src/bundles.rs
+++ b/amethyst_controls/src/bundles.rs
@@ -125,6 +125,12 @@ impl<T: BindingTypes> ArcBallControlBundle<T> {
     }
 }
 
+impl<T: BindingTypes> Default for ArcBallControlBundle<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a, 'b, T: BindingTypes> SystemBundle<'a, 'b> for ArcBallControlBundle<T> {
     fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<(), Error> {
         builder.add(ArcBallRotationSystem::default(), "arc_ball_rotation", &[]);

--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -62,7 +62,7 @@ impl<'a, T: BindingTypes> System<'a> for FlyMovementSystem<T> {
 
         if let Some(dir) = Unit::try_new(Vector3::new(x, y, z), convert(1.0e-6)) {
             for (transform, _) in (&mut transform, &tag).join() {
-                let delta_sec = time.delta_seconds() as f64;
+                let delta_sec = f64::from(time.delta_seconds());
                 transform.append_translation_along(dir, delta_sec * self.speed.as_f64());
             }
         }
@@ -154,10 +154,10 @@ impl<'a> System<'a> for FreeRotationSystem {
                     if let DeviceEvent::MouseMotion { delta: (x, y) } = *event {
                         for (transform, _) in (&mut transform, &tag).join() {
                             transform.append_rotation_x_axis(
-                                (-y * self.sensitivity_y as f64).to_radians(),
+                                (-y * f64::from(self.sensitivity_y)).to_radians(),
                             );
                             transform.prepend_rotation_y_axis(
-                                (-x * self.sensitivity_x as f64).to_radians(),
+                                (-x * f64::from(self.sensitivity_x)).to_radians(),
                             );
                         }
                     }
@@ -175,6 +175,7 @@ impl<'a> System<'a> for FreeRotationSystem {
 }
 
 /// A system which reads Events and saves if a window has lost focus in a WindowFocus resource
+#[derive(Default)]
 pub struct MouseFocusUpdateSystem {
     event_reader: Option<ReaderId<Event>>,
 }
@@ -182,7 +183,7 @@ pub struct MouseFocusUpdateSystem {
 impl MouseFocusUpdateSystem {
     /// Builds a new MouseFocusUpdateSystem.
     pub fn new() -> MouseFocusUpdateSystem {
-        MouseFocusUpdateSystem { event_reader: None }
+        MouseFocusUpdateSystem::default()
     }
 }
 
@@ -210,6 +211,7 @@ impl<'a> System<'a> for MouseFocusUpdateSystem {
 
 /// System which hides the cursor when the window is focused.
 /// Requires the usage MouseFocusUpdateSystem at the same time.
+#[derive(Default)]
 pub struct CursorHideSystem {
     is_hidden: bool,
 }

--- a/amethyst_core/src/float.rs
+++ b/amethyst_core/src/float.rs
@@ -3,7 +3,7 @@ use std::{
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign},
 };
 
-use crate::num::*;
+use crate::num::{Bounded, FromPrimitive, Num, One, ParseFloatError, Signed, Zero};
 use alga::general::*;
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 use nalgebra::Complex;
@@ -32,14 +32,14 @@ type FloatBase = f32;
 pub struct Float(FloatBase);
 
 impl Float {
-    /// Get the internal value as a f32. Can cause a loss of precision or a loss of data if using
+    /// Get the internal value as a f32. Will cause a loss in precision if using
     /// the "float64" feature.
     pub fn as_f32(self) -> f32 {
         self.0 as f32
     }
-    /// Get the internal value as a f64.
+    /// Get the internal value as a f64. Guaranteed to be lossless.
     pub fn as_f64(self) -> f64 {
-        self.0 as f64
+        f64::from(self.0)
     }
 }
 
@@ -693,7 +693,7 @@ impl SubsetOf<f32> for Float {
 impl SubsetOf<f64> for Float {
     #[inline]
     fn to_superset(&self) -> f64 {
-        self.0 as f64
+        f64::from(self.0)
     }
 
     #[inline]
@@ -732,7 +732,7 @@ impl SubsetOf<Float> for f64 {
 
     #[inline]
     unsafe fn from_superset_unchecked(element: &Float) -> Self {
-        element.0 as Self
+        f64::from(element.0)
     }
 
     #[inline]

--- a/amethyst_core/src/timing.rs
+++ b/amethyst_core/src/timing.rs
@@ -172,12 +172,11 @@ impl Time {
     /// This should only be called by the engine.  Bad things might happen if you call this in
     /// your game.
     pub fn step_fixed_update(&mut self) -> bool {
-        match self.fixed_time_accumulator >= self.fixed_seconds {
-            true => {
-                self.fixed_time_accumulator -= self.fixed_seconds;
-                true
-            }
-            false => false,
+        if self.fixed_time_accumulator >= self.fixed_seconds {
+            self.fixed_time_accumulator -= self.fixed_seconds;
+            true
+        } else {
+            false
         }
     }
 

--- a/amethyst_core/src/transform/components/transform.rs
+++ b/amethyst_core/src/transform/components/transform.rs
@@ -567,7 +567,7 @@ impl Transform {
     ///
     /// We can exploit the extra information we have to perform this inverse faster than `O(n^3)`.
     pub fn global_view_matrix(&self) -> Matrix4<Float> {
-        let mut res = self.global_matrix.clone();
+        let mut res = self.global_matrix;
 
         // Perform an in-place inversion of the 3x3 matrix
         {
@@ -576,7 +576,7 @@ impl Transform {
         }
 
         let mut translation = -res.column(3).xyz();
-        translation = res.clone().fixed_slice::<na::U3, na::U3>(0, 0) * translation;
+        translation = res.fixed_slice::<na::U3, na::U3>(0, 0) * translation;
 
         let mut res_trans = res.column_mut(3);
         res_trans.x = translation.x;
@@ -613,7 +613,7 @@ impl Component for Transform {
 impl From<Vector3<Float>> for Transform {
     fn from(translation: Vector3<Float>) -> Self {
         Transform {
-            isometry: Isometry3::new(translation.into(), na::zero()),
+            isometry: Isometry3::new(translation, na::zero()),
             ..Default::default()
         }
     }
@@ -682,7 +682,7 @@ impl<'de> Deserialize<'de> for Transform {
                         rotation[2],
                     )),
                 );
-                let scale = Vector3::new(scale[0].into(), scale[1].into(), scale[2].into());
+                let scale = Vector3::new(scale[0], scale[1], scale[2]);
 
                 Ok(Transform {
                     isometry,
@@ -745,7 +745,7 @@ impl<'de> Deserialize<'de> for Transform {
             }
         }
 
-        const FIELDS: &'static [&'static str] = &["translation", "rotation", "scale"];
+        const FIELDS: &[&str] = &["translation", "rotation", "scale"];
         deserializer.deserialize_struct("Transform", FIELDS, TransformVisitor::default())
     }
 }

--- a/amethyst_core/src/transform/systems.rs
+++ b/amethyst_core/src/transform/systems.rs
@@ -12,6 +12,7 @@ use crate::transform::{HierarchyEvent, Parent, ParentHierarchy, Transform};
 use thread_profiler::profile_scope;
 
 /// Handles updating `global_matrix` field from `Transform` components.
+#[derive(Default)]
 pub struct TransformSystem {
     local_modified: BitSet,
     locals_events_id: Option<ReaderId<ComponentEvent>>,
@@ -21,11 +22,7 @@ pub struct TransformSystem {
 impl TransformSystem {
     /// Creates a new transform processor.
     pub fn new() -> TransformSystem {
-        TransformSystem {
-            locals_events_id: None,
-            parent_events_id: None,
-            local_modified: BitSet::default(),
-        }
+        TransformSystem::default()
     }
 }
 

--- a/amethyst_derive/src/event_reader.rs
+++ b/amethyst_derive/src/event_reader.rs
@@ -15,18 +15,15 @@ pub fn impl_event_reader(ast: &DeriveInput) -> TokenStream {
                 .expect("reader attribute incorrectly defined")
         })
     {
-        match meta {
-            Meta::List(l) => {
-                for nested_meta in l.nested.iter() {
-                    match *nested_meta {
-                        NestedMeta::Meta(Meta::Word(ref word)) => {
-                            reader_name = Some(word.clone());
-                        }
-                        _ => panic!("reader attribute does not contain a single name"),
+        if let Meta::List(l) = meta {
+            for nested_meta in l.nested.iter() {
+                match *nested_meta {
+                    NestedMeta::Meta(Meta::Word(ref word)) => {
+                        reader_name = Some(word.clone());
                     }
+                    _ => panic!("reader attribute does not contain a single name"),
                 }
             }
-            _ => (),
         };
     }
 

--- a/amethyst_derive/src/prefab_data.rs
+++ b/amethyst_derive/src/prefab_data.rs
@@ -62,10 +62,10 @@ fn prepare_prefab_aggregate_fields(
             }
         };
         let tuple_index = Literal::usize_unsuffixed(i);
-        let name = field.ident.clone().unwrap_or(Ident::new(
-            &format!("field_{}", field_number),
-            Span::call_site(),
-        ));
+        let name = field
+            .ident
+            .clone()
+            .unwrap_or_else(|| Ident::new(&format!("field_{}", field_number), Span::call_site()));
         if is_component {
             subs.push(None);
             add_to_entity.push(quote! {
@@ -290,8 +290,8 @@ fn gen_def_lt_tokens(generics: &Generics) -> TokenStream {
     let lts: Vec<_> = generics
         .lifetimes()
         .map(|x| {
-            let ref lt = x.lifetime;
-            let ref bounds = x.bounds;
+            let lt = &x.lifetime;
+            let bounds = &x.bounds;
 
             if bounds.is_empty() {
                 quote! { #lt }
@@ -308,8 +308,8 @@ fn gen_def_ty_params(generics: &Generics) -> TokenStream {
     let ty_params: Vec<_> = generics
         .type_params()
         .map(|x| {
-            let ref ty = x.ident;
-            let ref bounds = x.bounds;
+            let ty = &x.ident;
+            let bounds = &x.bounds;
 
             quote! { #ty: #( #bounds )+* }
         })
@@ -327,20 +327,17 @@ fn is_component_prefab(attrs: &[Attribute]) -> bool {
                 .expect("prefab attribute incorrectly defined")
         })
     {
-        match meta {
-            Meta::List(l) => {
-                for nested_meta in l.nested.iter() {
-                    match *nested_meta {
-                        NestedMeta::Meta(Meta::Word(ref word)) => {
-                            if word == "Component" {
-                                return true;
-                            }
+        if let Meta::List(l) = meta {
+            for nested_meta in l.nested.iter() {
+                match *nested_meta {
+                    NestedMeta::Meta(Meta::Word(ref word)) => {
+                        if word == "Component" {
+                            return true;
                         }
-                        _ => panic!("prefab attribute does not contain a single word value"),
                     }
+                    _ => panic!("prefab attribute does not contain a single word value"),
                 }
             }
-            _ => (),
         };
     }
     false

--- a/amethyst_derive/src/widget_id.rs
+++ b/amethyst_derive/src/widget_id.rs
@@ -21,13 +21,11 @@ pub fn impl_widget_id(ast: &DeriveInput) -> TokenStream {
                 panic!("Only 1 variant can be marked as default widget id")
             }
 
-            let default_variant = if !maybe_marked_default.is_empty() {
+            if !maybe_marked_default.is_empty() {
                 maybe_marked_default[0].clone()
             } else {
                 data_enum.variants[0].ident.clone()
-            };
-
-            default_variant
+            }
         }
         _ => panic!("WidgetId derive only supports enums"),
     };

--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -14,7 +14,7 @@
 pub use backtrace::Backtrace;
 use std::{
     borrow::Cow,
-    env, error, ffi, fmt, result,
+    env, error, fmt, result,
     sync::atomic::{self, AtomicUsize},
 };
 
@@ -304,8 +304,8 @@ where
 }
 
 /// Test if backtracing is enabled.
-fn is_backtrace_enabled<F: Fn(&str) -> Option<ffi::OsString>>(get_var: F) -> bool {
-    match get_var(RUST_BACKTRACE) {
+fn is_backtrace_enabled() -> bool {
+    match env::var_os(RUST_BACKTRACE) {
         Some(ref val) if val != "0" => true,
         _ => false,
     }
@@ -320,7 +320,7 @@ static BACKTRACE_STATUS: AtomicUsize = AtomicUsize::new(0);
 fn new_backtrace() -> Option<Backtrace> {
     match BACKTRACE_STATUS.load(atomic::Ordering::Relaxed) {
         0 => {
-            let enabled = is_backtrace_enabled(|var| env::var_os(var));
+            let enabled = is_backtrace_enabled();
 
             BACKTRACE_STATUS.store(enabled as usize + 1, atomic::Ordering::Relaxed);
 

--- a/amethyst_gltf/src/format/animation.rs
+++ b/amethyst_gltf/src/format/animation.rs
@@ -66,7 +66,7 @@ fn load_channel(
             TransformChannel::Translation,
             Sampler {
                 input,
-                function: map_interpolation_type(&sampler.interpolation()),
+                function: map_interpolation_type(sampler.interpolation()),
                 output: translations
                     .map(Vector3::from)
                     .map(|t| convert::<_, Vector3<Float>>(t).into())
@@ -74,7 +74,7 @@ fn load_channel(
             },
         )),
         Rotations(rotations) => {
-            let ty = map_interpolation_type(&sampler.interpolation());
+            let ty = map_interpolation_type(sampler.interpolation());
             let ty = if ty == InterpolationFunction::Linear {
                 InterpolationFunction::SphericalLinear
             } else {
@@ -99,7 +99,7 @@ fn load_channel(
             TransformChannel::Scale,
             Sampler {
                 input,
-                function: map_interpolation_type(&sampler.interpolation()),
+                function: map_interpolation_type(sampler.interpolation()),
                 output: scales
                     .map(Vector3::from)
                     .map(|s| convert::<_, Vector3<Float>>(s).into())
@@ -110,13 +110,13 @@ fn load_channel(
     }
 }
 
-fn map_interpolation_type<T>(ty: &gltf::animation::Interpolation) -> InterpolationFunction<T>
+fn map_interpolation_type<T>(ty: gltf::animation::Interpolation) -> InterpolationFunction<T>
 where
     T: InterpolationPrimitive,
 {
     use gltf::animation::Interpolation::*;
 
-    match *ty {
+    match ty {
         Linear => InterpolationFunction::Linear,
         Step => InterpolationFunction::Step,
         CubicSpline => InterpolationFunction::CubicSpline,

--- a/amethyst_gltf/src/format/importer.rs
+++ b/amethyst_gltf/src/format/importer.rs
@@ -71,7 +71,7 @@ fn read_to_end<P: AsRef<Path>>(source: Arc<dyn AssetSource>, path: P) -> Result<
 }
 
 fn parse_data_uri(uri: &str) -> Result<Vec<u8>, Error> {
-    let encoded = uri.split(",").nth(1).expect("URI does not contain ','");
+    let encoded = uri.split(',').nth(1).expect("URI does not contain ','");
     let decoded = base64::decode(&encoded)?;
     Ok(decoded)
 }
@@ -90,7 +90,10 @@ fn load_external_buffers(
                 if uri.starts_with("data:") {
                     parse_data_uri(uri)?
                 } else {
-                    let path = base_path.parent().unwrap_or(Path::new("./")).join(uri);
+                    let path = base_path
+                        .parent()
+                        .unwrap_or_else(|| Path::new("./"))
+                        .join(uri);
                     read_to_end(source.clone(), &path)?
                 }
             }
@@ -123,11 +126,7 @@ fn import_binary(
     source: Arc<dyn AssetSource>,
     base_path: &Path,
 ) -> Result<(Gltf, Buffers), Error> {
-    let gltf::binary::Glb {
-        header: _,
-        json,
-        bin,
-    } = gltf::binary::Glb::from_slice(data)?;
+    let gltf::binary::Glb { json, bin, .. } = gltf::binary::Glb::from_slice(data)?;
     let gltf = Gltf::from_slice(&json)?;
     let bin = bin.map(|x| x.to_vec());
     let buffers = Buffers(load_external_buffers(source, base_path, &gltf, bin)?);
@@ -168,7 +167,10 @@ pub fn get_image_data(
                     Ok((data, ImageFormat::from_mime_type(mimetype)))
                 }
             } else {
-                let path = base_path.parent().unwrap_or(Path::new("./")).join(uri);
+                let path = base_path
+                    .parent()
+                    .unwrap_or_else(|| Path::new("./"))
+                    .join(uri);
                 let data = source.load(
                     path.to_str()
                         .expect("Path contains invalid UTF-8 characters"),

--- a/amethyst_gltf/src/format/material.rs
+++ b/amethyst_gltf/src/format/material.rs
@@ -150,10 +150,7 @@ fn load_texture(
     let (data, format) = get_image_data(&texture.source(), buffers, source, name.as_ref())?;
 
     let metadata = ImageTextureConfig {
-        repr: match srgb {
-            true => Repr::Srgb,
-            false => Repr::Unorm,
-        },
+        repr: if srgb { Repr::Srgb } else { Repr::Unorm },
         format: match format {
             ImportDataFormat::Png => Some(DataFormat::PNG),
             ImportDataFormat::Jpeg => Some(DataFormat::JPEG),

--- a/amethyst_gltf/src/format/mesh.rs
+++ b/amethyst_gltf/src/format/mesh.rs
@@ -65,7 +65,7 @@ pub fn load_mesh(
         trace!("Loading indices");
         use gltf::mesh::util::ReadIndices;
         let indices = match reader.read_indices() {
-            Some(ReadIndices::U8(iter)) => Indices::U16(iter.map(|i| i as u16).collect()),
+            Some(ReadIndices::U8(iter)) => Indices::U16(iter.map(u16::from).collect()),
             Some(ReadIndices::U16(iter)) => Indices::U16(iter.collect()),
             Some(ReadIndices::U32(iter)) => Indices::U32(iter.collect()),
             None => Indices::None,
@@ -177,7 +177,7 @@ pub fn load_mesh(
 
 fn calculate_normals(positions: &[Position], indices: &Indices) -> Vec<Normal> {
     let mut normals = vec![zero::<Vector3<f32>>(); positions.len()];
-    let num_faces = indices.len().unwrap_or(positions.len()) / 3;
+    let num_faces = indices.len().unwrap_or_else(|| positions.len()) / 3;
     for face in 0..num_faces {
         let i0 = indices.map(face, 0);
         let i1 = indices.map(face, 1);
@@ -203,7 +203,7 @@ fn calculate_tangents(
     indices: &Indices,
 ) -> Vec<Tangent> {
     let mut tangents = vec![Tangent([0.0, 0.0, 0.0, 0.0]); positions.len()];
-    let num_faces = indices.len().unwrap_or(positions.len()) / 3;
+    let num_faces = indices.len().unwrap_or_else(|| positions.len()) / 3;
     mikktspace::generate_tangents(
         &|| 3,
         &|| num_faces,

--- a/amethyst_gltf/src/format/mod.rs
+++ b/amethyst_gltf/src/format/mod.rs
@@ -242,12 +242,10 @@ fn load_node(
             if let Some((material_id, material)) =
                 material_index.and_then(|index| gltf.materials().nth(index).map(|m| (index, m)))
             {
-                if !material_set.materials.contains_key(&material_id) {
-                    material_set.materials.insert(
-                        material_id,
-                        load_material(&material, buffers, source.clone(), name)?,
-                    );
-                }
+                material_set
+                    .materials
+                    .entry(material_id)
+                    .or_insert(load_material(&material, buffers, source.clone(), name)?);
                 prefab_data.material_id = Some(material_id);
             }
             // if we have a skin we need to track the mesh entities
@@ -265,12 +263,10 @@ fn load_node(
                 if let Some((material_id, material)) =
                     material_index.and_then(|index| gltf.materials().nth(index).map(|m| (index, m)))
                 {
-                    if !material_set.materials.contains_key(&material_id) {
-                        material_set.materials.insert(
-                            material_id,
-                            load_material(&material, buffers, source.clone(), name)?,
-                        );
-                    }
+                    material_set
+                        .materials
+                        .entry(material_id)
+                        .or_insert(load_material(&material, buffers, source.clone(), name)?);
                     prefab_data.material_id = Some(material_id);
                 }
 

--- a/amethyst_gltf/src/format/skin.rs
+++ b/amethyst_gltf/src/format/skin.rs
@@ -36,10 +36,10 @@ pub fn load_skin(
         .map(|matrices| {
             matrices
                 .map(Matrix4::from)
-                .map(|m| convert::<_, Matrix4<Float>>(m))
+                .map(convert::<_, Matrix4<Float>>)
                 .collect()
         })
-        .unwrap_or(vec![Matrix4::identity().into(); joints.len()]);
+        .unwrap_or_else(|| vec![Matrix4::identity(); joints.len()]);
 
     for (_bind_index, joint_index) in joints.iter().enumerate() {
         prefab

--- a/amethyst_input/src/input_handler.rs
+++ b/amethyst_input/src/input_handler.rs
@@ -622,7 +622,7 @@ impl<T: BindingTypes> InputHandler<T> {
 
         // check for actions being bound to any invoked mouse wheel
         for (action, combinations) in self.bindings.actions.iter() {
-            for ref combination in combinations {
+            for combination in combinations {
                 if let Some(dir) = dir_x {
                     if combination.contains(&Button::MouseWheel(dir))
                         && combination

--- a/amethyst_network/src/network_socket.rs
+++ b/amethyst_network/src/network_socket.rs
@@ -133,7 +133,7 @@ where
                     match NetEvent::<E>::from_packet(packet) {
                         Ok(event) => {
                             for connection in (&mut net_connections).join() {
-                                if &connection.target_addr == &from_addr {
+                                if connection.target_addr == from_addr {
                                     connection.receive_buffer.single_write(event.clone());
                                 }
                             }

--- a/amethyst_rendy/src/batch.rs
+++ b/amethyst_rendy/src/batch.rs
@@ -89,7 +89,7 @@ where
     }
 
     pub fn prune(&mut self) {
-        self.map.retain(|_, b| b.len() > 0);
+        self.map.retain(|_, b| !b.is_empty());
     }
 
     pub fn insert(&mut self, pk: PK, sk: SK, data: impl IntoIterator<Item = C::Item>) {
@@ -115,13 +115,13 @@ where
         }
     }
 
-    pub fn data<'a>(&'a self) -> impl Iterator<Item = &'a C> {
+    pub fn data(&self) -> impl Iterator<Item = &C> {
         self.map
             .iter()
             .flat_map(|(_, batch)| batch.iter().map(|data| &data.1))
     }
 
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = (&'a PK, impl Iterator<Item = &'a (SK, C)>)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&PK, impl Iterator<Item = &(SK, C)>)> {
         self.map.iter().map(|(pk, batch)| (pk, batch.iter()))
     }
 
@@ -227,7 +227,7 @@ where
     }
 
     pub fn prune(&mut self) {
-        self.map.retain(|_, b| b.len() > 0);
+        self.map.retain(|_, b| !b.is_empty());
     }
 
     pub fn insert(&mut self, pk: PK, data: impl IntoIterator<Item = D>) {

--- a/amethyst_rendy/src/pass/base_3d.rs
+++ b/amethyst_rendy/src/pass/base_3d.rs
@@ -402,9 +402,9 @@ impl<B: Backend, T: Base3DPassDef<B>> RenderGroup<B, Resources> for DrawBase3D<B
             factory
                 .device()
                 .destroy_graphics_pipeline(self.pipeline_basic);
-            self.pipeline_skinned.take().map(|pipeline| {
+            if let Some(pipeline) = self.pipeline_skinned.take() {
                 factory.device().destroy_graphics_pipeline(pipeline);
-            });
+            }
             factory
                 .device()
                 .destroy_pipeline_layout(self.pipeline_layout);
@@ -686,9 +686,9 @@ impl<B: Backend, T: Base3DPassDef<B>> RenderGroup<B, Resources> for DrawBase3DTr
             factory
                 .device()
                 .destroy_graphics_pipeline(self.pipeline_basic);
-            self.pipeline_skinned.take().map(|pipeline| {
+            if let Some(pipeline) = self.pipeline_skinned.take() {
                 factory.device().destroy_graphics_pipeline(pipeline);
-            });
+            }
             factory
                 .device()
                 .destroy_pipeline_layout(self.pipeline_layout);

--- a/amethyst_rendy/src/pass/debug_lines.rs
+++ b/amethyst_rendy/src/pass/debug_lines.rs
@@ -70,7 +70,7 @@ impl<B: Backend> RenderGroupDesc<B, Resources> for DrawDebugLinesDesc {
         )?;
 
         Ok(Box::new(DrawDebugLines::<B> {
-            pipeline: pipeline,
+            pipeline,
             pipeline_layout,
             env,
             args,
@@ -164,7 +164,7 @@ impl<B: Backend> RenderGroup<B, Resources> for DrawDebugLines<B> {
         #[cfg(feature = "profiler")]
         profile_scope!("draw");
 
-        if self.lines.len() == 0 {
+        if self.lines.is_empty() {
             return;
         }
 

--- a/amethyst_rendy/src/pass/flat2d.rs
+++ b/amethyst_rendy/src/pass/flat2d.rs
@@ -72,7 +72,7 @@ impl<B: Backend> RenderGroupDesc<B, Resources> for DrawFlat2DDesc {
         )?;
 
         Ok(Box::new(DrawFlat2D::<B> {
-            pipeline: pipeline,
+            pipeline,
             pipeline_layout,
             env,
             textures,
@@ -273,7 +273,7 @@ impl<B: Backend> RenderGroupDesc<B, Resources> for DrawFlat2DTransparentDesc {
         )?;
 
         Ok(Box::new(DrawFlat2DTransparent::<B> {
-            pipeline: pipeline,
+            pipeline,
             pipeline_layout,
             env,
             textures,

--- a/amethyst_rendy/src/pass/skybox.rs
+++ b/amethyst_rendy/src/pass/skybox.rs
@@ -110,7 +110,7 @@ impl<B: Backend> RenderGroupDesc<B, Resources> for DrawSkyboxDesc {
         )?;
 
         Ok(Box::new(DrawSkybox::<B> {
-            pipeline: pipeline,
+            pipeline,
             pipeline_layout,
             env,
             colors,

--- a/amethyst_rendy/src/sprite/mod.rs
+++ b/amethyst_rendy/src/sprite/mod.rs
@@ -108,13 +108,15 @@ impl Sprite {
         let top = (pixel_top) / image_h;
         let bottom = (pixel_bottom) / image_h;
 
-        let (left, right) = match flip_horizontal {
-            false => (left, right),
-            true => (right, left),
+        let (left, right) = if flip_horizontal {
+            (right, left)
+        } else {
+            (left, right)
         };
-        let (top, bottom) = match flip_vertical {
-            false => (top, bottom),
-            true => (bottom, top),
+        let (top, bottom) = if flip_vertical {
+            (bottom, top)
+        } else {
+            (top, bottom)
         };
 
         let tex_coords = TextureCoordinates {

--- a/amethyst_rendy/src/sprite_visibility.rs
+++ b/amethyst_rendy/src/sprite_visibility.rs
@@ -82,7 +82,7 @@ impl<'a> System<'a> for SpriteVisibilitySortingSystem {
             .and_then(|a| transform.get(a.entity))
             .or_else(|| (&camera, &transform).join().map(|ct| ct.1).next());
         let camera_backward = camera
-            .map(|c| c.global_matrix().column(2).xyz().into())
+            .map(|c| c.global_matrix().column(2).xyz())
             .unwrap_or_else(Vector3::z);
         let camera_centroid = camera
             .map(|t| t.global_matrix().transform_point(&origin))

--- a/amethyst_rendy/src/submodules/environment.rs
+++ b/amethyst_rendy/src/submodules/environment.rs
@@ -246,6 +246,6 @@ impl<B: Backend> PerImageEnvironmentSub<B> {
             write_into_slice(&mut dst_slice[usize_range(env_range)], Some(env));
         }
 
-        return new_buffer;
+        new_buffer
     }
 }

--- a/amethyst_rendy/src/submodules/material.rs
+++ b/amethyst_rendy/src/submodules/material.rs
@@ -112,7 +112,7 @@ impl<B: Backend> SlottedBuffer<B> {
             .unwrap();
         unsafe {
             let mut writer = mapped
-                .write(factory.device(), 0..0 + data.len() as u64)
+                .write(factory.device(), 0..data.len() as u64)
                 .unwrap();
             writer.write(data);
         }

--- a/amethyst_rendy/src/submodules/skinning.rs
+++ b/amethyst_rendy/src/submodules/skinning.rs
@@ -97,7 +97,7 @@ impl<B: Backend> PerImageSkinningSub<B> {
     }
 
     fn commit(&mut self, factory: &Factory<B>, data: &[u8]) {
-        if data.len() == 0 {
+        if data.is_empty() {
             return;
         }
 

--- a/amethyst_rendy/src/submodules/vertex.rs
+++ b/amethyst_rendy/src/submodules/vertex.rs
@@ -102,7 +102,7 @@ impl<B: Backend> IndexData<B, u32> {
 /// This structure wraps [PerImageDynamicVertexData], managing multiple instances and providing
 /// an easy-to-use interface for having per-image buffers. This is needed because multiple images
 /// (frames) can be in flight at any given time, so multiple buffers are needed for the same data.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct DynamicVertexData<B: Backend, V: VertexDataBufferType, T: 'static> {
     per_image: Vec<PerImageDynamicVertexData<B, V>>,
     marker: PhantomData<T>,

--- a/amethyst_rendy/src/system.rs
+++ b/amethyst_rendy/src/system.rs
@@ -122,7 +122,7 @@ where
                 #[cfg(feature = "profiler")]
                 profile_scope!("process_mesh");
 
-                b.0.build(*queue_id, &mut factory)
+                b.0.build(*queue_id, &factory)
                     .map(B::wrap_mesh)
                     .map(ProcessingState::Loaded)
                     .map_err(|e| e.compat().into())

--- a/amethyst_rendy/src/util.rs
+++ b/amethyst_rendy/src/util.rs
@@ -192,7 +192,7 @@ pub fn set_layout_bindings(
         .collect()
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct LookupBuilder<I: Hash + Eq> {
     forward: fnv::FnvHashMap<I, usize>,
     len: usize,

--- a/amethyst_rendy/src/visibility.rs
+++ b/amethyst_rendy/src/visibility.rs
@@ -35,6 +35,7 @@ pub struct Visibility {
 ///
 /// Note that this should run after `Transform` has been updated for the current frame, and
 /// before rendering occurs.
+#[derive(Default)]
 pub struct VisibilitySortingSystem {
     centroids: Vec<Internals>,
     transparent: Vec<Internals>,
@@ -87,10 +88,7 @@ struct Internals {
 impl VisibilitySortingSystem {
     /// Create new sorting system
     pub fn new() -> Self {
-        VisibilitySortingSystem {
-            centroids: Vec::default(),
-            transparent: Vec::default(),
-        }
+        Self::default()
     }
 }
 
@@ -229,6 +227,6 @@ impl Frustum {
                 return false;
             }
         }
-        return true;
+        true
     }
 }

--- a/amethyst_test/src/amethyst_application.rs
+++ b/amethyst_test/src/amethyst_application.rs
@@ -152,9 +152,9 @@ where
     // However, `Self` has `PhantomData<T>`, which means we cannot send `self` to a thread. Instead
     // we have to take all of the other fields and send those through.
     //
-    // Need to `#[allow(type_complexity)]` because the type declaration would have unused type
+    // Need to `#[allow(clippy::type_complexity)]` because the type declaration would have unused type
     // parameters which causes a compilation failure.
-    #[allow(unknown_lints, type_complexity)]
+    #[allow(unknown_lints, clippy::type_complexity)]
     fn build_internal(
         (bundle_add_fns, resource_add_fns, state_fns): (
             Vec<BundleAddFn>,

--- a/amethyst_ui/src/button/builder.rs
+++ b/amethyst_ui/src/button/builder.rs
@@ -282,19 +282,19 @@ impl<'a, G: PartialEq + Send + Sync + 'static, I: WidgetId> UiButtonBuilder<G, I
             let retrigger = UiButtonActionRetrigger {
                 on_click_start: actions_with_target(
                     &mut self.on_click_start.into_iter(),
-                    &image_entity,
+                    image_entity,
                 ),
                 on_click_stop: actions_with_target(
                     &mut self.on_click_stop.into_iter(),
-                    &image_entity,
+                    image_entity,
                 ),
                 on_hover_start: actions_with_target(
                     &mut self.on_hover_start.into_iter(),
-                    &image_entity,
+                    image_entity,
                 ),
                 on_hover_stop: actions_with_target(
                     &mut self.on_hover_stop.into_iter(),
-                    &image_entity,
+                    image_entity,
                 ),
             };
 
@@ -412,13 +412,13 @@ impl<'a, G: PartialEq + Send + Sync + 'static, I: WidgetId> UiButtonBuilder<G, I
     }
 }
 
-fn actions_with_target<I>(actions: I, target: &Entity) -> Vec<UiButtonAction>
+fn actions_with_target<I>(actions: I, target: Entity) -> Vec<UiButtonAction>
 where
     I: Iterator<Item = UiButtonActionType>,
 {
     actions
         .map(|action| UiButtonAction {
-            target: *target,
+            target,
             event_type: action,
         })
         .collect()

--- a/amethyst_ui/src/event.rs
+++ b/amethyst_ui/src/event.rs
@@ -90,6 +90,7 @@ impl Component for Interactable {
 
 /// The system that generates events for `Interactable` enabled entities.
 /// The generic types A and B represent the A and B generic parameter of the InputHandler<A,B>.
+#[derive(Default)]
 pub struct UiMouseSystem<T: BindingTypes> {
     was_down: bool,
     click_started_on: Option<Entity>,

--- a/amethyst_ui/src/pass.rs
+++ b/amethyst_ui/src/pass.rs
@@ -308,7 +308,7 @@ impl<B: Backend> RenderGroup<B, Resources> for DrawUi<B> {
             };
 
             if let Some(glyph_data) = glyphs.get(entity) {
-                if glyph_data.sel_vertices.len() > 0 {
+                if !glyph_data.vertices.is_empty() {
                     self.batches
                         .insert(white_tex_id, glyph_data.sel_vertices.iter().cloned());
                 }
@@ -357,7 +357,7 @@ impl<B: Backend> RenderGroup<B, Resources> for DrawUi<B> {
                     }
                 }
 
-                if glyph_data.vertices.len() > 0 {
+                if !glyph_data.vertices.is_empty() {
                     self.batches
                         .insert(glyph_tex_id, glyph_data.vertices.iter().cloned());
                 }
@@ -478,8 +478,8 @@ fn render_image<B: Backend>(
 ) -> bool {
     let color = match (raw_image, tint.as_ref()) {
         (UiImage::SolidColor(color), Some(t)) => mul_blend(color, t),
-        (UiImage::SolidColor(color), None) => color.clone(),
-        (_, Some(t)) => t.clone(),
+        (UiImage::SolidColor(color), None) => *color,
+        (_, Some(t)) => *t,
         (_, None) => [1., 1., 1., 1.],
     };
 

--- a/amethyst_ui/src/prefab.rs
+++ b/amethyst_ui/src/prefab.rs
@@ -443,7 +443,7 @@ where
         ) = system_data;
 
         let text_entity = children.get(0).expect("Invalid: Should have text child");
-        let widget = UiButton::new(entity.clone(), text_entity.clone());
+        let widget = UiButton::new(entity, *text_entity);
         if let Some(id) = &self.id {
             widgets.add_with_id(id.clone(), widget);
         } else {

--- a/amethyst_ui/src/text.rs
+++ b/amethyst_ui/src/text.rs
@@ -134,6 +134,7 @@ impl Component for TextEditing {
 }
 
 /// This system processes the underlying UI data as needed.
+#[derive(Default)]
 pub struct TextEditingMouseSystem {
     /// A reader for winit events.
     reader: Option<ReaderId<Event>>,

--- a/amethyst_ui/src/text_editing.rs
+++ b/amethyst_ui/src/text_editing.rs
@@ -156,7 +156,7 @@ impl<'a> System<'a> for TextEditingInputSystem {
                         VirtualKeyCode::Left => {
                             if focused_edit.highlight_vector == 0 || modifiers.shift {
                                 if focused_edit.cursor_position > 0 {
-                                    let delta = if ctrl_or_cmd(&modifiers) {
+                                    let delta = if ctrl_or_cmd(modifiers) {
                                         let mut graphemes = 0;
                                         for word in focused_text.text.split_word_bounds() {
                                             let word_graphemes =
@@ -189,7 +189,7 @@ impl<'a> System<'a> for TextEditingInputSystem {
                             if focused_edit.highlight_vector == 0 || modifiers.shift {
                                 let glyph_len = focused_text.text.graphemes(true).count();
                                 if (focused_edit.cursor_position as usize) < glyph_len {
-                                    let delta = if ctrl_or_cmd(&modifiers) {
+                                    let delta = if ctrl_or_cmd(modifiers) {
                                         let mut graphemes = 0;
                                         for word in focused_text.text.split_word_bounds() {
                                             graphemes += word.graphemes(true).count() as isize;
@@ -215,14 +215,14 @@ impl<'a> System<'a> for TextEditingInputSystem {
                             }
                         }
                         VirtualKeyCode::A => {
-                            if ctrl_or_cmd(&modifiers) {
+                            if ctrl_or_cmd(modifiers) {
                                 let glyph_len = focused_text.text.graphemes(true).count() as isize;
                                 focused_edit.cursor_position = glyph_len;
                                 focused_edit.highlight_vector = -glyph_len;
                             }
                         }
                         VirtualKeyCode::X => {
-                            if ctrl_or_cmd(&modifiers) {
+                            if ctrl_or_cmd(modifiers) {
                                 let new_clip = extract_highlighted(focused_edit, focused_text);
                                 if !new_clip.is_empty() {
                                     match ClipboardProvider::new().and_then(
@@ -241,7 +241,7 @@ impl<'a> System<'a> for TextEditingInputSystem {
                             }
                         }
                         VirtualKeyCode::C => {
-                            if ctrl_or_cmd(&modifiers) {
+                            if ctrl_or_cmd(modifiers) {
                                 let new_clip = read_highlighted(focused_edit, focused_text);
                                 if !new_clip.is_empty() {
                                     if let Err(e) = ClipboardProvider::new().and_then(
@@ -255,7 +255,7 @@ impl<'a> System<'a> for TextEditingInputSystem {
                             }
                         }
                         VirtualKeyCode::V => {
-                            if ctrl_or_cmd(&modifiers) {
+                            if ctrl_or_cmd(modifiers) {
                                 delete_highlighted(focused_edit, focused_text);
 
                                 match ClipboardProvider::new()
@@ -341,7 +341,7 @@ impl<'a> System<'a> for TextEditingInputSystem {
 }
 
 /// Returns if the command key is down on OSX, and the CTRL key for everything else.
-fn ctrl_or_cmd(modifiers: &ModifiersState) -> bool {
+fn ctrl_or_cmd(modifiers: ModifiersState) -> bool {
     (cfg!(target_os = "macos") && modifiers.logo)
         || (cfg!(not(target_os = "macos")) && modifiers.ctrl)
 }

--- a/amethyst_window/src/monitor.rs
+++ b/amethyst_window/src/monitor.rs
@@ -69,7 +69,7 @@ impl MonitorIdent {
             .iter()
             .enumerate()
             .filter(|(_, m)| m.get_name().map(|n| n == self.1).unwrap_or(false))
-            .max_by_key(|(i, _)| (*i as i32 - self.0 as i32).abs() as u16)
+            .max_by_key(|(i, _)| (*i as i32 - i32::from(self.0)).abs() as u16)
             .map(|(_, m)| m)
             .unwrap_or_else(|| monitors.primary())
     }

--- a/amethyst_window/src/resources.rs
+++ b/amethyst_window/src/resources.rs
@@ -17,8 +17,8 @@ impl ScreenDimensions {
     /// Creates a new screen dimensions object with the given width and height.
     pub fn new(w: u32, h: u32, hidpi: f64) -> Self {
         ScreenDimensions {
-            w: w as f64,
-            h: h as f64,
+            w: f64::from(w),
+            h: f64::from(h),
             aspect_ratio: w as f32 / h as f32,
             hidpi,
             dirty: false,


### PR DESCRIPTION
## Description

Fixes 120 clippy lint warnings. The 57 warnings that remain are mostly related to code complexity (very large functions, functions that take 10+ arguments, etc.).

## Additions

- impl Default on some types
- Add is_empty method on types that have a len method.

## Modifications

- Various code style improvements.
- Some function signatures were changed slightly.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated. (it won't)
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR. (none added)
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
