### PR TITLE
Only run clippy on `nightly` rust.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,37 +69,18 @@ pipeline {
             }
         }
         stage('Cargo Clippy') {
-            parallel {
-                stage("stable") {
-                    environment {
-                        RUSTFLAGS = "-D warnings"
-                    }
-                    agent {
-                        docker {
-                            image 'amethystrs/builder-linux:stable'
-                            label 'docker'
-                        }
-                    }
-                    steps {
-                        echo 'Running Cargo clippy...'
-                        sh 'cargo clippy --all --all-targets --features "vulkan sdl_controller json saveload"'
-                    }
+            environment {
+                RUSTFLAGS = "-D warnings"
+            }
+            agent {
+                docker {
+                    image 'amethystrs/builder-linux:nightly'
+                    label 'docker'
                 }
-                stage("nightly") {
-                    environment {
-                        RUSTFLAGS = "-D warnings"
-                    }
-                    agent {
-                        docker {
-                            image 'amethystrs/builder-linux:nightly'
-                            label 'docker'
-                        }
-                    }
-                    steps {
-                        echo 'Running Cargo clippy...'
-                        sh 'cargo clippy --all --all-targets --features "vulkan sdl_controller json saveload"'
-                    }
-                }
+            }
+            steps {
+                echo 'Running Cargo clippy...'
+                sh 'cargo clippy --all --all-targets --features "vulkan sdl_controller json saveload"'
             }
         }
         // Separate stage for coverage to prevent race condition with the linux test stage (repo lock contention).


### PR DESCRIPTION
## Description

This avoids a race condition during building, and there is not much value having separate clippy runs on both `stable` and `nightly`.
`nightly` is chosen because `stable` clippy contains some bugs at the time of writing.

Example race condition failure: https://jenkins.amethyst-engine.org/blue/organizations/jenkins/amethyst/detail/PR-1793/2/pipeline

```
Command "git merge 2509c433252f6cb7a461cc84efbce07cefa2be28" returned status code 128:
stdout: 
stderr: fatal: Unable to create '/home/jenkins/workspace/amethyst_PR-1793/.git/index.lock': File exists.

Another git process seems to be running in this repository, e.g.
an editor opened by 'git commit'. Please make sure all processes
are terminated then try again. If it still fails, a git process
may have crashed in this repository earlier:
remove the file manually to continue.
```

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Updated the content of the book if this PR would make the book outdated.
- **n/a** Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- **n/a** Ran `cargo +stable fmt --all`
- **n/a** Ran `cargo clippy --all`
- **n/a** Ran `cargo test --all --features "empty"`