### PR TITLE
Improvement/system desc ergonomics

### DIFF
--- a/amethyst_derive/src/system_desc.rs
+++ b/amethyst_derive/src/system_desc.rs
@@ -140,7 +140,7 @@ fn system_desc_struct(context: &Context<'_>) -> TokenStream {
     }
 }
 
-fn system_desc_fields<'ast>(ast: &'ast DeriveInput) -> SystemDescFields<'ast> {
+fn system_desc_fields(ast: &DeriveInput) -> SystemDescFields<'_> {
     // This includes any `PhantomData` fields to avoid unused type parameters.
     let fields = ast.fields();
 

--- a/amethyst_derive/src/system_desc.rs
+++ b/amethyst_derive/src/system_desc.rs
@@ -512,13 +512,11 @@ fn call_system_constructor(context: &Context<'_>) -> TokenStream {
                         }
                     }
                 }
+            } else if has_fields_skipped_or_phantom {
+                quote!(#system_name::default())
             } else {
-                if has_fields_skipped_or_phantom {
-                    quote!(#system_name::default())
-                } else {
-                    quote! {
-                        #system_name {}
-                    }
+                quote! {
+                    #system_name {}
                 }
             }
         }

--- a/amethyst_derive/tests/system_desc.rs
+++ b/amethyst_derive/tests/system_desc.rs
@@ -1,0 +1,179 @@
+use std::marker::PhantomData;
+
+use amethyst_core::{
+    ecs::{System, SystemData, World, WorldExt},
+    shrev::{EventChannel, ReaderId},
+    SystemDesc,
+};
+use amethyst_error::Error;
+
+use amethyst_derive::SystemDesc;
+
+#[test]
+fn simple_derive() -> Result<(), Error> {
+    #[derive(Debug, SystemDesc)]
+    struct SystemUnit;
+
+    impl<'s> System<'s> for SystemUnit {
+        type SystemData = ();
+        fn run(&mut self, _: Self::SystemData) {}
+    }
+
+    let mut world = World::new();
+
+    <SystemUnit as SystemDesc<'_, '_, _>>::build(SystemUnit, &mut world);
+
+    Ok(())
+}
+
+#[test]
+fn rename_struct() -> Result<(), Error> {
+    #[derive(Debug, SystemDesc)]
+    #[system_desc(name(SystemUnitDesc))]
+    struct SystemUnit;
+
+    impl<'s> System<'s> for SystemUnit {
+        type SystemData = ();
+        fn run(&mut self, _: Self::SystemData) {}
+    }
+
+    let mut world = World::new();
+
+    SystemUnitDesc.build(&mut world);
+
+    Ok(())
+}
+
+#[test]
+fn struct_tuple_with_phantom() -> Result<(), Error> {
+    // Expects `System` to `impl Default`
+    #[derive(Debug, SystemDesc)]
+    #[system_desc(name(SystemTuplePhantomDesc))]
+    struct SystemTuplePhantom<T>(PhantomData<T>);
+    impl<T> Default for SystemTuplePhantom<T> {
+        fn default() -> Self {
+            SystemTuplePhantom(PhantomData)
+        }
+    }
+
+    impl<'s, T> System<'s> for SystemTuplePhantom<T> {
+        type SystemData = ();
+        fn run(&mut self, _: Self::SystemData) {}
+    }
+
+    let mut world = World::new();
+
+    SystemTuplePhantomDesc::<()>::default().build(&mut world);
+
+    Ok(())
+}
+
+#[test]
+fn struct_tuple_with_skip() -> Result<(), Error> {
+    // Expects `System` to `impl Default`
+    #[derive(Debug, Default, SystemDesc)]
+    #[system_desc(name(SystemTupleSkipDesc))]
+    struct SystemTupleSkip(#[system_desc(skip)] u32);
+
+    impl<'s> System<'s> for SystemTupleSkip {
+        type SystemData = ();
+        fn run(&mut self, _: Self::SystemData) {}
+    }
+
+    let mut world = World::new();
+
+    SystemTupleSkipDesc::default().build(&mut world);
+
+    Ok(())
+}
+
+#[test]
+fn struct_tuple_with_passthrough() -> Result<(), Error> {
+    #[derive(Debug, Default, SystemDesc)]
+    #[system_desc(name(SystemTuplePassthroughDesc))]
+    struct SystemTuplePassthrough(u32);
+
+    impl<'s> System<'s> for SystemTuplePassthrough {
+        type SystemData = ();
+        fn run(&mut self, _: Self::SystemData) {}
+    }
+
+    let mut world = World::new();
+
+    SystemTuplePassthroughDesc::new(123).build(&mut world);
+
+    Ok(())
+}
+
+#[test]
+fn struct_tuple_with_event_channel_reader() -> Result<(), Error> {
+    // Expects `System` to have a `new` constructor.
+    #[derive(Debug, SystemDesc)]
+    #[system_desc(name(SystemTupleEventChannelDesc))]
+    struct SystemTupleEventChannel(#[system_desc(event_channel_reader)] ReaderId<u32>);
+    impl SystemTupleEventChannel {
+        fn new(reader_id: ReaderId<u32>) -> Self {
+            Self(reader_id)
+        }
+    }
+
+    impl<'s> System<'s> for SystemTupleEventChannel {
+        type SystemData = ();
+        fn run(&mut self, _: Self::SystemData) {}
+    }
+
+    let mut world = World::new();
+    world.insert(EventChannel::<u32>::new());
+
+    SystemTupleEventChannelDesc::default().build(&mut world);
+
+    Ok(())
+}
+
+#[test]
+fn struct_tuple_complex() -> Result<(), Error> {
+    // Expects `System` to have a `new` constructor.
+    pub trait Magic {}
+    impl Magic for i8 {}
+    impl Magic for i16 {}
+
+    #[derive(Debug, SystemDesc)]
+    #[system_desc(name(SystemTupleComplexDesc))]
+    struct SystemTupleComplex<'x, T1, T2>(
+        u8,
+        PhantomData<&'x T1>,
+        #[system_desc(event_channel_reader)] ReaderId<u32>,
+        #[system_desc(skip)] i32,
+        PhantomData<T2>,
+        u32,
+    )
+    where
+        T1: Magic,
+        T2: Magic;
+
+    impl<'x, T1, T2> SystemTupleComplex<'x, T1, T2>
+    where
+        T1: Magic,
+        T2: Magic,
+    {
+        fn new(a: u8, reader_id: ReaderId<u32>, d: u32) -> Self {
+            Self(a, PhantomData, reader_id, 999, PhantomData, d)
+        }
+    }
+
+    impl<'s, 'x, T1, T2> System<'s> for SystemTupleComplex<'x, T1, T2>
+    where
+        T1: Magic,
+        T2: Magic,
+    {
+        type SystemData = ();
+        fn run(&mut self, _: Self::SystemData) {}
+    }
+
+    let mut world = World::new();
+    world.insert(EventChannel::<u32>::new());
+
+    SystemTupleComplexDesc::<'_, i8, i16>::new(1u8, 4u32).build(&mut world);
+
+    Ok(())
+}

--- a/amethyst_ui/src/glyphs.rs
+++ b/amethyst_ui/src/glyphs.rs
@@ -98,11 +98,8 @@ pub struct UiGlyphsSystem<B: Backend> {
     marker: PhantomData<B>,
 }
 
-impl<B: Backend> UiGlyphsSystem<B> {
-    /// Create new UI glyphs system
-    ///
-    /// This is not public as users should use the `UiGlyphsSystemDesc` system descriptor instead.
-    pub(crate) fn new() -> Self {
+impl<B: Backend> Default for UiGlyphsSystem<B> {
+    fn default() -> Self {
         Self {
             glyph_brush: GlyphBrushBuilder::using_fonts(vec![])
                 .initial_cache_size((512, 512))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * All `-Builder` structs in amethyst_ui/prefab.rs are now called `-Data`. ([#1859])
 * `AmethystApplication` takes in a `System` instead of a closure for `with_system`. ([#1882])
 * `AmethystApplication::with_thread_local` constraint relaxed to `RunNow` (previously `System`). ([#1882])
+* `SystemDesc` proc macro supports `#[system_desc(event_reader_id)]` to register event reader. ([#1883])
 
 ### Fixed
 
@@ -39,6 +40,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1870]: https://github.com/amethyst/amethyst/pull/1870
 [#1881]: https://github.com/amethyst/amethyst/pull/1881
 [#1882]: https://github.com/amethyst/amethyst/pull/1882
+[#1883]: https://github.com/amethyst/amethyst/pull/1883
 
 ## [0.12.0] - 2019-07-30
 


### PR DESCRIPTION
## Description

Extend `SystemDesc` derive to generate implementation for system with event channel reader fields. Essentially:

```patch
-#[derive(Debug)]
+#[derive(Debug, SystemDesc)]
+#[system_desc(name(SystemWithEventChannelDesc))]
 struct SystemWithEventChannel {
+    #[system_desc(event_channel_reader)]
     u32_reader: ReaderId<u32>,
 }

-use amethyst_core::SystemDesc;
-
-/// Builds a `SystemWithEventChannel`.
-#[derive(Default, Debug)]
-pub struct SystemWithEventChannelDesc;
-
-impl<'a, 'b> SystemDesc<'a, 'b, SystemWithEventChannel> for SystemWithEventChannelDesc {
-    fn build(self, world: &mut World) -> SystemWithEventChannel {
-        <SystemWithEventChannel as System<'_>>::SystemData::setup(world);
-
-        let u32_reader = world.fetch_mut::<EventChannel<u32>>().register_reader();
-
-        SystemWithEventChannel::new()
-    }
-}
```

**Note:** built on top of #1882, so build is green. See commit 932a58d2 onwards

## Modifications

* `SystemDesc` proc macro supports `#[system_desc(event_reader_id)]` to register event reader.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
