### PR TITLE
Fix to issue #1768: SpriteSheetFormat is wrongly documented

### DIFF
--- a/amethyst_rendy/src/sprite/mod.rs
+++ b/amethyst_rendy/src/sprite/mod.rs
@@ -414,6 +414,7 @@ impl SpriteGrid {
 ///
 /// Example:
 /// ```text,ignore
+/// #![enable(implicit_some)]
 /// (
 ///     // Width of the texture
 ///     texture_width: 48,


### PR DESCRIPTION
## Description

this just corrects the example for SpriteSheetFormat to have an #![enable(implicit_some)]

## Additions

## Removals

## Modifications

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
