### PR TITLE
Exposed dispatcher operation trait

### DIFF
--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -30,6 +30,7 @@ specs = { version = "0.15", features = ["shred-derive"] }
 specs-hierarchy = "0.5.1"
 getset = "0.0.7"
 derive-new = "0.5.6"
+derivative = "1.0"
 
 thread_profiler = { version = "0.3", optional = true }
 

--- a/amethyst_core/src/deferred_dispatcher_operation.rs
+++ b/amethyst_core/src/deferred_dispatcher_operation.rs
@@ -1,0 +1,168 @@
+//! Provides the ability to store `Systems`, `Bundles`, `Barriers`, in a normal vector for deferred dispatcher construction.
+
+use std::marker::PhantomData;
+
+use derivative::Derivative;
+
+use amethyst_error::Error;
+
+use crate::{
+    ecs::prelude::{DispatcherBuilder, RunNow, System, World},
+    RunNowDesc, SystemBundle, SystemDesc,
+};
+
+/// Trait to capture deferred dispatcher builder operations.
+pub trait DispatcherOperation<'a, 'b> {
+    /// Executes the dispatcher builder instruction.
+    fn exec(
+        self: Box<Self>,
+        world: &mut World,
+        dispatcher_builder: &mut DispatcherBuilder<'a, 'b>,
+    ) -> Result<(), Error>;
+}
+
+/// Deferred operation Add Barrier
+#[derive(Debug)]
+pub struct AddBarrier;
+
+impl<'a, 'b> DispatcherOperation<'a, 'b> for AddBarrier {
+    fn exec(
+        self: Box<Self>,
+        _world: &mut World,
+        dispatcher_builder: &mut DispatcherBuilder<'a, 'b>,
+    ) -> Result<(), Error> {
+        dispatcher_builder.add_barrier();
+        Ok(())
+    }
+}
+
+/// Deferred operation Add System
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct AddSystem<S> {
+    /// System object
+    #[derivative(Debug = "ignore")]
+    pub system: S,
+    /// System name
+    pub name: &'static str,
+    /// System dependencies list
+    pub dependencies: &'static [&'static str],
+}
+
+impl<'a, 'b, S> DispatcherOperation<'a, 'b> for AddSystem<S>
+where
+    S: for<'s> System<'s> + Send + 'a,
+{
+    fn exec(
+        self: Box<Self>,
+        _world: &mut World,
+        dispatcher_builder: &mut DispatcherBuilder<'a, 'b>,
+    ) -> Result<(), Error> {
+        dispatcher_builder.add(self.system, self.name, self.dependencies);
+        Ok(())
+    }
+}
+
+/// Deferred operation Add System Desc
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct AddSystemDesc<SD, S> {
+    /// System description
+    #[derivative(Debug = "ignore")]
+    pub system_desc: SD,
+    /// System name
+    pub name: &'static str,
+    /// System dependencies
+    pub dependencies: &'static [&'static str],
+    /// Generic type holder
+    pub marker: PhantomData<S>,
+}
+
+impl<'a, 'b, SD, S> DispatcherOperation<'a, 'b> for AddSystemDesc<SD, S>
+where
+    SD: SystemDesc<'a, 'b, S>,
+    S: for<'s> System<'s> + Send + 'a,
+{
+    fn exec(
+        self: Box<Self>,
+        world: &mut World,
+        dispatcher_builder: &mut DispatcherBuilder<'a, 'b>,
+    ) -> Result<(), Error> {
+        let system = self.system_desc.build(world);
+        dispatcher_builder.add(system, self.name, self.dependencies);
+        Ok(())
+    }
+}
+
+/// Deferred operation Add Thread Local
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct AddThreadLocal<S> {
+    /// System object
+    #[derivative(Debug = "ignore")]
+    pub system: S,
+}
+
+impl<'a, 'b, S> DispatcherOperation<'a, 'b> for AddThreadLocal<S>
+where
+    S: for<'c> RunNow<'c> + 'b,
+{
+    fn exec(
+        self: Box<Self>,
+        _world: &mut World,
+        dispatcher_builder: &mut DispatcherBuilder<'a, 'b>,
+    ) -> Result<(), Error> {
+        dispatcher_builder.add_thread_local(self.system);
+        Ok(())
+    }
+}
+
+/// Deferred operation Add Thread Local Desc
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct AddThreadLocalDesc<SD, S> {
+    /// System description
+    #[derivative(Debug = "ignore")]
+    pub system_desc: SD,
+    /// Generic type holder
+    pub marker: PhantomData<S>,
+}
+
+impl<'a, 'b, SD, S> DispatcherOperation<'a, 'b> for AddThreadLocalDesc<SD, S>
+where
+    SD: RunNowDesc<'a, 'b, S>,
+    S: for<'c> RunNow<'c> + 'b,
+{
+    fn exec(
+        self: Box<Self>,
+        world: &mut World,
+        dispatcher_builder: &mut DispatcherBuilder<'a, 'b>,
+    ) -> Result<(), Error> {
+        let system = self.system_desc.build(world);
+        dispatcher_builder.add_thread_local(system);
+        Ok(())
+    }
+}
+
+/// Deferred operation Add Bundle
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct AddBundle<B> {
+    /// Bundle object
+    #[derivative(Debug = "ignore")]
+    pub bundle: B,
+}
+
+impl<'a, 'b, B> DispatcherOperation<'a, 'b> for AddBundle<B>
+where
+    B: SystemBundle<'a, 'b>,
+{
+    fn exec(
+        self: Box<Self>,
+        world: &mut World,
+        dispatcher_builder: &mut DispatcherBuilder<'a, 'b>,
+    ) -> Result<(), Error> {
+        self.bundle.build(world, dispatcher_builder)?;
+        Ok(())
+    }
+}

