### PR TITLE
make sentry an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT/Apache-2.0"
 travis-ci = { repository = "amethyst/amethyst", branch = "master" }
 
 [features]
-default = ["animation", "audio", "locale", "network", "renderer"]
+default = ["animation", "audio", "locale", "network", "renderer", "sentry"]
 
 vulkan = ["amethyst_rendy/vulkan"]
 metal = ["amethyst_rendy/metal"]
@@ -126,7 +126,7 @@ fern = { version = "0.5", features = ["colored"] }
 log = { version = "0.4.6", features = ["serde"] }
 rayon = "1.0.2"
 rustc_version_runtime = "0.1"
-sentry = "0.15.4"
+sentry = { version = "0.15.4", optional = true}
 winit = { version = "0.19", features = ["serde", "icon_loading"] }
 serde = { version = "1.0", features = ["derive"] }
 palette = { version = "0.4", features = ["serde"] }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ### Added
 
+* Add a feature flag `sentry` to disable the sentry dependency. ([#1804])
 * Fixes and renames regression from ([#1442]) added back `position_from_world` as `screen_to_world`. Also added
 `world_to_screen`. Also adds `Transform::copy_local_to_global()' for `debug_assertion` builds ([#1733])
 * Add `add_rectangle`, `add_rotated_rectangle`, `add_box`, `add_rotated_box`, `add_circle`, `add_rotated_circle`,
@@ -37,6 +38,7 @@ and the corresponding draw functions to `DebugLines`, to draw simple shapes with
 
 * Fix animation unwrap on missing animated component. ([#1773])
 
+[#1804]: https://github.com/amethyst/amethyst/pull/1804
 [#1791]: https://github.com/amethyst/amethyst/pull/1791
 [#1766]: https://github.com/amethyst/amethyst/pull/1766
 [#1719]: https://github.com/amethyst/amethyst/pull/1719

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,6 +6,7 @@ use crate::shred::Resource;
 use derivative::Derivative;
 use log::{debug, info, log_enabled, trace, Level};
 use rayon::ThreadPoolBuilder;
+#[cfg(feature = "sentry")]
 use sentry::integrations::panic::register_panic_handler;
 use winit::Event;
 
@@ -221,6 +222,7 @@ where
     where
         for<'b> R: EventReader<'b, Event = E>,
     {
+        #[cfg(feature = "sentry")]
         let _sentry_guard = if let Some(dsn) = option_env!("SENTRY_DSN") {
             let guard = sentry::init(dsn);
             register_panic_handler();
@@ -493,8 +495,11 @@ where
         info!("Version: {}", env!("CARGO_PKG_VERSION"));
         info!("Platform: {}", env!("VERGEN_TARGET_TRIPLE"));
         info!("Amethyst git commit: {}", env!("VERGEN_SHA"));
-        if let Some(sentry) = option_env!("SENTRY_DSN") {
-            info!("Sentry DSN: {}", sentry);
+        #[cfg(feature = "sentry")]
+        {
+            if let Some(sentry) = option_env!("SENTRY_DSN") {
+                info!("Sentry DSN: {}", sentry);
+            }
         }
 
         let rustc_meta = rustc_version_runtime::version_meta();


### PR DESCRIPTION
## Description

sentry pulls in the whole reqwest (hyper/tokio) depencency tree. With this feature flag those depencies can be avoided.

on my local project (almost empty) this reduces the compile time quite a bit. Using opt-level=1
```
# no-sentry
$ touch src/main.rs && cargo build
Finished dev [unoptimized + debuginfo] target(s) in 16.38s

# sentry
$ touch src/main.rs && cargo build
Finished dev [unoptimized + debuginfo] target(s) in 41.64s
```


## Additions
* Add a feature flag `sentry` to disable the sentry dependency.

## Removals

## Modifications

## PR Checklist
- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all`
- [ ] Ran `cargo test --all --features "empty"`