### PR TITLE
Feature/1512/axis change input event

### DIFF
--- a/amethyst_input/src/bindings.rs
+++ b/amethyst_input/src/bindings.rs
@@ -39,6 +39,7 @@ use super::{Axis, Button};
 ///     UsePowerup(PlayerId),
 /// }
 ///
+/// #[derive(Debug)]
 /// struct DriverBindingTypes;
 /// impl BindingTypes for DriverBindingTypes {
 ///     type Axis = AxisBinding;

--- a/amethyst_input/src/bundle.rs
+++ b/amethyst_input/src/bundle.rs
@@ -12,7 +12,7 @@ use crate::sdl_events_system::ControllerMappings;
 
 /// Bundle for adding the `InputHandler`.
 ///
-/// This also adds the Winit EventHandler and the `InputEvent<T::Action>` EventHandler
+/// This also adds the Winit EventHandler and the `InputEvent<T>` EventHandler
 /// where `T::Action` is the type for Actions you have assigned here.
 ///
 /// ## Type parameters

--- a/amethyst_input/src/controller.rs
+++ b/amethyst_input/src/controller.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::event::InputEvent;
+use crate::{bindings::BindingTypes, event::InputEvent};
 
 /// Controller axes matching SDL controller model
 #[derive(Eq, PartialEq, Debug, Copy, Clone, Serialize, Deserialize)]
@@ -118,7 +118,10 @@ pub enum ControllerEvent {
     },
 }
 
