### PR TITLE
Maintenance/use system desc improvements

### DIFF
--- a/amethyst_animation/src/skinning/systems.rs
+++ b/amethyst_animation/src/skinning/systems.rs
@@ -6,6 +6,7 @@ use amethyst_core::{
     math::{convert, Matrix4},
     SystemDesc, Transform,
 };
+use amethyst_derive::SystemDesc;
 use amethyst_rendy::skinning::JointTransforms;
 
 use log::error;
@@ -15,29 +16,19 @@ use thread_profiler::profile_scope;
 
 use super::resources::*;
 
-/// Builds a `VertexSkinningSystem`.
-#[derive(Default, Debug)]
-pub struct VertexSkinningSystemDesc;
-
-impl<'a, 'b> SystemDesc<'a, 'b, VertexSkinningSystem> for VertexSkinningSystemDesc {
-    fn build(self, world: &mut World) -> VertexSkinningSystem {
-        <VertexSkinningSystem as System<'_>>::SystemData::setup(world);
-        let mut transform = WriteStorage::<Transform>::fetch(&world);
-        let updated_id = transform.register_reader();
-
-        VertexSkinningSystem::new(updated_id)
-    }
-}
-
 /// System for performing vertex skinning.
 ///
 /// Needs to run after global transforms have been updated for the current frame.
-#[derive(Debug)]
+#[derive(Debug, SystemDesc)]
+#[system_desc(name(VertexSkinningSystemDesc))]
 pub struct VertexSkinningSystem {
     /// Also scratch space, used while determining which skins need to be updated.
+    #[system_desc(skip)]
     updated: BitSet,
+    #[system_desc(skip)]
     updated_skins: BitSet,
     /// Used for tracking modifications to global transforms
+    #[system_desc(flagged_storage_reader(Transform))]
     updated_id: ReaderId<ComponentEvent>,
 }
 

--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -21,6 +21,7 @@ travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
 amethyst_core = { path = "../amethyst_core", version = "0.7.0" }
+amethyst_derive = { path = "../amethyst_derive", version = "0.5.0"}
 amethyst_error = { path = "../amethyst_error", version = "0.2.0" }
 crossbeam-queue = "0.1.2"
 derivative = "1.0"

--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -119,25 +119,6 @@ impl<'a> System<'a> for ArcBallRotationSystem {
     }
 }
 
-/// Builds a `FreeRotationSystem`.
-#[derive(Default, Debug, new)]
-pub struct FreeRotationSystemDesc {
-    /// Sensitivity on the x axis.
-    pub sensitivity_x: f32,
-    /// Sensitivity on the y axis.
-    pub sensitivity_y: f32,
-}
-
-impl<'a, 'b> SystemDesc<'a, 'b, FreeRotationSystem> for FreeRotationSystemDesc {
-    fn build(self, world: &mut World) -> FreeRotationSystem {
-        <FreeRotationSystem as System<'_>>::SystemData::setup(world);
-
-        let event_reader = world.fetch_mut::<EventChannel<Event>>().register_reader();
-
-        FreeRotationSystem::new(self.sensitivity_x, self.sensitivity_y, event_reader)
-    }
-}
-
 /// The system that manages the view rotation.
 ///
 /// Controlled by the mouse.
@@ -145,10 +126,12 @@ impl<'a, 'b> SystemDesc<'a, 'b, FreeRotationSystem> for FreeRotationSystemDesc {
 ///
 /// Can be manually disabled by making the mouse visible using the `HideCursor` resource:
 /// `HideCursor.hide = false`
-#[derive(Debug, new)]
+#[derive(Debug, SystemDesc, new)]
+#[system_desc(name(FreeRotationSystemDesc))]
 pub struct FreeRotationSystem {
     sensitivity_x: f32,
     sensitivity_y: f32,
+    #[system_desc(event_channel_reader)]
     event_reader: ReaderId<Event>,
 }
 
@@ -185,23 +168,11 @@ impl<'a> System<'a> for FreeRotationSystem {
     }
 }
 
