### PR TITLE
no_inline all the things

### DIFF
--- a/amethyst_animation/src/lib.rs
+++ b/amethyst_animation/src/lib.rs
@@ -54,8 +54,10 @@
 #![warn(clippy::all)]
 #![allow(clippy::new_without_default)]
 
+#[doc(no_inline)]
 pub use minterpolate::{InterpolationFunction, InterpolationPrimitive};
 
+#[doc(no_inline)]
 pub use self::{
     bundle::{AnimationBundle, SamplingBundle, VertexSkinningBundle},
     material::{MaterialChannel, MaterialPrimitive},

--- a/amethyst_animation/src/skinning/mod.rs
+++ b/amethyst_animation/src/skinning/mod.rs
@@ -1,3 +1,4 @@
+#[doc(no_inline)]
 pub use self::{resources::*, systems::*};
 
 mod resources;

--- a/amethyst_animation/src/systems/mod.rs
+++ b/amethyst_animation/src/systems/mod.rs
@@ -2,6 +2,7 @@ use amethyst_assets::Processor;
 
 use crate::resources::{Animation, Sampler};
 
+#[doc(no_inline)]
 pub use self::{control::AnimationControlSystem, sampling::SamplerInterpolationSystem};
 
 mod control;

--- a/amethyst_assets/src/lib.rs
+++ b/amethyst_assets/src/lib.rs
@@ -10,7 +10,9 @@
 #![warn(missing_docs, rust_2018_idioms, rust_2018_compatibility)]
 
 #[cfg(feature = "json")]
+#[doc(no_inline)]
 pub use crate::formats::JsonFormat;
+#[doc(no_inline)]
 pub use crate::{
     asset::{Asset, Format, FormatValue, ProcessableAsset, SerializableFormat},
     cache::Cache,
@@ -25,6 +27,7 @@ pub use crate::{
     storage::{AssetStorage, Handle, ProcessingState, Processor, WeakHandle},
 };
 
+#[doc(no_inline)]
 pub use rayon::ThreadPool;
 
 mod asset;

--- a/amethyst_assets/src/prefab/mod.rs
+++ b/amethyst_assets/src/prefab/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     Asset, AssetStorage, Format, Handle, Loader, Progress, ProgressCounter, SerializableFormat,
 };
 
+#[doc(no_inline)]
 pub use self::system::PrefabLoaderSystem;
 
 mod impls;

--- a/amethyst_assets/src/source/mod.rs
+++ b/amethyst_assets/src/source/mod.rs
@@ -1,5 +1,6 @@
 use amethyst_error::Error;
 
+#[doc(no_inline)]
 pub use self::dir::Directory;
 
 #[cfg(feature = "profiler")]

--- a/amethyst_audio/src/components/mod.rs
+++ b/amethyst_audio/src/components/mod.rs
@@ -1,5 +1,6 @@
 //! `amethyst` audio ecs components
 
+#[doc(no_inline)]
 pub use self::{audio_emitter::AudioEmitter, audio_listener::AudioListener};
 
 use amethyst_assets::PrefabData;

--- a/amethyst_audio/src/lib.rs
+++ b/amethyst_audio/src/lib.rs
@@ -8,6 +8,7 @@
 #![warn(clippy::all)]
 #![allow(clippy::new_without_default)]
 
+#[doc(no_inline)]
 pub use self::{
     bundle::AudioBundle,
     components::*,

--- a/amethyst_audio/src/systems/mod.rs
+++ b/amethyst_audio/src/systems/mod.rs
@@ -1,5 +1,6 @@
 //! `amethyst` audio ecs systems
 
+#[doc(no_inline)]
 pub use self::{audio::AudioSystem, dj::DjSystem};
 
 mod audio;

--- a/amethyst_controls/src/lib.rs
+++ b/amethyst_controls/src/lib.rs
@@ -9,6 +9,7 @@
 #![warn(clippy::all)]
 #![allow(clippy::new_without_default)]
 
+#[doc(no_inline)]
 pub use self::{
     bundles::{ArcBallControlBundle, FlyControlBundle},
     components::{ArcBallControlTag, ControlTagPrefab, FlyControlTag},

--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -28,6 +28,7 @@ use rayon;
 
 use std::sync::Arc;
 
+#[doc(no_inline)]
 pub use crate::{
     bundle::SystemBundle,
     event::EventReader,
@@ -36,6 +37,7 @@ pub use crate::{
     transform::*,
 };
 
+#[doc(no_inline)]
 pub use self::{
     axis::{Axis2, Axis3},
     hidden::{Hidden, HiddenPropagate},

--- a/amethyst_core/src/transform/components/mod.rs
+++ b/amethyst_core/src/transform/components/mod.rs
@@ -1,5 +1,6 @@
 //! Components for the transform processor.
 
+#[doc(no_inline)]
 pub use self::{
     parent::{HierarchyEvent, Parent, ParentHierarchy},
     transform::Transform,

--- a/amethyst_core/src/transform/components/parent.rs
+++ b/amethyst_core/src/transform/components/parent.rs
@@ -1,5 +1,6 @@
 use crate::ecs::prelude::{Component, DenseVecStorage, Entity, FlaggedStorage};
 
+#[doc(no_inline)]
 pub use specs_hierarchy::HierarchyEvent;
 use specs_hierarchy::{Hierarchy, Parent as HParent};
 

--- a/amethyst_core/src/transform/mod.rs
+++ b/amethyst_core/src/transform/mod.rs
@@ -1,5 +1,6 @@
 //! `amethyst` transform ecs module
 
+#[doc(no_inline)]
 pub use self::{bundle::TransformBundle, components::*, systems::*};
 
 pub mod bundle;

--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -18,6 +18,7 @@
 #![warn(clippy::all)]
 #![allow(clippy::new_without_default)]
 
+#[doc(no_inline)]
 pub use backtrace::Backtrace;
 use std::{
     borrow::Cow,

--- a/amethyst_gltf/src/lib.rs
+++ b/amethyst_gltf/src/lib.rs
@@ -27,6 +27,7 @@ use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, ops::Range};
 
+#[doc(no_inline)]
 pub use crate::format::GltfSceneFormat;
 
 mod error;

--- a/amethyst_input/src/lib.rs
+++ b/amethyst_input/src/lib.rs
@@ -10,7 +10,9 @@
 #![allow(clippy::new_without_default)]
 
 #[cfg(feature = "sdl_controller")]
+#[doc(no_inline)]
 pub use self::sdl_events_system::SdlEventsSystem;
+#[doc(no_inline)]
 pub use self::{
     axis::Axis,
     bindings::{BindingError, BindingTypes, Bindings, StringBindings},
@@ -26,6 +28,7 @@ pub use self::{
         is_key_up, is_mouse_button_down,
     },
 };
+#[doc(no_inline)]
 pub use winit::{ElementState, VirtualKeyCode};
 
 use std::iter::Iterator;

--- a/amethyst_locale/src/lib.rs
+++ b/amethyst_locale/src/lib.rs
@@ -13,6 +13,7 @@
 use amethyst_assets::{Asset, Format, Handle};
 use amethyst_core::ecs::prelude::VecStorage;
 use amethyst_error::Error;
+#[doc(no_inline)]
 pub use fluent::*;
 use serde::{Deserialize, Serialize};
 use unic_langid::langid;

--- a/amethyst_network/src/lib.rs
+++ b/amethyst_network/src/lib.rs
@@ -9,6 +9,7 @@
 #![warn(clippy::all)]
 #![allow(clippy::new_without_default)]
 
+#[doc(no_inline)]
 pub use crate::{
     bundle::NetworkBundle,
     connection::{ConnectionState, NetConnection, NetIdentity},

--- a/amethyst_network/src/server/mod.rs
+++ b/amethyst_network/src/server/mod.rs
@@ -1,4 +1,5 @@
 mod config;
 mod host;
 
+#[doc(no_inline)]
 pub use self::{config::ServerConfig, host::Host};

--- a/amethyst_rendy/src/lib.rs
+++ b/amethyst_rendy/src/lib.rs
@@ -54,9 +54,9 @@ extern crate shred_derive;
 #[macro_use]
 mod macros;
 
-#[doc(inline)]
+#[doc(no_inline)]
 pub use palette;
-#[doc(inline)]
+#[doc(no_inline)]
 pub use rendy;
 
 pub mod pass;
@@ -89,7 +89,7 @@ pub mod util;
 #[cfg(feature = "test-support")]
 mod render_test_bundle;
 
-#[doc(inline)]
+#[doc(no_inline)]
 pub use crate::{
     bundle::{RenderPlugin, RenderingBundle},
     camera::{ActiveCamera, Camera},
@@ -107,8 +107,10 @@ pub use crate::{
 };
 
 #[cfg(feature = "test-support")]
+#[doc(no_inline)]
 pub use render_test_bundle::{RenderEmptyBundle, RenderTestBundle};
 
+#[doc(no_inline)]
 pub use rendy::{
     factory::Factory,
     graph::{
@@ -121,5 +123,6 @@ pub use rendy::{
 pub mod loaders {
     //! Loaders re-exported from `rendy` for loading the most common image types as textures.
 
+    #[doc(no_inline)]
     pub use rendy::texture::palette::{load_from_linear_rgba, load_from_srgb, load_from_srgba};
 }

--- a/amethyst_rendy/src/pass/mod.rs
+++ b/amethyst_rendy/src/pass/mod.rs
@@ -8,6 +8,7 @@ mod pbr;
 mod shaded;
 mod skybox;
 
+#[doc(no_inline)]
 pub use self::{base_3d::*, debug_lines::*, flat::*, flat2d::*, pbr::*, shaded::*, skybox::*};
 
 use rendy::{hal::pso::ShaderStageFlags, shader::SpirvShader};

--- a/amethyst_rendy/src/plugins.rs
+++ b/amethyst_rendy/src/plugins.rs
@@ -13,6 +13,7 @@ use palette::Srgb;
 use rendy::graph::render::RenderGroupDesc;
 
 #[cfg(feature = "window")]
+#[doc(no_inline)]
 pub use window::RenderToWindow;
 
 #[cfg(feature = "window")]

--- a/amethyst_rendy/src/submodules/mod.rs
+++ b/amethyst_rendy/src/submodules/mod.rs
@@ -9,10 +9,17 @@ mod vertex;
 
 pub mod gather;
 
+#[doc(no_inline)]
 pub use environment::*;
+#[doc(no_inline)]
 pub use flat_environment::*;
+#[doc(no_inline)]
 pub use material::*;
+#[doc(no_inline)]
 pub use skinning::*;
+#[doc(no_inline)]
 pub use texture::*;
+#[doc(no_inline)]
 pub use uniform::*;
+#[doc(no_inline)]
 pub use vertex::*;

--- a/amethyst_test/src/fixture/mod.rs
+++ b/amethyst_test/src/fixture/mod.rs
@@ -3,6 +3,7 @@
 //! Technically all effect and assertion functions can be moved here if it is useful for external
 //! crates.
 
+#[doc(no_inline)]
 pub use self::{
     material_animation_fixture::MaterialAnimationFixture,
     sprite_render_animation_fixture::SpriteRenderAnimationFixture,

--- a/amethyst_test/src/lib.rs
+++ b/amethyst_test/src/lib.rs
@@ -312,6 +312,7 @@
 //! # }
 //! ```
 
+#[doc(no_inline)]
 pub use crate::{
     amethyst_application::{AmethystApplication, HIDPI, SCREEN_HEIGHT, SCREEN_WIDTH},
     effect_return::EffectReturn,

--- a/amethyst_test/src/prelude.rs
+++ b/amethyst_test/src/prelude.rs
@@ -1,3 +1,4 @@
 //! Commonly used imports.
 
+#[doc(no_inline)]
 pub use crate::{AmethystApplication, EffectReturn, FunctionState, PopState, SequencerState};

--- a/amethyst_test/src/state/mod.rs
+++ b/amethyst_test/src/state/mod.rs
@@ -1,3 +1,4 @@
+#[doc(no_inline)]
 pub use self::{
     custom_dispatcher_state::{CustomDispatcherState, CustomDispatcherStateBuilder},
     function_state::FunctionState,

--- a/amethyst_ui/src/button/mod.rs
+++ b/amethyst_ui/src/button/mod.rs
@@ -1,3 +1,4 @@
+#[doc(no_inline)]
 pub use self::{
     actions::{UiButtonAction, UiButtonActionType},
     builder::{UiButtonBuilder, UiButtonBuilderResources},

--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -9,6 +9,7 @@
 #![warn(clippy::all)]
 #![allow(clippy::new_without_default)]
 
+#[doc(no_inline)]
 pub use self::{
     blink::BlinkSystem,
     bundle::UiBundle,

--- a/amethyst_utils/src/lib.rs
+++ b/amethyst_utils/src/lib.rs
@@ -9,6 +9,7 @@
 #![warn(clippy::all)]
 #![allow(clippy::new_without_default)]
 
+#[doc(no_inline)]
 pub use self::app_root_dir::*;
 
 pub mod app_root_dir;

--- a/amethyst_window/src/lib.rs
+++ b/amethyst_window/src/lib.rs
@@ -17,7 +17,9 @@ mod resources;
 mod system;
 
 #[cfg(feature = "test-support")]
+#[doc(no_inline)]
 pub use crate::bundle::{SCREEN_HEIGHT, SCREEN_WIDTH};
+#[doc(no_inline)]
 pub use crate::{
     bundle::WindowBundle,
     config::DisplayConfig,
@@ -25,4 +27,5 @@ pub use crate::{
     resources::ScreenDimensions,
     system::{EventsLoopSystem, WindowSystem},
 };
+#[doc(no_inline)]
 pub use winit::{Icon, Window};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,10 +85,12 @@ pub use amethyst_utils as utils;
 pub use amethyst_window as window;
 pub use winit;
 
+#[doc(no_inline)]
 pub use crate::core::{ecs, shred, shrev};
 #[doc(hidden)]
 pub use crate::derive::*;
 
+#[doc(no_inline)]
 pub use self::{
     app::{Application, ApplicationBuilder, CoreApplication},
     callback_queue::{Callback, CallbackQueue},

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,3 +1,4 @@
+#[doc(no_inline)]
 pub use log::LevelFilter;
 
 use log::debug;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,6 @@
 //! Contains common types that can be glob-imported (`*`) for convenience.
 
+#[doc(no_inline)]
 pub use crate::{
     app::{Application, ApplicationBuilder, CoreApplication},
     callback_queue::{Callback, CallbackQueue},


### PR DESCRIPTION
## Description

Adds `#[doc(no_inline)]` to pretty much all of the re-exports across all Amethyst crates.

This is potentially controversial, but as I've been recently been trying to learn Amethyst, the abundance of re-exports makes it incredibly difficult for me to learn what things are part of Amethyst and which things are re-exports from other crates.

One downside is that many of these items will not properly link to the documentation for the crates they're a part of, as these crates do not include a [`#![doc(html_root_url)]`](https://doc.rust-lang.org/rustdoc/the-doc-attribute.html#testattr) attribute. This is a bug of these crates and I don't think that a good solution is inlining these items.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] ~~Updated the content of the book if this PR would make the book outdated.~~ (N/A)
- [X] ~~Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.~~ (don't think it needs one; let me know if it should)
- [x] ~~Added unit tests for new code added in this PR.~~ (N/A)
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
