### PR TITLE
Fixed compilation errors in `render_test_bundle`.

### DIFF
--- a/amethyst_rendy/src/render_test_bundle.rs
+++ b/amethyst_rendy/src/render_test_bundle.rs
@@ -1,21 +1,17 @@
-use std::{marker::PhantomData, ops::Deref, sync::Arc};
+use std::marker::PhantomData;
 
-use amethyst_assets::Processor;
-use amethyst_core::{
-    bundle::SystemBundle,
-    ecs::{DispatcherBuilder, ReadExpect, Resources, SystemData},
-};
+use amethyst_core::{bundle::SystemBundle, ecs::DispatcherBuilder};
 use amethyst_error::Error;
 use derive_new::new;
 
-use crate::{sprite::SpriteSheet, types::Backend, RenderingBundle};
+use crate::{types::Backend, RenderingBundle};
 
 /// Adds basic rendering system to the dispatcher.
 ///
 /// This test bundle requires the user to also add the `TransformBundle`.
 ///
-/// This is only meant for testing and only provides very basic sprite rendering. You need to enable the
-/// `test-support` flag to use this.
+/// This is only meant for testing and only provides very basic sprite rendering. You need to enable
+/// the `test-support` flag to use this.
 #[derive(Debug, new)]
 pub struct RenderTestBundle<B>(PhantomData<B>);
 
@@ -24,7 +20,8 @@ where
     B: Backend,
 {
     fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<(), Error> {
-        let mut bundle = RenderingBundle::<B>::new().with_plugin(crate::plugins::RenderFlat2D);
+        let mut bundle =
+            RenderingBundle::<B>::new().with_plugin(crate::plugins::RenderFlat2D::default());
 
         #[cfg(feature = "window")]
         bundle.add_plugin(crate::plugins::RenderToWindow::from_config(
@@ -34,8 +31,7 @@ where
             },
         ));
 
-        bundle.build(builder);
-
+        bundle.build(builder)?;
         Ok(())
     }
 }
@@ -53,7 +49,7 @@ where
 {
     fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<(), Error> {
         let bundle = RenderingBundle::<B>::new();
-        bundle.build(builder);
+        bundle.build(builder)?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Description

Fixed compilation errors and warnings in `render_test_bundle.rs`. Related to #1771.

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Updated the content of the book if this PR would make the book outdated.
- **n/a** Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all`
- [x] Ran `cargo test --all --features "empty"`