-/// Builds a `MouseFocusUpdateSystem`.
-#[derive(Default, Debug)]
-pub struct MouseFocusUpdateSystemDesc;
-
-impl<'a, 'b> SystemDesc<'a, 'b, MouseFocusUpdateSystem> for MouseFocusUpdateSystemDesc {
-    fn build(self, world: &mut World) -> MouseFocusUpdateSystem {
-        <MouseFocusUpdateSystem as System<'_>>::SystemData::setup(world);
-
-        let event_reader = world.fetch_mut::<EventChannel<Event>>().register_reader();
-
-        MouseFocusUpdateSystem::new(event_reader)
-    }
-}
-
 /// A system which reads Events and saves if a window has lost focus in a WindowFocus resource
-#[derive(Debug, new)]
+#[derive(Debug, SystemDesc, new)]
+#[system_desc(name(MouseFocusUpdateSystemDesc))]
 pub struct MouseFocusUpdateSystem {
+    #[system_desc(event_channel_reader)]
     event_reader: ReaderId<Event>,
 }
 
@@ -222,24 +193,20 @@ impl<'a> System<'a> for MouseFocusUpdateSystem {
     }
 }
 
-/// Builds a `CursorHideSystem`.
-#[derive(Default, Debug)]
-pub struct CursorHideSystemDesc;
-
-impl<'a, 'b> SystemDesc<'a, 'b, CursorHideSystem> for CursorHideSystemDesc {
-    fn build(self, world: &mut World) -> CursorHideSystem {
-        <CursorHideSystem as System<'_>>::SystemData::setup(world);
-
-        CursorHideSystem::new()
-    }
-}
-
 /// System which hides the cursor when the window is focused.
 /// Requires the usage MouseFocusUpdateSystem at the same time.
-#[derive(Debug, new)]
+#[derive(Debug, SystemDesc, new)]
+#[system_desc(name(CursorHideSystemDesc))]
 pub struct CursorHideSystem {
     #[new(value = "true")]
+    #[system_desc(skip)]
     is_hidden: bool,
+}
+
+impl Default for CursorHideSystem {
+    fn default() -> Self {
+        CursorHideSystem::new()
+    }
 }
 
 impl<'a> System<'a> for CursorHideSystem {

--- a/amethyst_ui/src/button/system.rs
+++ b/amethyst_ui/src/button/system.rs
@@ -1,9 +1,11 @@
+use std::{collections::HashMap, fmt::Debug};
+
 use amethyst_core::{
     ecs::{Entity, ReadExpect, System, SystemData, World, Write, WriteStorage},
     shrev::{EventChannel, ReaderId},
     ParentHierarchy, SystemDesc,
 };
-use std::{collections::HashMap, fmt::Debug};
+use amethyst_derive::SystemDesc;
 
 use crate::{UiButtonAction, UiButtonActionType::*, UiImage, UiText};
 
@@ -53,30 +55,18 @@ where
     }
 }
 
-/// Builds a `UiButtonSystem`.
-#[derive(Default, Debug)]
-pub struct UiButtonSystemDesc;
-
-impl<'a, 'b> SystemDesc<'a, 'b, UiButtonSystem> for UiButtonSystemDesc {
-    fn build(self, world: &mut World) -> UiButtonSystem {
-        <UiButtonSystem as System<'_>>::SystemData::setup(world);
-
-        let event_reader = world
-            .fetch_mut::<EventChannel<UiButtonAction>>()
-            .register_reader();
-
-        UiButtonSystem::new(event_reader)
-    }
-}
-
 /// This system manages button mouse events.  It changes images and text colors, as well as playing audio
 /// when necessary.
 ///
 /// It's automatically registered with the `UiBundle`.
