### PR TITLE
fix the name of FPSCounter structs

### DIFF
--- a/amethyst_utils/src/fps_counter.rs
+++ b/amethyst_utils/src/fps_counter.rs
@@ -12,12 +12,12 @@ use crate::circular_buffer::CircularBuffer;
 #[cfg(feature = "profiler")]
 use thread_profiler::profile_scope;
 
-/// The FPSCounter resource needed by the FPSCounterSystem.
+/// The FpsCounter resource needed by the FpsCounterSystem.
 ///
-/// Add it to your resources to be able to use the FPSCounterSystem.
+/// Add it to your resources to be able to use the FpsCounterSystem.
 ///
 /// # Usage
-/// Get the FPSCounter resource from the world then call either `frame_fps` or `sampled_fps` to
+/// Get the FpsCounter resource from the world then call either `frame_fps` or `sampled_fps` to
 /// get the FPS.
 ///
 /// frame_fps will return the framerate of the current frame. That is, the framerate at which the
@@ -27,29 +27,29 @@ use thread_profiler::profile_scope;
 ///
 /// # Example
 /// ```rust
-/// # use amethyst_utils::fps_counter::FPSCounter;
+/// # use amethyst_utils::fps_counter::FpsCounter;
 /// # use amethyst_core::ecs::World;
 /// # let mut world = World::new();
-/// # let counter = FPSCounter::new(2);
+/// # let counter = FpsCounter::new(2);
 /// # world.add_resource(counter);
-/// let mut counter = world.write_resource::<FPSCounter>();
+/// let mut counter = world.write_resource::<FpsCounter>();
 ///
 /// ```
