### PR TITLE
Updated `rodio` to `0.9`

### DIFF
--- a/amethyst_audio/Cargo.toml
+++ b/amethyst_audio/Cargo.toml
@@ -25,7 +25,7 @@ amethyst_core = { path = "../amethyst_core", version = "0.5.0"}
 amethyst_error = { path = "../amethyst_error", version = "0.1.0"}
 cpal = "0.8"
 log = "0.4.6"
-rodio = "0.8"
+rodio = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 thread_profiler = { version = "0.3", optional = true }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -88,6 +88,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * Added a `pivot` field to `UiTransform`. ([#1571])
 * Fix fly_camera example initial camera and cube position. ([#1582])
 * Add to fly_camera example code to release and capture back mouse input, and to show and hide cursor. ([#1582])
+* Updated `rodio` to `0.9`. ([#1683])
 
 #### Rendy support
 
@@ -178,6 +179,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1595]: https://github.com/amethyst/amethyst/issues/1595
 [#1599]: https://github.com/amethyst/amethyst/pull/1599
 [#1642]: https://github.com/amethyst/amethyst/pull/1642
+[#1683]: https://github.com/amethyst/amethyst/pull/1683
 
 ## [0.10.0] - 2018-12
 


### PR DESCRIPTION
## Description

Bumped `rodio` to `0.9`.

This removes the dependency on `cgmath`, as well as avoids a security
vulnerability from `claxon`.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- **n/a** Ran `cargo +stable fmt --all` locally if this modified any rs files.
- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
