### PR TITLE
Make the GltfSceneOptions field of GltfSceneFormat public.

### DIFF
--- a/amethyst_gltf/src/format/mod.rs
+++ b/amethyst_gltf/src/format/mod.rs
@@ -39,7 +39,7 @@ mod skin;
 /// See `GltfSceneOptions` for more information about the load options.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct GltfSceneFormat(GltfSceneOptions);
+pub struct GltfSceneFormat(pub GltfSceneOptions);
 
 impl Format<Prefab<GltfPrefab>> for GltfSceneFormat {
     fn name(&self) -> &'static str {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@ and the corresponding draw functions to `DebugLines`, to draw simple shapes with
 
 * Fix animation unwrap on missing animated component. ([#1773])
 
+[#1791]: https://github.com/amethyst/amethyst/pull/1791
 [#1766]: https://github.com/amethyst/amethyst/pull/1766
 [#1719]: https://github.com/amethyst/amethyst/pull/1719
 [#1747]: https://github.com/amethyst/amethyst/pull/1747

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ and the corresponding draw functions to `DebugLines`, to draw simple shapes with
 * Inverted mouse wheel scroll direction event. Now using winit's standard.  ([#1767])
 * Add `load_from_data_async` to Asset Loader. ([#1753])
 * Add `SerializableFormat` marker trait which is now needed to be implemented for all the formats that are supposed to be serialized. ([#1720])
+* Make the GltfSceneOptions field of GltfSceneFormat public. ([#1791])
 
 ### Fixed
 * Fix stack overflow on serializing `Box<dyn Format<_>>`. ([#1720])


### PR DESCRIPTION
This allows users to set the options before manually loading a scene.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [X] Updated the content of the book if this PR would make the book outdated.
- [X] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [X] Added unit tests for new code added in this PR.
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [X] Ran `cargo +stable fmt --all`
- [X] Ran `cargo clippy --all --features empty`
- [X] Ran `cargo test --all --features empty`