-pub struct FPSCounter {
+pub struct FpsCounter {
     buf: CircularBuffer<u64>,
     sum: u64,
 }
 
-impl Default for FPSCounter {
+impl Default for FpsCounter {
     fn default() -> Self {
-        FPSCounter::new(20)
+        FpsCounter::new(20)
     }
 }
 
-impl FPSCounter {
-    ///Creates a new FPSCounter that calculates the average fps over samplesize values.
-    pub fn new(samplesize: usize) -> FPSCounter {
-        FPSCounter {
+impl FpsCounter {
+    ///Creates a new FpsCounter that calculates the average fps over samplesize values.
+    pub fn new(samplesize: usize) -> FpsCounter {
+        FpsCounter {
             buf: CircularBuffer::<u64>::new(samplesize),
             sum: 0,
         }
@@ -81,11 +81,11 @@ impl FPSCounter {
 }
 
 /// Add this system to your game to automatically push FPS values
-/// to the [FPSCounter](../resources/struct.FPSCounter.html) resource with id 0
-pub struct FPSCounterSystem;
+/// to the [FpsCounter](../resources/struct.FpsCounter.html) resource with id 0
+pub struct FpsCounterSystem;
 
-impl<'a> System<'a> for FPSCounterSystem {
-    type SystemData = (Read<'a, Time>, Write<'a, FPSCounter>);
+impl<'a> System<'a> for FpsCounterSystem {
+    type SystemData = (Read<'a, Time>, Write<'a, FpsCounter>);
     fn run(&mut self, (time, mut counter): Self::SystemData) {
         #[cfg(feature = "profiler")]
         profile_scope!("fps_counter_system");
@@ -100,13 +100,13 @@ impl<'a> System<'a> for FPSCounterSystem {
     }
 }
 
-///Automatically adds a FPSCounterSystem and a FPSCounter resource with the specified sample size.
+///Automatically adds a FpsCounterSystem and a FpsCounter resource with the specified sample size.
 #[derive(Default)]
-pub struct FPSCounterBundle;
+pub struct FpsCounterBundle;
 
-impl<'a, 'b> SystemBundle<'a, 'b> for FPSCounterBundle {
+impl<'a, 'b> SystemBundle<'a, 'b> for FpsCounterBundle {
     fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<(), Error> {
-        builder.add(FPSCounterSystem, "fps_counter_system", &[]);
+        builder.add(FpsCounterSystem, "fps_counter_system", &[]);
         Ok(())
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+* Rename FPSCounter, FPSCounterBundle, FPSCounterSystem to FpsCounter, FpsCounterBundle, FpsCounterSystem. ([#1719])
+
+[#1719]: https://github.com/amethyst/amethyst/pull/1719
+
 ## [0.11.0] - 2019-06
 
 ### Added

--- a/examples/custom_game_data/example_system.rs
+++ b/examples/custom_game_data/example_system.rs
@@ -7,7 +7,7 @@ use amethyst::{
     ecs::prelude::{Entity, Join, Read, ReadStorage, System, WriteExpect, WriteStorage},
     renderer::{camera::Camera, light::Light},
     ui::{UiFinder, UiText},
-    utils::fps_counter::FPSCounter,
+    utils::fps_counter::FpsCounter,
 };
 
 #[derive(Default)]
@@ -23,7 +23,7 @@ impl<'a> System<'a> for ExampleSystem {
         WriteStorage<'a, Transform>,
         WriteExpect<'a, DemoState>,
         WriteStorage<'a, UiText>,
-        Read<'a, FPSCounter>,
+        Read<'a, FpsCounter>,
         UiFinder<'a>,
     );
 

--- a/examples/custom_game_data/main.rs
+++ b/examples/custom_game_data/main.rs
@@ -31,7 +31,7 @@ use amethyst::{
         GraphCreator, RenderingSystem,
     },
     ui::{DrawUiDesc, UiBundle, UiCreator, UiLoader, UiPrefab},
-    utils::{application_root_dir, fps_counter::FPSCounterBundle, scene::BasicScenePrefab},
+    utils::{application_root_dir, fps_counter::FpsCounterBundle, scene::BasicScenePrefab},
     window::{ScreenDimensions, Window, WindowBundle},
     winit::VirtualKeyCode,
     Error,
@@ -223,7 +223,7 @@ fn main() -> Result<(), Error> {
         .with_running::<ExampleSystem>(ExampleSystem::default(), "example_system", &[])
         .with_base_bundle(TransformBundle::new())?
         .with_base_bundle(UiBundle::<DefaultBackend, StringBindings>::new())?
-        .with_base_bundle(FPSCounterBundle::default())?
+        .with_base_bundle(FpsCounterBundle::default())?
         .with_base_bundle(InputBundle::<StringBindings>::new())?
         .with_base_bundle(WindowBundle::from_config_path(display_config_path))?
         .with_thread_local(RenderingSystem::<DefaultBackend, _>::new(

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -44,7 +44,7 @@ use amethyst::{
     ui::{DrawUiDesc, UiBundle, UiCreator, UiFinder, UiText},
     utils::{
         application_root_dir,
-        fps_counter::{FPSCounter, FPSCounterBundle},
+        fps_counter::{FpsCounter, FpsCounterBundle},
         scene::BasicScenePrefab,
     },
     window::{ScreenDimensions, Window, WindowBundle},
@@ -216,7 +216,7 @@ fn main() -> Result<(), Error> {
         .with_bundle(TransformBundle::new().with_dep(&["example_system"]))?
         .with_bundle(UiBundle::<DefaultBackend, StringBindings>::new())?
         .with_bundle(HotReloadBundle::default())?
-        .with_bundle(FPSCounterBundle::default())?
+        .with_bundle(FpsCounterBundle::default())?
         .with_bundle(InputBundle::<StringBindings>::new())?
         .with_thread_local(RenderingSystem::<DefaultBackend, _>::new(
             ExampleGraph::default(),
@@ -261,7 +261,7 @@ impl<'a> System<'a> for ExampleSystem {
         WriteStorage<'a, Transform>,
         Write<'a, DemoState>,
         WriteStorage<'a, UiText>,
-        Read<'a, FPSCounter>,
+        Read<'a, FpsCounter>,
         UiFinder<'a>,
     );
 

--- a/examples/rendy/main.rs
+++ b/examples/rendy/main.rs
@@ -24,7 +24,7 @@ use amethyst::{
     utils::{
         application_root_dir,
         auto_fov::{AutoFov, AutoFovSystem},
-        fps_counter::FPSCounterBundle,
+        fps_counter::FpsCounterBundle,
         tag::TagFinder,
     },
     window::{ScreenDimensions, Window, WindowBundle},
@@ -515,7 +515,7 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(WindowBundle::from_config_path(display_config_path))?
         .with(OrbitSystem, "orbit", &[])
         .with(AutoFovSystem::default(), "auto_fov", &[])
-        .with_bundle(FPSCounterBundle::default())?
+        .with_bundle(FpsCounterBundle::default())?
         .with(
             PrefabLoaderSystem::<ScenePrefabData>::default(),
             "scene_loader",

--- a/examples/ui/main.rs
+++ b/examples/ui/main.rs
@@ -24,7 +24,7 @@ use amethyst::{
     ui::{DrawUiDesc, UiBundle, UiCreator, UiEvent, UiFinder, UiText},
     utils::{
         application_root_dir,
-        fps_counter::{FPSCounter, FPSCounterBundle},
+        fps_counter::{FpsCounter, FpsCounterBundle},
         scene::BasicScenePrefab,
     },
     window::{ScreenDimensions, Window, WindowBundle},
@@ -103,7 +103,7 @@ impl SimpleState for Example {
         {
             if let Some(fps_display) = self.fps_display.and_then(|entity| ui_text.get_mut(entity)) {
                 if world.read_resource::<Time>().frame_number() % 20 == 0 {
-                    let fps = world.read_resource::<FPSCounter>().sampled_fps();
+                    let fps = world.read_resource::<FpsCounter>().sampled_fps();
                     fps_display.text = format!("FPS: {:.*}", 2, fps);
                 }
             }
@@ -142,7 +142,7 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(UiBundle::<DefaultBackend, StringBindings>::new())?
         .with(Processor::<Source>::new(), "source_processor", &[])
         .with(UiEventHandlerSystem::new(), "ui_event_handler", &[])
-        .with_bundle(FPSCounterBundle::default())?
+        .with_bundle(FpsCounterBundle::default())?
         .with_bundle(InputBundle::<StringBindings>::new())?
         .with_thread_local(RenderingSystem::<DefaultBackend, _>::new(
             ExampleGraph::default(),


### PR DESCRIPTION
## Description
Rename FPSCounter, FPSCounterBundle, FPSCounterSystem to FpsCounter, FpsCounterBundle, FpsCounterSystem, as recommended by the [Rust API Guidlines](https://rust-lang-nursery.github.io/api-guidelines/naming.html).

actual command:

    git grep -lz 'FPSCounter' | xargs -0r sed -i 's/FPSCounter/FpsCounter/g'

## Modifications

- Rename FPSCounter, FPSCounterBundle, FPSCounterSystem to FpsCounter, FpsCounterBundle, FpsCounterSystem.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
