### PR TITLE
Bump to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>", "Amethyst Foundation <contact@amethyst.rs>"]
 edition = "2018"
 description = "Data-oriented game engine written in Rust"
@@ -103,21 +103,21 @@ members = [
 ]
 
 [dependencies]
-amethyst_animation = { path = "amethyst_animation", version = "0.5.0", optional = true }
-amethyst_assets = { path = "amethyst_assets", version = "0.6.0" }
-amethyst_audio = { path = "amethyst_audio", version = "0.5.0", optional = true }
-amethyst_config = { path = "amethyst_config", version = "0.9.0" }
-amethyst_core = { path = "amethyst_core", version = "0.5.0" }
+amethyst_animation = { path = "amethyst_animation", version = "0.6.0", optional = true }
+amethyst_assets = { path = "amethyst_assets", version = "0.7.0" }
+amethyst_audio = { path = "amethyst_audio", version = "0.6.0", optional = true }
+amethyst_config = { path = "amethyst_config", version = "0.10.0" }
+amethyst_core = { path = "amethyst_core", version = "0.6.0" }
 amethyst_error = { path = "amethyst_error", version = "0.1.0" }
-amethyst_controls = { path = "amethyst_controls", version = "0.4.0" }
-amethyst_derive = { path = "amethyst_derive", version = "0.3.0" }
-amethyst_gltf = { path = "amethyst_gltf", version = "0.5.0", optional = true }
-amethyst_network = { path = "amethyst_network", version = "0.3.1", optional = true }
-amethyst_locale = { path = "amethyst_locale", version = "0.4.0", optional = true }
-amethyst_rendy = { path = "amethyst_rendy", optional = true }
-amethyst_input = { path = "amethyst_input", version = "0.6.0" }
-amethyst_ui = { path = "amethyst_ui", version = "0.5.0" }
-amethyst_utils = { path = "amethyst_utils", version = "0.5.0" }
+amethyst_controls = { path = "amethyst_controls", version = "0.5.0" }
+amethyst_derive = { path = "amethyst_derive", version = "0.4.0" }
+amethyst_gltf = { path = "amethyst_gltf", version = "0.6.0", optional = true }
+amethyst_network = { path = "amethyst_network", version = "0.4.0", optional = true }
+amethyst_locale = { path = "amethyst_locale", version = "0.5.0", optional = true }
+amethyst_rendy = { path = "amethyst_rendy", version = "0.1.0", optional = true }
+amethyst_input = { path = "amethyst_input", version = "0.7.0" }
+amethyst_ui = { path = "amethyst_ui", version = "0.6.0" }
+amethyst_utils = { path = "amethyst_utils", version = "0.6.0" }
 amethyst_window = { path = "amethyst_window", version = "0.1.0" }
 crossbeam-channel = "0.3.1"
 derivative = "1.0"

--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ Please visit the [features page][feat] for a list of features Amethyst provides.
 
 ## Navigation
 
-* [**Link to the book (latest release)**][bks]
+* [**Link to the book (0.11)**][bks11]
+* [**Link to the book (0.10)**][bks10]
 * [**Link to the book (master)**][bkm]
-* [**Link to the examples (latest release)**][exr]
+* [**Link to the examples (0.11)**][exr11]
+* [**Link to the examples (0.10)**][exr10]
 * [**Link to the examples (master)**][exm]
 
 ## Usage
@@ -75,9 +77,11 @@ While the engine can be hard to use at times, we made a lot of [documentation][b
 
 If you don't understand a part of the documentation, please let us know. Join us on Discord or open an issue; we are always happy to help!
 
-[bks]: https://book.amethyst.rs/stable/
+[bks11]: https://book.amethyst.rs/stable/
+[bks10]: https://book.amethyst.rs/v0.10.0/
 [bkm]: https://book.amethyst.rs/master/
-[exr]: https://github.com/amethyst/amethyst/tree/v0.10.0/examples
+[exr11]: https://github.com/amethyst/amethyst/tree/v0.11.0/examples
+[exr10]: https://github.com/amethyst/amethyst/tree/v0.10.0/examples
 [exm]: https://github.com/amethyst/amethyst/tree/master/examples
 
 ## Getting started

--- a/amethyst_animation/Cargo.toml
+++ b/amethyst_animation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst_animation"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Simon Rönnberg <seamonr@gmail.com>"]
 edition = "2018"
 description = "Animation support for Amethyst"
@@ -18,10 +18,10 @@ appveyor = { repository = "amethyst/amethyst", branch = "master" }
 travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
