### PR TITLE
Fix a compile error in the pong tutorial

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-03.md
+++ b/book/src/pong-tutorial/pong-tutorial-03.md
@@ -330,7 +330,7 @@ fn run(&mut self, (mut transforms, paddles, input): Self::SystemData) {
         };
         if let Some(mv_amount) = movement {
             let scaled_amount = 1.2 * mv_amount as f32;
-            let paddle_y = transform.translation().y;
+            let paddle_y = transform.translation().y.as_f32();
             transform.set_translation_y(
                 (paddle_y + scaled_amount)
                     .min(ARENA_HEIGHT - PADDLE_HEIGHT * 0.5)


### PR DESCRIPTION
### Description

I followed this tutorial until this point where a compile-time error occurs:

```
  (paddle_y + scaled_amount)
            ^ mismatched types: f32 and amethyst::core::Float
```
