### PR TITLE
[FEEDBACK] Transform Parent Relation

### DIFF
--- a/amethyst_core/src/transform/components/mod.rs
+++ b/amethyst_core/src/transform/components/mod.rs
@@ -2,7 +2,7 @@
 
 pub use self::{
     parent::{HierarchyEvent, Parent, ParentHierarchy},
-    transform::Transform,
+    transform::{ParentTransformRelation, Transform},
 };
 
 mod parent;

--- a/amethyst_core/src/transform/components/transform.rs
+++ b/amethyst_core/src/transform/components/transform.rs
@@ -698,7 +698,7 @@ impl<'de> Deserialize<'de> for Transform {
 
                 let parent_relation: ParentTransformRelation = seq
                     .next_element()?
-                    .map_or_else(|| ParentTransformRelation::Relative, |v| v);
+                    .unwrap_or(ParentTransformRelation::Relative);
 
                 let isometry = Isometry3::from_parts(
                     Translation3::new(translation[0], translation[1], translation[2]),

--- a/amethyst_core/src/transform/components/transform.rs
+++ b/amethyst_core/src/transform/components/transform.rs
@@ -797,6 +797,7 @@ impl Serialize for Transform {
             translation: [Float; 3],
             rotation: [Float; 4],
             scale: [Float; 3],
+            parent_relation: ParentTransformRelation,
         }
 
         let pos: [Float; 3] = self.isometry.translation.vector.into();
@@ -808,6 +809,7 @@ impl Serialize for Transform {
                 translation: [pos[0], pos[1], pos[2]],
                 rotation: [rot[0], rot[1], rot[2], rot[3]],
                 scale: [scale[0], scale[1], scale[2]],
+                parent_relation: self.parent_relation,
             },
             serializer,
         )
@@ -819,7 +821,7 @@ mod tests {
     use crate::{
         approx::*,
         math::{UnitQuaternion, Vector3},
-        Transform,
+        ParentTransformRelation, Transform,
     };
 
     /// Sanity test for concat operation
@@ -901,6 +903,7 @@ mod tests {
         );
     }
 
+    // Test with parent relation changed
     #[test]
     fn ser_deser() {
         let mut transform = Transform::default();
@@ -913,6 +916,8 @@ mod tests {
             )
             .unwrap(),
         );
+        transform.set_parent_relation(ParentTransformRelation::Absolute);
+
         let s: String =
             ron::ser::to_string_pretty(&transform, ron::ser::PrettyConfig::default()).unwrap();
         let transform2: Transform = ron::de::from_str(&s).unwrap();

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,8 @@ it is attached to. ([#1282])
 * Add `amethyst_input::InputHandler::send_frame_begin` ([#1642])
 * Add `amethyst_input::InputHandler::mouse_wheel_value` ([#1642])
 * Added `Float::from_f32` and `Float::from_f64` `const fn`s so `Float` can be used as `const`. ([#1687])
+* Add `amethyst_core::transform::ParentTransformRelation` type, used in `amethyst_core::transform::Transform::parent_relation`
+to declare a transforms relationship with its parent ([#1701])
 
 ### Changed
 
@@ -185,6 +187,7 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 [#1642]: https://github.com/amethyst/amethyst/pull/1642
 [#1683]: https://github.com/amethyst/amethyst/pull/1683
 [#1687]: https://github.com/amethyst/amethyst/pull/1687
+[#1701]: https://github.com/amethyst/amethyst/pull/1701
 
 ## [0.10.0] - 2018-12
 


### PR DESCRIPTION
## Description

This adds a new optional relationship to transforms which allows you to dictate how it is updated in relation to its parent.Currently, there is no way to specify this. 

This PR adds 
```rust
pub enum ParentTransformRelation {
    /// A relative transformation, which is the default, will modify this transform based on its
    /// parents
    Relative,
    /// An absolutely transform will ignore parents and be considered a world transform.
    Absolute,
}
```
This specifies whether a Transform should be updated relative to its parent, or stay an absolute world coordinate. 

This allows the use of the built-in parent and Hierarchy system without necessarily forcing relative transforms for everything all the time.  

## Additions

- amethyst::core::transform::ParentTransformRelation
- Transform now has `parent_relation` and appropriate getters/setters
- Added optional deserialization and serialization for the type so its backwards compat.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