-amethyst_assets = { path = "../amethyst_assets/", version = "0.6.0" }
-amethyst_core = { path = "../amethyst_core/", version = "0.5.0" }
+amethyst_assets = { path = "../amethyst_assets/", version = "0.7.0" }
+amethyst_core = { path = "../amethyst_core/", version = "0.6.0" }
 amethyst_error = { path = "../amethyst_error/", version = "0.1.0" }
-amethyst_derive = { path = "../amethyst_derive", version = "0.3.0" }
+amethyst_derive = { path = "../amethyst_derive", version = "0.4.0" }
 amethyst_rendy = { path = "../amethyst_rendy", version = "0.1.0" }
 derivative = "1.0"
 fnv = "1"

--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst_assets"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["torkleyy <torkleyy@gmail.com>"]
 readme = "README.md"
 edition = "2018"
@@ -21,7 +21,7 @@ appveyor = { repository = "amethyst/amethyst", branch = "master" }
 travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
-amethyst_core = { path = "../amethyst_core", version = "0.5.0" }
+amethyst_core = { path = "../amethyst_core", version = "0.6.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.1.0" }
 crossbeam = "0.4.1"
 derivative = "1.0"

--- a/amethyst_audio/Cargo.toml
+++ b/amethyst_audio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst_audio"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Xaeroxe <kieseljake@gmail.com>"]
 edition = "2018"
 description = "Audio support for Amethyst"
@@ -20,8 +20,8 @@ appveyor = { repository = "amethyst/amethyst", branch = "master" }
 travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
-amethyst_assets = { path = "../amethyst_assets", version = "0.6.0"}
-amethyst_core = { path = "../amethyst_core", version = "0.5.0"}
+amethyst_assets = { path = "../amethyst_assets", version = "0.7.0"}
+amethyst_core = { path = "../amethyst_core", version = "0.6.0"}
 amethyst_error = { path = "../amethyst_error", version = "0.1.0"}
 cpal = "0.8"
 log = "0.4.6"
@@ -30,7 +30,7 @@ serde = { version = "1.0", features = ["derive"] }
 thread_profiler = { version = "0.3", optional = true }
 
 [dev-dependencies]
-amethyst_utils = { path = "../amethyst_utils", version = "0.5.0"}
+amethyst_utils = { path = "../amethyst_utils", version = "0.6.0"}
 
 [dependencies.smallvec]
 version = "0.6"

--- a/amethyst_config/Cargo.toml
+++ b/amethyst_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst_config"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Aceeri <conmcclusk@gmail.com>"]
 edition = "2018"
 description = "Loading from .ron files into Rust structures with defaults to prevent hard errors."

--- a/amethyst_controls/Cargo.toml
+++ b/amethyst_controls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst_controls"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Joël Lupien <jojolepromain@gmail.com>"]
 edition = "2018"
 description = "Amethyst controls"
@@ -16,10 +16,10 @@ appveyor = { repository = "amethyst/amethyst" }
 travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
-amethyst_assets = { path = "../amethyst_assets", version = "0.6.0" }
-amethyst_core = { path = "../amethyst_core", version = "0.5.0" }
+amethyst_assets = { path = "../amethyst_assets", version = "0.7.0" }
+amethyst_core = { path = "../amethyst_core", version = "0.6.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.1.0" }
-amethyst_input = { path = "../amethyst_input", version = "0.6.0" }
+amethyst_input = { path = "../amethyst_input", version = "0.7.0" }
 serde = { version = "1.0", features = ["derive"] }
 winit = { version = "0.19", features = ["serde"] }
 log = "0.4.6"

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst_core"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Simon Rönnberg <seamonr@gmail.com>"]
 edition = "2018"
 description = "Amethyst core"
@@ -37,7 +37,7 @@ derive-new = "0.5.6"
 thread_profiler = { version = "0.3", optional = true }
 
 [dev-dependencies]
-amethyst = { path = "..", version = "0.10.0" }
+amethyst = { path = "..", version = "0.11.0" }
 ron = "0.5.1"
 
 [features]

--- a/amethyst_derive/Cargo.toml
+++ b/amethyst_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst_derive"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Simon Rönnberg <seamonr@gmail.com>"]
 edition = "2018"
 description = "Amethyst derive"
@@ -21,10 +21,10 @@ quote = "0.6"
 proc-macro2 = "0.4"
 
 [dev-dependencies]
-amethyst_core = { path = "../amethyst_core", version = "0.5.0" }
-amethyst_assets = { path = "../amethyst_assets", version = "0.6.0" }
+amethyst_core = { path = "../amethyst_core", version = "0.6.0" }
+amethyst_assets = { path = "../amethyst_assets", version = "0.7.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.1.0" }
-amethyst_test = { path = "../amethyst_test", version = "0.1.0" }
+amethyst_test = { path = "../amethyst_test", version = "0.2.0" }
 
 [lib]
 name = "amethyst_derive"

