### PR TITLE
Add link to starter project to 'Getting Started' book section

### DIFF
--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -48,7 +48,7 @@ you should get `Cargo.toml`, `src/main.rs` and `resources/display_config.ron`.
 
 ### Starter Project
 
-If you want to get running as quickly as possibly and start playing around with Amethyst, you can also use a starter project. These are specifically made for certain times of games, and will set you up with the groundwork needed to start right away.  
+If you want to get running as quickly as possibly and start playing around with Amethyst, you can also use a starter project. These are specifically made for certain types of games, and will set you up with the groundwork needed to start right away.  
 The `README.md` file on these will include everything you need to know to run the starter project.
 
 > **Note:** Right now, the only starter available is for 2D games. This will expand over time, and offer more options for different types of games.

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -46,6 +46,15 @@ amethyst new <game-name>
 
 you should get `Cargo.toml`, `src/main.rs` and `resources/display_config.ron`.
 
+### Starter Project
+
+If you want to get running as quickly as possibly and start playing around with Amethyst, you can also use a starter project. These are specifically made for certain times of games, and will set you up with the groundwork needed to start right away.  
+The `README.md` file on these will include everything you need to know to run the starter project.
+
+> **Note:** Right now, the only starter available is for 2D games. This will expand over time, and offer more options for different types of games.
+
+* [2D Starter](https://github.com/amethyst/amethyst-starter-2d)
+
 ### Cargo (Manual)
 
 In case you're doing this with `cargo`, here's what you need to do:
@@ -63,7 +72,7 @@ Amethyst is divided in two major versions:
 
 > **Note:** You can see which version you're currently looking at by checking the URL
   in your browser. The book / documentation for `master` contains "master" in the address,
-  the crates.io version is called "latest".
+  the crates.io version is called "stable".
 
 Depending on the book version that you choose to read, make sure that the amethyst version in your Cargo.toml matches that.
 


### PR DESCRIPTION
## Description

This PR adds a link to the only currently existing starter project to the "Getting Started" section of the book. I initially planned to add an entire chapter for this, which the front page could then also link to - However, I decided against it for now. Once we have more starter projects for different types of games, I think this would be a good idea though.

On a side note, I think we should update the PR template to make sure that the starters don't break. They'll be targeting the same version as the CLI, so maybe just mentioning it in the version release manual would be enough too.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all`
- [x] Ran `cargo test --all --features "empty"`