### PR TITLE
[WIP] raw Render Graph creation

### DIFF
--- a/amethyst_rendy/src/lib.rs
+++ b/amethyst_rendy/src/lib.rs
@@ -91,7 +91,7 @@ mod render_test_bundle;
 
 #[doc(inline)]
 pub use crate::{
-    bundle::{RenderPlugin, RenderingBundle},
+    bundle::{RenderingBundle, PluggableRenderingBundle, RenderPlugin},
     camera::{ActiveCamera, Camera},
     formats::{
         mesh::MeshPrefab,
@@ -100,7 +100,7 @@ pub use crate::{
     mtl::{Material, MaterialDefaults},
     plugins::*,
     sprite::{Sprite, SpriteRender, SpriteSheet, SpriteSheetFormat},
-    system::{GraphCreator, RenderingSystem},
+    system::{GraphCreator, MeshProcessorSystem, RenderingSystem, TextureProcessorSystem},
     transparent::Transparent,
     types::{Backend, Mesh, Texture},
     util::{simple_shader_set, ChangeDetection},

--- a/amethyst_rendy/src/render_test_bundle.rs
+++ b/amethyst_rendy/src/render_test_bundle.rs
@@ -4,7 +4,7 @@ use amethyst_core::{bundle::SystemBundle, ecs::DispatcherBuilder};
 use amethyst_error::Error;
 use derive_new::new;
 
-use crate::{types::Backend, RenderingBundle};
+use crate::{types::Backend, PluggableRenderingBundle};
 
 /// Adds basic rendering system to the dispatcher.
 ///
@@ -20,8 +20,8 @@ where
     B: Backend,
 {
     fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<(), Error> {
-        let mut bundle =
-            RenderingBundle::<B>::new().with_plugin(crate::plugins::RenderFlat2D::default());
+        let mut bundle = PluggableRenderingBundle::<B>::new()
+            .with_plugin(crate::plugins::RenderFlat2D::default());
 
         #[cfg(feature = "window")]
         bundle.add_plugin(crate::plugins::RenderToWindow::from_config(
@@ -48,7 +48,7 @@ where
     B: Backend,
 {
     fn build(self, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<(), Error> {
-        let bundle = RenderingBundle::<B>::new();
+        let bundle = PluggableRenderingBundle::<B>::new();
         bundle.build(builder)?;
         Ok(())
     }

--- a/amethyst_rendy/src/system.rs
+++ b/amethyst_rendy/src/system.rs
@@ -187,8 +187,8 @@ where
 /// Asset processing system for `Mesh` asset type.
 #[derive(Debug, derivative::Derivative)]
 #[derivative(Default(bound = ""))]
-pub struct MeshProcessor<B: Backend>(PhantomData<B>);
-impl<'a, B: Backend> System<'a> for MeshProcessor<B> {
+pub struct MeshProcessorSystem<B: Backend>(PhantomData<B>);
+impl<'a, B: Backend> System<'a> for MeshProcessorSystem<B> {
     type SystemData = (
         Write<'a, AssetStorage<Mesh>>,
         ReadExpect<'a, QueueId>,
@@ -226,8 +226,8 @@ impl<'a, B: Backend> System<'a> for MeshProcessor<B> {
 /// Asset processing system for `Texture` asset type.
 #[derive(Debug, derivative::Derivative)]
 #[derivative(Default(bound = ""))]
-pub struct TextureProcessor<B: Backend>(PhantomData<B>);
-impl<'a, B: Backend> System<'a> for TextureProcessor<B> {
+pub struct TextureProcessorSystem<B: Backend>(PhantomData<B>);
+impl<'a, B: Backend> System<'a> for TextureProcessorSystem<B> {
     type SystemData = (
         Write<'a, AssetStorage<Texture>>,
         ReadExpect<'a, QueueId>,

--- a/examples/animation/main.rs
+++ b/examples/animation/main.rs
@@ -11,7 +11,7 @@ use amethyst::{
         plugins::{RenderPbr3D, RenderToWindow},
         rendy::mesh::{Normal, Position, Tangent, TexCoord},
         types::DefaultBackend,
-        RenderingBundle,
+        PluggableRenderingBundle,
     },
     utils::{application_root_dir, scene::BasicScenePrefab},
     winit::{ElementState, VirtualKeyCode},
@@ -231,7 +231,7 @@ fn main() -> amethyst::Result<()> {
         ))?
         .with_bundle(TransformBundle::new().with_dep(&["sampler_interpolation_system"]))?
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path).with_clear(CLEAR_COLOR),
                 )

--- a/examples/arc_ball_camera/main.rs
+++ b/examples/arc_ball_camera/main.rs
@@ -17,7 +17,7 @@ use amethyst::{
         plugins::{RenderShaded3D, RenderSkybox, RenderToWindow},
         rendy::mesh::{Normal, Position, TexCoord},
         types::DefaultBackend,
-        RenderingBundle,
+        PluggableRenderingBundle,
     },
     utils::{application_root_dir, scene::BasicScenePrefab},
     Error,
@@ -122,7 +122,7 @@ fn main() -> Result<(), Error> {
             &["input_system"],
         )
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 .with_plugin(RenderToWindow::from_config_path(display_config_path))
                 .with_plugin(RenderShaded3D::default())
                 .with_plugin(RenderSkybox::with_colors(

--- a/examples/asset_loading/main.rs
+++ b/examples/asset_loading/main.rs
@@ -18,7 +18,7 @@ use amethyst::{
             texture::palette::load_from_srgba,
         },
         types::{DefaultBackend, Mesh, MeshData},
-        RenderingBundle,
+        PluggableRenderingBundle,
     },
     utils::application_root_dir,
 };
@@ -125,7 +125,7 @@ fn main() -> Result<(), Error> {
         .with_bundle(InputBundle::<StringBindings>::new())?
         .with_bundle(TransformBundle::new())?
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 .with_plugin(RenderToWindow::from_config_path(display_config_path))
                 .with_plugin(RenderShaded3D::default())
                 .with_plugin(RenderSkybox::with_colors(

--- a/examples/auto_fov/main.rs
+++ b/examples/auto_fov/main.rs
@@ -18,7 +18,7 @@ use amethyst::{
         plugins::{RenderShaded3D, RenderToWindow},
         rendy::mesh::{Normal, Position, Tangent, TexCoord},
         types::DefaultBackend,
-        RenderingBundle,
+        PluggableRenderingBundle,
     },
     ui::{RenderUi, UiBundle, UiCreator, UiFinder, UiText},
     utils::{
@@ -49,7 +49,7 @@ fn main() -> Result<(), Error> {
         .with_bundle(InputBundle::<StringBindings>::new())?
         .with_bundle(UiBundle::<StringBindings>::new())?
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path).with_clear(CLEAR_COLOR),
                 )

--- a/examples/custom_game_data/main.rs
+++ b/examples/custom_game_data/main.rs
@@ -20,7 +20,7 @@ use amethyst::{
         plugins::{RenderShaded3D, RenderToWindow},
         rendy::mesh::{Normal, Position, TexCoord},
         types::DefaultBackend,
-        RenderingBundle,
+        PluggableRenderingBundle,
     },
     ui::{RenderUi, UiBundle, UiCreator, UiLoader, UiPrefab},
     utils::{application_root_dir, fps_counter::FpsCounterBundle, scene::BasicScenePrefab},
@@ -210,7 +210,7 @@ fn main() -> Result<(), Error> {
         .with_base_bundle(FpsCounterBundle::default())?
         .with_base_bundle(InputBundle::<StringBindings>::new())?
         .with_base_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path)
                         .with_clear([0.0, 0.0, 0.0, 1.0]),

--- a/examples/custom_ui/main.rs
+++ b/examples/custom_ui/main.rs
@@ -9,7 +9,7 @@ use amethyst::{
         plugins::RenderToWindow,
         rendy::mesh::{Normal, Position, TexCoord},
         types::DefaultBackend,
-        RenderingBundle,
+        PluggableRenderingBundle,
     },
     ui::{RenderUi, ToNativeWidget, UiBundle, UiCreator, UiTransformBuilder, UiWidget},
     utils::{application_root_dir, scene::BasicScenePrefab},
@@ -101,7 +101,7 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(TransformBundle::new())?
         .with_bundle(UiBundle::<StringBindings, CustomUi>::new())?
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path)
                         .with_clear([0.34, 0.36, 0.52, 1.0]),

--- a/examples/debug_lines/main.rs
+++ b/examples/debug_lines/main.rs
@@ -16,7 +16,7 @@ use amethyst::{
         palette::Srgba,
         plugins::{RenderDebugLines, RenderSkybox, RenderToWindow},
         types::DefaultBackend,
-        RenderingBundle,
+        PluggableRenderingBundle,
     },
     utils::application_root_dir,
     winit::VirtualKeyCode,
@@ -186,7 +186,7 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(fly_control_bundle)?
         .with_bundle(TransformBundle::new().with_dep(&["fly_movement"]))?
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 .with_plugin(RenderToWindow::from_config_path(display_config_path))
                 .with_plugin(RenderDebugLines::default())
                 .with_plugin(RenderSkybox::default()),

--- a/examples/debug_lines_ortho/main.rs
+++ b/examples/debug_lines_ortho/main.rs
@@ -13,7 +13,7 @@ use amethyst::{
         palette::Srgba,
         plugins::{RenderDebugLines, RenderToWindow},
         types::DefaultBackend,
-        RenderingBundle,
+        PluggableRenderingBundle,
     },
     utils::application_root_dir,
     window::ScreenDimensions,
@@ -110,7 +110,7 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(TransformBundle::new())?
         .with(ExampleLinesSystem, "example_lines_system", &[])
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path)
                         .with_clear([0.0, 0.0, 0.0, 1.0]),

--- a/examples/fly_camera/main.rs
+++ b/examples/fly_camera/main.rs
@@ -10,7 +10,7 @@ use amethyst::{
         plugins::{RenderShaded3D, RenderToWindow},
         rendy::mesh::{Normal, Position, TexCoord},
         types::DefaultBackend,
-        RenderingBundle,
+        PluggableRenderingBundle,
     },
     utils::{application_root_dir, scene::BasicScenePrefab},
     winit::{MouseButton, VirtualKeyCode},
@@ -78,7 +78,7 @@ fn main() -> Result<(), Error> {
             InputBundle::<StringBindings>::new().with_bindings_from_file(&key_bindings_path)?,
         )?
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path)
                         .with_clear([0.34, 0.36, 0.52, 1.0]),

--- a/examples/gltf/main.rs
+++ b/examples/gltf/main.rs
@@ -20,7 +20,7 @@ use amethyst::{
         light::LightPrefab,
         plugins::{RenderPbr3D, RenderSkybox, RenderToWindow},
         types::DefaultBackend,
-        RenderingBundle,
+        PluggableRenderingBundle,
     },
     utils::{
         application_root_dir,
@@ -214,7 +214,7 @@ fn main() -> Result<(), amethyst::Error> {
             "sampler_interpolation",
         ]))?
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 .with_plugin(RenderToWindow::from_config_path(display_config_path))
                 .with_plugin(RenderPbr3D::default().with_skinning())
                 .with_plugin(RenderSkybox::default()),

--- a/examples/material/main.rs
+++ b/examples/material/main.rs
@@ -14,7 +14,7 @@ use amethyst::{
         },
         shape::Shape,
         types::DefaultBackend,
-        Mesh, RenderingBundle, Texture,
+        Mesh, PluggableRenderingBundle, Texture,
     },
     utils::application_root_dir,
     window::ScreenDimensions,
@@ -150,7 +150,7 @@ fn main() -> amethyst::Result<()> {
     let game_data = GameDataBuilder::default()
         .with_bundle(TransformBundle::new())?
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path)
                         .with_clear([0.34, 0.36, 0.52, 1.0]),

--- a/examples/pong/main.rs
+++ b/examples/pong/main.rs
@@ -14,7 +14,7 @@ use amethyst::{
     renderer::{
         plugins::{RenderFlat2D, RenderToWindow},
         types::DefaultBackend,
-        RenderingBundle,
+        PluggableRenderingBundle,
     },
     ui::{RenderUi, UiBundle},
     utils::application_root_dir,
@@ -74,7 +74,7 @@ fn main() -> amethyst::Result<()> {
         )
         .with_bundle(UiBundle::<StringBindings>::new())?
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 // The RenderToWindow plugin provides all the scaffolding for opening a window and drawing on it
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path)

--- a/examples/pong_tutorial_01/main.rs
+++ b/examples/pong_tutorial_01/main.rs
@@ -5,7 +5,7 @@ use amethyst::{
     renderer::{
         plugins::{RenderFlat2D, RenderToWindow},
         types::DefaultBackend,
-        RenderingBundle,
+        PluggableRenderingBundle,
     },
     utils::application_root_dir,
 };
@@ -21,7 +21,7 @@ fn main() -> amethyst::Result<()> {
     let display_config_path = app_root.join("examples/pong_tutorial_01/config/display.ron");
 
     let game_data = GameDataBuilder::default().with_bundle(
-        RenderingBundle::<DefaultBackend>::new()
+        PluggableRenderingBundle::<DefaultBackend>::new()
             // The RenderToWindow plugin provides all the scaffolding for opening a window and drawing on it
             .with_plugin(
                 RenderToWindow::from_config_path(display_config_path)

--- a/examples/pong_tutorial_02/main.rs
+++ b/examples/pong_tutorial_02/main.rs
@@ -9,7 +9,7 @@ use amethyst::{
     renderer::{
         plugins::{RenderFlat2D, RenderToWindow},
         types::DefaultBackend,
-        RenderingBundle,
+        PluggableRenderingBundle,
     },
     utils::application_root_dir,
 };
@@ -24,7 +24,7 @@ fn main() -> amethyst::Result<()> {
         // Add the transform bundle which handles tracking entity positions
         .with_bundle(TransformBundle::new())?
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 // The RenderToWindow plugin provides all the scaffolding for opening a window and drawing on it
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path)

--- a/examples/pong_tutorial_03/main.rs
+++ b/examples/pong_tutorial_03/main.rs
@@ -11,7 +11,7 @@ use amethyst::{
     renderer::{
         plugins::{RenderFlat2D, RenderToWindow},
         types::DefaultBackend,
-        RenderingBundle,
+        PluggableRenderingBundle,
     },
     utils::application_root_dir,
 };
@@ -33,7 +33,7 @@ fn main() -> amethyst::Result<()> {
         // We have now added our own system, the PaddleSystem, defined in systems/paddle.rs
         .with(systems::PaddleSystem, "paddle_system", &["input_system"])
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 // The RenderToWindow plugin provides all the scaffolding for opening a window and drawing on it
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path)

--- a/examples/pong_tutorial_04/main.rs
+++ b/examples/pong_tutorial_04/main.rs
@@ -11,7 +11,7 @@ use amethyst::{
     renderer::{
         plugins::{RenderFlat2D, RenderToWindow},
         types::DefaultBackend,
-        RenderingBundle,
+        PluggableRenderingBundle,
     },
     utils::application_root_dir,
 };
@@ -39,7 +39,7 @@ fn main() -> amethyst::Result<()> {
             &["paddle_system", "ball_system"],
         )
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 // The RenderToWindow plugin provides all the scaffolding for opening a window and drawing on it
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path)

--- a/examples/pong_tutorial_05/main.rs
+++ b/examples/pong_tutorial_05/main.rs
@@ -11,7 +11,7 @@ use amethyst::{
     renderer::{
         plugins::{RenderFlat2D, RenderToWindow},
         types::DefaultBackend,
-        RenderingBundle,
+        PluggableRenderingBundle,
     },
     ui::{RenderUi, UiBundle},
     utils::application_root_dir,
@@ -44,7 +44,7 @@ fn main() -> amethyst::Result<()> {
         // The renderer must be executed on the same thread consecutively, so we initialize it as thread_local
         // which will always execute on the main thread.
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 // The RenderToWindow plugin provides all the scaffolding for opening a window and drawing on it
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path)

--- a/examples/prefab/main.rs
+++ b/examples/prefab/main.rs
@@ -8,7 +8,7 @@ use amethyst::{
         plugins::{RenderShaded3D, RenderToWindow},
         rendy::mesh::{Normal, Position, TexCoord},
         types::DefaultBackend,
-        RenderingBundle,
+        PluggableRenderingBundle,
     },
     utils::{application_root_dir, scene::BasicScenePrefab},
     Error,
@@ -42,7 +42,7 @@ fn main() -> Result<(), Error> {
         .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[])
         .with_bundle(TransformBundle::new())?
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path)
                         .with_clear([0.34, 0.36, 0.52, 1.0]),

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -26,7 +26,7 @@ use amethyst::{
         rendy::mesh::{Normal, Position, TexCoord},
         resources::AmbientColor,
         types::DefaultBackend,
-        Camera, RenderingBundle,
+        Camera, PluggableRenderingBundle,
     },
     ui::{RenderUi, UiBundle, UiCreator, UiFinder, UiText},
     utils::{
@@ -204,7 +204,7 @@ fn main() -> Result<(), Error> {
         .with_bundle(FpsCounterBundle::default())?
         .with_bundle(InputBundle::<StringBindings>::new())?
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path)
                         .with_clear([0.34, 0.36, 0.52, 1.0]),

--- a/examples/rendy/main.rs
+++ b/examples/rendy/main.rs
@@ -38,9 +38,10 @@ use amethyst::{
         shape::Shape,
         types::{DefaultBackend, Mesh, Texture},
         visibility::BoundingSphere,
-        ActiveCamera, Camera, Factory, ImageFormat, Material, MaterialDefaults, RenderDebugLines,
-        RenderFlat2D, RenderFlat3D, RenderPbr3D, RenderShaded3D, RenderSkybox, RenderToWindow,
-        RenderingBundle, SpriteRender, SpriteSheet, SpriteSheetFormat, Transparent,
+        ActiveCamera, Camera, Factory, ImageFormat, Material, MaterialDefaults,
+        PluggableRenderingBundle, RenderDebugLines, RenderFlat2D, RenderFlat3D, RenderPbr3D,
+        RenderShaded3D, RenderSkybox, RenderToWindow, SpriteRender, SpriteSheet, SpriteSheetFormat,
+        Transparent,
     },
     utils::{
         application_root_dir,
@@ -642,7 +643,7 @@ fn main() -> amethyst::Result<()> {
             "sampler_interpolation",
         ]))?
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 .with_plugin(RenderToWindow::from_config_path(display_config_path))
                 .with_plugin(RenderSwitchable3D::default())
                 .with_plugin(RenderFlat2D::default())

--- a/examples/sphere/main.rs
+++ b/examples/sphere/main.rs
@@ -8,7 +8,7 @@ use amethyst::{
         plugins::{RenderShaded3D, RenderToWindow},
         rendy::mesh::{Normal, Position, TexCoord},
         types::DefaultBackend,
-        RenderingBundle,
+        PluggableRenderingBundle,
     },
     utils::{application_root_dir, scene::BasicScenePrefab},
 };
@@ -37,7 +37,7 @@ fn main() -> amethyst::Result<()> {
         .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[])
         .with_bundle(TransformBundle::new())?
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path)
                         .with_clear([0.34, 0.36, 0.52, 1.0]),

--- a/examples/spotlights/main.rs
+++ b/examples/spotlights/main.rs
@@ -6,7 +6,7 @@ use amethyst::{
         plugins::{RenderPbr3D, RenderToWindow},
         rendy::mesh::{Normal, Position, Tangent, TexCoord},
         types::DefaultBackend,
-        RenderingBundle,
+        PluggableRenderingBundle,
     },
     utils::{application_root_dir, scene::BasicScenePrefab},
 };
@@ -35,7 +35,7 @@ fn main() -> amethyst::Result<()> {
         .with(PrefabLoaderSystem::<MyPrefabData>::default(), "", &[])
         .with_bundle(TransformBundle::new())?
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path)
                         .with_clear([0.34, 0.36, 0.52, 1.0]),

--- a/examples/sprite_animation/main.rs
+++ b/examples/sprite_animation/main.rs
@@ -18,7 +18,7 @@ use amethyst::{
         plugins::{RenderFlat2D, RenderToWindow},
         sprite::{prefab::SpriteScenePrefab, SpriteRender},
         types::DefaultBackend,
-        RenderingBundle,
+        PluggableRenderingBundle,
     },
     utils::application_root_dir,
     window::ScreenDimensions,
@@ -151,7 +151,7 @@ fn main() -> amethyst::Result<()> {
                 .with_dep(&["sprite_animation_control", "sprite_sampler_interpolation"]),
         )?
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path)
                         .with_clear([0.34, 0.36, 0.52, 1.0]),

--- a/examples/sprite_camera_follow/main.rs
+++ b/examples/sprite_camera_follow/main.rs
@@ -7,8 +7,8 @@ use amethyst::{
     renderer::{
         plugins::{RenderFlat2D, RenderToWindow},
         types::DefaultBackend,
-        Camera, ImageFormat, RenderingBundle, SpriteRender, SpriteSheet, SpriteSheetFormat,
-        Texture, Transparent,
+        Camera, ImageFormat, PluggableRenderingBundle, SpriteRender, SpriteSheet,
+        SpriteSheetFormat, Texture, Transparent,
     },
     utils::application_root_dir,
     window::ScreenDimensions,
@@ -210,7 +210,7 @@ fn main() -> amethyst::Result<()> {
         )?
         .with(MovementSystem, "movement", &[])
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path)
                         .with_clear([0.34, 0.36, 0.52, 1.0]),

--- a/examples/sprites_ordered/main.rs
+++ b/examples/sprites_ordered/main.rs
@@ -16,7 +16,8 @@ use amethyst::{
         camera::Projection,
         plugins::{RenderFlat2D, RenderToWindow},
         types::DefaultBackend,
-        Camera, ImageFormat, RenderingBundle, SpriteRender, SpriteSheet, Texture, Transparent,
+        Camera, ImageFormat, PluggableRenderingBundle, SpriteRender, SpriteSheet, Texture,
+        Transparent,
     },
     utils::application_root_dir,
     window::ScreenDimensions,
@@ -370,7 +371,7 @@ fn main() -> amethyst::Result<()> {
     let game_data = GameDataBuilder::default()
         .with_bundle(TransformBundle::new())?
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path)
                         .with_clear([0.34, 0.36, 0.52, 1.0]),

--- a/examples/ui/main.rs
+++ b/examples/ui/main.rs
@@ -11,7 +11,7 @@ use amethyst::{
         plugins::RenderToWindow,
         rendy::mesh::{Normal, Position, TexCoord},
         types::DefaultBackend,
-        RenderingBundle,
+        PluggableRenderingBundle,
     },
     shrev::{EventChannel, ReaderId},
     ui::{RenderUi, UiBundle, UiCreator, UiEvent, UiFinder, UiText},
@@ -136,7 +136,7 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(FpsCounterBundle::default())?
         .with_bundle(InputBundle::<StringBindings>::new())?
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
+            PluggableRenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path)
                         .with_clear([0.34, 0.36, 0.52, 1.0]),


### PR DESCRIPTION
## Description

Related to this PR #1772.

@Frizi Your work to make the Render Graph creation more easy is really nice and I really like this idea. The only problem that I find is that it doesn't allow (anymore) to create a custom render graph.

This removes completely the possibility to deeply customize the rendering and control the pipeline, decreasing a lot the Flexibility of this engine.

I made this PR to make it possible to also define a custom render graph (as before) in order to take advantage of the two solutions.

~~Actually the code that I written allow to specify a custom render graph, but since you moved part of the code from the RenderingSystem inside the plugins is no more possible to easily create a render graph.
For this reason I'm asking your help, to find a solution and make this engine flexible as before.~~

## Modifications
- Renamed `TextureProcessor` to `TextureProcessorSystem` and `MeshProcessor` to `MeshProcessorSystem` to unify `System`s naming.
- Renamed `RenderingBundle` to `PluggableRenderingBundle` and `RenderingBundleGraphCreator` to `PluggableRenderGraphCreator` to better specify the new functionality.
- Added `RenderingBundle` which accept a raw `RenderGraph` that allow more customization of the `Rendering`.

## PR Checklist

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [ ] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