--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst_gltf"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Rhuagh <seamonr@gmail.com>"]
 edition = "2018"
 description = "GLTF asset loading"
@@ -16,11 +16,11 @@ appveyor = { repository = "amethyst/amethyst" }
 travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
-amethyst_assets = { path = "../amethyst_assets/", version = "0.6.0" }
-amethyst_animation = { path = "../amethyst_animation/", version = "0.5.0" }
-amethyst_rendy = { path = "../amethyst_rendy", version = "0.1.0" }
-amethyst_core = { path = "../amethyst_core/", version = "0.5.0" }
+amethyst_assets = { path = "../amethyst_assets/", version = "0.7.0" }
+amethyst_animation = { path = "../amethyst_animation/", version = "0.6.0" }
+amethyst_core = { path = "../amethyst_core/", version = "0.6.0" }
 amethyst_error = { path = "../amethyst_error/", version = "0.1.0" }
+amethyst_rendy = { path = "../amethyst_rendy", version = "0.1.0" }
 err-derive = "0.1"
 base64 = "0.10"
 fnv = "1"

--- a/amethyst_input/Cargo.toml
+++ b/amethyst_input/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst_input"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Rhuagh <seamonr@gmail.com>", "Xaeroxe <kieseljake@gmail.com>"]
 edition = "2018"
 description = "Input rebinding "
@@ -16,9 +16,9 @@ appveyor = { repository = "amethyst/amethyst" }
 travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
-amethyst_core = { path = "../amethyst_core/", version = "0.5.0" }
+amethyst_core = { path = "../amethyst_core/", version = "0.6.0" }
 amethyst_error = { path = "../amethyst_error/", version = "0.1.0" }
-amethyst_config = { path = "../amethyst_config/", version = "0.9.0" }
+amethyst_config = { path = "../amethyst_config/", version = "0.10.0" }
 amethyst_window = { path = "../amethyst_window/", version = "0.1.0" }
 derivative = "1.0"
 fnv = "1"

--- a/amethyst_locale/Cargo.toml
+++ b/amethyst_locale/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst_locale"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Joël Lupien <jojolepromain@gmail.com>"]
 readme = "README.md"
 edition = "2018"
@@ -21,8 +21,8 @@ appveyor = { repository = "amethyst/amethyst", branch = "master" }
 travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
-amethyst_assets = { path = "../amethyst_assets", version = "0.6.0" }
-amethyst_core = { path = "../amethyst_core", version = "0.5.0" }
+amethyst_assets = { path = "../amethyst_assets", version = "0.7.0" }
+amethyst_core = { path = "../amethyst_core", version = "0.6.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.1.0" }
 serde = { version = "1.0", features = ["derive"] }
 fluent = "0.4.3"

--- a/amethyst_network/Cargo.toml
+++ b/amethyst_network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst_network"
-version = "0.3.1"
+version = "0.4.0"
 authors = [
 	"Joël Lupien (Jojolepro) <jojolepromain@gmail.com>",
 	"Lucio Franco (LucioFranco) <luciofranco14@gmail.com>",
@@ -23,7 +23,7 @@ nightly = [ "amethyst_core/nightly" ]
 float64 = ["amethyst_core/float64"]
 
 [dependencies]
-amethyst_core = { path = "../amethyst_core", version = "0.5" }
+amethyst_core = { path = "../amethyst_core", version = "0.6" }
 amethyst_error = { path = "../amethyst_error", version = "0.1.0" }
 serde = { version = "1", features = ["derive"] }
 shrev = "1.0"

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -8,9 +8,9 @@ keywords = ["game", "engine", "renderer", "3d", "amethyst"]
 categories = ["rendering", "rendering::engine"]
 
 [dependencies]
-amethyst_assets = { path = "../amethyst_assets", version = "0.6" }
-amethyst_core = { path = "../amethyst_core", version = "0.5" }
-amethyst_derive = { path = "../amethyst_derive", version = "0.3" }
+amethyst_assets = { path = "../amethyst_assets", version = "0.7" }
+amethyst_core = { path = "../amethyst_core", version = "0.6" }
+amethyst_derive = { path = "../amethyst_derive", version = "0.4" }
 amethyst_error = { path = "../amethyst_error", version = "0.1" }
 amethyst_window = { path = "../amethyst_window", version = "0.1" }
 derive-new = "0.5.6"

--- a/amethyst_test/Cargo.toml
+++ b/amethyst_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst_test"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Azriel Hoh <azriel91@gmail.com>"]
 edition = "2018"
 description = "Amethyst test utilities crate"
