### PR TITLE
Fixed small typo in pong tutorial pt.3

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-03.md
+++ b/book/src/pong-tutorial/pong-tutorial-03.md
@@ -68,6 +68,7 @@ let input_bundle = InputBundle::<StringBindings>::new()
 
 # let path = "./resources/display_config.ron";
 # let config = DisplayConfig::load(&path);
+# let assets_dir = "assets";
 # struct Pong;
 # impl SimpleState for Pong { }
 let game_data = GameDataBuilder::default()
@@ -75,7 +76,7 @@ let game_data = GameDataBuilder::default()
     .with_bundle(input_bundle)?
     // ..
     ;
-let mut game = Application::new("./", Pong, game_data)?;
+let mut game = Application::new(assets_dir, Pong, game_data)?;
 game.run();
 # Ok(())
 # }
@@ -387,4 +388,4 @@ explore another key concept in real-time games: time. We'll make our game aware
 of time, and add a ball for our paddles to bounce back and forth.
 
 [doc_time]: https://docs-src.amethyst.rs/stable/amethyst_core/timing/struct.Time.html
-[doc_bindings]: https://docs-src.amethyst.rs/stable/amethyst_input/struct.Bindings.html 
+[doc_bindings]: https://docs-src.amethyst.rs/stable/amethyst_input/struct.Bindings.html


### PR DESCRIPTION
## Description

Fixed an issue in the pong tutorial pt. 3 that broke the asset loading mechanism.

## Modifications

- Replaced directory string "./" with `assets_dir` variable.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all`
- [ ] Ran `cargo test --all --features "empty"`