### PR TITLE
Maintenance/update amethyst test

### DIFF
--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -230,13 +230,6 @@ impl<'a, 'b> SystemDesc<'a, 'b, CursorHideSystem> for CursorHideSystemDesc {
     fn build(self, world: &mut World) -> CursorHideSystem {
         <CursorHideSystem as System<'_>>::SystemData::setup(world);
 
-        let win = world.fetch::<Window>();
-
-        if let Err(err) = win.grab_cursor(true) {
-            log::error!("Unable to grab the cursor. Error: {:?}", err);
-        }
-        win.hide_cursor(true);
-
         CursorHideSystem::new()
     }
 }

--- a/amethyst_derive/tests/test.rs
+++ b/amethyst_derive/tests/test.rs
@@ -108,7 +108,7 @@ mod tests {
     macro_rules! assert_prefab {
         ($prefab_type:ident, $prefab:expr, $assertion:expr) => {
             assert!(AmethystApplication::blank()
-                .with_system(
+                .with_system_desc(
                     PrefabLoaderSystemDesc::<$prefab_type>::default(),
                     "test_loader",
                     &[]

--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -23,7 +23,7 @@ amethyst_rendy = { path = "../amethyst_rendy", version = "0.2.0" }
 err-derive = "0.1"
 base64 = "0.10"
 fnv = "1"
-gltf = "0.12"
+gltf = "0.13"
 gfx = "0.17"
 hibitset = { version = "0.5.1", features = ["parallel"] }
 itertools = "0.7"

--- a/amethyst_test/src/amethyst_application.rs
+++ b/amethyst_test/src/amethyst_application.rs
@@ -2,7 +2,7 @@ use std::{any::Any, marker::PhantomData, panic, path::PathBuf, sync::Mutex};
 
 use amethyst::{
     self,
-    core::{transform::TransformBundle, EventReader, SystemBundle, SystemDesc},
+    core::{transform::TransformBundle, EventReader, RunNowDesc, SystemBundle, SystemDesc},
     ecs::prelude::*,
     error::Error,
     input::{BindingTypes, InputBundle},
@@ -17,8 +17,8 @@ use derivative::Derivative;
 use lazy_static::lazy_static;
 
 use crate::{
-    CustomDispatcherStateBuilder, FunctionState, GameUpdate, SequencerState, SystemInjectionBundle,
-    ThreadLocalInjectionBundle,
+    CustomDispatcherStateBuilder, FunctionState, GameUpdate, SequencerState,
+    SystemDescInjectionBundle, SystemInjectionBundle, ThreadLocalInjectionBundle,
 };
 
 type BundleAddFn = Box<
@@ -366,8 +366,8 @@ where
         self.resource_add_fns
             .push(Box::new(move |world: &mut World| {
                 let resource = resource_opt.take();
-                if resource.is_some() {
-                    world.insert(resource.unwrap());
+                if let Some(resource) = resource {
+                    world.insert(resource);
                 }
             }));
         self
@@ -393,37 +393,78 @@ where
     ///
     /// # Parameters
     ///
+    /// * `system`: `System` to run.
+    /// * `name`: Name to register the system with, used for dependency ordering.
+    /// * `deps`: Names of systems that must run before this system.
+    pub fn with_system<Sys>(
+        self,
+        system: Sys,
+        name: &'static str,
+        deps: &'static [&'static str],
+    ) -> Self
+    where
+        Sys: for<'sys_local> System<'sys_local> + Send + 'static,
+    {
+        self.with_bundle_fn(move || SystemInjectionBundle::new(system, name, deps))
+    }
+
+    /// Registers a `System` into this application's `GameData`.
+    ///
+    /// # Parameters
+    ///
     /// * `system_desc`: Descriptor to instantiate the `System`.
     /// * `name`: Name to register the system with, used for dependency ordering.
     /// * `deps`: Names of systems that must run before this system.
-    pub fn with_system<N, SD, S>(self, system_desc: SD, name: N, deps: &[N]) -> Self
+    pub fn with_system_desc<SD, S>(
+        self,
+        system_desc: SD,
+        name: &'static str,
+        deps: &'static [&'static str],
+    ) -> Self
     where
-        N: Into<String> + Clone,
         SD: SystemDesc<'static, 'static, S> + Send + Sync + 'static,
         S: for<'sys_local> System<'sys_local> + Send + 'static,
     {
-        let name = name.into();
-        let deps = deps
-            .iter()
-            .map(|dep| dep.clone().into())
-            .collect::<Vec<String>>();
-        self.with_bundle_fn(move || SystemInjectionBundle::new(system_desc, name, deps))
+        self.with_bundle_fn(move || SystemDescInjectionBundle::new(system_desc, name, deps))
     }
 
     /// Registers a thread local `System` into this application's `GameData`.
     ///
     /// # Parameters
     ///
-    /// * `system_desc`: Descriptor to instantiate the thread local system.
-    pub fn with_thread_local<SD, S>(self, system_desc: SD) -> Self
+    /// * `run_now_desc`: Descriptor to instantiate the thread local system.
+    pub fn with_thread_local<RNDesc, RN>(self, run_now_desc: RNDesc) -> Self
     where
-        SD: SystemDesc<'static, 'static, S> + Send + Sync + 'static,
-        S: for<'sys_local> System<'sys_local> + Send + 'static,
-        // Ideally we can use the following lesser bound, but this would cause a duplication of
-        // traits and types which may not be worth it at this point in time.
-        // S: for<'sys_local> RunNow<'sys_local> + Send + 'static,
+        RNDesc: RunNowDesc<'static, 'static, RN> + Send + Sync + 'static,
+        RN: for<'sys_local> RunNow<'sys_local> + Send + 'static,
     {
-        self.with_bundle_fn(move || ThreadLocalInjectionBundle::new(system_desc))
+        self.with_bundle_fn(move || ThreadLocalInjectionBundle::new(run_now_desc))
+    }
+
+    /// Registers a `System` to run in a `CustomDispatcherState`.
+    ///
+    /// This will run the system once in a dedicated `State`, allowing you to inspect the effects of
+    /// the system after setting up the world to a desired state.
+    ///
+    /// # Parameters
+    ///
+    /// * `system`: `System` to run.
+    /// * `name`: Name to register the system with, used for dependency ordering.
+    /// * `deps`: Names of systems that must run before this system.
+    pub fn with_system_single<Sys>(
+        self,
+        system: Sys,
+        name: &'static str,
+        deps: &'static [&'static str],
+    ) -> Self
+    where
+        Sys: for<'sys_local> System<'sys_local> + Send + Sync + 'static,
+    {
+        self.with_state(move || {
+            CustomDispatcherStateBuilder::new()
+                .with_system(system, name, deps)
+                .build()
+        })
     }
 
     /// Registers a `System` to run in a `CustomDispatcherState`.
@@ -436,20 +477,19 @@ where
     /// * `system_desc`: Descriptor to instantiate the `System`.
     /// * `name`: Name to register the system with, used for dependency ordering.
     /// * `deps`: Names of systems that must run before this system.
-    pub fn with_system_single<N, SD, S>(self, system_desc: SD, name: N, deps: &[N]) -> Self
+    pub fn with_system_desc_single<SD, S>(
+        self,
+        system_desc: SD,
+        name: &'static str,
+        deps: &'static [&'static str],
+    ) -> Self
     where
-        N: Into<String> + Clone,
         SD: SystemDesc<'static, 'static, S> + Send + Sync + 'static,
         S: for<'sys_local> System<'sys_local> + Send + Sync + 'static,
     {
-        let name = name.into();
-        let deps = deps
-            .iter()
-            .map(|dep| dep.clone().into())
-            .collect::<Vec<String>>();
         self.with_state(move || {
             CustomDispatcherStateBuilder::new()
-                .with(system_desc, name, deps)
+                .with_system_desc(system_desc, name, deps)
                 .build()
         })
     }

--- a/amethyst_test/src/amethyst_application.rs
+++ b/amethyst_test/src/amethyst_application.rs
@@ -396,14 +396,14 @@ where
     /// * `system`: `System` to run.
     /// * `name`: Name to register the system with, used for dependency ordering.
     /// * `deps`: Names of systems that must run before this system.
-    pub fn with_system<Sys>(
+    pub fn with_system<S>(
         self,
-        system: Sys,
+        system: S,
         name: &'static str,
         deps: &'static [&'static str],
     ) -> Self
     where
-        Sys: for<'sys_local> System<'sys_local> + Send + 'static,
+        S: for<'sys_local> System<'sys_local> + Send + 'static,
     {
         self.with_bundle_fn(move || SystemInjectionBundle::new(system, name, deps))
     }
@@ -451,14 +451,14 @@ where
     /// * `system`: `System` to run.
     /// * `name`: Name to register the system with, used for dependency ordering.
     /// * `deps`: Names of systems that must run before this system.
-    pub fn with_system_single<Sys>(
+    pub fn with_system_single<S>(
         self,
-        system: Sys,
+        system: S,
         name: &'static str,
         deps: &'static [&'static str],
     ) -> Self
     where
-        Sys: for<'sys_local> System<'sys_local> + Send + Sync + 'static,
+        S: for<'sys_local> System<'sys_local> + Send + Sync + 'static,
     {
         self.with_state(move || {
             CustomDispatcherStateBuilder::new()

--- a/amethyst_test/src/lib.rs
+++ b/amethyst_test/src/lib.rs
@@ -117,13 +117,12 @@
 //!
 //! ```rust,no_run
 //! # use amethyst::{
-//! #     core::{bundle::SystemBundle, SystemDesc},
-//! #     derive::SystemDesc,
+//! #     core::bundle::SystemBundle,
 //! #     ecs::prelude::*,
 //! #     prelude::*,
 //! # };
 //! #
-//! # #[derive(Debug, SystemDesc)]
+//! # #[derive(Debug)]
 //! # struct MySystem;
 //! #
 //! # impl<'s> System<'s> for MySystem {
@@ -174,8 +173,7 @@
 //! ```rust
 //! # use amethyst_test::prelude::*;
 //! # use amethyst::{
-//! #     core::{bundle::SystemBundle, SystemDesc},
-//! #     derive::SystemDesc,
+//! #     core::bundle::SystemBundle,
 //! #     ecs::prelude::*,
 //! #     prelude::*,
 //! # };
@@ -183,8 +181,7 @@
 //! # #[derive(Debug)]
 //! # struct ApplicationResource;
 //! #
-//! # #[derive(Debug, SystemDesc)]
-//! # #[system_desc(insert(ApplicationResource))]
+//! # #[derive(Debug)]
 //! # struct MySystem;
 //! #
 //! # impl<'s> System<'s> for MySystem {
@@ -198,7 +195,8 @@
 //! # impl<'a, 'b> SystemBundle<'a, 'b> for MyBundle {
 //! #     fn build(self, world: &mut World, builder: &mut DispatcherBuilder<'a, 'b>)
 //! #     -> amethyst::Result<()> {
-//! #         builder.add(MySystem.build(world), "my_system", &[]);
+//! #         world.insert(ApplicationResource);
+//! #         builder.add(MySystem, "my_system", &[]);
 //! #         Ok(())
 //! #     }
 //! # }
@@ -224,8 +222,6 @@
 //! ```rust
 //! # use amethyst_test::prelude::*;
 //! # use amethyst::{
-//! #     core::SystemDesc,
-//! #     derive::SystemDesc,
 //! #     ecs::prelude::*,
 //! #     prelude::*,
 //! # };
@@ -236,7 +232,7 @@
 //! #     type Storage = DenseVecStorage<Self>;
 //! # }
 //! #
-//! # #[derive(Debug, SystemDesc)]
+//! # #[derive(Debug)]
 //! # struct MySystem;
 //! #
 //! # impl<'s> System<'s> for MySystem {
@@ -285,8 +281,6 @@
 //! ```rust
 //! # use amethyst_test::prelude::*;
 //! # use amethyst::{
-//! #     core::SystemDesc,
-//! #     derive::SystemDesc,
 //! #     ecs::prelude::*,
 //! #     prelude::*,
 //! # };
@@ -294,7 +288,7 @@
 //! # // !Default
 //! # struct MyResource(pub i32);
 //! #
-//! # #[derive(Debug, SystemDesc)]
+//! # #[derive(Debug)]
 //! # struct MySystem;
 //! #
 //! # impl<'s> System<'s> for MySystem {
@@ -340,6 +334,7 @@ pub use crate::{
     },
 };
 pub(crate) use crate::{
+    system_desc_injection_bundle::SystemDescInjectionBundle,
     system_injection_bundle::SystemInjectionBundle,
     thread_local_injection_bundle::ThreadLocalInjectionBundle,
 };
@@ -350,5 +345,6 @@ mod fixture;
 mod game_update;
 pub mod prelude;
 mod state;
+mod system_desc_injection_bundle;
 mod system_injection_bundle;
 mod thread_local_injection_bundle;

--- a/amethyst_test/src/system_desc_injection_bundle.rs
+++ b/amethyst_test/src/system_desc_injection_bundle.rs
@@ -1,0 +1,45 @@
+use std::marker::PhantomData;
+
+use amethyst::{
+    core::{bundle::SystemBundle, SystemDesc},
+    ecs::prelude::*,
+    error::Error,
+};
+
+use derive_new::new;
+
+/// Adds a specified `System` to the dispatcher.
+#[derive(Debug, new)]
+pub(crate) struct SystemDescInjectionBundle<'a, 'b, SD, S>
+where
+    SD: SystemDesc<'a, 'b, S>,
+    S: for<'s> System<'s> + Send,
+{
+    /// Function to instantiate `System` to add to the dispatcher.
+    system_desc: SD,
+    /// Name to register the system with.
+    system_name: &'static str,
+    /// Names of the system dependencies.
+    system_dependencies: &'static [&'static str],
+    /// Marker.
+    system_marker: PhantomData<(&'a SD, &'b S)>,
+}
+
+impl<'a, 'b, SD, S> SystemBundle<'a, 'b> for SystemDescInjectionBundle<'a, 'b, SD, S>
+where
+    SD: SystemDesc<'a, 'b, S>,
+    S: for<'s> System<'s> + Send + 'a,
+{
+    fn build(
+        self,
+        world: &mut World,
+        builder: &mut DispatcherBuilder<'a, 'b>,
+    ) -> Result<(), Error> {
+        builder.add(
+            self.system_desc.build(world),
+            self.system_name,
+            self.system_dependencies,
+        );
+        Ok(())
+    }
+}

--- a/amethyst_test/src/system_injection_bundle.rs
+++ b/amethyst_test/src/system_injection_bundle.rs
@@ -1,49 +1,31 @@
-use std::marker::PhantomData;
-
-use amethyst::{
-    core::{bundle::SystemBundle, SystemDesc},
-    ecs::prelude::*,
-    error::Error,
-};
+use amethyst::{core::bundle::SystemBundle, ecs::prelude::*, error::Error};
 
 use derive_new::new;
 
 /// Adds a specified `System` to the dispatcher.
 #[derive(Debug, new)]
-pub(crate) struct SystemInjectionBundle<'a, 'b, SD, S>
+pub(crate) struct SystemInjectionBundle<Sys>
 where
-    SD: SystemDesc<'a, 'b, S>,
-    S: for<'s> System<'s> + Send,
+    Sys: for<'s> System<'s> + Send,
 {
     /// Function to instantiate `System` to add to the dispatcher.
-    system_desc: SD,
+    system: Sys,
     /// Name to register the system with.
-    system_name: String,
+    system_name: &'static str,
     /// Names of the system dependencies.
-    system_dependencies: Vec<String>,
-    /// Marker.
-    system_marker: PhantomData<(&'a SD, &'b S)>,
+    system_dependencies: &'static [&'static str],
 }
 
-impl<'a, 'b, SD, S> SystemBundle<'a, 'b> for SystemInjectionBundle<'a, 'b, SD, S>
+impl<'a, 'b, Sys> SystemBundle<'a, 'b> for SystemInjectionBundle<Sys>
 where
-    SD: SystemDesc<'a, 'b, S>,
-    S: for<'s> System<'s> + Send + 'a,
+    Sys: for<'s> System<'s> + Send + 'a,
 {
     fn build(
         self,
-        world: &mut World,
+        _world: &mut World,
         builder: &mut DispatcherBuilder<'a, 'b>,
     ) -> Result<(), Error> {
-        builder.add(
-            self.system_desc.build(world),
-            &self.system_name,
-            &self
-                .system_dependencies
-                .iter()
-                .map(|dep| dep.as_str())
-                .collect::<Vec<&str>>(),
-        );
+        builder.add(self.system, self.system_name, self.system_dependencies);
         Ok(())
     }
 }

--- a/amethyst_test/src/system_injection_bundle.rs
+++ b/amethyst_test/src/system_injection_bundle.rs
@@ -4,21 +4,21 @@ use derive_new::new;
 
 /// Adds a specified `System` to the dispatcher.
 #[derive(Debug, new)]
-pub(crate) struct SystemInjectionBundle<Sys>
+pub(crate) struct SystemInjectionBundle<S>
 where
-    Sys: for<'s> System<'s> + Send,
+    S: for<'s> System<'s> + Send,
 {
     /// Function to instantiate `System` to add to the dispatcher.
-    system: Sys,
+    system: S,
     /// Name to register the system with.
     system_name: &'static str,
     /// Names of the system dependencies.
     system_dependencies: &'static [&'static str],
 }
 
-impl<'a, 'b, Sys> SystemBundle<'a, 'b> for SystemInjectionBundle<Sys>
+impl<'a, 'b, S> SystemBundle<'a, 'b> for SystemInjectionBundle<S>
 where
-    Sys: for<'s> System<'s> + Send + 'a,
+    S: for<'s> System<'s> + Send + 'a,
 {
     fn build(
         self,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,10 +28,13 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ### Fixed
 
+* `RenderingBundle` is registered last in all examples. ([#1881])
+
 [#1780]: https://github.com/amethyst/amethyst/pull/1780
 [#1859]: https://github.com/amethyst/amethyst/pull/1859
 [#1842]: https://github.com/amethyst/amethyst/pull/1842
 [#1870]: https://github.com/amethyst/amethyst/pull/1870
+[#1881]: https://github.com/amethyst/amethyst/pull/1881
 
 ## [0.12.0] - 2019-07-30
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,11 +20,14 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * `UiButtonData` is now exported from `amethyst_ui` and can be used for custom widgets. ([#1859])
 * Add an audio subchapter to the pong chapter. ([#1842])
 * Add `DispatcherOperation` to store dispatcher build logic, which can be executed lazily. ([#1870])
-
+* `AmethystApplication` takes in `SystemDesc`s through `with_system_desc`. ([#1882])
+* `AmethystApplication::with_thread_local_desc` takes in `RunNowDesc`. ([#1882])
 
 ### Changed
 
 * All `-Builder` structs in amethyst_ui/prefab.rs are now called `-Data`. ([#1859])
+* `AmethystApplication` takes in a `System` instead of a closure for `with_system`. ([#1882])
+* `AmethystApplication::with_thread_local` constraint relaxed to `RunNow` (previously `System`). ([#1882])
 
 ### Fixed
 
@@ -35,6 +38,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1842]: https://github.com/amethyst/amethyst/pull/1842
 [#1870]: https://github.com/amethyst/amethyst/pull/1870
 [#1881]: https://github.com/amethyst/amethyst/pull/1881
+[#1882]: https://github.com/amethyst/amethyst/pull/1882
 
 ## [0.12.0] - 2019-07-30
 

--- a/examples/animation/main.rs
+++ b/examples/animation/main.rs
@@ -225,18 +225,18 @@ fn main() -> amethyst::Result<()> {
 
     let game_data = GameDataBuilder::default()
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
+        .with_bundle(AnimationBundle::<AnimationId, Transform>::new(
+            "animation_control_system",
+            "sampler_interpolation_system",
+        ))?
+        .with_bundle(TransformBundle::new().with_dep(&["sampler_interpolation_system"]))?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
                     RenderToWindow::from_config_path(display_config_path).with_clear(CLEAR_COLOR),
                 )
                 .with_plugin(RenderPbr3D::default()),
-        )?
-        .with_bundle(AnimationBundle::<AnimationId, Transform>::new(
-            "animation_control_system",
-            "sampler_interpolation_system",
-        ))?
-        .with_bundle(TransformBundle::new().with_dep(&["sampler_interpolation_system"]))?;
+        )?;
     let state: Example = Default::default();
     let mut game = Application::new(assets_dir, state, game_data)?;
     game.run();

--- a/examples/arc_ball_camera/main.rs
+++ b/examples/arc_ball_camera/main.rs
@@ -119,15 +119,6 @@ fn main() -> Result<(), Error> {
 
     let game_data = GameDataBuilder::default()
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
-        .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
-                .with_plugin(RenderToWindow::from_config_path(display_config_path))
-                .with_plugin(RenderShaded3D::default())
-                .with_plugin(RenderSkybox::with_colors(
-                    Srgb::new(0.82, 0.51, 0.50),
-                    Srgb::new(0.18, 0.11, 0.85),
-                )),
-        )?
         .with_bundle(TransformBundle::new().with_dep(&[]))?
         .with_bundle(
             InputBundle::<StringBindings>::new().with_bindings_from_file(&key_bindings_path)?,
@@ -137,7 +128,16 @@ fn main() -> Result<(), Error> {
             CameraDistanceSystemDesc::default(),
             "camera_distance_system",
             &["input_system"],
-        );
+        )
+        .with_bundle(
+            RenderingBundle::<DefaultBackend>::new()
+                .with_plugin(RenderToWindow::from_config_path(display_config_path))
+                .with_plugin(RenderShaded3D::default())
+                .with_plugin(RenderSkybox::with_colors(
+                    Srgb::new(0.82, 0.51, 0.50),
+                    Srgb::new(0.18, 0.11, 0.85),
+                )),
+        )?;
 
     let mut game = Application::build(assets_dir, ExampleState)?.build(game_data)?;
     game.run();

--- a/examples/asset_loading/main.rs
+++ b/examples/asset_loading/main.rs
@@ -123,6 +123,8 @@ fn main() -> Result<(), Error> {
     let display_config_path = app_root.join("examples/asset_loading/config/display.ron");
 
     let game_data = GameDataBuilder::default()
+        .with_bundle(InputBundle::<StringBindings>::new())?
+        .with_bundle(TransformBundle::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(RenderToWindow::from_config_path(display_config_path))
@@ -131,9 +133,7 @@ fn main() -> Result<(), Error> {
                     Srgb::new(0.82, 0.51, 0.50),
                     Srgb::new(0.18, 0.11, 0.85),
                 )),
-        )?
-        .with_bundle(InputBundle::<StringBindings>::new())?
-        .with_bundle(TransformBundle::new())?;
+        )?;
     let mut game = Application::new(assets_dir, AssetsExample, game_data)?;
     game.run();
     Ok(())

--- a/examples/auto_fov/main.rs
+++ b/examples/auto_fov/main.rs
@@ -51,6 +51,9 @@ fn main() -> Result<(), Error> {
         // frame), preventing any flickering
         .with(AutoFovSystem::new(), "auto_fov", &["prefab"])
         .with(ShowFovSystem::new(), "show_fov", &["auto_fov"])
+        .with_bundle(TransformBundle::new())?
+        .with_bundle(InputBundle::<StringBindings>::new())?
+        .with_bundle(UiBundle::<StringBindings>::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
@@ -58,10 +61,7 @@ fn main() -> Result<(), Error> {
                 )
                 .with_plugin(RenderShaded3D::default())
                 .with_plugin(RenderUi::default()),
-        )?
-        .with_bundle(TransformBundle::new())?
-        .with_bundle(InputBundle::<StringBindings>::new())?
-        .with_bundle(UiBundle::<StringBindings>::new())?;
+        )?;
 
     let mut game = Application::build(assets_dir, Loading::new())?.build(game_data)?;
     game.run();

--- a/examples/custom_game_data/main.rs
+++ b/examples/custom_game_data/main.rs
@@ -206,6 +206,10 @@ fn main() -> Result<(), Error> {
     let game_data = CustomGameDataBuilder::default()
         .with_base(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
         .with_running(ExampleSystem::default(), "example_system", &[])
+        .with_base_bundle(TransformBundle::new())
+        .with_base_bundle(UiBundle::<StringBindings>::new())
+        .with_base_bundle(FpsCounterBundle::default())
+        .with_base_bundle(InputBundle::<StringBindings>::new())
         .with_base_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
@@ -214,11 +218,7 @@ fn main() -> Result<(), Error> {
                 )
                 .with_plugin(RenderShaded3D::default())
                 .with_plugin(RenderUi::default()),
-        )
-        .with_base_bundle(TransformBundle::new())
-        .with_base_bundle(UiBundle::<StringBindings>::new())
-        .with_base_bundle(FpsCounterBundle::default())
-        .with_base_bundle(InputBundle::<StringBindings>::new());
+        );
 
     let mut game = Application::build(assets_dir, Loading::default())?.build(game_data)?;
     game.run();

--- a/examples/debug_lines/main.rs
+++ b/examples/debug_lines/main.rs
@@ -182,17 +182,17 @@ fn main() -> amethyst::Result<()> {
 
     let game_data = GameDataBuilder::default()
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
-                .with_plugin(RenderToWindow::from_config_path(display_config_path))
-                .with_plugin(RenderDebugLines::default())
-                .with_plugin(RenderSkybox::default()),
-        )?
-        .with_bundle(
             InputBundle::<StringBindings>::new().with_bindings_from_file(&key_bindings_path)?,
         )?
         .with(ExampleLinesSystem, "example_lines_system", &[])
         .with_bundle(fly_control_bundle)?
-        .with_bundle(TransformBundle::new().with_dep(&["fly_movement"]))?;
+        .with_bundle(TransformBundle::new().with_dep(&["fly_movement"]))?
+        .with_bundle(
+            RenderingBundle::<DefaultBackend>::new()
+                .with_plugin(RenderToWindow::from_config_path(display_config_path))
+                .with_plugin(RenderDebugLines::default())
+                .with_plugin(RenderSkybox::default()),
+        )?;
 
     let mut game = Application::new(assets_dir, ExampleState, game_data)?;
     game.run();

--- a/examples/debug_lines_ortho/main.rs
+++ b/examples/debug_lines_ortho/main.rs
@@ -116,6 +116,7 @@ fn main() -> amethyst::Result<()> {
 
     let game_data = GameDataBuilder::default()
         .with(ExampleLinesSystem::new(), "example_lines_system", &[])
+        .with_bundle(TransformBundle::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
@@ -123,8 +124,7 @@ fn main() -> amethyst::Result<()> {
                         .with_clear([0.0, 0.0, 0.0, 1.0]),
                 )
                 .with_plugin(RenderDebugLines::default()),
-        )?
-        .with_bundle(TransformBundle::new())?;
+        )?;
 
     let mut game = Application::new(assets_dir, ExampleState, game_data)?;
     game.run();

--- a/examples/fly_camera/main.rs
+++ b/examples/fly_camera/main.rs
@@ -67,14 +67,6 @@ fn main() -> Result<(), Error> {
     let game_data = GameDataBuilder::default()
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
-                .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)
-                        .with_clear([0.34, 0.36, 0.52, 1.0]),
-                )
-                .with_plugin(RenderShaded3D::default()),
-        )?
-        .with_bundle(
             FlyControlBundle::<StringBindings>::new(
                 Some(String::from("move_x")),
                 Some(String::from("move_y")),
@@ -85,6 +77,14 @@ fn main() -> Result<(), Error> {
         .with_bundle(TransformBundle::new().with_dep(&["fly_movement"]))?
         .with_bundle(
             InputBundle::<StringBindings>::new().with_bindings_from_file(&key_bindings_path)?,
+        )?
+        .with_bundle(
+            RenderingBundle::<DefaultBackend>::new()
+                .with_plugin(
+                    RenderToWindow::from_config_path(display_config_path)
+                        .with_clear([0.34, 0.36, 0.52, 1.0]),
+                )
+                .with_plugin(RenderShaded3D::default()),
         )?;
 
     let mut game = Application::build(assets_dir, ExampleState)?.build(game_data)?;

--- a/examples/gltf/main.rs
+++ b/examples/gltf/main.rs
@@ -10,12 +10,9 @@ use amethyst::{
         ProgressCounter, RonFormat,
     },
     controls::{ControlTagPrefab, FlyControlBundle},
-    core::{
-        transform::{Transform, TransformBundle},
-        SystemDesc,
-    },
+    core::transform::{Transform, TransformBundle},
     derive::PrefabData,
-    ecs::{Entity, ReadStorage, World, Write, WriteStorage},
+    ecs::{Entity, ReadStorage, Write, WriteStorage},
     input::{is_close_requested, is_key_down, StringBindings, VirtualKeyCode},
     prelude::*,
     renderer::{
@@ -32,7 +29,7 @@ use amethyst::{
     },
     Error,
 };
-use amethyst_gltf::{GltfSceneAsset, GltfSceneFormat, GltfSceneLoaderSystem};
+use amethyst_gltf::{GltfSceneAsset, GltfSceneFormat, GltfSceneLoaderSystemDesc};
 
 use serde::{Deserialize, Serialize};
 
@@ -197,17 +194,6 @@ fn main() -> Result<(), amethyst::Error> {
             "gltf_loader",
             &["scene_loader"], // This is important so that entity instantiation is performed in a single frame.
         )
-        // `VisibilitySortingSystem` (part of `RenderPbr3D`) should depend on:
-        // &["fly_movement", "transform_system", "auto_fov"]
-        //
-        // There is currently no way to pass the dependencies to that system. However, since that
-        // system is thread local as part of rendering, it runs after all of the systems anyway.
-        .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
-                .with_plugin(RenderToWindow::from_config_path(display_config_path))
-                .with_plugin(RenderPbr3D::default().with_skinning())
-                .with_plugin(RenderSkybox::default()),
-        )?
         .with_bundle(
             AnimationBundle::<usize, Transform>::new("animation_control", "sampler_interpolation")
                 .with_dep(&["gltf_loader"]),
@@ -226,7 +212,18 @@ fn main() -> Result<(), amethyst::Error> {
             "transform_system",
             "animation_control",
             "sampler_interpolation",
-        ]))?;
+        ]))?
+        // `VisibilitySortingSystem` (part of `RenderPbr3D`) should depend on:
+        // &["fly_movement", "transform_system", "auto_fov"]
+        //
+        // There is currently no way to pass the dependencies to that system. However, since that
+        // system is thread local as part of rendering, it runs after all of the systems anyway.
+        .with_bundle(
+            RenderingBundle::<DefaultBackend>::new()
+                .with_plugin(RenderToWindow::from_config_path(display_config_path))
+                .with_plugin(RenderPbr3D::default().with_skinning())
+                .with_plugin(RenderSkybox::default()),
+        )?;
 
     let mut game = Application::build(assets_dir, Example::default())?.build(game_data)?;
     game.run();

--- a/examples/material/main.rs
+++ b/examples/material/main.rs
@@ -151,6 +151,7 @@ fn main() -> amethyst::Result<()> {
     let assets_dir = app_root.join("examples/assets/");
 
     let game_data = GameDataBuilder::default()
+        .with_bundle(TransformBundle::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
@@ -158,8 +159,7 @@ fn main() -> amethyst::Result<()> {
                         .with_clear([0.34, 0.36, 0.52, 1.0]),
                 )
                 .with_plugin(RenderPbr3D::default()),
-        )?
-        .with_bundle(TransformBundle::new())?;
+        )?;
 
     let mut game = Application::new(assets_dir, Example, game_data)?;
     game.run();

--- a/examples/pong/main.rs
+++ b/examples/pong/main.rs
@@ -61,17 +61,6 @@ fn main() -> amethyst::Result<()> {
 
     let game_data = GameDataBuilder::default()
         // Add the transform bundle which handles tracking entity positions
-        .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
-                // The RenderToWindow plugin provides all the scaffolding for opening a window and
-                // drawing on it
-                .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)
-                        .with_clear([0.34, 0.36, 0.52, 1.0]),
-                )
-                .with_plugin(RenderFlat2D::default())
-                .with_plugin(RenderUi::default()),
-        )?
         .with_bundle(TransformBundle::new())?
         .with_bundle(
             InputBundle::<StringBindings>::new().with_bindings_from_file(key_bindings_path)?,
@@ -83,7 +72,18 @@ fn main() -> amethyst::Result<()> {
             "dj_system",
             &[],
         )
-        .with_bundle(UiBundle::<StringBindings>::new())?;
+        .with_bundle(UiBundle::<StringBindings>::new())?
+        .with_bundle(
+            RenderingBundle::<DefaultBackend>::new()
+                // The RenderToWindow plugin provides all the scaffolding for opening a window and
+                // drawing on it
+                .with_plugin(
+                    RenderToWindow::from_config_path(display_config_path)
+                        .with_clear([0.34, 0.36, 0.52, 1.0]),
+                )
+                .with_plugin(RenderFlat2D::default())
+                .with_plugin(RenderUi::default()),
+        )?;
 
     let mut game = Application::build(assets_dir, Pong::default())?
         .with_frame_limit(

--- a/examples/pong_tutorial_02/main.rs
+++ b/examples/pong_tutorial_02/main.rs
@@ -25,6 +25,8 @@ fn main() -> amethyst::Result<()> {
     let assets_dir = app_root.join("examples/assets/");
 
     let game_data = GameDataBuilder::default()
+        // Add the transform bundle which handles tracking entity positions
+        .with_bundle(TransformBundle::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 // The RenderToWindow plugin provides all the scaffolding for opening a window and
@@ -35,9 +37,7 @@ fn main() -> amethyst::Result<()> {
                 )
                 // RenderFlat2D plugin is used to render entities with `SpriteRender` component.
                 .with_plugin(RenderFlat2D::default()),
-        )?
-        // Add the transform bundle which handles tracking entity positions
-        .with_bundle(TransformBundle::new())?;
+        )?;
 
     let mut game = Application::new(assets_dir, Pong, game_data)?;
     game.run();

--- a/examples/pong_tutorial_03/main.rs
+++ b/examples/pong_tutorial_03/main.rs
@@ -27,6 +27,15 @@ fn main() -> amethyst::Result<()> {
     let assets_dir = app_root.join("examples/assets/");
 
     let game_data = GameDataBuilder::default()
+        // Add the transform bundle which handles tracking entity positions
+        .with_bundle(TransformBundle::new())?
+        .with_bundle(
+            InputBundle::<StringBindings>::new().with_bindings_from_file(
+                app_root.join("examples/pong_tutorial_03/config/bindings.ron"),
+            )?,
+        )?
+        // We have now added our own system, the PaddleSystem, defined in systems/paddle.rs
+        .with(systems::PaddleSystem, "paddle_system", &["input_system"])
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 // The RenderToWindow plugin provides all the scaffolding for opening a window and
@@ -37,16 +46,7 @@ fn main() -> amethyst::Result<()> {
                 )
                 // RenderFlat2D plugin is used to render entities with `SpriteRender` component.
                 .with_plugin(RenderFlat2D::default()),
-        )?
-        // Add the transform bundle which handles tracking entity positions
-        .with_bundle(TransformBundle::new())?
-        .with_bundle(
-            InputBundle::<StringBindings>::new().with_bindings_from_file(
-                app_root.join("examples/pong_tutorial_03/config/bindings.ron"),
-            )?,
-        )?
-        // We have now added our own system, the PaddleSystem, defined in systems/paddle.rs
-        .with(systems::PaddleSystem, "paddle_system", &["input_system"]);
+        )?;
 
     let mut game = Application::new(assets_dir, Pong, game_data)?;
     game.run();

--- a/examples/pong_tutorial_04/main.rs
+++ b/examples/pong_tutorial_04/main.rs
@@ -27,17 +27,6 @@ fn main() -> amethyst::Result<()> {
     let assets_dir = app_root.join("examples/assets/");
 
     let game_data = GameDataBuilder::default()
-        .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
-                // The RenderToWindow plugin provides all the scaffolding for opening a window and
-                // drawing on it
-                .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)
-                        .with_clear([0.0, 0.0, 0.0, 1.0]),
-                )
-                // RenderFlat2D plugin is used to render entities with `SpriteRender` component.
-                .with_plugin(RenderFlat2D::default()),
-        )?
         // Add the transform bundle which handles tracking entity positions
         .with_bundle(TransformBundle::new())?
         .with_bundle(
@@ -52,7 +41,18 @@ fn main() -> amethyst::Result<()> {
             systems::BounceSystem,
             "collision_system",
             &["paddle_system", "ball_system"],
-        );
+        )
+        .with_bundle(
+            RenderingBundle::<DefaultBackend>::new()
+                // The RenderToWindow plugin provides all the scaffolding for opening a window and
+                // drawing on it
+                .with_plugin(
+                    RenderToWindow::from_config_path(display_config_path)
+                        .with_clear([0.0, 0.0, 0.0, 1.0]),
+                )
+                // RenderFlat2D plugin is used to render entities with `SpriteRender` component.
+                .with_plugin(RenderFlat2D::default()),
+        )?;
 
     let mut game = Application::new(assets_dir, Pong::default(), game_data)?;
     game.run();

--- a/examples/pong_tutorial_05/main.rs
+++ b/examples/pong_tutorial_05/main.rs
@@ -28,18 +28,6 @@ fn main() -> amethyst::Result<()> {
     let assets_dir = app_root.join("examples/assets/");
 
     let game_data = GameDataBuilder::default()
-        .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
-                // The RenderToWindow plugin provides all the scaffolding for opening a window and
-                // drawing on it
-                .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)
-                        .with_clear([0.0, 0.0, 0.0, 1.0]),
-                )
-                // RenderFlat2D plugin is used to render entities with `SpriteRender` component.
-                .with_plugin(RenderFlat2D::default())
-                .with_plugin(RenderUi::default()),
-        )?
         // Add the transform bundle which handles tracking entity positions
         .with_bundle(TransformBundle::new())?
         .with_bundle(
@@ -56,7 +44,19 @@ fn main() -> amethyst::Result<()> {
             "collision_system",
             &["paddle_system", "ball_system"],
         )
-        .with(systems::WinnerSystem, "winner_system", &["ball_system"]);
+        .with(systems::WinnerSystem, "winner_system", &["ball_system"])
+        .with_bundle(
+            RenderingBundle::<DefaultBackend>::new()
+                // The RenderToWindow plugin provides all the scaffolding for opening a window and
+                // drawing on it
+                .with_plugin(
+                    RenderToWindow::from_config_path(display_config_path)
+                        .with_clear([0.0, 0.0, 0.0, 1.0]),
+                )
+                // RenderFlat2D plugin is used to render entities with `SpriteRender` component.
+                .with_plugin(RenderFlat2D::default())
+                .with_plugin(RenderUi::default()),
+        )?;
 
     let mut game = Application::new(assets_dir, Pong::default(), game_data)?;
     game.run();

--- a/examples/prefab/main.rs
+++ b/examples/prefab/main.rs
@@ -40,6 +40,7 @@ fn main() -> Result<(), Error> {
 
     let game_data = GameDataBuilder::default()
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
+        .with_bundle(TransformBundle::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
@@ -47,8 +48,7 @@ fn main() -> Result<(), Error> {
                         .with_clear([0.34, 0.36, 0.52, 1.0]),
                 )
                 .with_plugin(RenderShaded3D::default()),
-        )?
-        .with_bundle(TransformBundle::new())?;
+        )?;
 
     let mut game = Application::new(assets_dir, AssetsExample, game_data)?;
     game.run();

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -202,6 +202,11 @@ fn main() -> Result<(), Error> {
     let game_data = GameDataBuilder::default()
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
         .with(ExampleSystem::default(), "example_system", &[])
+        .with_bundle(TransformBundle::new().with_dep(&["example_system"]))?
+        .with_bundle(UiBundle::<StringBindings>::new())?
+        .with_bundle(HotReloadBundle::default())?
+        .with_bundle(FpsCounterBundle::default())?
+        .with_bundle(InputBundle::<StringBindings>::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
@@ -210,12 +215,7 @@ fn main() -> Result<(), Error> {
                 )
                 .with_plugin(RenderShaded3D::default())
                 .with_plugin(RenderUi::default()),
-        )?
-        .with_bundle(TransformBundle::new().with_dep(&["example_system"]))?
-        .with_bundle(UiBundle::<StringBindings>::new())?
-        .with_bundle(HotReloadBundle::default())?
-        .with_bundle(FpsCounterBundle::default())?
-        .with_bundle(InputBundle::<StringBindings>::new())?;
+        )?;
     let mut game = Application::build(assets_dir, Loading::default())?.build(game_data)?;
     game.run();
     Ok(())

--- a/examples/rendy/main.rs
+++ b/examples/rendy/main.rs
@@ -13,13 +13,13 @@ use amethyst::{
     core::{
         ecs::{
             Component, DenseVecStorage, DispatcherBuilder, Entities, Entity, Join, Read,
-            ReadExpect, ReadStorage, System, SystemData, World, Write, WriteStorage,
+            ReadStorage, System, SystemData, World, Write, WriteStorage,
         },
         math::{Unit, UnitQuaternion, Vector3},
-        SystemDesc, Time, Transform, TransformBundle,
+        Time, Transform, TransformBundle,
     },
     error::Error,
-    gltf::GltfSceneLoaderSystem,
+    gltf::GltfSceneLoaderSystemDesc,
     input::{
         is_close_requested, is_key_down, is_key_up, Axis, Bindings, Button, InputBundle,
         StringBindings,
@@ -597,13 +597,13 @@ fn main() -> amethyst::Result<()> {
         .with(OrbitSystem, "orbit", &[])
         .with(AutoFovSystem::default(), "auto_fov", &[])
         .with_bundle(FpsCounterBundle::default())?
-        .with(
-            PrefabLoaderSystemDesc::<ScenePrefabData>::default().build(&mut world),
+        .with_system_desc(
+            PrefabLoaderSystemDesc::<ScenePrefabData>::default(),
             "scene_loader",
             &[],
         )
-        .with(
-            GltfSceneLoaderSystem::new(&mut world),
+        .with_system_desc(
+            GltfSceneLoaderSystemDesc::default(),
             "gltf_loader",
             &["scene_loader"], // This is important so that entity instantiation is performed in a single frame.
         )
@@ -653,12 +653,7 @@ fn main() -> amethyst::Result<()> {
                 )),
         )?;
 
-    let mut game = Application::new(
-        assets_dir & assets_directory,
-        Example::new(),
-        game_data,
-        world,
-    )?;
+    let mut game = Application::new(assets_dir, Example::new(), game_data)?;
     game.run();
     Ok(())
 }

--- a/examples/rendy/main.rs
+++ b/examples/rendy/main.rs
@@ -544,6 +544,18 @@ fn toggle_or_cycle_animation(
     }
 }
 
+// This is required because rustc does not recognize .ctor segments when considering which symbols
+// to include when linking static libraries, so we need to reference a symbol in each module that
+// registers an importer since it uses inventory::submit and the .ctor linkage hack.
+fn init_modules() {
+    {
+        use amethyst::assets::{Format, Prefab};
+        let _w = amethyst::audio::output::outputs();
+        let _p = Prefab::<()>::new();
+        let _name = ImageFormat::default().name();
+    }
+}
+
 fn main() -> amethyst::Result<()> {
     amethyst::Logger::from_config(amethyst::LoggerConfig {
         stdout: amethyst::StdoutLog::Off,
@@ -560,6 +572,8 @@ fn main() -> amethyst::Result<()> {
     // .level_for("amethyst_rendy", log::LevelFilter::Trace)
     // .level_for("gfx_backend_metal", log::LevelFilter::Trace)
     .start();
+
+    init_modules();
 
     let app_root = application_root_dir()?;
 

--- a/examples/sphere/main.rs
+++ b/examples/sphere/main.rs
@@ -37,6 +37,7 @@ fn main() -> amethyst::Result<()> {
 
     let game_data = GameDataBuilder::default()
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
+        .with_bundle(TransformBundle::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
@@ -44,8 +45,7 @@ fn main() -> amethyst::Result<()> {
                         .with_clear([0.34, 0.36, 0.52, 1.0]),
                 )
                 .with_plugin(RenderShaded3D::default()),
-        )?
-        .with_bundle(TransformBundle::new())?;
+        )?;
     let mut game = Application::new(assets_dir, Example, game_data)?;
     game.run();
     Ok(())

--- a/examples/sprite_camera_follow/main.rs
+++ b/examples/sprite_camera_follow/main.rs
@@ -207,6 +207,13 @@ fn main() -> amethyst::Result<()> {
     let display_config_path = app_root.join("examples/sprite_camera_follow/config/display.ron");
 
     let game_data = GameDataBuilder::default()
+        .with_bundle(TransformBundle::new())?
+        .with_bundle(
+            InputBundle::<StringBindings>::new().with_bindings_from_file(
+                app_root.join("examples/sprite_camera_follow/config/input.ron"),
+            )?,
+        )?
+        .with(MovementSystem, "movement", &[])
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
@@ -214,14 +221,7 @@ fn main() -> amethyst::Result<()> {
                         .with_clear([0.34, 0.36, 0.52, 1.0]),
                 )
                 .with_plugin(RenderFlat2D::default()),
-        )?
-        .with_bundle(TransformBundle::new())?
-        .with_bundle(
-            InputBundle::<StringBindings>::new().with_bindings_from_file(
-                app_root.join("examples/sprite_camera_follow/config/input.ron"),
-            )?,
-        )?
-        .with(MovementSystem, "movement", &[]);
+        )?;
 
     let mut game = Application::build(assets_dir, Example)?.build(game_data)?;
     game.run();

--- a/examples/sprites_ordered/main.rs
+++ b/examples/sprites_ordered/main.rs
@@ -368,6 +368,7 @@ fn main() -> amethyst::Result<()> {
     let assets_dir = app_root.join("examples/assets/");
 
     let game_data = GameDataBuilder::default()
+        .with_bundle(TransformBundle::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
@@ -375,8 +376,7 @@ fn main() -> amethyst::Result<()> {
                         .with_clear([0.34, 0.36, 0.52, 1.0]),
                 )
                 .with_plugin(RenderFlat2D::default()),
-        )?
-        .with_bundle(TransformBundle::new())?;
+        )?;
 
     let mut game = Application::new(assets_dir, Example::new(), game_data)?;
     game.run();

--- a/examples/ui/main.rs
+++ b/examples/ui/main.rs
@@ -129,6 +129,12 @@ fn main() -> amethyst::Result<()> {
 
     let game_data = GameDataBuilder::default()
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
+        .with_bundle(TransformBundle::new())?
+        .with_bundle(UiBundle::<StringBindings>::new())?
+        .with(Processor::<Source>::new(), "source_processor", &[])
+        .with_system_desc(UiEventHandlerSystemDesc::default(), "ui_event_handler", &[])
+        .with_bundle(FpsCounterBundle::default())?
+        .with_bundle(InputBundle::<StringBindings>::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
@@ -136,13 +142,7 @@ fn main() -> amethyst::Result<()> {
                         .with_clear([0.34, 0.36, 0.52, 1.0]),
                 )
                 .with_plugin(RenderUi::default()),
-        )?
-        .with_bundle(TransformBundle::new())?
-        .with_bundle(UiBundle::<StringBindings>::new())?
-        .with(Processor::<Source>::new(), "source_processor", &[])
-        .with_system_desc(UiEventHandlerSystemDesc::default(), "ui_event_handler", &[])
-        .with_bundle(FpsCounterBundle::default())?
-        .with_bundle(InputBundle::<StringBindings>::new())?;
+        )?;
 
     let mut game = Application::build(assets_dir, Example::default())?
         // Unlimited FPS


### PR DESCRIPTION
## Description

Updated `amethyst_test::AmethystApplication` to take both `System` and `SystemDesc`

(currently sits on top of #1881 so that CI succeeds).

## Additions

* `AmethystApplication` takes in `SystemDesc`s through `with_system_desc`.
* `AmethystApplication::with_thread_local_desc` takes in `RunNowDesc`.

## Modifications

* `AmethystApplication` takes in a `System` instead of a closure for `with_system`.
* `AmethystApplication::with_thread_local` constraint relaxed to `RunNow` (previously `System`).

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
