### PR TITLE
Add EntityUuid component to core

### DIFF
--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -33,6 +33,7 @@ specs-hierarchy = { version = "0.3" }
 shrev = "1.0"
 getset = "0.0.7"
 derive-new = "0.5.6"
+uuid = { version = "0.7", features = ["serde", "v4"] }
 
 thread_profiler = { version = "0.3", optional = true }
 

--- a/amethyst_core/src/entity_uuid.rs
+++ b/amethyst_core/src/entity_uuid.rs
@@ -6,13 +6,14 @@
 //! identification in a networked multiplayer situation.
 
 use fnv::FnvHashMap;
-use hibitset::BitSetLike;
-use shrev::ReaderId;
 use specs::{
-    storage::ComponentEvent, BitSet, Component, Entities, Entity, FlaggedStorage, ReadStorage,
-    Resources, System, SystemData, Write, WriteStorage,
+    Component, Entity, FlaggedStorage,
+    System, Write,
 };
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+
+use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
 
 /// An identifier for an entity which can persist across game sessions, and across machines.
 ///
@@ -20,9 +21,11 @@ use uuid::Uuid;
 /// identification in a networked multiplayer situation.
 ///
 /// Once the Uuid is initialized in this structure it should not be altered.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct EntityUuid {
     uuid: Uuid,
