### PR TITLE
Improved docs for Transform Parent 

### DIFF
--- a/amethyst_core/src/transform/components/parent.rs
+++ b/amethyst_core/src/transform/components/parent.rs
@@ -10,15 +10,13 @@ pub type ParentHierarchy = Hierarchy<Parent>;
 ///
 /// The entity with this component *has* a parent, rather than *is* a parent.
 ///
-/// If the parent enitity has a transform, then all of that transform 
-/// (scale, then rotation, then translation) will be applied the object
-/// before any of the child's tranform is applied. For example, if a 
-/// parent rotates 45 degrees then child translations will be as if 
-/// the axes are rotated 45 degrees.
+/// If the parent entity contains a transform, then the child's transform
+/// will be applied relative to the parent's transform. For example, if a
+/// parent rotates 45 degrees around the Z axis, then the child's coordinate
+/// system will start out also rotated by 45 degrees around the Z axis.
 ///
-/// If the parent entity has is own parent (and so on) then the transforms 
+/// If the parent entity has is own parent (and so on) then the transforms
 /// will all be applied in order from the oldest ancestor to the child.
-
 #[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, new)]
 pub struct Parent {
     /// The parent entity

--- a/amethyst_core/src/transform/components/parent.rs
+++ b/amethyst_core/src/transform/components/parent.rs
@@ -15,7 +15,7 @@ pub type ParentHierarchy = Hierarchy<Parent>;
 /// parent rotates 45 degrees around the Z axis, then the child's coordinate
 /// system will start out also rotated by 45 degrees around the Z axis.
 ///
-/// If the parent entity has is own parent (and so on) then the transforms
+/// If the parent entity has its own parent (and so on) then the transforms
 /// will all be applied in order from the oldest ancestor to the child.
 #[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, new)]
 pub struct Parent {

--- a/amethyst_core/src/transform/components/parent.rs
+++ b/amethyst_core/src/transform/components/parent.rs
@@ -9,6 +9,16 @@ pub type ParentHierarchy = Hierarchy<Parent>;
 /// Component for defining a parent entity.
 ///
 /// The entity with this component *has* a parent, rather than *is* a parent.
+///
+/// If the parent enitity has a transform, then all of that transform 
+/// (scale, then rotation, then translation) will be applied the object
+/// before any of the child's tranform is applied. For example, if a 
+/// parent rotates 45 degrees then child translations will be as if 
+/// the axes are rotated 45 degrees.
+///
+/// If the parent entity has is own parent (and so on) then the transforms 
+/// will all be applied in order from the oldest ancestor to the child.
+
 #[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, new)]
 pub struct Parent {
     /// The parent entity

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -63,9 +63,9 @@ done the following things first:
    respective branch.
 2. You have processed your source code with `cargo fmt` (we use latest rustup stable).
 3. All of the following commands completed without errors.
-   * `cargo build`
-   * `cargo test --all`
-   * `cargo run --example {example-name}`
+   * `cargo build --features "empty"
+   * `cargo test --all --features "empty"`
+   * `cargo run --example {example-name} --features YOUR_BACKEND`
    * `mdbook test book -L target/debug/deps`
 4. You have granted non-exclusive right to your source code under both the
    [MIT License][lm] and the [Apache License 2.0][la]. Unless you explicitly

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -63,7 +63,7 @@ done the following things first:
    respective branch.
 2. You have processed your source code with `cargo fmt` (we use latest rustup stable).
 3. All of the following commands completed without errors.
-   * `cargo build --features "empty"
+   * `cargo build --features "empty"`
    * `cargo test --all --features "empty"`
    * `cargo run --example {example-name} --features YOUR_BACKEND`
    * `mdbook test book -L target/debug/deps`


### PR DESCRIPTION
## Description

Improved docs for Transform Parent to better describe what the component does. Also updated the Contribution docs to include --features "empty" and --features YOUR BACKEND with the change to 0.11.

## Additions

- No API additions, only docs

## Removals

- No API removals, only docs

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Ran `cargo test --all` locally if this modified any rs files.
- [x] Ran `cargo +stable fmt --all` locally if this modified any rs files.
- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