-#[derive(Debug)]
+#[derive(Debug, SystemDesc)]
+#[system_desc(name(UiButtonSystemDesc))]
 pub struct UiButtonSystem {
+    #[system_desc(event_channel_reader)]
     event_reader: ReaderId<UiButtonAction>,
+    #[system_desc(skip)]
     set_images: HashMap<Entity, ActionChangeStack<UiImage>>,
+    #[system_desc(skip)]
     set_text_colors: HashMap<Entity, ActionChangeStack<[f32; 4]>>,
 }
 

--- a/amethyst_ui/src/event_retrigger.rs
+++ b/amethyst_ui/src/event_retrigger.rs
@@ -46,6 +46,8 @@ pub trait EventRetrigger: Component {
         R: EventReceiver<Self::Out>;
 }
 
+// Unable to derive `SystemDesc` on `EventRetriggerSystem` because the proc macro doesn't yet
+// support creating a `PhantomData` for computed fields.
 /// Builds an `EventRetriggerSystem`.
 #[derive(Derivative, Debug)]
 #[derivative(Default(bound = ""))]

--- a/amethyst_ui/src/resize.rs
+++ b/amethyst_ui/src/resize.rs
@@ -6,6 +6,7 @@ use amethyst_core::{
     shrev::ReaderId,
     SystemDesc,
 };
+use amethyst_derive::SystemDesc;
 use amethyst_window::ScreenDimensions;
 
 #[cfg(feature = "profiler")]
@@ -40,27 +41,16 @@ impl Component for UiResize {
     type Storage = FlaggedStorage<Self>;
 }
 
-/// Builds a `ResizeSystem`.
-#[derive(Default, Debug)]
-pub struct ResizeSystemDesc;
-
-impl<'a, 'b> SystemDesc<'a, 'b, ResizeSystem> for ResizeSystemDesc {
-    fn build(self, world: &mut World) -> ResizeSystem {
-        <ResizeSystem as System<'_>>::SystemData::setup(world);
-
-        let mut resize = WriteStorage::<UiResize>::fetch(&world);
-        let resize_events_id = resize.register_reader();
-
-        ResizeSystem::new(resize_events_id)
-    }
-}
-
 /// This system rearranges UI elements whenever the screen is resized using their `UiResize`
 /// component.
-#[derive(Debug)]
+#[derive(Debug, SystemDesc)]
+#[system_desc(name(ResizeSystemDesc))]
 pub struct ResizeSystem {
+    #[system_desc(skip)]
     screen_size: (f32, f32),
+    #[system_desc(flagged_storage_reader(UiResize))]
     resize_events_id: ReaderId<ComponentEvent>,
+    #[system_desc(skip)]
     local_modified: BitSet,
 }
 

--- a/amethyst_ui/src/selection.rs
+++ b/amethyst_ui/src/selection.rs
@@ -13,6 +13,7 @@ use amethyst_core::{
     shrev::EventChannel,
     SystemDesc,
 };
+use amethyst_derive::SystemDesc;
 use amethyst_input::{BindingTypes, InputHandler};
 
 use crate::{CachedSelectionOrder, UiEvent, UiEventType};
@@ -55,31 +56,16 @@ impl Component for Selected {
     type Storage = DenseVecStorage<Self>;
 }
 
-/// Builds a `SelectionKeyboardSystem`.
-#[derive(Derivative, Debug)]
-#[derivative(Default(bound = ""))]
-pub struct SelectionKeyboardSystemDesc<G> {
-    marker: PhantomData<G>,
-}
-
-impl<'a, 'b, G> SystemDesc<'a, 'b, SelectionKeyboardSystem<G>> for SelectionKeyboardSystemDesc<G>
-where
-    G: Send + Sync + 'static + PartialEq,
-{
-    fn build(self, world: &mut World) -> SelectionKeyboardSystem<G> {
-        <SelectionKeyboardSystem<G> as System<'_>>::SystemData::setup(world);
-
-        let window_reader_id = world.fetch_mut::<EventChannel<Event>>().register_reader();
-
-        SelectionKeyboardSystem::new(window_reader_id)
-    }
-}
-
 /// System managing the selection of entities.
 /// Reacts to `UiEvent`.
 /// Reacts to Tab and Shift+Tab.