--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -40,10 +40,11 @@ pub use self::{
     hidden::{Hidden, HiddenPropagate},
     hide_system::HideHierarchySystem,
     named::{Named, WithNamed},
-    system_desc::SystemDesc,
+    system_desc::{RunNowDesc, SystemDesc},
 };
 
 pub mod bundle;
+pub mod deferred_dispatcher_operation;
 pub mod frame_limiter;
 pub mod timing;
 pub mod transform;

--- a/amethyst_core/src/system_desc.rs
+++ b/amethyst_core/src/system_desc.rs
@@ -1,9 +1,22 @@
-use specs::{System, World};
+use specs::{RunNow, System, World};
 
 /// Initializes a `System` with some interaction with the `World`.
 pub trait SystemDesc<'a, 'b, S>
 where
     S: System<'a>,
+{
+    /// Builds and returns a `System`.
+    ///
+    /// # Parameters
+    ///
+    /// * `world`: `World` that the system will run on.
+    fn build(self, world: &mut World) -> S;
+}
+
+/// Initializes a `RunNow` with some interaction with the `World`.
+pub trait RunNowDesc<'a, 'b, S>
+where
+    S: RunNow<'b>,
 {
     /// Builds and returns a `System`.
     ///

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * `SystemDesc` proc macro derive to simplify defining `SystemDesc`s. ([#1780])
 * `UiButtonData` is now exported from `amethyst_ui` and can be used for custom widgets. ([#1859])
 * Add an audio subchapter to the pong chapter. ([#1842])
+* Add `DispatcherOperation` to store dispatcher build logic, which can be executed lazily. ([#1870])
+
 
 ### Changed
 
@@ -29,6 +31,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1780]: https://github.com/amethyst/amethyst/pull/1780
 [#1859]: https://github.com/amethyst/amethyst/pull/1859
 [#1842]: https://github.com/amethyst/amethyst/pull/1842
+[#1870]: https://github.com/amethyst/amethyst/pull/1870
 
 ## [0.12.0] - 2019-07-30
 


### PR DESCRIPTION
## Description

I need to construct a `Dispatcher` composed by many parts. So I need, to collect all the `Systems` that compose it, and then I can build the `Dispatcher`.

To create such a thing, I need something similar to the deferred operations that @jojolepro already worked on.

In order to prevent code duplication, my idea is to move it inside the amethyst_core.
Moving this inside the core, allow to use this mechanism even with a custom GameData, and will reduce code duplication even more.

For this reasons, I'm moving it inside the core, in this way these are exposed and more easy to use.

## Modifications

- Moved the `DispatcherOperation` and all related to it, inside the `amethyst_core`.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
