### PR TITLE
Upgrade winit to 0.20.0-alpha3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ log = { version = "0.4.6", features = ["serde"] }
 rayon = "1.1.0"
 rustc_version_runtime = "0.1"
 sentry = { version = "0.15.4", optional = true }
-winit = { version = "0.19", features = ["serde", "icon_loading"] }
+winit = { version = "0.20.0-alpha3", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 palette = { version = "0.4", features = ["serde"] }
 

--- a/amethyst_controls/Cargo.toml
+++ b/amethyst_controls/Cargo.toml
@@ -22,7 +22,7 @@ amethyst_error = { path = "../amethyst_error", version = "0.2.0" }
 amethyst_input = { path = "../amethyst_input", version = "0.8.0" }
 derive-new = "0.5"
 serde = { version = "1.0", features = ["derive"] }
-winit = { version = "0.19", features = ["serde"] }
+winit = { version = "0.20.0-alpha3", features = ["serde"] }
 log = "0.4.6"
 
 thread_profiler = { version = "0.3", optional = true }

--- a/amethyst_input/Cargo.toml
+++ b/amethyst_input/Cargo.toml
@@ -23,7 +23,7 @@ derivative = "1.0"
 derive-new = "0.5"
 fnv = "1"
 serde = { version = "1", features = ["derive"] }
-winit = { version = "0.19", features = ["serde"] }
+winit = { version = "0.20.0-alpha3", features = ["serde"] }
 sdl2 = { version = "0.31.0", optional = true }
 
 thread_profiler = { version = "0.3", optional = true }

--- a/amethyst_input/src/bindings.rs
+++ b/amethyst_input/src/bindings.rs
@@ -505,7 +505,7 @@ impl<T: BindingTypes> Bindings<T> {
 mod tests {
     use super::*;
     use crate::{button::*, controller::ControllerAxis};
-    use winit::{MouseButton, VirtualKeyCode};
+    use winit::event::{MouseButton, VirtualKeyCode};
 
     #[test]
     fn add_and_remove_actions() {

--- a/amethyst_input/src/button.rs
+++ b/amethyst_input/src/button.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use winit::{MouseButton, VirtualKeyCode};
+use winit::event::{MouseButton, VirtualKeyCode};
 
 use super::{controller::ControllerButton, scroll_direction::ScrollDirection};
 

--- a/amethyst_input/src/event.rs
+++ b/amethyst_input/src/event.rs
@@ -1,6 +1,6 @@
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
-use winit::{MouseButton, VirtualKeyCode};
+use winit::event::{MouseButton, VirtualKeyCode};
 
 use super::{
     bindings::BindingTypes,

--- a/amethyst_input/src/input_handler.rs
+++ b/amethyst_input/src/input_handler.rs
@@ -11,8 +11,11 @@ use derivative::Derivative;
 use smallvec::SmallVec;
 use std::{borrow::Borrow, hash::Hash};
 use winit::{
-    dpi::LogicalPosition, DeviceEvent, ElementState, Event, KeyboardInput, MouseButton,
-    MouseScrollDelta, VirtualKeyCode, WindowEvent,
+    dpi::LogicalPosition,
+    event::{
+        DeviceEvent, ElementState, Event, KeyboardInput, MouseButton, MouseScrollDelta,
+        VirtualKeyCode, WindowEvent,
+    },
 };
 
 /// This struct holds state information about input devices.
@@ -57,7 +60,7 @@ where
     /// the world as a resource.
     pub fn send_event(
         &mut self,
-        event: &Event,
+        event: &Event<()>,
         event_handler: &mut EventChannel<InputEvent<T>>,
         hidpi: f32,
     ) {
@@ -748,8 +751,10 @@ mod tests {
 
     use super::*;
     use winit::{
-        DeviceId, ElementState, Event, KeyboardInput, ModifiersState, ScanCode, WindowEvent,
-        WindowId,
+        event::{
+            DeviceId, ElementState, Event, KeyboardInput, ModifiersState, ScanCode, WindowEvent,
+        },
+        window::WindowId,
     };
 
     const HIDPI: f32 = 1.0;
@@ -1229,11 +1234,11 @@ right: `{:?}`",
         }
     }
 
-    fn key_press(scancode: ScanCode, virtual_keycode: VirtualKeyCode) -> Event {
+    fn key_press(scancode: ScanCode, virtual_keycode: VirtualKeyCode) -> Event<()> {
         key_event(scancode, virtual_keycode, ElementState::Pressed)
     }
 
-    fn key_release(scancode: ScanCode, virtual_keycode: VirtualKeyCode) -> Event {
+    fn key_release(scancode: ScanCode, virtual_keycode: VirtualKeyCode) -> Event<()> {
         key_event(scancode, virtual_keycode, ElementState::Released)
     }
 
@@ -1241,7 +1246,7 @@ right: `{:?}`",
         scancode: ScanCode,
         virtual_keycode: VirtualKeyCode,
         state: ElementState,
-    ) -> Event {
+    ) -> Event<()> {
         Event::WindowEvent {
             window_id: unsafe { WindowId::dummy() },
             event: WindowEvent::KeyboardInput {
@@ -1261,15 +1266,15 @@ right: `{:?}`",
         }
     }
 
-    fn mouse_press(button: MouseButton) -> Event {
+    fn mouse_press(button: MouseButton) -> Event<()> {
         mouse_event(button, ElementState::Pressed)
     }
 
-    fn mouse_release(button: MouseButton) -> Event {
+    fn mouse_release(button: MouseButton) -> Event<()> {
         mouse_event(button, ElementState::Released)
     }
 
-    fn mouse_event(button: MouseButton, state: ElementState) -> Event {
+    fn mouse_event(button: MouseButton, state: ElementState) -> Event<()> {
         Event::WindowEvent {
             window_id: unsafe { WindowId::dummy() },
             event: WindowEvent::MouseInput {
@@ -1286,7 +1291,7 @@ right: `{:?}`",
         }
     }
 
-    fn mouse_wheel(x: f32, y: f32) -> Event {
+    fn mouse_wheel(x: f32, y: f32) -> Event<()> {
         Event::DeviceEvent {
             device_id: unsafe { DeviceId::dummy() },
             event: DeviceEvent::MouseWheel {

--- a/amethyst_input/src/lib.rs
+++ b/amethyst_input/src/lib.rs
@@ -26,7 +26,7 @@ pub use self::{
         is_key_up, is_mouse_button_down,
     },
 };
-pub use winit::{ElementState, VirtualKeyCode};
+pub use winit::event::{ElementState, VirtualKeyCode};
 
 use std::iter::Iterator;
 

--- a/amethyst_input/src/system.rs
+++ b/amethyst_input/src/system.rs
@@ -1,6 +1,6 @@
 //! Input system
 use derive_new::new;
-use winit::Event;
+use winit::event::Event;
 
 use crate::{BindingTypes, Bindings, InputEvent, InputHandler};
 use amethyst_core::{
@@ -32,7 +32,9 @@ where
     fn build(self, world: &mut World) -> InputSystem<T> {
         <InputSystem<T> as System<'_>>::SystemData::setup(world);
 
-        let reader = world.fetch_mut::<EventChannel<Event>>().register_reader();
+        let reader = world
+            .fetch_mut::<EventChannel<Event<()>>>()
+            .register_reader();
         if let Some(bindings) = self.bindings.as_ref() {
             world.fetch_mut::<InputHandler<T>>().bindings = bindings.clone();
         }
@@ -50,18 +52,18 @@ pub struct InputSystem<T>
 where
     T: BindingTypes,
 {
-    reader: ReaderId<Event>,
+    reader: ReaderId<Event<()>>,
     bindings: Option<Bindings<T>>,
 }
 
 impl<T: BindingTypes> InputSystem<T> {
     /// Create a new input system. Needs a reader id for `EventHandler<winit::Event>`.
-    pub fn new(reader: ReaderId<Event>, bindings: Option<Bindings<T>>) -> Self {
+    pub fn new(reader: ReaderId<Event<()>>, bindings: Option<Bindings<T>>) -> Self {
         InputSystem { reader, bindings }
     }
 
     fn process_event(
-        event: &Event,
+        event: &Event<()>,
         handler: &mut InputHandler<T>,
         output: &mut EventChannel<InputEvent<T>>,
         hidpi: f32,
@@ -72,7 +74,7 @@ impl<T: BindingTypes> InputSystem<T> {
 
 impl<'a, T: BindingTypes> System<'a> for InputSystem<T> {
     type SystemData = (
-        Read<'a, EventChannel<Event>>,
+        Read<'a, EventChannel<Event<()>>>,
         Write<'a, InputHandler<T>>,
         Write<'a, EventChannel<InputEvent<T>>>,
         ReadExpect<'a, ScreenDimensions>,

--- a/amethyst_input/src/util.rs
+++ b/amethyst_input/src/util.rs
@@ -1,9 +1,9 @@
 use crate::{input_handler::InputHandler, BindingTypes};
-use winit::{ElementState, Event, KeyboardInput, MouseButton, VirtualKeyCode, WindowEvent};
+use winit::event::{ElementState, Event, KeyboardInput, MouseButton, VirtualKeyCode, WindowEvent};
 
 /// If this event was for manipulating a keyboard key then this will return the `VirtualKeyCode`
 /// and the new state.
-pub fn get_key(event: &Event) -> Option<(VirtualKeyCode, ElementState)> {
+pub fn get_key(event: &Event<()>) -> Option<(VirtualKeyCode, ElementState)> {
     match *event {
         Event::WindowEvent { ref event, .. } => match *event {
             WindowEvent::KeyboardInput {
@@ -23,7 +23,7 @@ pub fn get_key(event: &Event) -> Option<(VirtualKeyCode, ElementState)> {
 
 /// Returns true if the event passed in is a key down event for the
 /// provided `VirtualKeyCode`.
-pub fn is_key_down(event: &Event, key_code: VirtualKeyCode) -> bool {
+pub fn is_key_down(event: &Event<()>, key_code: VirtualKeyCode) -> bool {
     if let Some((key, state)) = get_key(event) {
         return key == key_code && state == ElementState::Pressed;
     }
@@ -33,7 +33,7 @@ pub fn is_key_down(event: &Event, key_code: VirtualKeyCode) -> bool {
 
 /// Returns true if the event passed in is a key up event for the
 /// provided `VirtualKeyCode`.
-pub fn is_key_up(event: &Event, key_code: VirtualKeyCode) -> bool {
+pub fn is_key_up(event: &Event<()>, key_code: VirtualKeyCode) -> bool {
     if let Some((key, state)) = get_key(event) {
         return key == key_code && state == ElementState::Released;
     }
@@ -42,7 +42,7 @@ pub fn is_key_up(event: &Event, key_code: VirtualKeyCode) -> bool {
 }
 
 /// Returns true if the event passed in is a request to close the game window.
-pub fn is_close_requested(event: &Event) -> bool {
+pub fn is_close_requested(event: &Event<()>) -> bool {
     match *event {
         Event::WindowEvent { ref event, .. } => match *event {
             WindowEvent::CloseRequested => true,
@@ -65,7 +65,7 @@ pub fn get_input_axis_simple<T: BindingTypes>(
 
 /// If this event was for manipulating a mouse button, this will return the `MouseButton`
 /// and the new state.
-pub fn get_mouse_button(event: &Event) -> Option<(MouseButton, ElementState)> {
+pub fn get_mouse_button(event: &Event<()>) -> Option<(MouseButton, ElementState)> {
     match *event {
         Event::WindowEvent { ref event, .. } => match *event {
             WindowEvent::MouseInput { button, state, .. } => Some((button, state)),
@@ -77,7 +77,7 @@ pub fn get_mouse_button(event: &Event) -> Option<(MouseButton, ElementState)> {
 
 /// Returns true if the event passed in is a mouse button down event for the
 /// provided `MouseButton`.
-pub fn is_mouse_button_down(event: &Event, button: MouseButton) -> bool {
+pub fn is_mouse_button_down(event: &Event<()>, button: MouseButton) -> bool {
     if let Some((pressed_button, state)) = get_mouse_button(event) {
         pressed_button == button && state == ElementState::Pressed
     } else {

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -40,7 +40,7 @@ approx = "0.3.2"
 rayon = "1.1.0"
 more-asserts = "0.2.1"
 criterion = "0.2.11"
-winit = "0.19"
+winit = "0.20.0-alpha3"
 approx = "0.3"
 
 [features]

--- a/amethyst_rendy/src/bundle.rs
+++ b/amethyst_rendy/src/bundle.rs
@@ -883,17 +883,14 @@ mod tests {
     #[test]
     #[ignore] // CI can't run tests requiring actual backend
     fn main_pass_surface_plan() {
-        use winit::{EventsLoop, WindowBuilder};
+        use winit::{event_loop::EventLoop, window::WindowBuilder};
 
-        let ev_loop = EventsLoop::new();
+        let ev_loop = EventLoop::new();
         let mut window_builder = WindowBuilder::new();
         window_builder.window.visible = false;
         let window = window_builder.build(&ev_loop).unwrap();
 
-        let size = window
-            .get_inner_size()
-            .unwrap()
-            .to_physical(window.get_hidpi_factor());
+        let size = window.inner_size().to_physical(window.hidpi_factor());
         let window_kind = crate::Kind::D2(size.width as u32, size.height as u32, 1, 1);
 
         let config: rendy::factory::Config = Default::default();

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -32,7 +32,7 @@ serde = { version = "1.0", features = ["derive"] }
 smallvec = "0.6"
 unicode-normalization = "0.1"
 unicode-segmentation = "1.2"
-winit = { version = "0.19", features = ["serde"] }
+winit = { version = "0.20.0-alpha3", features = ["serde"] }
 log = "0.4.6"
 font-kit = "0.1"
 paste = "0.1"

--- a/amethyst_ui/src/event.rs
+++ b/amethyst_ui/src/event.rs
@@ -13,7 +13,7 @@ use amethyst_input::{BindingTypes, InputHandler};
 use amethyst_window::ScreenDimensions;
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
-use winit::MouseButton;
+use winit::event::MouseButton;
 
 pub trait TargetedEvent {
     fn get_target(&self) -> Entity;

--- a/amethyst_ui/src/selection.rs
+++ b/amethyst_ui/src/selection.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use derivative::Derivative;
 use derive_new::new;
 use serde::{Deserialize, Serialize};
-use winit::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent};
+use winit::event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent};
 
 use amethyst_core::{
     ecs::{
@@ -69,7 +69,9 @@ where
     fn build(self, world: &mut World) -> SelectionKeyboardSystem<G> {
         <SelectionKeyboardSystem<G> as System<'_>>::SystemData::setup(world);
 
-        let window_reader_id = world.fetch_mut::<EventChannel<Event>>().register_reader();
+        let window_reader_id = world
+            .fetch_mut::<EventChannel<Event<()>>>()
+            .register_reader();
 
         SelectionKeyboardSystem::new(window_reader_id)
     }
@@ -80,7 +82,7 @@ where
 /// Reacts to Tab and Shift+Tab.
 #[derive(Debug)]
 pub struct SelectionKeyboardSystem<G> {
-    window_reader_id: ReaderId<Event>,
+    window_reader_id: ReaderId<Event<()>>,
     phantom: PhantomData<G>,
 }
 
@@ -89,7 +91,7 @@ where
     G: Send + Sync + 'static + PartialEq,
 {
     /// Creates a new `SelectionKeyboardSystem`.
-    pub fn new(window_reader_id: ReaderId<Event>) -> Self {
+    pub fn new(window_reader_id: ReaderId<Event<()>>) -> Self {
         Self {
             window_reader_id,
             phantom: PhantomData,
@@ -102,7 +104,7 @@ where
     G: Send + Sync + 'static + PartialEq,
 {
     type SystemData = (
-        Read<'a, EventChannel<Event>>,
+        Read<'a, EventChannel<Event<()>>>,
         Read<'a, CachedSelectionOrder>,
         WriteStorage<'a, Selected>,
         Write<'a, EventChannel<UiEvent>>,

--- a/amethyst_ui/src/text.rs
+++ b/amethyst_ui/src/text.rs
@@ -3,7 +3,7 @@
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 use unicode_normalization::{char::is_combining_mark, UnicodeNormalization};
-use winit::{ElementState, Event, MouseButton, WindowEvent};
+use winit::event::{ElementState, Event, MouseButton, WindowEvent};
 
 use amethyst_core::{
     ecs::prelude::{
@@ -143,7 +143,9 @@ impl<'a, 'b> SystemDesc<'a, 'b, TextEditingMouseSystem> for TextEditingMouseSyst
     fn build(self, world: &mut World) -> TextEditingMouseSystem {
         <TextEditingMouseSystem as System<'_>>::SystemData::setup(world);
 
-        let reader = world.fetch_mut::<EventChannel<Event>>().register_reader();
+        let reader = world
+            .fetch_mut::<EventChannel<Event<()>>>()
+            .register_reader();
 
         TextEditingMouseSystem::new(reader)
     }
@@ -153,7 +155,7 @@ impl<'a, 'b> SystemDesc<'a, 'b, TextEditingMouseSystem> for TextEditingMouseSyst
 #[derive(Debug)]
 pub struct TextEditingMouseSystem {
     /// A reader for winit events.
-    reader: ReaderId<Event>,
+    reader: ReaderId<Event<()>>,
     /// This is set to true while the left mouse button is pressed.
     left_mouse_button_pressed: bool,
     /// The screen coordinates of the mouse
@@ -162,7 +164,7 @@ pub struct TextEditingMouseSystem {
 
 impl TextEditingMouseSystem {
     /// Creates a new instance of this system
-    pub fn new(reader: ReaderId<Event>) -> Self {
+    pub fn new(reader: ReaderId<Event<()>>) -> Self {
         Self {
             reader,
             left_mouse_button_pressed: false,
@@ -176,7 +178,7 @@ impl<'a> System<'a> for TextEditingMouseSystem {
         WriteStorage<'a, UiText>,
         WriteStorage<'a, TextEditing>,
         ReadStorage<'a, Selected>,
-        Read<'a, EventChannel<Event>>,
+        Read<'a, EventChannel<Event<()>>>,
         ReadExpect<'a, ScreenDimensions>,
         Read<'a, Time>,
     );

--- a/amethyst_ui/src/text_editing.rs
+++ b/amethyst_ui/src/text_editing.rs
@@ -4,7 +4,9 @@ use clipboard::{ClipboardContext, ClipboardProvider};
 use log::error;
 use unicode_normalization::{char::is_combining_mark, UnicodeNormalization};
 use unicode_segmentation::UnicodeSegmentation;
-use winit::{ElementState, Event, KeyboardInput, ModifiersState, VirtualKeyCode, WindowEvent};
+use winit::event::{
+    ElementState, Event, KeyboardInput, ModifiersState, VirtualKeyCode, WindowEvent,
+};
 
 use crate::{LineMode, Selected, TextEditing, UiEvent, UiEventType, UiText};
 use amethyst_core::{
@@ -23,7 +25,9 @@ impl<'a, 'b> SystemDesc<'a, 'b, TextEditingInputSystem> for TextEditingInputSyst
     fn build(self, world: &mut World) -> TextEditingInputSystem {
         <TextEditingInputSystem as System<'_>>::SystemData::setup(world);
 
-        let reader = world.fetch_mut::<EventChannel<Event>>().register_reader();
+        let reader = world
+            .fetch_mut::<EventChannel<Event<()>>>()
+            .register_reader();
 
         TextEditingInputSystem::new(reader)
     }
@@ -37,12 +41,12 @@ impl<'a, 'b> SystemDesc<'a, 'b, TextEditingInputSystem> for TextEditingInputSyst
 #[derive(Debug)]
 pub struct TextEditingInputSystem {
     /// A reader for winit events.
-    reader: ReaderId<Event>,
+    reader: ReaderId<Event<()>>,
 }
 
 impl TextEditingInputSystem {
     /// Creates a new instance of this system
-    pub fn new(reader: ReaderId<Event>) -> Self {
+    pub fn new(reader: ReaderId<Event<()>>) -> Self {
         Self { reader }
     }
 }
@@ -53,7 +57,7 @@ impl<'a> System<'a> for TextEditingInputSystem {
         WriteStorage<'a, UiText>,
         WriteStorage<'a, TextEditing>,
         ReadStorage<'a, Selected>,
-        Read<'a, EventChannel<Event>>,
+        Read<'a, EventChannel<Event<()>>>,
         Write<'a, EventChannel<UiEvent>>,
     );
 

--- a/amethyst_window/Cargo.toml
+++ b/amethyst_window/Cargo.toml
@@ -20,7 +20,7 @@ amethyst_error = { path = "../amethyst_error/", version = "0.2.0" }
 log = "0.4.6"
 serde = { version = "1", features = ["derive"] }
 thread_profiler = { version = "0.3", optional = true }
-winit = { version = "0.19", features = ["serde", "icon_loading"] }
+winit = { version = "0.20.0-alpha3", features = ["serde"] }
 
 [features]
 profiler = [ "thread_profiler/thread_profiler" ]

--- a/amethyst_window/src/lib.rs
+++ b/amethyst_window/src/lib.rs
@@ -23,6 +23,6 @@ pub use crate::{
     config::DisplayConfig,
     monitor::{MonitorIdent, MonitorsAccess},
     resources::ScreenDimensions,
-    system::{EventsLoopSystem, WindowSystem},
+    system::{EventLoopSystem, WindowSystem},
 };
-pub use winit::{Icon, Window};
+pub use winit::window::{Icon, Window};

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,11 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 * Systems needing initialization with world resources must go through a `SystemDesc` intermediate builder. ([#1780])
 
+### Breaking changes
+
+* `amethyst::winit` is now winit 0.20.0
+* `CoreApplication` now creates an `EventChannel<Event<()>>`
+
 ### Added
 
 * `SystemDesc` proc macro derive to simplify defining `SystemDesc`s. ([#1780])

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,11 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * `AmethystApplication` takes in a `System` instead of a closure for `with_system`. ([#1882])
 * `AmethystApplication::with_thread_local` constraint relaxed to `RunNow` (previously `System`). ([#1882])
 
+### Removed
+* Remove methods creating a `WindowSystem` from a DisplayConfig
+* Remove multitouch option from DisplayConfig (now enabled by default)
+* Remove Icon loading
+
 ### Fixed
 
 * `RenderingBundle` is registered last in all examples. ([#1881])

--- a/examples/animation/main.rs
+++ b/examples/animation/main.rs
@@ -14,7 +14,7 @@ use amethyst::{
         RenderingBundle,
     },
     utils::{application_root_dir, scene::BasicScenePrefab},
-    winit::{ElementState, VirtualKeyCode},
+    winit::event::{ElementState, VirtualKeyCode},
 };
 use serde::{Deserialize, Serialize};
 

--- a/examples/auto_fov/main.rs
+++ b/examples/auto_fov/main.rs
@@ -26,7 +26,7 @@ use amethyst::{
         tag::{Tag, TagFinder},
     },
     window::ScreenDimensions,
-    winit::VirtualKeyCode,
+    winit::event::VirtualKeyCode,
     Error,
 };
 use log::{error, info};

--- a/examples/custom_game_data/main.rs
+++ b/examples/custom_game_data/main.rs
@@ -25,7 +25,7 @@ use amethyst::{
     },
     ui::{RenderUi, UiBundle, UiCreator, UiLoader, UiPrefab},
     utils::{application_root_dir, fps_counter::FpsCounterBundle, scene::BasicScenePrefab},
-    winit::VirtualKeyCode,
+    winit::event::VirtualKeyCode,
     Error,
 };
 

--- a/examples/debug_lines/main.rs
+++ b/examples/debug_lines/main.rs
@@ -20,7 +20,7 @@ use amethyst::{
         RenderingBundle,
     },
     utils::application_root_dir,
-    winit::VirtualKeyCode,
+    winit::event::VirtualKeyCode,
 };
 
 #[derive(SystemDesc)]

--- a/examples/fly_camera/main.rs
+++ b/examples/fly_camera/main.rs
@@ -14,7 +14,7 @@ use amethyst::{
         RenderingBundle,
     },
     utils::{application_root_dir, scene::BasicScenePrefab},
-    winit::{MouseButton, VirtualKeyCode},
+    winit::event::{MouseButton, VirtualKeyCode},
     Error,
 };
 

--- a/examples/sprite_camera_follow/main.rs
+++ b/examples/sprite_camera_follow/main.rs
@@ -177,9 +177,11 @@ impl SimpleState for Example {
     ) -> SimpleTrans {
         let StateData { world, .. } = data;
         if let StateEvent::Window(event) = &event {
-            if is_close_requested(&event) || is_key_down(&event, winit::VirtualKeyCode::Escape) {
+            if is_close_requested(&event)
+                || is_key_down(&event, winit::event::VirtualKeyCode::Escape)
+            {
                 Trans::Quit
-            } else if is_key_down(&event, winit::VirtualKeyCode::Space) {
+            } else if is_key_down(&event, winit::event::VirtualKeyCode::Space) {
                 world.exec(
                     |(named, transforms): (ReadStorage<Named>, ReadStorage<Transform>)| {
                         for (name, transform) in (&named, &transforms).join() {

--- a/examples/sprites_ordered/main.rs
+++ b/examples/sprites_ordered/main.rs
@@ -20,7 +20,7 @@ use amethyst::{
     },
     utils::application_root_dir,
     window::ScreenDimensions,
-    winit::VirtualKeyCode,
+    winit::event::VirtualKeyCode,
 };
 
 use log::info;

--- a/examples/ui/main.rs
+++ b/examples/ui/main.rs
@@ -20,7 +20,7 @@ use amethyst::{
         fps_counter::{FpsCounter, FpsCounterBundle},
         scene::BasicScenePrefab,
     },
-    winit::VirtualKeyCode,
+    winit::event::VirtualKeyCode,
 };
 use log::info;
 

--- a/examples/window/main.rs
+++ b/examples/window/main.rs
@@ -2,7 +2,7 @@
 
 use amethyst::{
     input::is_key_down, prelude::*, utils::application_root_dir, window::WindowBundle,
-    winit::VirtualKeyCode,
+    winit::event::VirtualKeyCode,
 };
 
 struct ExampleState;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ```rust,no_run
 //! use amethyst::prelude::*;
-//! use amethyst::winit::{Event, KeyboardInput, VirtualKeyCode, WindowEvent};
+//! use amethyst::winit::event::{Event, KeyboardInput, VirtualKeyCode, WindowEvent};
 //!
 //! struct GameState;
 //!

--- a/src/state.rs
+++ b/src/state.rs
@@ -152,7 +152,7 @@ pub trait EmptyState {
     /// Executed on every frame before updating, for use in reacting to events.
     fn handle_event(&mut self, _data: StateData<'_, ()>, event: StateEvent) -> EmptyTrans {
         if let StateEvent::Window(event) = &event {
-            if is_close_requested(&event) {
+            if is_close_requested(event) {
                 Trans::Quit
             } else {
                 Trans::None
@@ -259,7 +259,7 @@ pub trait SimpleState {
         event: StateEvent,
     ) -> SimpleTrans {
         if let StateEvent::Window(event) = &event {
-            if is_close_requested(&event) {
+            if is_close_requested(event) {
                 Trans::Quit
             } else {
                 Trans::None

--- a/src/state_event.rs
+++ b/src/state_event.rs
@@ -1,5 +1,5 @@
 use derivative::Derivative;
-use winit::Event;
+use winit::event::Event;
 
 use crate::{
     core::{
@@ -22,7 +22,7 @@ where
     T: BindingTypes,
 {
     /// Events sent by the winit window.
-    Window(Event),
+    Window(Event<()>),
     /// Events sent by the ui system.
     Ui(UiEvent),
     /// Events sent by the input system.


### PR DESCRIPTION
Decided to check how complex the changes would be. Turns out it wasn't that complicated.

## Description

This fixes #1786 

## Modifications

As winit is reexported as amethyst::winit all internal API changes in winit are also breaking changes for amethyst. For example in some examples i had to change the from `use winit::` to `use::winit::event::`.  

Also `winit::event::Event` is now generic over a user defined Event type. I just set it to `Event<()>` everywhere, as I don't see a reason why one should inject custom winit events instead of using their own Event channel.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