-#[derive(Debug)]
-pub struct SelectionKeyboardSystem<G> {
+#[derive(Debug, SystemDesc)]
+#[system_desc(name(SelectionKeyboardSystemDesc))]
+pub struct SelectionKeyboardSystem<G>
+where
+    G: Send + Sync + 'static + PartialEq,
+{
+    #[system_desc(event_channel_reader)]
     window_reader_id: ReaderId<Event>,
     phantom: PhantomData<G>,
 }

--- a/amethyst_ui/src/sound.rs
+++ b/amethyst_ui/src/sound.rs
@@ -8,6 +8,7 @@ use amethyst_core::{
     shrev::{EventChannel, ReaderId},
     SystemDesc,
 };
+use amethyst_derive::SystemDesc;
 
 use crate::{
     event::{UiEvent, UiEventType::*},
@@ -70,26 +71,12 @@ impl EventRetrigger for UiSoundRetrigger {
     }
 }
 
-/// Builds a `UiSoundSystem`.
-#[derive(Default, Debug)]
-pub struct UiSoundSystemDesc;
-
-impl<'a, 'b> SystemDesc<'a, 'b, UiSoundSystem> for UiSoundSystemDesc {
-    fn build(self, world: &mut World) -> UiSoundSystem {
-        <UiSoundSystem as System<'_>>::SystemData::setup(world);
-
-        let event_reader = world
-            .fetch_mut::<EventChannel<UiPlaySoundAction>>()
-            .register_reader();
-
-        UiSoundSystem::new(event_reader)
-    }
-}
-
 /// Handles any dispatches `UiPlaySoundAction`s and plays the received
 /// sounds through the set `Output`.
-#[derive(Debug)]
+#[derive(Debug, SystemDesc)]
+#[system_desc(name(UiSoundSystemDesc))]
 pub struct UiSoundSystem {
+    #[system_desc(event_channel_reader)]
     event_reader: ReaderId<UiPlaySoundAction>,
 }
 

--- a/amethyst_ui/src/text.rs
+++ b/amethyst_ui/src/text.rs
@@ -14,6 +14,7 @@ use amethyst_core::{
     timing::Time,
     SystemDesc,
 };
+use amethyst_derive::SystemDesc;
 use amethyst_window::ScreenDimensions;
 
 use super::*;
@@ -135,28 +136,18 @@ impl Component for TextEditing {
     type Storage = DenseVecStorage<Self>;
 }
 
-/// Builds a `TextEditingMouseSystem`.
-#[derive(Default, Debug)]
-pub struct TextEditingMouseSystemDesc;
-
-impl<'a, 'b> SystemDesc<'a, 'b, TextEditingMouseSystem> for TextEditingMouseSystemDesc {
-    fn build(self, world: &mut World) -> TextEditingMouseSystem {
-        <TextEditingMouseSystem as System<'_>>::SystemData::setup(world);
-
-        let reader = world.fetch_mut::<EventChannel<Event>>().register_reader();
-
-        TextEditingMouseSystem::new(reader)
-    }
-}
-
 /// This system processes the underlying UI data as needed.
-#[derive(Debug)]
+#[derive(Debug, SystemDesc)]
+#[system_desc(name(TextEditingMouseSystemDesc))]
 pub struct TextEditingMouseSystem {
     /// A reader for winit events.
+    #[system_desc(event_channel_reader)]
     reader: ReaderId<Event>,
     /// This is set to true while the left mouse button is pressed.
+    #[system_desc(skip)]
     left_mouse_button_pressed: bool,
     /// The screen coordinates of the mouse
+    #[system_desc(skip)]
     mouse_position: (f32, f32),
 }
 

--- a/amethyst_ui/src/text_editing.rs
+++ b/amethyst_ui/src/text_editing.rs
@@ -6,7 +6,6 @@ use unicode_normalization::{char::is_combining_mark, UnicodeNormalization};
 use unicode_segmentation::UnicodeSegmentation;
 use winit::{ElementState, Event, KeyboardInput, ModifiersState, VirtualKeyCode, WindowEvent};
 
-use crate::{LineMode, Selected, TextEditing, UiEvent, UiEventType, UiText};
 use amethyst_core::{
     ecs::prelude::{
         Entities, Join, Read, ReadStorage, System, SystemData, World, Write, WriteStorage,
@@ -14,29 +13,20 @@ use amethyst_core::{
     shrev::{EventChannel, ReaderId},
     SystemDesc,
 };
+use amethyst_derive::SystemDesc;
 
-/// Builds a `TextEditingInputSystem`.
-#[derive(Default, Debug)]
-pub struct TextEditingInputSystemDesc;
-
-impl<'a, 'b> SystemDesc<'a, 'b, TextEditingInputSystem> for TextEditingInputSystemDesc {
-    fn build(self, world: &mut World) -> TextEditingInputSystem {
-        <TextEditingInputSystem as System<'_>>::SystemData::setup(world);
-
-        let reader = world.fetch_mut::<EventChannel<Event>>().register_reader();
-
-        TextEditingInputSystem::new(reader)
-    }
-}
+use crate::{LineMode, Selected, TextEditing, UiEvent, UiEventType, UiText};
 
 /// System managing the keyboard inputs for the editable text fields.
 /// ## Features
 /// * Adds and removes text.
 /// * Moves selection cursor.
 /// * Grows and shrinks selected text zone.
-#[derive(Debug)]
+#[derive(Debug, SystemDesc)]
+#[system_desc(name(TextEditingInputSystemDesc))]
 pub struct TextEditingInputSystem {
     /// A reader for winit events.
+    #[system_desc(event_channel_reader)]
     reader: ReaderId<Event>,
 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * `AmethystApplication::with_thread_local` constraint relaxed to `RunNow` (previously `System`). ([#1882])
 * `SystemDesc` proc macro supports `#[system_desc(event_reader_id)]` to register event reader. ([#1883])
 * `SystemDesc` proc macro supports `#[system_desc(flagged_storage_reader(Component))]`. ([#1886])
+* Use `SystemDesc` derive to generate `SystemDesc` implementations for common case systems. ([#1887])
 * `DispatcherOperation` stores system name and dependencies as `String`s. ([#1891])
 * `TextureProcessor` renamed to `TextureProcessorSystem` ([#1839]).
 * `MeshProcessor` renamed to `MeshProcessorSystem` ([#1839]).
@@ -48,6 +49,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1882]: https://github.com/amethyst/amethyst/pull/1882
 [#1883]: https://github.com/amethyst/amethyst/pull/1883
 [#1886]: https://github.com/amethyst/amethyst/pull/1886
+[#1887]: https://github.com/amethyst/amethyst/pull/1887
 [#1891]: https://github.com/amethyst/amethyst/pull/1891
 [#1896]: https://github.com/amethyst/amethyst/pull/1896
 [#1839]: https://github.com/amethyst/amethyst/pull/1839

--- a/examples/arc_ball_camera/main.rs
+++ b/examples/arc_ball_camera/main.rs
@@ -8,6 +8,7 @@ use amethyst::{
         transform::{Transform, TransformBundle},
         SystemDesc,
     },
+    derive::SystemDesc,
     ecs::prelude::{Join, Read, ReadStorage, System, SystemData, World, WorldExt, WriteStorage},
     input::{
         is_key_down, InputBundle, InputEvent, ScrollDirection, StringBindings, VirtualKeyCode,
@@ -53,23 +54,10 @@ impl SimpleState for ExampleState {
     }
 }
 
-/// Builds a `CameraDistanceSystem`.
-#[derive(Default, Debug)]
-pub struct CameraDistanceSystemDesc;
-
-impl<'a, 'b> SystemDesc<'a, 'b, CameraDistanceSystem> for CameraDistanceSystemDesc {
-    fn build(self, world: &mut World) -> CameraDistanceSystem {
-        <CameraDistanceSystem as System<'_>>::SystemData::setup(world);
-
-        let event_reader = world
-            .fetch_mut::<EventChannel<InputEvent<StringBindings>>>()
-            .register_reader();
-
-        CameraDistanceSystem::new(event_reader)
-    }
-}
-
+#[derive(SystemDesc)]
+#[system_desc(name(CameraDistanceSystemDesc))]
 struct CameraDistanceSystem {
+    #[system_desc(event_channel_reader)]
     event_reader: ReaderId<InputEvent<StringBindings>>,
 }
 

--- a/examples/events/main.rs
+++ b/examples/events/main.rs
@@ -65,21 +65,10 @@ impl<'a> System<'a> for SpammingSystem {
     }
 }
 
-/// Builds a `ReceivingSystem`.
-#[derive(Default, Debug)]
-pub struct ReceivingSystemDesc;
-
-impl<'a, 'b> SystemDesc<'a, 'b, ReceivingSystem> for ReceivingSystemDesc {
-    fn build(self, world: &mut World) -> ReceivingSystem {
-        <ReceivingSystem as System<'_>>::SystemData::setup(world);
-
-        let reader = world.fetch_mut::<EventChannel<MyEvent>>().register_reader();
-
-        ReceivingSystem::new(reader)
-    }
-}
-
+#[derive(SystemDesc)]
+#[system_desc(name(ReceivingSystemDesc))]
 struct ReceivingSystem {
+    #[system_desc(event_channel_reader)]
     reader: ReaderId<MyEvent>,
 }
 

--- a/examples/ui/main.rs
+++ b/examples/ui/main.rs
@@ -4,6 +4,7 @@ use amethyst::{
     assets::{PrefabLoader, PrefabLoaderSystemDesc, Processor, RonFormat},
     audio::{output::init_output, Source},
     core::{frame_limiter::FrameRateLimitStrategy, transform::TransformBundle, SystemDesc, Time},
+    derive::SystemDesc,
     ecs::prelude::{Entity, System, SystemData, World, WorldExt, Write},
     input::{is_close_requested, is_key_down, InputBundle, StringBindings},
     prelude::*,
@@ -152,22 +153,11 @@ fn main() -> amethyst::Result<()> {
     Ok(())
 }
 
-/// Builds a `UiEventHandlerSystem`.
-#[derive(Default, Debug)]
-pub struct UiEventHandlerSystemDesc;
-
-impl<'a, 'b> SystemDesc<'a, 'b, UiEventHandlerSystem> for UiEventHandlerSystemDesc {
-    fn build(self, world: &mut World) -> UiEventHandlerSystem {
-        <UiEventHandlerSystem as System<'_>>::SystemData::setup(world);
-
-        let reader_id = Write::<'_, EventChannel<UiEvent>>::fetch(world).register_reader();
-
-        UiEventHandlerSystem::new(reader_id)
-    }
-}
-
 /// This shows how to handle UI events.
+#[derive(SystemDesc)]
+#[system_desc(name(UiEventHandlerSystemDesc))]
 pub struct UiEventHandlerSystem {
+    #[system_desc(event_channel_reader)]
     reader_id: ReaderId<UiEvent>,
 }
 


### PR DESCRIPTION
## Description

Updated amethyst code to use `SystemDesc` derive where possible.

(based on top of #1886)

## Modifications

* Use `SystemDesc` derive to generate `SystemDesc` implementations for common case systems.

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
