### PR TITLE
Update Fluent to 0.7

### DIFF
--- a/amethyst_locale/Cargo.toml
+++ b/amethyst_locale/Cargo.toml
@@ -25,10 +25,8 @@ amethyst_assets = { path = "../amethyst_assets", version = "0.8.0" }
 amethyst_core = { path = "../amethyst_core", version = "0.7.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.2.0" }
 serde = { version = "1.0", features = ["derive"] }
-fluent = "0.6.0"
-# `fluent`'s Cargo.toml is happy to take `intl_pluralrules` 1.1.0, but the code is not compatible,
-# so we need to lock this down.
-intl_pluralrules = "=1.0.3"
+fluent = "0.7.0"
+unic-langid = { version = "0.4", features = ["macros"] }
 
 thread_profiler = { version = "0.3", optional = true }
 

--- a/amethyst_locale/src/lib.rs
+++ b/amethyst_locale/src/lib.rs
@@ -9,13 +9,13 @@
     rust_2018_compatibility
 )]
 #![warn(clippy::all)]
-#![allow(clippy::new_without_default)]
 
 use amethyst_assets::{Asset, Format, Handle};
 use amethyst_core::ecs::prelude::VecStorage;
 use amethyst_error::Error;
 pub use fluent::*;
 use serde::{Deserialize, Serialize};
+use unic_langid::langid;
 
 /// Loads the strings from localisation files.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
@@ -33,8 +33,14 @@ impl Format<Locale> for LocaleFormat {
         let s = String::from_utf8(bytes)?;
 
         let resource = FluentResource::try_new(s).expect("Failed to parse locale data");
+        let lang_en = langid!("en");
+        let mut bundle = FluentBundle::new(&[lang_en]);
 
-        Ok(Locale { resource })
+        bundle
+            .add_resource(resource)
+            .expect("Failed to add resource");
+
+        Ok(Locale { bundle })
     }
 }
 
@@ -44,8 +50,8 @@ pub type LocaleHandle = Handle<Locale>;
 /// A loaded locale.
 #[allow(missing_debug_implementations)]
 pub struct Locale {
-    /// The backing fluent resource.
-    pub resource: FluentResource,
+    /// The bundle stores its resources for now.
+    pub bundle: FluentBundle<FluentResource>,
 }
 
 impl Asset for Locale {

--- a/examples/locale/main.rs
+++ b/examples/locale/main.rs
@@ -58,10 +58,20 @@ impl SimpleState for Example {
             let store = data.world.read_resource::<AssetStorage<Locale>>();
             for h in [&self.handle_en, &self.handle_fr].iter() {
                 if let Some(locale) = h.as_ref().and_then(|h| store.get(h)) {
-                    let mut bundle = FluentBundle::new(&[""]);
-                    bundle.add_resource(&locale.resource).unwrap();
-                    println!("{}", bundle.format("hello", None).unwrap().0);
-                    println!("{}", bundle.format("bye", None).unwrap().0);
+                    let bundle = &locale.bundle;
+                    let msg_hello = bundle
+                        .get_message("hello")
+                        .expect("Failed to load message for hello");
+                    let msg_bye = bundle
+                        .get_message("bye")
+                        .expect("Failed to load message for bye");
+                    let hello_value = msg_hello.value.expect("Hello message has no value");
+                    let bye_value = msg_bye.value.expect("Bye message has no value");
+
+                    let mut errors = vec![];
+                    println!("{}", bundle.format_pattern(hello_value, None, &mut errors));
+                    println!("{}", bundle.format_pattern(bye_value, None, &mut errors));
+                    assert_eq!(errors.len(), 0);
                 }
             }
             Trans::Quit


### PR DESCRIPTION
## Description

Updated Fluent to 0.7

## Additions

- See [the changlog for fluent-bundle 0.7](https://github.com/projectfluent/fluent-rs/blob/master/fluent-bundle/CHANGELOG.md)

## Modifications

- Restores the functionality removed in the [update to fluent 0.6](https://github.com/amethyst/amethyst/pull/1800)

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