@@ -13,7 +13,7 @@ repository = "https://github.com/amethyst/amethyst"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-amethyst = { path = "..", version = "0.10.0" }
+amethyst = { path = "..", version = "0.11.0" }
 boxfnonce = "0.1"
 derivative = "1.0"
 derive-new = "0.5"

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst_ui"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Jacob Kiesel <kieseljake@gmail.com>", "Joël Lupien <jojolepromain@gmail.com>"]
 edition = "2018"
 description = "Amethyst UI crate"
@@ -13,13 +13,13 @@ repository = "https://github.com/amethyst/amethyst"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-amethyst_assets = { path = "../amethyst_assets", version = "0.6.0" }
-amethyst_audio = { path = "../amethyst_audio", version = "0.5.0"}
-amethyst_core = { path = "../amethyst_core", version = "0.5.0" }
+amethyst_assets = { path = "../amethyst_assets", version = "0.7.0" }
+amethyst_audio = { path = "../amethyst_audio", version = "0.6.0"}
+amethyst_core = { path = "../amethyst_core", version = "0.6.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.1.0" }
+amethyst_input = { path = "../amethyst_input", version = "0.7.0" }
 amethyst_rendy = { path = "../amethyst_rendy", version = "0.1.0" }
 amethyst_window = { path = "../amethyst_window", version = "0.1.0" }
-amethyst_input = { path = "../amethyst_input", version = "0.6.0" }
 clipboard = "0.5"
 derivative = "1.0"
 derive-new = "0.5.6"

--- a/amethyst_utils/Cargo.toml
+++ b/amethyst_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst_utils"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Simon Rönnberg <seamonr@gmail.com>", "Joël Lupien <jojolepromain@gmail.com>"]
 edition = "2018"
 description = "Amethyst utils"
@@ -16,11 +16,11 @@ appveyor = { repository = "amethyst/amethyst" }
 travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
-amethyst_assets = { path = "../amethyst_assets", version = "0.6.0" }
-amethyst_controls = { path = "../amethyst_controls", version = "0.4.0" }
-amethyst_core = { path = "../amethyst_core", version = "0.5.0" }
+amethyst_assets = { path = "../amethyst_assets", version = "0.7.0" }
+amethyst_controls = { path = "../amethyst_controls", version = "0.5.0" }
+amethyst_core = { path = "../amethyst_core", version = "0.6.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.1.0" }
-amethyst_derive = { path = "../amethyst_derive", version = "0.3.0" }
+amethyst_derive = { path = "../amethyst_derive", version = "0.4.0" }
 amethyst_rendy = { path = "../amethyst_rendy", version = "0.1.0" }
 amethyst_window = { path = "../amethyst_window", version = "0.1.0" }
 log = "0.4.6"

--- a/amethyst_window/Cargo.toml
+++ b/amethyst_window/Cargo.toml
@@ -14,8 +14,8 @@ appveyor = { repository = "amethyst/amethyst" }
 travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
-amethyst_core = { path = "../amethyst_core", version = "0.5" }
-amethyst_config = { path = "../amethyst_config" }
+amethyst_core = { path = "../amethyst_core", version = "0.6" }
+amethyst_config = { path = "../amethyst_config", version = "0.10" }
 amethyst_error = { path = "../amethyst_error/", version = "0.1.0" }
 
 log = "0.4.6"

--- a/book/src/pong-tutorial/pong-tutorial-01.md
+++ b/book/src/pong-tutorial/pong-tutorial-01.md
@@ -19,7 +19,7 @@ authors = []
 edition = "2018"
 
 [dependencies.amethyst]
-git = "https://github.com/amethyst/amethyst.git"
+version = "0.11"
 features = ["vulkan"]
 ```
 
@@ -27,7 +27,7 @@ Alternatively, if you are developing on macOS, you might want to use the `metal`
 
 ```toml
 [dependencies.amethyst]
-git = "https://github.com/amethyst/amethyst.git"
+version = "0.11"
 features = ["metal"]
 ```
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ## [Unreleased]
 
+## [0.11.0] - 2019-06
+
 ### Added
 
 * Introduce `application_dir` utility ([#1213])
@@ -882,7 +884,9 @@ extra bounds from `AnimatablePrefab` and `AnimationSetPrefab` ([#1435])
 
 * Initial release
 
-[Unreleased]: https://github.com/amethyst/amethyst/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/amethyst/amethyst/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/amethyst/amethyst/compare/v0.10.0...v0.11.0
+[0.10.0]: https://github.com/amethyst/amethyst/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/amethyst/amethyst/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/amethyst/amethyst/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/amethyst/amethyst/compare/v0.5.1...v0.7.0


### PR DESCRIPTION
## Description

* Bumps the version of all crates, except the unreleased ones
* Update links
* Update book

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Ran `cargo test --all` locally if this modified any rs files.
- [ ] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
