### PR TITLE
Add clarification to Shape docs

### DIFF
--- a/amethyst_rendy/src/shape.rs
+++ b/amethyst_rendy/src/shape.rs
@@ -88,11 +88,12 @@ where
 /// Shape generators
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub enum Shape {
-    /// Sphere, number of points around the equator, number of points pole to pole
+    /// Sphere, number of points around the equator, number of points pole to pole.
+    /// Sphere has radius of 1, so it's diameter is 2 units
     Sphere(usize, usize),
     /// Cone, number of subdivisions around the radius, must be > 1
     Cone(usize),
-    /// Cube
+    /// Cube with vertices in [-1, +1] range, so it's width is 2 units
     Cube,
     /// Cylinder, number of points across the radius, optional subdivides along the height
     Cylinder(usize, Option<usize>),


### PR DESCRIPTION

## Description

It's not obvious that the size of the cube is 1 for newcomers like me, so it would be nice have this information in docs.
Also see https://github.com/gfx-rs/genmesh/issues/38

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all`
- [ ] Ran `cargo test --all --features "empty"`