### PR TITLE
Use derive_new on amethyst_controls

### DIFF
--- a/amethyst_controls/Cargo.toml
+++ b/amethyst_controls/Cargo.toml
@@ -23,6 +23,7 @@ amethyst_input = { path = "../amethyst_input", version = "0.8.0" }
 serde = { version = "1.0", features = ["derive"] }
 winit = { version = "0.19", features = ["serde"] }
 log = "0.4.6"
+derive-new="0.5.7"
 
 thread_profiler = { version = "0.3", optional = true }
 

--- a/amethyst_controls/src/bundles.rs
+++ b/amethyst_controls/src/bundles.rs
@@ -6,6 +6,8 @@ use amethyst_input::BindingTypes;
 
 use super::*;
 
+use derive_new::new;
+
 /// The bundle that creates a flying movement system.
 ///
 /// Note: Will not actually create a moving entity. It will only register the needed resources and
@@ -27,10 +29,13 @@ use super::*;
 /// * `FreeRotationSystem`
 /// * `MouseFocusUpdateSystem`
 /// * `CursorHideSystem`
-#[derive(Debug)]
+#[derive(new, Debug)]
 pub struct FlyControlBundle<T: BindingTypes> {
+    #[new(value = "1.0")]
     sensitivity_x: f32,
+    #[new(value = "1.0")]
     sensitivity_y: f32,
+    #[new(value = "one()")]
     speed: f32,
     right_input_axis: Option<T::Axis>,
     up_input_axis: Option<T::Axis>,
@@ -38,22 +43,6 @@ pub struct FlyControlBundle<T: BindingTypes> {
 }
 
 impl<T: BindingTypes> FlyControlBundle<T> {
-    /// Builds a new fly control bundle using the provided axes as controls.
-    pub fn new(
-        right_input_axis: Option<T::Axis>,
-        up_input_axis: Option<T::Axis>,
-        forward_input_axis: Option<T::Axis>,
-    ) -> Self {
-        FlyControlBundle {
-            sensitivity_x: 1.0,
-            sensitivity_y: 1.0,
-            speed: one(),
-            right_input_axis,
-            up_input_axis,
-            forward_input_axis,
-        }
-    }
-
     /// Alters the mouse sensitivy on this `FlyControlBundle`
     pub fn with_sensitivity(mut self, x: f32, y: f32) -> Self {
         self.sensitivity_x = x;
@@ -100,25 +89,17 @@ impl<'a, 'b, T: BindingTypes> SystemBundle<'a, 'b> for FlyControlBundle<T> {
 /// The generic parameters A and B are the ones used in InputHandler<A,B>.
 /// You might want to add "fly_movement" and "free_rotation" as dependencies of the TransformSystem.
 /// Adding this bundle will grab the mouse, hide it and keep it centered.
-///
 /// See the `arc_ball_camera` example to see how to use the arc ball camera.
-#[derive(Debug)]
+#[derive(new, Debug)]
 pub struct ArcBallControlBundle<T: BindingTypes> {
+    #[new(value = "1.0")]
     sensitivity_x: f32,
+    #[new(value = "1.0")]
     sensitivity_y: f32,
     _marker: PhantomData<T>,
 }
 
 impl<T: BindingTypes> ArcBallControlBundle<T> {
-    /// Builds a new `ArcBallControlBundle` with a default sensitivity of 1.0
-    pub fn new() -> Self {
-        ArcBallControlBundle {
-            sensitivity_x: 1.0,
-            sensitivity_y: 1.0,
-            _marker: PhantomData,
-        }
-    }
-
     /// Builds a new `ArcBallControlBundle` with the provided mouse sensitivity values.
     pub fn with_sensitivity(mut self, x: f32, y: f32) -> Self {
         self.sensitivity_x = x;

--- a/amethyst_controls/src/bundles.rs
+++ b/amethyst_controls/src/bundles.rs
@@ -1,12 +1,10 @@
 use std::marker::PhantomData;
 
-use amethyst_core::{bundle::SystemBundle, ecs::prelude::DispatcherBuilder, math::one};
+use amethyst_core::{bundle::SystemBundle, ecs::prelude::DispatcherBuilder};
 use amethyst_error::Error;
 use amethyst_input::BindingTypes;
 
 use super::*;
-
-use derive_new::new;
 
 /// The bundle that creates a flying movement system.
 ///
@@ -35,7 +33,7 @@ pub struct FlyControlBundle<T: BindingTypes> {
     sensitivity_x: f32,
     #[new(value = "1.0")]
     sensitivity_y: f32,
-    #[new(value = "one()")]
+    #[new(value = "1.0")]
     speed: f32,
     right_input_axis: Option<T::Axis>,
     up_input_axis: Option<T::Axis>,

--- a/amethyst_controls/src/lib.rs
+++ b/amethyst_controls/src/lib.rs
@@ -21,6 +21,9 @@ pub use self::{
 
 use amethyst_core;
 
+#[macro_use]
+extern crate derive_new;
+
 mod bundles;
 mod components;
 mod resources;

--- a/amethyst_controls/src/resources.rs
+++ b/amethyst_controls/src/resources.rs
@@ -1,7 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-use derive_new::new;
-
 /// Struct which holds information about whether the window is focused.
 /// Written to by MouseFocusUpdateSystem
 #[derive(new, Debug, Clone, Copy, Default, Serialize, Deserialize)]

--- a/amethyst_controls/src/resources.rs
+++ b/amethyst_controls/src/resources.rs
@@ -1,18 +1,14 @@
 use serde::{Deserialize, Serialize};
 
+use derive_new::new;
+
 /// Struct which holds information about whether the window is focused.
 /// Written to by MouseFocusUpdateSystem
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[derive(new, Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct WindowFocus {
     /// If true then the window is actively focused.
+    #[new(value = "true")]
     pub is_focused: bool,
-}
-
-impl WindowFocus {
-    /// Builds a new WindowFocus resource.
-    pub fn new() -> WindowFocus {
-        WindowFocus { is_focused: true }
-    }
 }
 
 /// Resource indicating if the mouse should be grabbed and hidden by the CursorHideSystem

--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -12,8 +12,6 @@ use amethyst_core::{
 use amethyst_input::{get_input_axis_simple, BindingTypes, InputHandler};
 use winit::{DeviceEvent, Event, Window, WindowEvent};
 
-use derive_new::new;
-
 #[cfg(feature = "profiler")]
 use thread_profiler::profile_scope;
 

--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -12,6 +12,8 @@ use amethyst_core::{
 use amethyst_input::{get_input_axis_simple, BindingTypes, InputHandler};
 use winit::{DeviceEvent, Event, Window, WindowEvent};
 
+use derive_new::new;
+
 #[cfg(feature = "profiler")]
 use thread_profiler::profile_scope;
 
@@ -20,7 +22,7 @@ use thread_profiler::profile_scope;
 /// # Type parameters
 ///
 /// * `T`: This are the keys the `InputHandler` is using for axes and actions. Often, this is a `StringBindings`.
-#[derive(Debug)]
+#[derive(new, Debug)]
 pub struct FlyMovementSystem<T: BindingTypes> {
     /// The movement speed of the movement in units per second.
     speed: f32,
@@ -30,23 +32,6 @@ pub struct FlyMovementSystem<T: BindingTypes> {
     up_input_axis: Option<T::Axis>,
     /// The name of the input axis to locally move in the z coordinates.
     forward_input_axis: Option<T::Axis>,
-}
-
-impl<T: BindingTypes> FlyMovementSystem<T> {
-    /// Builds a new `FlyMovementSystem` using the provided speeds and axis controls.
-    pub fn new(
-        speed: f32,
-        right_input_axis: Option<T::Axis>,
-        up_input_axis: Option<T::Axis>,
-        forward_input_axis: Option<T::Axis>,
-    ) -> Self {
-        FlyMovementSystem {
-            speed,
-            right_input_axis,
-            up_input_axis,
-            forward_input_axis,
-        }
-    }
 }
 
 impl<'a, T: BindingTypes> System<'a> for FlyMovementSystem<T> {
@@ -124,22 +109,12 @@ impl<'a> System<'a> for ArcBallRotationSystem {
 /// # Type parameters
 ///
 /// * `T`: This are the keys the `InputHandler` is using for axes and actions. Often, this is a `StringBindings`.
-#[derive(Debug)]
+#[derive(new, Debug)]
 pub struct FreeRotationSystem {
     sensitivity_x: f32,
     sensitivity_y: f32,
+    #[new(default)]
     event_reader: Option<ReaderId<Event>>,
-}
-
-impl FreeRotationSystem {
-    /// Builds a new `FreeRotationSystem` with the specified mouse sensitivity values.
-    pub fn new(sensitivity_x: f32, sensitivity_y: f32) -> Self {
-        FreeRotationSystem {
-            sensitivity_x,
-            sensitivity_y,
-            event_reader: None,
-        }
-    }
 }
 
 impl<'a> System<'a> for FreeRotationSystem {
@@ -187,16 +162,10 @@ impl<'a> System<'a> for FreeRotationSystem {
 }
 
 /// A system which reads Events and saves if a window has lost focus in a WindowFocus resource
-#[derive(Debug, Default)]
+#[derive(new, Debug, Default)]
 pub struct MouseFocusUpdateSystem {
+    #[new(default)]
     event_reader: Option<ReaderId<Event>>,
-}
-
-impl MouseFocusUpdateSystem {
-    /// Builds a new MouseFocusUpdateSystem.
-    pub fn new() -> MouseFocusUpdateSystem {
-        MouseFocusUpdateSystem::default()
-    }
 }
 
 impl<'a> System<'a> for MouseFocusUpdateSystem {
@@ -226,16 +195,10 @@ impl<'a> System<'a> for MouseFocusUpdateSystem {
 
 /// System which hides the cursor when the window is focused.
 /// Requires the usage MouseFocusUpdateSystem at the same time.
-#[derive(Debug, Default)]
+#[derive(new, Debug, Default)]
 pub struct CursorHideSystem {
+    #[new(default)]
     is_hidden: bool,
-}
-
-impl CursorHideSystem {
-    /// Constructs a new CursorHideSystem
-    pub fn new() -> CursorHideSystem {
-        CursorHideSystem { is_hidden: false }
-    }
 }
 
 impl<'a> System<'a> for CursorHideSystem {


### PR DESCRIPTION
## Description

Use derive_new crates for amethyst_controls crate

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [X] Ran `cargo +stable fmt --all`
- [X] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"
