### PR TITLE
Remove custom release profile config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,6 @@ license = "MIT/Apache-2.0"
 [badges]
 travis-ci = { repository = "amethyst/amethyst", branch = "master" }
 
-[profile.release]
-incremental = true
-debug = true
-debug-assertions = true
-
 [features]
 default = ["animation", "audio", "locale", "network", "renderer"]
 


### PR DESCRIPTION
## Description

Removes the `[profile.release]` section from `Cargo.toml` to make the binaries small again.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Ran `cargo test --all` locally if this modified any rs files.
- [ ] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
