### PR TITLE
Minor improvement to description of 2d camera position

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -117,15 +117,18 @@ will.
     projection of the size of our arena. We also attach a `Transform` component,
     representing its position in the world.
 
-    A default camera can be created with `standard_2d` which size of our arena.
-    This camera makes the X go right, Y go up and center of the screen being at
-    the position of the camera in space, i.e. whatever we pass to `set_translation_xyz`.
-    Our setup makes the `(0, 0)` point in space be represented on the bottom left of the screen,
-    and `(ARENA_WIDTH, ARENA_HEIGHT)` being at the top right.
+    The `Camera::standard_2d` function creates a default 2D camera that is
+    pointed along the world's **Z** axis. The area in front of the camera has a
+    horizontal **X** axis, and a vertical **Y** axis. The **X** axis increases
+    moving to the right, and the **Y** axis increases moving up. The camera's
+    position is the center of the viewable area. We position the camera with
+    `set_translation_xyz` to the middle of our game arena so that `(0, 0)` is
+    the bottom left of the viewable area, and `(ARENA_WIDTH, ARENA_HEIGHT)` is
+    the top right.
 
-    Notice that we shifted the camera on the **Z** axis. This is to make sure
-    that the camera is able to see the sprites that sit on the **XY** plane
-    where **Z** is 0.0:
+    Notice that we also shifted the camera `1.0` along the **Z** axis. This is
+    to make sure that the camera is able to see the sprites that sit on the
+    **XY** plane where **Z** is 0.0:
 
     ![Camera Z shift](../images/pong_tutorial/camera.png)
 


### PR DESCRIPTION
## Description

Just fixing up a somewhat messy description of the default camera's placement in the pong tut

## Modifications

- Changed one paragraph in the pong tutorial step 2

## PR Checklist

By placing an x in the boxes I certify that I have:

- :white_check_mark: Ran `cargo test --all` locally if this modified any rs files.
- N/A Ran `cargo +stable fmt --all` locally if this modified any rs files.
- :white_check_mark: Updated the content of the book if this PR would make the book outdated.
- N/A Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- N/A Added unit tests for new APIs if any were added in this PR.
- :white_check_mark: Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.