### PR TITLE
Add libX11-devel to the Fedora dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ $ pacman -Sy grep gcc pkgconfig openssl alsa-lib cmake make python3 freetype2 aw
 ### Fedora
 
 ```
-# dnf install pkgconfig gcc openssl-devel alsa-lib-devel cmake make gcc-c++ freetype-devel expat-devel libxcb-devel
+# dnf install pkgconfig gcc openssl-devel alsa-lib-devel cmake make gcc-c++ freetype-devel expat-devel libxcb-devel libX11-devel
 ```
 
 ### openSUSE


### PR DESCRIPTION
## Description

When building an amethyst project, the compiler errored out (Fedora 28):

```
[local@computer client]$ cargo run
   Compiling x11 v2.18.1
   Compiling alsa-sys v0.1.2
   Compiling nonzero_signed v1.0.3
   Compiling libm v0.1.4
error: failed to run custom build command for `x11 v2.18.1`

Caused by:
  process didn't exit successfully: `/home/alexanderlyon/Programming/rustown/client/target/debug/build/x11-9893ff11b522b7a6/build-script-build` (exit code: 101)
--- stderr
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Failure { command: "\"pkg-config\" \"--libs\" \"--cflags\" \"x11\" \"x11 >= 1.4.99.1\"", output: Output { status: ExitStatus(ExitStatus(256)), stdout: "", stderr: "Package x11 was not found in the pkg-config search path.\nPerhaps you should add the directory containing `x11.pc\'\nto the PKG_CONFIG_PATH environment variable\nPackage \'x11\', required by \'virtual:world\', not found\nPackage \'x11\', required by \'virtual:world\', not found\n" } }', src/libcore/result.rs:1084:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.

warning: build failed, waiting for other jobs to finish...
error: build failed
```

This error was resolved by installing `libX11-devel`, which I have added to the readme.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
