### PR TITLE
Link to GitHub Contributors in AUTHORS.md

### DIFF
--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -1,33 +1,5 @@
 # Authors
 
-* Aceeri
-* Colin Sherratt
-* Demur Rumed
-* Douglas Eugene Reisinger II
-* Dzmitry Malyshau
-* Emil Gardström
-* Eyal Kalderon
-* happenslol (Hilmar Wiegand)
-* Hittherhod
-* Ilya Bogdanov
-* Joël Lupien
-* khskarl (Karll Henning)
-* Konstantin Zverev
-* Lucas Ince
-* Lucio Franco
-* Lukas Schmierer
-* Matthias Schuster
-* Moxinilian (Théo Degioanni)
-* msiglreith
-* NCrashed (Anton Gushcha)
-* Nikita Chashchinskii
-* Oflor
-* ohnoimdead (Tres Henry)
-* Robbie Cooper
-* Scott Corbeil
-* Simon Rönnberg
-* Thomas Schaller
-* White-Oak
-* Xaeroxe (Jacob Kiesel)
-* Telzhaak
-* Alve™ (Alve Larsson)
+See the [GitHub Contributors][contributors] list.
+
+[contributors]: https://github.com/amethyst/amethyst/graphs/contributors


### PR DESCRIPTION
## Description

Replace the out-of-date authors list with a link to the GitHub contributors.

Resolves #1844

## Additions

N/A

## Removals

N/A

## Modifications

N/A

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

<!--If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
-->