### PR TITLE
Improvement/system desc ergonomics 2

### DIFF
--- a/amethyst_derive/Cargo.toml
+++ b/amethyst_derive/Cargo.toml
@@ -19,7 +19,7 @@ heck = "0.3.1"
 syn = { version = "0.15", features = ["visit"] }
 quote = "0.6"
 proc-macro2 = "0.4"
-proc_macro_roids = "0.3.0"
+proc_macro_roids = "0.4"
 
 [dev-dependencies]
 amethyst_core = { path = "../amethyst_core", version = "0.7.0" }

--- a/amethyst_derive/src/system_desc.rs
+++ b/amethyst_derive/src/system_desc.rs
@@ -261,7 +261,7 @@ fn impl_constructor_body(context: &Context<'_>) -> TokenStream {
                 .iter()
                 .map(|field| {
                     if field.is_phantom_data() {
-                        quote!(std::marker::PhantomData::default())
+                        quote!(std::marker::PhantomData)
                     } else {
                         let type_name_snake = snake_case(field);
                         quote!(#type_name_snake)
@@ -284,7 +284,7 @@ fn impl_constructor_body(context: &Context<'_>) -> TokenStream {
                         .expect("Expected named field to have an ident.");
 
                     if field.is_phantom_data() {
-                        quote!(#field_name: std::marker::PhantomData::default())
+                        quote!(#field_name: std::marker::PhantomData)
                     } else {
                         quote!(#field_name)
                     }

--- a/amethyst_derive/src/system_desc.rs
+++ b/amethyst_derive/src/system_desc.rs
@@ -2,7 +2,7 @@
 
 use heck::SnakeCase;
 use proc_macro2::{Literal, Span, TokenStream};
-use proc_macro_roids::{DeriveInputStructExt, FieldExt};
+use proc_macro_roids::{DeriveInputExt, DeriveInputStructExt, FieldExt};
 use quote::quote;
 use syn::{
     parse_quote, punctuated::Pair, AngleBracketedGenericArguments, Attribute, DeriveInput, Expr,
@@ -540,74 +540,13 @@ fn call_system_constructor(context: &Context<'_>) -> TokenStream {
 /// Extracts the name from the `#[system_desc(name(..))]` attribute.
 #[allow(clippy::let_and_return)] // Needed due to bug in clippy.
 fn system_desc_name(ast: &DeriveInput) -> Option<Ident> {
-    let meta_lists = ast
-        .attrs
-        .iter()
-        .map(Attribute::parse_meta)
-        .filter_map(Result::ok)
-        .filter(|meta| meta.name() == "system_desc")
-        .filter_map(|meta| {
-            if let Meta::List(meta_list) = meta {
-                Some(meta_list)
-            } else {
-                None
-            }
-        })
-        .collect::<Vec<MetaList>>();
-
-    // Each `meta_list` is the `system_desc(..)` item.
-    let name = meta_lists
-        .iter()
-        .flat_map(|meta_list| {
-            meta_list
-                .nested
-                .iter()
-                .filter_map(|nested_meta| {
-                    if let NestedMeta::Meta(meta) = nested_meta {
-                        Some(meta)
-                    } else {
-                        None
-                    }
-                })
-                .filter(|meta| meta.name() == "name")
-        })
-        // `meta` is the `name(..)` item.
-        .filter_map(|meta| {
-            if let Meta::List(meta_list) = meta {
-                Some(meta_list)
-            } else {
-                None
-            }
-        })
-        // We want to insert a resource for each item in the list.
-        .map(|meta_list| {
-            if meta_list.nested.len() != 1 {
-                panic!(
-                    "Expected exactly one identifier for `#[system_desc(name(..))]`. `{:?}`.",
-                    &meta_list.nested
-                );
-            }
-
-            meta_list
-                .nested
-                .first()
-                .map(|pair| {
-                    let nested_meta = pair.value();
-                    if let NestedMeta::Meta(Meta::Word(ident)) = nested_meta {
-                        ident.clone()
-                    } else {
-                        panic!(
-                            "`{:?}` is an invalid value in this position.\n\
-                             Expected a single identifier.",
-                            nested_meta,
-                        );
-                    }
-                })
-                .expect("Expected one meta item to exist.")
-        })
-        .next();
-
-    name
+    ast.tag_parameter("system_desc", "name").map(|meta| {
+        if let Meta::Word(ident) = meta {
+            ident
+        } else {
+            panic!("Expected name parameter to be an `Ident`.")
+        }
+    })
 }
 
 /// Inserts resources specified inside the `#[system_desc(insert(..))]` attribute.
@@ -702,50 +641,70 @@ fn field_computation_expressions(system_desc_fields: &SystemDescFields<'_>) -> T
     system_desc_fields.field_mappings.iter().fold(
         TokenStream::new(),
         |mut token_stream, field_mapping| {
-            if let FieldMapping {
-                field_variant: FieldVariant::Compute(FieldToCompute::EventChannelReader(field)),
-                ..
-            } = field_mapping
-            {
-                let field_name = field.ident.clone().unwrap_or_else(|| snake_case(field));
-                let event_type_path = if let Type::Path(TypePath {
-                    path: Path { segments, .. },
-                    ..
-                }) = &field.ty
-                {
-                    if let Some(Pair::End(path_segment)) = segments.last() {
-                        if let PathArguments::AngleBracketed(AngleBracketedGenericArguments {
-                            args,
-                            ..
-                        }) = &path_segment.arguments
-                        {
-                            if let Some(Pair::End(GenericArgument::Type(Type::Path(TypePath {
-                                path,
+            match &field_mapping.field_variant {
+                FieldVariant::Compute(FieldToCompute::EventChannelReader(field)) => {
+                    let field_name = field.ident.clone().unwrap_or_else(|| snake_case(field));
+                    // For a `ReaderId<EventType>` type, this code figures out `EventType`.
+                    let event_type_path = if let Type::Path(TypePath {
+                        path: Path { segments, .. },
+                        ..
+                    }) = &field.ty
+                    {
+                        if let Some(Pair::End(path_segment)) = segments.last() {
+                            if let PathArguments::AngleBracketed(AngleBracketedGenericArguments {
+                                args,
                                 ..
-                            })))) = args.first()
+                            }) = &path_segment.arguments
                             {
-                                path
+                                if let Some(Pair::End(GenericArgument::Type(Type::Path(
+                                    TypePath { path, .. },
+                                )))) = args.first()
+                                {
+                                    path
+                                } else {
+                                    panic!(
+                                        "Expected `{}` first generic parameter to be a type.",
+                                        &field_name
+                                    )
+                                }
                             } else {
-                                panic!(
-                                    "Expected `{}` first generic parameter to be a type.",
-                                    &field_name
-                                )
+                                panic!("Expected `{}` field to have type parameters.", &field_name)
                             }
                         } else {
-                            panic!("Expected `{}` field to have type parameters.", &field_name)
+                            panic!("Expected `{}` field last segment to exist.", &field_name)
                         }
                     } else {
-                        panic!("Expected `{}` field last segment to exist.", &field_name)
-                    }
-                } else {
-                    panic!("Expected `{}` field type to be `Type::Path`.", &field_name)
-                };
-                let tokens = quote! {
-                    let #field_name = world
-                        .fetch_mut::<EventChannel<#event_type_path>>()
-                        .register_reader();
-                };
-                token_stream.extend(tokens);
+                        panic!("Expected `{}` field type to be `Type::Path`.", &field_name)
+                    };
+
+                    let tokens = quote! {
+                        let #field_name = world
+                            .fetch_mut::<EventChannel<#event_type_path>>()
+                            .register_reader();
+                    };
+                    token_stream.extend(tokens);
+                }
+                FieldVariant::Compute(FieldToCompute::FlaggedStorageReader(field)) => {
+                    let field_name = field.ident.clone().unwrap_or_else(|| snake_case(field));
+                    let component_path = {
+                        let meta = field.tag_parameter("system_desc", "flagged_storage_reader");
+                        if let Some(Meta::Word(ident)) = meta {
+                            ident
+                        } else {
+                            panic!(
+                                "Expected component type name for `flagged_storage_reader` \
+                                 parameter. Got: `{:?}`",
+                                &meta
+                            )
+                        }
+                    };
+                    let tokens = quote! {
+                        let #field_name = WriteStorage::<#component_path>::fetch(&world)
+                            .register_reader();
+                    };
+                    token_stream.extend(tokens);
+                }
+                _ => {}
             }
 
             token_stream

--- a/amethyst_derive/tests/system_desc.rs
+++ b/amethyst_derive/tests/system_desc.rs
@@ -333,3 +333,36 @@ fn struct_named_complex() -> Result<(), Error> {
 
     Ok(())
 }
+
+#[test]
+fn system_with_flagged_storage_reader() -> Result<(), Error> {
+    use amethyst_core::{
+        ecs::{storage::ComponentEvent, WriteStorage},
+        transform::Transform,
+    };
+
+    // Expects `System` to have a `new` constructor.
+    #[derive(Debug, SystemDesc)]
+    #[system_desc(name(SystemWithFlaggedStorageReaderDesc))]
+    struct SystemWithFlaggedStorageReader {
+        #[system_desc(flagged_storage_reader(Transform))]
+        transform_events: ReaderId<ComponentEvent>,
+    }
+    impl SystemWithFlaggedStorageReader {
+        fn new(transform_events: ReaderId<ComponentEvent>) -> Self {
+            Self { transform_events }
+        }
+    }
+
+    impl<'s> System<'s> for SystemWithFlaggedStorageReader {
+        type SystemData = ();
+        fn run(&mut self, _: Self::SystemData) {}
+    }
+
+    let mut world = World::new();
+    world.register::<Transform>();
+
+    SystemWithFlaggedStorageReaderDesc::default().build(&mut world);
+
+    Ok(())
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * `AmethystApplication` takes in a `System` instead of a closure for `with_system`. ([#1882])
 * `AmethystApplication::with_thread_local` constraint relaxed to `RunNow` (previously `System`). ([#1882])
 * `SystemDesc` proc macro supports `#[system_desc(event_reader_id)]` to register event reader. ([#1883])
+* `SystemDesc` proc macro supports `#[system_desc(flagged_storage_reader(Component))]`. ([#1886])
 
 ### Fixed
 
@@ -41,6 +42,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1881]: https://github.com/amethyst/amethyst/pull/1881
 [#1882]: https://github.com/amethyst/amethyst/pull/1882
 [#1883]: https://github.com/amethyst/amethyst/pull/1883
+[#1886]: https://github.com/amethyst/amethyst/pull/1886
 
 ## [0.12.0] - 2019-07-30
 


### PR DESCRIPTION
## Description

Extends `SystemDesc` derive to support this:

```rust
#[derive(Debug, SystemDesc)]
#[system_desc(name(SystemWithFlaggedStorageReaderDesc))]
struct SystemWithFlaggedStorageReader {
    #[system_desc(flagged_storage_reader(Transform))]
    transform_events: ReaderId<ComponentEvent>,
}
impl SystemWithFlaggedStorageReader {
    fn new(transform_events: ReaderId<ComponentEvent>) -> Self {
        Self { transform_events }
    }
}
```

## Modifications

* `SystemDesc` proc macro supports `#[system_desc(flagged_storage_reader(Component))]`.

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
