### PR TITLE
Implement `const fn new` for `Float`

### DIFF
--- a/amethyst_core/src/float.rs
+++ b/amethyst_core/src/float.rs
@@ -29,14 +29,27 @@ type FloatBase = f32;
 #[derive(Alga, Clone, Copy, PartialOrd, PartialEq, Serialize, Deserialize, Debug)]
 #[alga_traits(Field(Additive, Multiplicative))]
 #[serde(transparent)]
-pub struct Float(pub FloatBase);
+pub struct Float(FloatBase);
 
 impl Float {
+    /// Returns a new `Float`.
+    #[cfg(feature = "float64")]
+    pub const fn new(value: f64) -> Self {
+        Float(value)
+    }
+
+    /// Returns a new `Float`.
+    #[cfg(not(feature = "float64"))]
+    pub const fn new(value: f32) -> Self {
+        Float(value)
+    }
+
     /// Get the internal value as a f32. Will cause a loss in precision if using
     /// the "float64" feature.
     pub fn as_f32(self) -> f32 {
         self.0 as f32
     }
+
     /// Get the internal value as a f64. Guaranteed to be lossless.
     pub fn as_f64(self) -> f64 {
         f64::from(self.0)

--- a/amethyst_core/src/float.rs
+++ b/amethyst_core/src/float.rs
@@ -29,7 +29,7 @@ type FloatBase = f32;
 #[derive(Alga, Clone, Copy, PartialOrd, PartialEq, Serialize, Deserialize, Debug)]
 #[alga_traits(Field(Additive, Multiplicative))]
 #[serde(transparent)]
-pub struct Float(FloatBase);
+pub struct Float(pub FloatBase);
 
 impl Float {
     /// Get the internal value as a f32. Will cause a loss in precision if using

--- a/amethyst_core/src/float.rs
+++ b/amethyst_core/src/float.rs
@@ -32,16 +32,14 @@ type FloatBase = f32;
 pub struct Float(FloatBase);
 
 impl Float {
-    /// Returns a new `Float`.
-    #[cfg(feature = "float64")]
-    pub const fn new(value: f64) -> Self {
-        Float(value)
+    /// Returns a new `Float` from a `f64`.
+    pub const fn from_f64(value: f64) -> Self {
+        Float(value as FloatBase)
     }
 
-    /// Returns a new `Float`.
-    #[cfg(not(feature = "float64"))]
-    pub const fn new(value: f32) -> Self {
-        Float(value)
+    /// Returns a new `Float` from a `f32`.
+    pub const fn from_f32(value: f32) -> Self {
+        Float(value as FloatBase)
     }
 
     /// Get the internal value as a f32. Will cause a loss in precision if using

--- a/amethyst_core/src/float.rs
+++ b/amethyst_core/src/float.rs
@@ -44,13 +44,13 @@ impl Float {
 
     /// Get the internal value as a f32. Will cause a loss in precision if using
     /// the "float64" feature.
-    pub fn as_f32(self) -> f32 {
+    pub const fn as_f32(self) -> f32 {
         self.0 as f32
     }
 
     /// Get the internal value as a f64. Guaranteed to be lossless.
-    pub fn as_f64(self) -> f64 {
-        f64::from(self.0)
+    pub const fn as_f64(self) -> f64 {
+        self.0 as f64
     }
 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,7 +44,7 @@ it is attached to. ([#1282])
 * Add `amethyst_input::BindingError::MouseWheelAlreadyBound` ([#1642])
 * Add `amethyst_input::InputHandler::send_frame_begin` ([#1642])
 * Add `amethyst_input::InputHandler::mouse_wheel_value` ([#1642])
-* Added `Float::new` `const fn` so `Float` can be used as `const`. ([#1687])
+* Added `Float::from_f32` and `Float::from_f64` `const fn`s so `Float` can be used as `const`. ([#1687])
 
 ### Changed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -89,6 +89,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * Fix fly_camera example initial camera and cube position. ([#1582])
 * Add to fly_camera example code to release and capture back mouse input, and to show and hide cursor. ([#1582])
 * Updated `rodio` to `0.9`. ([#1683])
+* Make `Float` inner field public. ([#1687])
 
 #### Rendy support
 
@@ -180,6 +181,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1599]: https://github.com/amethyst/amethyst/pull/1599
 [#1642]: https://github.com/amethyst/amethyst/pull/1642
 [#1683]: https://github.com/amethyst/amethyst/pull/1683
+[#1687]: https://github.com/amethyst/amethyst/pull/1687
 
 ## [0.10.0] - 2018-12
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,10 +40,11 @@ it is attached to. ([#1282])
 * Added `events` example which demonstrates working even reader and writer in action. ([#1538])
 *  Implement builder like functionality for `AnimationSet` and `AnimationControlSet` ([#1568])
 * Add `get_mouse_button` and `is_mouse_button_down` utility functions to amethyst_input. ([#1582])
-- Add amethyst_input::Axis::MouseWheel ([#1642])
-- Add amethyst_input::BindingError::MouseWheelAlreadyBound ([#1642])
-- Add amethyst_input::InputHandler::send_frame_begin ([#1642])
-- Add amethyst_input::InputHandler::mouse_wheel_value ([#1642])
+* Add `amethyst_input::Axis::MouseWheel` ([#1642])
+* Add `amethyst_input::BindingError::MouseWheelAlreadyBound` ([#1642])
+* Add `amethyst_input::InputHandler::send_frame_begin` ([#1642])
+* Add `amethyst_input::InputHandler::mouse_wheel_value` ([#1642])
+* Added `Float::new` `const fn` so `Float` can be used as `const`. ([#1687])
 
 ### Changed
 
@@ -89,7 +90,6 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 * Fix fly_camera example initial camera and cube position. ([#1582])
 * Add to fly_camera example code to release and capture back mouse input, and to show and hide cursor. ([#1582])
 * Updated `rodio` to `0.9`. ([#1683])
-* Make `Float` inner field public. ([#1687])
 
 #### Rendy support
 


### PR DESCRIPTION
## Description

~~Change `Float(FloatBase)` to `Float(pub FloatBase)`, so that we can construct constants.~~

Implemented `const fn new(value: <f32/64>)` for `Float` based on feature flags. This allows us to declare `Float` constants.

```rust
const FIELD: Float = Float::new(123.);
```

## Modifications

* Make `Float` inner field public.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
