### PR TITLE
stage -> state typo fix

### DIFF
--- a/book/src/concepts/state.md
+++ b/book/src/concepts/state.md
@@ -2,9 +2,9 @@
 
 ## What is a state?
 The word "state" can mean a lot of different things in computer science.
-In the case of amethyst, it is used to represent the "game stage".
+In the case of amethyst, it is used to represent the "game state".
 
-A game stage is a *general* and *global* section of the game.
+A game state is a *general* and *global* section of the game.
 
 ## Example
 


### PR DESCRIPTION
## Description

This PR fixes two typos. The section on the concept of state switches to "stage" for no apparent reason and probably meant "state".

## Additions

## Removals

## Modifications

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
