### PR TITLE
Fix doc links in amethyst_rendy, bump versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>", "Amethyst Foundation <contact@amethyst.rs>"]
 edition = "2018"
 description = "Data-oriented game engine written in Rust"

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst_rendy"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Amethyst Foundation <contact@amethyst.rs>"]
 edition = "2018"
 description = "High-level rendering engine with multiple backends"

--- a/amethyst_rendy/src/lib.rs
+++ b/amethyst_rendy/src/lib.rs
@@ -8,29 +8,32 @@
 //! ### Submodules
 //!
 //! ### Passes
-//! * [pass::flat2d::DrawFlat2DDesc]
-//! * [pass::flat2d::DrawFlat2DTransparentDesc]
-//! * [pass::pbr::DrawPbrDesc]
-//! * [pass::flat::DrawFlatDesc]
-//! * [pass::shaded::DrawShadedDesc]
-//! * [pass::skybox::DrawSkyboxDesc]
-//! * [pass::debug_lines::DrawDebugLinesDesc]
+//!
+//! * [`DrawFlat2DDesc`](crate::pass::flat2d::DrawFlat2DDesc)
+//! * [`DrawFlat2DTransparentDesc`](crate::pass::flat2d::DrawFlat2DTransparentDesc)
+//! * [`DrawPbrDesc`](crate::pass::pbr::DrawPbrDesc)
+//! * [`DrawFlatDesc`](crate::pass::flat::DrawFlatDesc)
+//! * [`DrawShadedDesc`](crate::pass::shaded::DrawShadedDesc)
+//! * [`DrawSkyboxDesc`](crate::pass::skybox::DrawSkyboxDesc)
+//! * [`DrawDebugLinesDesc`](crate::pass::debug_lines::DrawDebugLinesDesc)
 //!
 //! ## Systems
-//! * [system::RenderingSystem]
-//! * [visibility::VisibilitySortingSystem]
-//! * [sprite_visibility::SpriteVisibilitySortingSystem]
+//!
+//! * [`RenderingSystem`](crate::system::RenderingSystem)
+//! * [`VisibilitySortingSystem`](crate::visibility::VisibilitySortingSystem)
+//! * [`SpriteVisibilitySortingSystem`](crate::sprite_visibility::SpriteVisibilitySortingSystem)
 //!
 //! ## Components
-//! * [camera::Camera]
-//! * [sprite_visibility::SpriteVisibility]
-//! * [visibility::Visibility]
-//! * [visibility::BoundingSphere]
-//! * [debug_drawing::DebugLinesComponent]
-//! * [light::Light]
-//! * [resources::Tint]
-//! * [skinning::JointTransforms]
-//! * [sprite::SpriteRender]
+//!
+//! * [`Camera`](camera::Camera)
+//! * [`SpriteVisibility`](sprite_visibility::SpriteVisibility)
+//! * [`Visibility`](visibility::Visibility)
+//! * [`BoundingSphere`](visibility::BoundingSphere)
+//! * [`DebugLinesComponent`](debug_drawing::DebugLinesComponent)
+//! * [`Light`](light::Light)
+//! * [`Tint`](resources::Tint)
+//! * [`JointTransforms`](skinning::JointTransforms)
+//! * [`SpriteRender`](sprite::SpriteRender)
 
 #![allow(dead_code)]
 #![allow(unused_variables)]


### PR DESCRIPTION
## Description

Fixed the rustdoc links in `amethyst_rendy`.

Bumped patch versions of `amethyst_rendy` and `amethyst`.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
