### PR TITLE
Correctly describe how to enable the nightly feature on Amethyst in the pong tutorial

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -334,7 +334,19 @@ thread 'main' panicked at 'Tried to fetch a resource of type "amethyst::ecs::sto
 Try adding the resource by inserting it manually or using the `setup` method.'
 ```
 
-To turn on the `nightly` feature, run: `cargo +nightly run --features nightly`.
+To turn on the `nightly` feature, enable the `nightly` flag for the Amethyst crate in your Cargo.toml file.
+#### In Dependencies:
+```
+[dependencies]
+amethyst = { version = "X.XX", features = ["nightly"] }
+```
+#### In Separate Table:
+```
+[dependencies.amethyst]
+version = "X.XX"
+features = ["nightly"]
+```
+Run using the nightly channel if you don't have it as your default: `cargo +nightly run`.
 
 For a `Component` to be used, there must be a `Storage<ComponentType>` resource
 set up in the `World`. The error message above means we have registered the

--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -334,7 +334,8 @@ thread 'main' panicked at 'Tried to fetch a resource of type "amethyst::ecs::sto
 Try adding the resource by inserting it manually or using the `setup` method.'
 ```
 
-To turn on the `nightly` feature, enable the `nightly` flag for the Amethyst crate in your Cargo.toml file.
+To turn on the `nightly` feature, enable the `nightly` flag for the Amethyst crate in your Cargo.toml file.  
+Use *one* of the below methods for declaring dependencies (using both will result in an error):
 #### In Dependencies:
 ```
 [dependencies]
@@ -346,7 +347,7 @@ amethyst = { version = "X.XX", features = ["nightly"] }
 version = "X.XX"
 features = ["nightly"]
 ```
-Run using the nightly channel if you don't have it as your default: `cargo +nightly run`.
+Run the project using the nightly channel if you don't have it as your default: `cargo +nightly run`.
 
 For a `Component` to be used, there must be a `Storage<ComponentType>` resource
 set up in the `World`. The error message above means we have registered the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,6 +57,7 @@ and the corresponding draw functions to `DebugLines`, to draw simple shapes with
 [#1720]: https://github.com/amethyst/amethyst/pull/1720
 [#1797]: https://github.com/amethyst/amethyst/pull/1797
 [#1772]: https://github.com/amethyst/amethyst/pull/1772
+[#1805]: https://github.com/amethyst/amethyst/pull/1805
 
 ## [0.11.0] - 2019-06
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,7 @@ and the corresponding draw functions to `DebugLines`, to draw simple shapes with
 * Add `SerializableFormat` marker trait which is now needed to be implemented for all the formats that are supposed to be serialized. ([#1720])
 * Make the GltfSceneOptions field of GltfSceneFormat public. ([#1791])
  `InputEvent<T>` now takes in the `BindingTypes` as a type parameter. ([#1797])
+* Fix the steps for enabling the nightly flag in the pong tutorial ([#1805])
 
 ### Fixed
 


### PR DESCRIPTION
## Description
Following the current directions in the pong tutorial for enabling the nightly flag results in an error saying 
```
error: Package `pong v0.1.0 (/home/user/git/pong)` does not have these features: `nightly`
```
This aligns the tutorial with the FAQ which describes how to do the same thing.

## Additions
- N/A

## Removals
- N/A

## Modifications
- Pong tutorial steps for enabling the nightly flag on Amethyst

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- ~Added unit tests for new code added in this PR.~
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- ~Ran `cargo +stable fmt --all`~
- ~Ran `cargo clippy --all`~
- ~Ran `cargo test --all --features "empty"`~