+    #[serde(skip)]
+    dead_signal: Arc<AtomicBool>,
 }
 
 impl Component for EntityUuid {
@@ -30,16 +33,12 @@ impl Component for EntityUuid {
 }
 
 impl EntityUuid {
-    /// Create a new instance with a new randomly generated Uuid.
-    fn new() -> Self {
-        Self {
-            uuid: Uuid::new_v4(),
-        }
-    }
-
     /// Create a new instance with a pre-defined Uuid, typically the Uuid would be deserialized from the disk or network.
     fn new_from_uuid(uuid: Uuid) -> Self {
-        Self { uuid }
+        Self {
+            uuid,
+            dead_signal: Arc::new(AtomicBool::new(false)),
+        }
     }
 
     /// Retrieve the Uuid structure contained in this component.
@@ -48,10 +47,16 @@ impl EntityUuid {
     }
 }
 
+impl Drop for EntityUuid {
+    fn drop(&mut self) {
+        self.dead_signal.store(true, Ordering::Relaxed);
+    }
+}
+
 /// An ECS resource which allows you to create new EntityUuid components, and later retrieve the entities with the contained UUID.
 #[derive(Debug, Default)]
 pub struct EntityUuidMap {
-    map: FnvHashMap<Uuid, Entity>,
+    map: FnvHashMap<Uuid, (Entity, Arc<AtomicBool>)>,
 }
 
 impl EntityUuidMap {
@@ -62,96 +67,92 @@ impl EntityUuidMap {
 
     /// Create a new EntityUuid component with a new randomly generated Uuid.
     pub fn new_uuid(&mut self, e: Entity) -> EntityUuid {
-        let r = EntityUuid::new();
-        self.map.insert(r.uuid, e);
-        r
+        self.with_uuid(Uuid::new_v4(), e)
     }
 
     /// Create a new EntityUuid component with a pre-defined Uuid, typically the Uuid would be deserialized from the disk or network.
     pub fn with_uuid(&mut self, uuid: Uuid, e: Entity) -> EntityUuid {
-        self.map.insert(uuid, e);
-        EntityUuid::new_from_uuid(uuid)
+        let r = EntityUuid::new_from_uuid(uuid);
+        self.map.insert(uuid, (e, r.dead_signal.clone()));
+        r
     }
 
     /// Retrieve the entity associated with this Uuid, if any.
     pub fn fetch_entity(&self, uuid: &Uuid) -> Option<Entity> {
-        self.map.get(uuid).cloned()
+        self.map.get(uuid).map(|v| &v.0).cloned()
     }
 }
 
 /// This system removes unused Uuid<->Entity mappings from the map.
 #[derive(Debug)]
-pub struct EntityUuidSystem {
-    reader: Option<ReaderId<ComponentEvent>>,
-    removed: BitSet,
-}
-
-impl EntityUuidSystem {
-    /// Create a new instance of this system.
-    pub fn new() -> Self {
-        Self {
-            reader: None,
-            removed: BitSet::new(),
-        }
-    }
-}
+pub struct EntityUuidSystem;
 
 impl<'s> System<'s> for EntityUuidSystem {
-    type SystemData = (
-        ReadStorage<'s, EntityUuid>,
-        Write<'s, EntityUuidMap>,
-        Entities<'s>,
-    );
+    type SystemData = Write<'s, EntityUuidMap>;
 
-    fn setup(&mut self, res: &mut Resources) {
-        Self::SystemData::setup(res);
-        self.reader = Some(
-            res.fetch_mut::<WriteStorage<'_, EntityUuid>>()
-                .channel_mut()
-                .register_reader(),
-        );
-    }
-
-    fn run(&mut self, (storage, mut map, entities): Self::SystemData) {
-        self.removed.clear();
-        let self_events_id = &mut self
-            .reader
-            .as_mut()
-            .expect("EntityUuidSystem::setup was not called before EntityUuidSystem::run");
-        for event in storage.channel().read(self_events_id) {
-            match event {
-                ComponentEvent::Removed(id) => {
-                    self.removed.add(*id);
-                }
-                _ => {}
-            }
-        }
-        for entity in (&self.removed).iter().map(|i| entities.entity(i)) {
-            map.map.retain(|_, &mut e| e != entity);
-        }
+    fn run(&mut self, mut map: Self::SystemData) {
+        map.map.retain(|_, (_, a)| !a.load(Ordering::Relaxed));
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use specs::{world::Builder, World};
+    use specs::{world::Builder, World, DispatcherBuilder};
     use uuid::Uuid;
 
     #[test]
     fn test_uuid_map() {
-        let mut m = EntityUuidMap::new();
         let mut w = World::new();
+        w.register::<EntityUuid>();
+        let mut d = DispatcherBuilder::new()
+            .with(EntityUuidSystem, "entity_uuid", &[])
+            .build();
+        d.setup(&mut w.res);
         let e1 = w.create_entity().build();
         let e2 = w.create_entity().build();
-        let u1 = m.new_uuid(e1);
-        let u2 = m.new_uuid(e2);
+        let uc1 = w.write_resource::<EntityUuidMap>().new_uuid(e1);
+        let u1 = uc1.uuid().clone();
+        let uc2 = w.write_resource::<EntityUuidMap>().new_uuid(e2);
+        let u2 = uc2.uuid().clone();
+        w.write_storage::<EntityUuid>().insert(e1, uc1).unwrap();
+        w.write_storage::<EntityUuid>().insert(e2, uc2).unwrap();
         assert_ne!(u1, u2);
-        assert_eq!(m.fetch_entity(u1.uuid()), Some(e1));
-        assert_eq!(m.fetch_entity(u2.uuid()), Some(e2));
+        assert_eq!(w.read_resource::<EntityUuidMap>().fetch_entity(&u1), Some(e1));
+        assert_eq!(w.read_resource::<EntityUuidMap>().fetch_entity(&u2), Some(e2));
         let u = Uuid::new_v4();
         let e3 = w.create_entity().build();
-        assert_eq!(m.with_uuid(u, e3).uuid(), &u);
-        assert_eq!(m.fetch_entity(&u), Some(e3));
+        let uc3 = w.write_resource::<EntityUuidMap>().with_uuid(u, e3);
+        let u3 = uc3.uuid().clone();
+        w.write_storage::<EntityUuid>().insert(e3, uc3).unwrap();
+        assert_eq!(u3, u);
+        assert_eq!(w.read_resource::<EntityUuidMap>().fetch_entity(&u), Some(e3));
+        w.delete_entity(e1).unwrap();
+        d.dispatch(&mut w.res);
+        assert_eq!(w.read_resource::<EntityUuidMap>().fetch_entity(&u1), None);
+        assert_eq!(w.read_resource::<EntityUuidMap>().fetch_entity(&u2), Some(e2));
+        assert_eq!(w.read_resource::<EntityUuidMap>().fetch_entity(&u3), Some(e3));
+
+        // Now we're going to create an entity with a UUID, delete it, and then
+        // make another in the same frame. Since we're only checking by id
+        // in the system, this makes sure we don't risk deleting a UUID
+        // if the entity index were to be re-used.
+        let e4 = w.create_entity().build();
+        let uc4 = w.write_resource::<EntityUuidMap>().new_uuid(e4);
+        let u4 = uc4.uuid().clone();
+        w.write_storage::<EntityUuid>().insert(e4, uc4).unwrap();
+        w.delete_entity(e4).unwrap();
+        let e5 = w.create_entity().build();
+        let uc5 = w.write_resource::<EntityUuidMap>().new_uuid(e5);
+        let u5 = uc5.uuid().clone();
+        w.write_storage::<EntityUuid>().insert(e5, uc5).unwrap();
+        d.dispatch(&mut w.res);
+        assert_eq!(w.read_resource::<EntityUuidMap>().fetch_entity(&u1), None);
+        assert_eq!(w.read_resource::<EntityUuidMap>().fetch_entity(&u2), Some(e2));
+        assert_eq!(w.read_resource::<EntityUuidMap>().fetch_entity(&u3), Some(e3));
+        assert_eq!(w.read_resource::<EntityUuidMap>().fetch_entity(&u4), None);
+        assert_eq!(w.read_resource::<EntityUuidMap>().fetch_entity(&u5), Some(e5));
+
+
     }
 }

--- a/amethyst_core/src/entity_uuid.rs
+++ b/amethyst_core/src/entity_uuid.rs
@@ -6,7 +6,7 @@
 //! identification in a networked multiplayer situation.
 
 use fnv::FnvHashMap;
-use specs::{Entity, Entities, System, Write};
+use specs::{Entities, Entity, System, Write};
 use uuid::Uuid;
 
 /// An ECS resource that presents a bi-directional mapping between Uuids and Entities.
@@ -79,10 +79,7 @@ impl EntityUuidMap {
 pub struct EntityUuidSystem;
 
 impl<'s> System<'s> for EntityUuidSystem {
-    type SystemData = (
-        Write<'s, EntityUuidMap>,
-        Entities<'s>,
-    );
+    type SystemData = (Write<'s, EntityUuidMap>, Entities<'s>);
 
     fn run(&mut self, (mut map, entities): Self::SystemData) {
         map.maintain(&entities);
@@ -92,7 +89,7 @@ impl<'s> System<'s> for EntityUuidSystem {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use specs::{World, world::Builder, System, SystemData};
+    use specs::{world::Builder, System, SystemData, World};
 
     #[test]
     fn test_uuid_map() {
@@ -129,7 +126,7 @@ mod tests {
             assert_eq!(e.fetch_uuid(e1), Some(&u3));
             assert_eq!(e.fetch_uuid(e2), Some(&u4));
         }
-        
+
         w.delete_entity(e1).unwrap();
         w.delete_entity(e2).unwrap();
         let mut s = EntityUuidSystem;

--- a/amethyst_core/src/entity_uuid.rs
+++ b/amethyst_core/src/entity_uuid.rs
@@ -1,0 +1,101 @@
+//! This module provides the EntityUuid component, and the EntityUuidMap resource.
+//!
+//! Together, these can be used to create entity identifiers that can persist across game sessions, and across machines.
+//!
+//! These properties make them useful for serializing a reference to an entity to disk, such as saving the game, or for
+//! identification in a networked multiplayer situation.
+
+use fnv::FnvHashMap;
+use specs::{Component, DenseVecStorage, Entity};
+use uuid::Uuid;
+
+/// An identifier for an entity which can persist across game sessions, and across machines.
+///
+/// These properties make it useful for serializing a reference to an entity to disk, such as saving the game, or for
+/// identification in a networked multiplayer situation.
+///
+/// Once the Uuid is initialized in this structure it should not be altered.
+#[derive(Debug, Eq, PartialEq)]
+pub struct EntityUuid {
+    uuid: Uuid,
+}
+
+impl Component for EntityUuid {
+    type Storage = DenseVecStorage<Self>;
+}
+
+impl EntityUuid {
+    /// Create a new instance with a new randomly generated Uuid.
+    fn new() -> Self {
+        Self {
+            uuid: Uuid::new_v4(),
+        }
+    }
+
+    /// Create a new instance with a pre-defined Uuid, typically the Uuid would be deserialized from the disk or network.
+    fn new_from_uuid(uuid: Uuid) -> Self {
+        Self { uuid }
+    }
+
+    /// Retrieve the Uuid structure contained in this component.
+    pub fn uuid(&self) -> &Uuid {
+        &self.uuid
+    }
+}
+
+/// An ECS resource which allows you to create new EntityUuid components, and later retrieve the entities with the contained UUID.
+#[derive(Debug)]
+pub struct EntityUuidMap {
+    map: FnvHashMap<Uuid, Entity>,
+}
+
+impl EntityUuidMap {
+    /// Create an empty instance of this resource.
+    pub fn new() -> Self {
+        Self {
+            map: FnvHashMap::default(),
+        }
+    }
+
+    /// Create a new EntityUuid component with a new randomly generated Uuid.
+    pub fn new_uuid(&mut self, e: Entity) -> EntityUuid {
+        let r = EntityUuid::new();
+        self.map.insert(r.uuid, e);
+        r
+    }
+
+    /// Create a new EntityUuid component with a pre-defined Uuid, typically the Uuid would be deserialized from the disk or network.
+    pub fn with_uuid(&mut self, uuid: Uuid, e: Entity) -> EntityUuid {
+        self.map.insert(uuid, e);
+        EntityUuid::new_from_uuid(uuid)
+    }
+
+    /// Retrieve the entity associated with this Uuid, if any.
+    pub fn fetch_entity(&self, uuid: &Uuid) -> Option<Entity> {
+        self.map.get(uuid).cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use specs::{world::Builder, World};
+    use uuid::Uuid;
+
+    #[test]
+    fn test_uuid_map() {
+        let mut m = EntityUuidMap::new();
+        let mut w = World::new();
+        let e1 = w.create_entity().build();
+        let e2 = w.create_entity().build();
+        let u1 = m.new_uuid(e1);
+        let u2 = m.new_uuid(e2);
+        assert_ne!(u1, u2);
+        assert_eq!(m.fetch_entity(u1.uuid()), Some(e1));
+        assert_eq!(m.fetch_entity(u2.uuid()), Some(e2));
+        let u = Uuid::new_v4();
+        let e3 = w.create_entity().build();
+        assert_eq!(m.with_uuid(u, e3).uuid(), &u);
+        assert_eq!(m.fetch_entity(&u), Some(e3));
+    }
+}

--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -44,6 +44,7 @@ pub use self::{
 };
 
 pub mod bundle;
+pub mod entity_uuid;
 pub mod frame_limiter;
 pub mod timing;
 pub mod transform;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * Add `add_rectangle`, `add_rotated_rectangle`, `add_box`, `add_rotated_box`, `add_circle`, `add_rotated_circle`,
 `add_cylinder`, `add_rotated_cylinder` and `add_sphere` functions to `DebugLinesComponent`
 and the corresponding draw functions to `DebugLines`, to draw simple shapes with debug lines. ([#1766])
-* Add `EntityUuid` component for tracking entities across game sessions, and across networked machines. ([#1798])
+* Add `EntityUuidMap` resource for tracking entities across game sessions, and across networked machines. ([#1798])
 
 ### Changed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * Add `add_rectangle`, `add_rotated_rectangle`, `add_box`, `add_rotated_box`, `add_circle`, `add_rotated_circle`,
 `add_cylinder`, `add_rotated_cylinder` and `add_sphere` functions to `DebugLinesComponent`
 and the corresponding draw functions to `DebugLines`, to draw simple shapes with debug lines. ([#1766])
+* Add `EntityUuid` component for tracking entities across game sessions, and across networked machines. ([#1798])
 
 ### Changed
 
@@ -48,6 +49,7 @@ and the corresponding draw functions to `DebugLines`, to draw simple shapes with
 [#1773]: https://github.com/amethyst/amethyst/pull/1773
 [#1753]: https://github.com/amethyst/amethyst/pull/1753
 [#1720]: https://github.com/amethyst/amethyst/pull/1720
+[#1798]: https://github.com/amethyst/amethyst/pull/1798
 
 ## [0.11.0] - 2019-06
 


### PR DESCRIPTION
## Description

Oftentimes while developing a game it's useful to have an entity reference that persists across game sessions, and across networked machines. Uuids serve this purpose quite well, as machines can generate them independently of each other with no fear of ID collisions. So, this PR adds the notion of an Entity Uuid to core, such that it can be used across Amethyst itself, and by downstream users.

## Additions

- amethyst_core::entity_uuid module
  - EntityUuidSystem
  - EntityUuidMap resource.

## Removals

None

## Modifications

None

## PR Checklist

By placing an x in the boxes I certify that I have:

- N/A Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all`
- [x] Ran `cargo test --all --features "empty"`