-impl<'a, T> Into<InputEvent<T>> for &'a ControllerEvent {
+impl<'a, T> Into<InputEvent<T>> for &'a ControllerEvent
+where
+    T: BindingTypes,
+{
     fn into(self) -> InputEvent<T> {
         use self::ControllerEvent::*;
         match *self {

--- a/amethyst_input/src/event.rs
+++ b/amethyst_input/src/event.rs
@@ -1,7 +1,9 @@
+use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 use winit::{MouseButton, VirtualKeyCode};
 
 use super::{
+    bindings::BindingTypes,
     button::Button,
     controller::{ControllerAxis, ControllerButton},
     scroll_direction::ScrollDirection,
@@ -11,20 +13,24 @@ use super::{
 ///
 /// Type parameter T is the type assigned to your Actions for your
 /// InputBundle or InputHandler.
-#[derive(PartialEq, Serialize, Deserialize, Debug, Clone)]
-pub enum InputEvent<T> {
+#[derive(PartialEq, Serialize, Deserialize, Debug, Derivative)]
+#[derivative(Clone(bound = ""))]
+pub enum InputEvent<T>
+where
+    T: BindingTypes,
+{
     /// A key was pressed down, sent exactly once per key press.
     KeyPressed {
-        /// The `VirtualKeyCode`, used for semantic info. i.e. "W" was pressed
+        /// `VirtualKeyCode`, used for semantic info. i.e. "W" was pressed
         key_code: VirtualKeyCode,
-        /// The scancode, used for positional info. i.e. The third key on the first row was pressed.
+        /// Scancode, used for positional info. i.e. The third key on the first row was pressed.
         scancode: u32,
     },
     /// A key was released, sent exactly once per key release.
     KeyReleased {
-        /// The `VirtualKeyCode`, used for semantic info. i.e. "W" was released
+        /// `VirtualKeyCode`, used for semantic info. i.e. "W" was released
         key_code: VirtualKeyCode,
-        /// The scancode, used for positional info. i.e. The third key on the first row was released.
+        /// Scancode, used for positional info. i.e. The third key on the first row was released.
         scancode: u32,
     },
     /// A unicode character was received by the window.  Good for typing.
@@ -44,7 +50,8 @@ pub enum InputEvent<T> {
         /// The amount the cursor moved vertically in pixels.
         delta_y: f32,
     },
-    /// The mouse device moved.  Use this for any use of the mouse that doesn't involve a standard mouse pointer.
+    /// The mouse device moved. Use this for any use of the mouse that doesn't involve a standard
+    /// mouse pointer.
     MouseMoved {
         /// The amount the mouse moved horizontally.
         delta_x: f32,
@@ -53,7 +60,18 @@ pub enum InputEvent<T> {
     },
     /// The mousewheel was moved in either direction
     MouseWheelMoved(ScrollDirection),
+    /// An axis value changed.
+    ///
+    /// Note that this variant is used for `BindingTypes::Axis`, not a `ControllerAxis`.
+    AxisMoved {
+        /// The axis that moved on the controller.
+        axis: T::Axis,
+        /// The amount that the axis moved.
+        value: f32,
+    },
     /// A controller Axis was moved.
+    ///
+    /// Note that this variant is used for a `ControllerAxis`, not `BindingTypes::Axis`.
     ControllerAxisMoved {
         /// The id for the controller whose axis moved.
         which: u32,
@@ -90,12 +108,12 @@ pub enum InputEvent<T> {
     ///
     /// If a combination is bound to an action, it will be pressed
     /// if all buttons within are pressed.
-    ActionPressed(T),
+    ActionPressed(T::Action),
     /// The associated action had any related button or combination released.
     ///
     /// If a combination is bound to an action, it will be released
     /// if any of the buttons within is released while all others are pressed.
-    ActionReleased(T),
+    ActionReleased(T::Action),
     /// The associated action has its mouse wheel moved.
-    ActionWheelMoved(T),
+    ActionWheelMoved(T::Action),
 }

--- a/amethyst_input/src/input_handler.rs
+++ b/amethyst_input/src/input_handler.rs
@@ -87,44 +87,7 @@ where
                             .iter()
                             .cloned(),
                         );
-                        for (axis, input_axis) in self.bindings.axes.iter() {
-                            if let Axis::Emulated { pos, neg } = input_axis {
-                                let value = self
-                                    .axis_value(axis)
-                                    .expect("Unreachable: `axis` is from bindings axes.");
-                                match *pos {
-                                    Button::Key(key_code_pos) if key_code_pos == key_code => {
-                                        event_handler.single_write(AxisMoved {
-                                            axis: axis.clone(),
-                                            value,
-                                        });
-                                    }
-                                    Button::ScanCode(scancode_pos) if scancode_pos == scancode => {
-                                        event_handler.single_write(AxisMoved {
-                                            axis: axis.clone(),
-                                            value,
-                                        });
-                                    }
-                                    _ => {}
-                                }
-
-                                match *neg {
-                                    Button::Key(key_code_neg) if key_code_neg == key_code => {
-                                        event_handler.single_write(AxisMoved {
-                                            axis: axis.clone(),
-                                            value,
-                                        });
-                                    }
-                                    Button::ScanCode(scancode_neg) if scancode_neg == scancode => {
-                                        event_handler.single_write(AxisMoved {
-                                            axis: axis.clone(),
-                                            value,
-                                        });
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
+                        self.send_axis_moved_events_key(event_handler, key_code, scancode);
                         for (action, combinations) in self.bindings.actions.iter() {
                             for combination in combinations.iter().filter(|c| {
                                 c.contains(&Button::Key(key_code))
@@ -162,44 +125,7 @@ where
                             .iter()
                             .cloned(),
                         );
-                        for (axis, input_axis) in self.bindings.axes.iter() {
-                            if let Axis::Emulated { pos, neg } = input_axis {
-                                let value = self
-                                    .axis_value(axis)
-                                    .expect("Unreachable: `axis` is from bindings axes.");
-                                match *pos {
-                                    Button::Key(key_code_pos) if key_code_pos == key_code => {
-                                        event_handler.single_write(AxisMoved {
-                                            axis: axis.clone(),
-                                            value,
-                                        });
-                                    }
-                                    Button::ScanCode(scancode_pos) if scancode_pos == scancode => {
-                                        event_handler.single_write(AxisMoved {
-                                            axis: axis.clone(),
-                                            value,
-                                        });
-                                    }
-                                    _ => {}
-                                }
-
-                                match *neg {
-                                    Button::Key(key_code_neg) if key_code_neg == key_code => {
-                                        event_handler.single_write(AxisMoved {
-                                            axis: axis.clone(),
-                                            value,
-                                        });
-                                    }
-                                    Button::ScanCode(scancode_neg) if scancode_neg == scancode => {
-                                        event_handler.single_write(AxisMoved {
-                                            axis: axis.clone(),
-                                            value,
-                                        });
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
+                        self.send_axis_moved_events_key(event_handler, key_code, scancode);
                         for (action, combinations) in self.bindings.actions.iter() {
                             for combination in combinations {
                                 if combination.contains(&Button::Key(key_code))
@@ -242,36 +168,7 @@ where
                             .iter()
                             .cloned(),
                         );
-                        for (axis, input_axis) in self.bindings.axes.iter() {
-                            if let Axis::Emulated { pos, neg } = input_axis {
-                                let value = self
-                                    .axis_value(axis)
-                                    .expect("Unreachable: `axis` is from bindings axes.");
-                                match *pos {
-                                    Button::Mouse(mouse_button_pos)
-                                        if mouse_button_pos == mouse_button =>
-                                    {
-                                        event_handler.single_write(AxisMoved {
-                                            axis: axis.clone(),
-                                            value,
-                                        });
-                                    }
-                                    _ => {}
-                                }
-
-                                match *neg {
-                                    Button::Mouse(mouse_button_neg)
-                                        if mouse_button_neg == mouse_button =>
-                                    {
-                                        event_handler.single_write(AxisMoved {
-                                            axis: axis.clone(),
-                                            value,
-                                        });
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
+                        self.send_axis_moved_events_mouse(event_handler, mouse_button);
                         for (action, combinations) in self.bindings.actions.iter() {
                             for combination in combinations
                                 .iter()
@@ -307,36 +204,7 @@ where
                             .iter()
                             .cloned(),
                         );
-                        for (axis, input_axis) in self.bindings.axes.iter() {
-                            if let Axis::Emulated { pos, neg } = input_axis {
-                                let value = self
-                                    .axis_value(axis)
-                                    .expect("Unreachable: `axis` is from bindings axes.");
-                                match *pos {
-                                    Button::Mouse(mouse_button_pos)
-                                        if mouse_button_pos == mouse_button =>
-                                    {
-                                        event_handler.single_write(AxisMoved {
-                                            axis: axis.clone(),
-                                            value,
-                                        });
-                                    }
-                                    _ => {}
-                                }
-
-                                match *neg {
-                                    Button::Mouse(mouse_button_neg)
-                                        if mouse_button_neg == mouse_button =>
-                                    {
-                                        event_handler.single_write(AxisMoved {
-                                            axis: axis.clone(),
-                                            value,
-                                        });
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
+                        self.send_axis_moved_events_mouse(event_handler, mouse_button);
                         for (action, combinations) in self.bindings.actions.iter() {
                             for combination in combinations {
                                 if combination.contains(&Button::Mouse(mouse_button))
@@ -792,6 +660,85 @@ where
 
         // send all collected events
         event_handler.iter_write(events);
+    }
+
+    fn send_axis_moved_events_key(
+        &self,
+        event_handler: &mut EventChannel<InputEvent<T>>,
+        key_code: VirtualKeyCode,
+        scancode: u32,
+    ) {
+        for (axis, input_axis) in self.bindings.axes.iter() {
+            if let Axis::Emulated { pos, neg } = input_axis {
+                let value = self
+                    .axis_value(axis)
+                    .expect("Unreachable: `axis` is from bindings axes.");
+                match *pos {
+                    Button::Key(key_code_pos) if key_code_pos == key_code => {
+                        event_handler.single_write(AxisMoved {
+                            axis: axis.clone(),
+                            value,
+                        });
+                    }
+                    Button::ScanCode(scancode_pos) if scancode_pos == scancode => {
+                        event_handler.single_write(AxisMoved {
+                            axis: axis.clone(),
+                            value,
+                        });
+                    }
+                    _ => {}
+                }
+
+                match *neg {
+                    Button::Key(key_code_neg) if key_code_neg == key_code => {
+                        event_handler.single_write(AxisMoved {
+                            axis: axis.clone(),
+                            value,
+                        });
+                    }
+                    Button::ScanCode(scancode_neg) if scancode_neg == scancode => {
+                        event_handler.single_write(AxisMoved {
+                            axis: axis.clone(),
+                            value,
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    fn send_axis_moved_events_mouse(
+        &self,
+        event_handler: &mut EventChannel<InputEvent<T>>,
+        mouse_button: MouseButton,
+    ) {
+        for (axis, input_axis) in self.bindings.axes.iter() {
+            if let Axis::Emulated { pos, neg } = input_axis {
+                let value = self
+                    .axis_value(axis)
+                    .expect("Unreachable: `axis` is from bindings axes.");
+                match *pos {
+                    Button::Mouse(mouse_button_pos) if mouse_button_pos == mouse_button => {
+                        event_handler.single_write(AxisMoved {
+                            axis: axis.clone(),
+                            value,
+                        });
+                    }
+                    _ => {}
+                }
+
+                match *neg {
+                    Button::Mouse(mouse_button_neg) if mouse_button_neg == mouse_button => {
+                        event_handler.single_write(AxisMoved {
+                            axis: axis.clone(),
+                            value,
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        }
     }
 }
 

--- a/amethyst_input/src/input_handler.rs
+++ b/amethyst_input/src/input_handler.rs
@@ -21,7 +21,10 @@ use winit::{
 /// that the key is pressed until it is released again.
 #[derive(Derivative)]
 #[derivative(Default(bound = ""), Debug(bound = ""))]
-pub struct InputHandler<T: BindingTypes> {
+pub struct InputHandler<T>
+where
+    T: BindingTypes,
+{
     /// Maps inputs to actions and axes.
     pub bindings: Bindings<T>,
     /// Encodes the VirtualKeyCode and corresponding scancode.
@@ -39,7 +42,10 @@ pub struct InputHandler<T: BindingTypes> {
     mouse_wheel_horizontal: f32,
 }
 
-impl<T: BindingTypes> InputHandler<T> {
+impl<T> InputHandler<T>
+where
+    T: BindingTypes,
+{
     /// Creates a new input handler.
     pub fn new() -> Self {
         Default::default()
@@ -52,7 +58,7 @@ impl<T: BindingTypes> InputHandler<T> {
     pub fn send_event(
         &mut self,
         event: &Event,
-        event_handler: &mut EventChannel<InputEvent<T::Action>>,
+        event_handler: &mut EventChannel<InputEvent<T>>,
         hidpi: f32,
     ) {
         match *event {
@@ -81,6 +87,44 @@ impl<T: BindingTypes> InputHandler<T> {
                             .iter()
                             .cloned(),
                         );
+                        for (axis, input_axis) in self.bindings.axes.iter() {
+                            if let Axis::Emulated { pos, neg } = input_axis {
+                                let value = self
+                                    .axis_value(axis)
+                                    .expect("Unreachable: `axis` is from bindings axes.");
+                                match *pos {
+                                    Button::Key(key_code_pos) if key_code_pos == key_code => {
+                                        event_handler.single_write(AxisMoved {
+                                            axis: axis.clone(),
+                                            value,
+                                        });
+                                    }
+                                    Button::ScanCode(scancode_pos) if scancode_pos == scancode => {
+                                        event_handler.single_write(AxisMoved {
+                                            axis: axis.clone(),
+                                            value,
+                                        });
+                                    }
+                                    _ => {}
+                                }
+
+                                match *neg {
+                                    Button::Key(key_code_neg) if key_code_neg == key_code => {
+                                        event_handler.single_write(AxisMoved {
+                                            axis: axis.clone(),
+                                            value,
+                                        });
+                                    }
+                                    Button::ScanCode(scancode_neg) if scancode_neg == scancode => {
+                                        event_handler.single_write(AxisMoved {
+                                            axis: axis.clone(),
+                                            value,
+                                        });
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
                         for (action, combinations) in self.bindings.actions.iter() {
                             for combination in combinations.iter().filter(|c| {
                                 c.contains(&Button::Key(key_code))
@@ -118,6 +162,44 @@ impl<T: BindingTypes> InputHandler<T> {
                             .iter()
                             .cloned(),
                         );
+                        for (axis, input_axis) in self.bindings.axes.iter() {
+                            if let Axis::Emulated { pos, neg } = input_axis {
+                                let value = self
+                                    .axis_value(axis)
+                                    .expect("Unreachable: `axis` is from bindings axes.");
+                                match *pos {
+                                    Button::Key(key_code_pos) if key_code_pos == key_code => {
+                                        event_handler.single_write(AxisMoved {
+                                            axis: axis.clone(),
+                                            value,
+                                        });
+                                    }
+                                    Button::ScanCode(scancode_pos) if scancode_pos == scancode => {
+                                        event_handler.single_write(AxisMoved {
+                                            axis: axis.clone(),
+                                            value,
+                                        });
+                                    }
+                                    _ => {}
+                                }
+
+                                match *neg {
+                                    Button::Key(key_code_neg) if key_code_neg == key_code => {
+                                        event_handler.single_write(AxisMoved {
+                                            axis: axis.clone(),
+                                            value,
+                                        });
+                                    }
+                                    Button::ScanCode(scancode_neg) if scancode_neg == scancode => {
+                                        event_handler.single_write(AxisMoved {
+                                            axis: axis.clone(),
+                                            value,
+                                        });
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
                         for (action, combinations) in self.bindings.actions.iter() {
                             for combination in combinations {
                                 if combination.contains(&Button::Key(key_code))
@@ -160,6 +242,36 @@ impl<T: BindingTypes> InputHandler<T> {
                             .iter()
                             .cloned(),
                         );
+                        for (axis, input_axis) in self.bindings.axes.iter() {
+                            if let Axis::Emulated { pos, neg } = input_axis {
+                                let value = self
+                                    .axis_value(axis)
+                                    .expect("Unreachable: `axis` is from bindings axes.");
+                                match *pos {
+                                    Button::Mouse(mouse_button_pos)
+                                        if mouse_button_pos == mouse_button =>
+                                    {
+                                        event_handler.single_write(AxisMoved {
+                                            axis: axis.clone(),
+                                            value,
+                                        });
+                                    }
+                                    _ => {}
+                                }
+
+                                match *neg {
+                                    Button::Mouse(mouse_button_neg)
+                                        if mouse_button_neg == mouse_button =>
+                                    {
+                                        event_handler.single_write(AxisMoved {
+                                            axis: axis.clone(),
+                                            value,
+                                        });
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
                         for (action, combinations) in self.bindings.actions.iter() {
                             for combination in combinations
                                 .iter()
@@ -195,6 +307,36 @@ impl<T: BindingTypes> InputHandler<T> {
                             .iter()
                             .cloned(),
                         );
+                        for (axis, input_axis) in self.bindings.axes.iter() {
+                            if let Axis::Emulated { pos, neg } = input_axis {
+                                let value = self
+                                    .axis_value(axis)
+                                    .expect("Unreachable: `axis` is from bindings axes.");
+                                match *pos {
+                                    Button::Mouse(mouse_button_pos)
+                                        if mouse_button_pos == mouse_button =>
+                                    {
+                                        event_handler.single_write(AxisMoved {
+                                            axis: axis.clone(),
+                                            value,
+                                        });
+                                    }
+                                    _ => {}
+                                }
+
+                                match *neg {
+                                    Button::Mouse(mouse_button_neg)
+                                        if mouse_button_neg == mouse_button =>
+                                    {
+                                        event_handler.single_write(AxisMoved {
+                                            axis: axis.clone(),
+                                            value,
+                                        });
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
                         for (action, combinations) in self.bindings.actions.iter() {
                             for combination in combinations {
                                 if combination.contains(&Button::Mouse(mouse_button))
@@ -273,7 +415,7 @@ impl<T: BindingTypes> InputHandler<T> {
     pub fn send_controller_event(
         &mut self,
         event: &ControllerEvent,
-        event_handler: &mut EventChannel<InputEvent<T::Action>>,
+        event_handler: &mut EventChannel<InputEvent<T>>,
     ) {
         use self::ControllerEvent::*;
 
@@ -592,9 +734,9 @@ impl<T: BindingTypes> InputHandler<T> {
         &self,
         delta_x: f32,
         delta_y: f32,
-        event_handler: &mut EventChannel<InputEvent<T::Action>>,
+        event_handler: &mut EventChannel<InputEvent<T>>,
     ) {
-        let mut events = Vec::<InputEvent<T::Action>>::new();
+        let mut events = Vec::<InputEvent<T>>::new();
 
         // determine if a horizontal scroll happend
         let dir_x = match delta_x {
@@ -672,7 +814,7 @@ mod tests {
         // Release the key and check for a release event of both the key and the action.
 
         let mut handler = InputHandler::<StringBindings>::new();
-        let mut events = EventChannel::<InputEvent<String>>::new();
+        let mut events = EventChannel::<InputEvent<StringBindings>>::new();
         let mut reader = events.register_reader();
         handler
             .bindings
@@ -721,7 +863,7 @@ mod tests {
         // Release the button and check for a release event of both the button and the action.
 
         let mut handler = InputHandler::<StringBindings>::new();
-        let mut events = EventChannel::<InputEvent<String>>::new();
+        let mut events = EventChannel::<InputEvent<StringBindings>>::new();
         let mut reader = events.register_reader();
         handler
             .bindings
@@ -764,7 +906,7 @@ mod tests {
         // Release second key, we should key release and no action release
 
         let mut handler = InputHandler::<StringBindings>::new();
-        let mut events = EventChannel::<InputEvent<String>>::new();
+        let mut events = EventChannel::<InputEvent<StringBindings>>::new();
         let mut reader = events.register_reader();
         handler
             .bindings
@@ -850,7 +992,8 @@ mod tests {
         // Release both and check for 0.
 
         let mut handler = InputHandler::<StringBindings>::new();
-        let mut events = EventChannel::<InputEvent<String>>::new();
+        let mut events = EventChannel::<InputEvent<StringBindings>>::new();
+        let mut reader = events.register_reader();
         handler
             .bindings
             .insert_axis(
@@ -862,14 +1005,87 @@ mod tests {
             )
             .unwrap();
         assert_eq!(handler.axis_value("test_axis"), Some(0.0));
+
         handler.send_event(&key_press(104, VirtualKeyCode::Up), &mut events, HIDPI);
+
+        let event_vec = events.read(&mut reader).cloned().collect::<Vec<_>>();
+        sets_are_equal(
+            &event_vec,
+            &[
+                InputEvent::AxisMoved {
+                    axis: String::from("test_axis"),
+                    value: 1.0,
+                },
+                InputEvent::KeyPressed {
+                    key_code: VirtualKeyCode::Up,
+                    scancode: 104,
+                },
+                InputEvent::ButtonPressed(Button::Key(VirtualKeyCode::Up)),
+                InputEvent::ButtonPressed(Button::ScanCode(104)),
+            ],
+        );
         assert_eq!(handler.axis_value("test_axis"), Some(1.0));
+
         handler.send_event(&key_release(104, VirtualKeyCode::Up), &mut events, HIDPI);
+
+        let event_vec = events.read(&mut reader).cloned().collect::<Vec<_>>();
+        sets_are_equal(
+            &event_vec,
+            &[
+                InputEvent::AxisMoved {
+                    axis: String::from("test_axis"),
+                    value: 0.0,
+                },
+                InputEvent::KeyReleased {
+                    key_code: VirtualKeyCode::Up,
+                    scancode: 104,
+                },
+                InputEvent::ButtonReleased(Button::Key(VirtualKeyCode::Up)),
+                InputEvent::ButtonReleased(Button::ScanCode(104)),
+            ],
+        );
         assert_eq!(handler.axis_value("test_axis"), Some(0.0));
+
         handler.send_event(&key_press(112, VirtualKeyCode::Down), &mut events, HIDPI);
+
+        let event_vec = events.read(&mut reader).cloned().collect::<Vec<_>>();
+        sets_are_equal(
+            &event_vec,
+            &[
+                InputEvent::AxisMoved {
+                    axis: String::from("test_axis"),
+                    value: -1.0,
+                },
+                InputEvent::KeyPressed {
+                    key_code: VirtualKeyCode::Down,
+                    scancode: 112,
+                },
+                InputEvent::ButtonPressed(Button::Key(VirtualKeyCode::Down)),
+                InputEvent::ButtonPressed(Button::ScanCode(112)),
+            ],
+        );
         assert_eq!(handler.axis_value("test_axis"), Some(-1.0));
+
         handler.send_event(&key_press(104, VirtualKeyCode::Up), &mut events, HIDPI);
+
+        let event_vec = events.read(&mut reader).cloned().collect::<Vec<_>>();
+        sets_are_equal(
+            &event_vec,
+            &[
+                InputEvent::AxisMoved {
+                    axis: String::from("test_axis"),
+                    value: 0.0,
+                },
+                InputEvent::KeyPressed {
+                    key_code: VirtualKeyCode::Up,
+                    scancode: 104,
+                },
+                InputEvent::ButtonPressed(Button::Key(VirtualKeyCode::Up)),
+                InputEvent::ButtonPressed(Button::ScanCode(104)),
+            ],
+        );
         assert_eq!(handler.axis_value("test_axis"), Some(0.0));
+
         handler.send_event(&key_release(104, VirtualKeyCode::Up), &mut events, HIDPI);
         handler.send_event(&key_release(112, VirtualKeyCode::Down), &mut events, HIDPI);
         assert_eq!(handler.axis_value("test_axis"), Some(0.0));
@@ -881,7 +1097,7 @@ mod tests {
         // in iterators
 
         let mut handler = InputHandler::<StringBindings>::new();
-        let mut events = EventChannel::<InputEvent<String>>::new();
+        let mut events = EventChannel::<InputEvent<StringBindings>>::new();
         assert_eq!(handler.keys_that_are_down().next(), None);
         assert_eq!(handler.scan_codes_that_are_down().next(), None);
         assert_eq!(handler.mouse_buttons_that_are_down().next(), None);
@@ -977,7 +1193,7 @@ mod tests {
     #[test]
     fn basic_key_check() {
         let mut handler = InputHandler::<StringBindings>::new();
-        let mut events = EventChannel::<InputEvent<String>>::new();
+        let mut events = EventChannel::<InputEvent<StringBindings>>::new();
         assert!(!handler.key_is_down(VirtualKeyCode::Up));
         assert!(!handler.scan_code_is_down(104));
         assert!(!handler.button_is_down(Button::Key(VirtualKeyCode::Up)));
@@ -997,7 +1213,7 @@ mod tests {
     #[test]
     fn basic_mouse_check() {
         let mut handler = InputHandler::<StringBindings>::new();
-        let mut events = EventChannel::<InputEvent<String>>::new();
+        let mut events = EventChannel::<InputEvent<StringBindings>>::new();
         assert!(!handler.mouse_button_is_down(MouseButton::Left));
         assert!(!handler.button_is_down(Button::Mouse(MouseButton::Left)));
         handler.send_event(&mouse_press(MouseButton::Left), &mut events, HIDPI);
@@ -1012,7 +1228,7 @@ mod tests {
     fn basic_mouse_wheel_check() {
         use approx::assert_ulps_eq;
         let mut handler = InputHandler::<StringBindings>::new();
-        let mut events = EventChannel::<InputEvent<String>>::new();
+        let mut events = EventChannel::<InputEvent<StringBindings>>::new();
         assert_ulps_eq!(handler.mouse_wheel_value(false), 0.0);
         assert_ulps_eq!(handler.mouse_wheel_value(true), 0.0);
         handler.send_event(&mouse_wheel(0.0, 5.0), &mut events, HIDPI);

--- a/amethyst_input/src/sdl_events_system.rs
+++ b/amethyst_input/src/sdl_events_system.rs
@@ -65,7 +65,7 @@ pub struct SdlEventsSystem<T: BindingTypes> {
 
 type SdlEventsData<'a, T> = (
     Write<'a, InputHandler<T>>,
-    Write<'a, EventChannel<InputEvent<<T as BindingTypes>::Action>>>,
+    Write<'a, EventChannel<InputEvent<T>>>,
 );
 
 impl<'a, T: BindingTypes> RunNow<'a> for SdlEventsSystem<T> {
@@ -127,7 +127,7 @@ impl<T: BindingTypes> SdlEventsSystem<T> {
         &mut self,
         event: &Event,
         handler: &mut InputHandler<T>,
-        output: &mut EventChannel<InputEvent<T::Action>>,
+        output: &mut EventChannel<InputEvent<T>>,
     ) {
         use self::ControllerEvent::*;
 
@@ -209,7 +209,7 @@ impl<T: BindingTypes> SdlEventsSystem<T> {
     fn initialize_controllers(
         &mut self,
         handler: &mut InputHandler<T>,
-        output: &mut EventChannel<InputEvent<T::Action>>,
+        output: &mut EventChannel<InputEvent<T>>,
     ) {
         use crate::controller::ControllerEvent::ControllerConnected;
 

--- a/amethyst_input/src/system.rs
+++ b/amethyst_input/src/system.rs
@@ -33,7 +33,7 @@ impl<T: BindingTypes> InputSystem<T> {
     fn process_event(
         event: &Event,
         handler: &mut InputHandler<T>,
-        output: &mut EventChannel<InputEvent<T::Action>>,
+        output: &mut EventChannel<InputEvent<T>>,
         hidpi: f32,
     ) {
         handler.send_event(event, output, hidpi as f32);
@@ -44,7 +44,7 @@ impl<'a, T: BindingTypes> System<'a> for InputSystem<T> {
     type SystemData = (
         Read<'a, EventChannel<Event>>,
         Write<'a, InputHandler<T>>,
-        Write<'a, EventChannel<InputEvent<T::Action>>>,
+        Write<'a, EventChannel<InputEvent<T>>>,
         ReadExpect<'a, ScreenDimensions>,
     );
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Change Log
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][kc], and this project adheres to
@@ -10,6 +11,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 ## [Unreleased]
 
 ## Breaking changes
+
 * `Float` newtype removed, moved back to `f32` primitive for all values ([#1747])
 
 ### Added
@@ -19,6 +21,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * Add `add_rectangle`, `add_rotated_rectangle`, `add_box`, `add_rotated_box`, `add_circle`, `add_rotated_circle`,
 `add_cylinder`, `add_rotated_cylinder` and `add_sphere` functions to `DebugLinesComponent`
 and the corresponding draw functions to `DebugLines`, to draw simple shapes with debug lines. ([#1766])
+* `InputEvent::AxisMoved` is sent upon button press / release. ([#1512], [#1797])
 
 ### Changed
 
@@ -29,14 +32,14 @@ and the corresponding draw functions to `DebugLines`, to draw simple shapes with
 * Add `load_from_data_async` to Asset Loader. ([#1753])
 * Add `SerializableFormat` marker trait which is now needed to be implemented for all the formats that are supposed to be serialized. ([#1720])
 * Make the GltfSceneOptions field of GltfSceneFormat public. ([#1791])
+ `InputEvent<T>` now takes in the `BindingTypes` as a type parameter. ([#1797])
 
 ### Fixed
+
 * Fix stack overflow on serializing `Box<dyn Format<_>>`. ([#1720])
-
-### Fixed
-
 * Fix animation unwrap on missing animated component. ([#1773])
 
+[#1512]: https://github.com/amethyst/amethyst/issues/1512
 [#1791]: https://github.com/amethyst/amethyst/pull/1791
 [#1766]: https://github.com/amethyst/amethyst/pull/1766
 [#1719]: https://github.com/amethyst/amethyst/pull/1719
@@ -48,6 +51,7 @@ and the corresponding draw functions to `DebugLines`, to draw simple shapes with
 [#1773]: https://github.com/amethyst/amethyst/pull/1773
 [#1753]: https://github.com/amethyst/amethyst/pull/1753
 [#1720]: https://github.com/amethyst/amethyst/pull/1720
+[#1797]: https://github.com/amethyst/amethyst/pull/1797
 
 ## [0.11.0] - 2019-06
 

--- a/examples/arc_ball_camera/main.rs
+++ b/examples/arc_ball_camera/main.rs
@@ -64,7 +64,7 @@ impl SimpleState for ExampleState {
 }
 
 struct CameraDistanceSystem {
-    event_reader: Option<ReaderId<InputEvent<String>>>,
+    event_reader: Option<ReaderId<InputEvent<StringBindings>>>,
 }
 
 impl CameraDistanceSystem {
@@ -75,7 +75,7 @@ impl CameraDistanceSystem {
 
 impl<'a> System<'a> for CameraDistanceSystem {
     type SystemData = (
-        Read<'a, EventChannel<InputEvent<String>>>,
+        Read<'a, EventChannel<InputEvent<StringBindings>>>,
         ReadStorage<'a, Transform>,
         WriteStorage<'a, ArcBallControlTag>,
     );
@@ -104,7 +104,7 @@ impl<'a> System<'a> for CameraDistanceSystem {
         Self::SystemData::setup(res);
 
         self.event_reader = Some(
-            res.fetch_mut::<EventChannel<InputEvent<String>>>()
+            res.fetch_mut::<EventChannel<InputEvent<StringBindings>>>()
                 .register_reader(),
         );
     }

--- a/src/state_event.rs
+++ b/src/state_event.rs
@@ -1,3 +1,6 @@
+use derivative::Derivative;
+use winit::Event;
+
 use crate::{
     core::{
         ecs::{Read, Resources, SystemData},
@@ -5,18 +8,18 @@ use crate::{
         EventReader,
     },
     derive::EventReader,
-    input::InputEvent,
+    input::{BindingTypes, InputEvent, StringBindings},
     ui::UiEvent,
 };
-use winit::Event;
 
 /// The enum holding the different types of event that can be received in a `State` in the
 /// `handle_event` method.
-#[derive(Clone, EventReader, Debug)]
+#[derive(Debug, Derivative, EventReader)]
+#[derivative(Clone(bound = ""))]
 #[reader(StateEventReader)]
-pub enum StateEvent<T = String>
+pub enum StateEvent<T = StringBindings>
 where
-    T: Clone + Send + Sync + 'static,
+    T: BindingTypes,
 {
     /// Events sent by the winit window.
     Window(Event),


### PR DESCRIPTION
## Description

Closes #1512.

## Additions

* `InputEvent::AxisMoved` is sent upon button press / release.

## Changes

* `InputEvent<T>` now takes in the `BindingTypes` as a type parameter. ([#1797])

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all`
- [x] Ran `cargo test --all --features "empty"`
