### PR TITLE
Print the test executable path during coverage.

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -53,6 +53,8 @@ for test_bin_by_crate in $test_bins_by_crate; do
   crate_coverage_dirs+=("${crate_coverage_dir}")
 
   (
+    echo "Running '${test_bin_path}'"
+
     export CARGO_MANIFEST_DIR="$crate_dir"
     kcov --include-pattern="${crate_dir}/src/,${crate_dir}/tests/" \
       "--exclude-line=${kcov_exclude_line}" \


### PR DESCRIPTION
## Description

This should help diagnose errors in coverage runs.

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Ran `cargo test --all` locally if this modified any rs files.
- **n/a** Ran `cargo +stable fmt --all` locally if this modified any rs files.
- **n/a** Updated the content of the book if this PR would make the book outdated.
- **n/a** Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new APIs if any were added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
