### PR TITLE
Maintenance/use strings for dispatcher operation

### DIFF
--- a/amethyst_core/src/deferred_dispatcher_operation.rs
+++ b/amethyst_core/src/deferred_dispatcher_operation.rs
@@ -44,9 +44,9 @@ pub struct AddSystem<S> {
     #[derivative(Debug = "ignore")]
     pub system: S,
     /// System name
-    pub name: &'static str,
+    pub name: String,
     /// System dependencies list
-    pub dependencies: &'static [&'static str],
+    pub dependencies: Vec<String>,
 }
 
 impl<'a, 'b, S> DispatcherOperation<'a, 'b> for AddSystem<S>
@@ -58,7 +58,12 @@ where
         _world: &mut World,
         dispatcher_builder: &mut DispatcherBuilder<'a, 'b>,
     ) -> Result<(), Error> {
-        dispatcher_builder.add(self.system, self.name, self.dependencies);
+        let dependencies = self
+            .dependencies
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<&str>>();
+        dispatcher_builder.add(self.system, &self.name, &dependencies);
         Ok(())
     }
 }
@@ -71,9 +76,9 @@ pub struct AddSystemDesc<SD, S> {
     #[derivative(Debug = "ignore")]
     pub system_desc: SD,
     /// System name
-    pub name: &'static str,
+    pub name: String,
     /// System dependencies
-    pub dependencies: &'static [&'static str],
+    pub dependencies: Vec<String>,
     /// Generic type holder
     pub marker: PhantomData<S>,
 }
@@ -89,7 +94,12 @@ where
         dispatcher_builder: &mut DispatcherBuilder<'a, 'b>,
     ) -> Result<(), Error> {
         let system = self.system_desc.build(world);
-        dispatcher_builder.add(system, self.name, self.dependencies);
+        let dependencies = self
+            .dependencies
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<&str>>();
+        dispatcher_builder.add(system, &self.name, &dependencies);
         Ok(())
     }
 }

--- a/amethyst_test/src/amethyst_application.rs
+++ b/amethyst_test/src/amethyst_application.rs
@@ -396,15 +396,17 @@ where
     /// * `system`: `System` to run.
     /// * `name`: Name to register the system with, used for dependency ordering.
     /// * `deps`: Names of systems that must run before this system.
-    pub fn with_system<S>(
-        self,
-        system: S,
-        name: &'static str,
-        deps: &'static [&'static str],
-    ) -> Self
+    pub fn with_system<S, N>(self, system: S, name: N, deps: &[N]) -> Self
     where
         S: for<'sys_local> System<'sys_local> + Send + 'static,
+        N: Into<String> + Clone,
     {
+        let name = Into::<String>::into(name);
+        let deps = deps
+            .iter()
+            .map(Clone::clone)
+            .map(Into::<String>::into)
+            .collect::<Vec<String>>();
         self.with_bundle_fn(move || SystemInjectionBundle::new(system, name, deps))
     }
 
@@ -415,16 +417,18 @@ where
     /// * `system_desc`: Descriptor to instantiate the `System`.
     /// * `name`: Name to register the system with, used for dependency ordering.
     /// * `deps`: Names of systems that must run before this system.
-    pub fn with_system_desc<SD, S>(
-        self,
-        system_desc: SD,
-        name: &'static str,
-        deps: &'static [&'static str],
-    ) -> Self
+    pub fn with_system_desc<SD, S, N>(self, system_desc: SD, name: N, deps: &[N]) -> Self
     where
         SD: SystemDesc<'static, 'static, S> + Send + Sync + 'static,
         S: for<'sys_local> System<'sys_local> + Send + 'static,
+        N: Into<String> + Clone,
     {
+        let name = Into::<String>::into(name);
+        let deps = deps
+            .iter()
+            .map(Clone::clone)
+            .map(Into::<String>::into)
+            .collect::<Vec<String>>();
         self.with_bundle_fn(move || SystemDescInjectionBundle::new(system_desc, name, deps))
     }
 
@@ -451,15 +455,17 @@ where
     /// * `system`: `System` to run.
     /// * `name`: Name to register the system with, used for dependency ordering.
     /// * `deps`: Names of systems that must run before this system.
-    pub fn with_system_single<S>(
-        self,
-        system: S,
-        name: &'static str,
-        deps: &'static [&'static str],
-    ) -> Self
+    pub fn with_system_single<S, N>(self, system: S, name: N, deps: &[N]) -> Self
     where
         S: for<'sys_local> System<'sys_local> + Send + Sync + 'static,
+        N: Into<String> + Clone,
     {
+        let name = Into::<String>::into(name);
+        let deps = deps
+            .iter()
+            .map(Clone::clone)
+            .map(Into::<String>::into)
+            .collect::<Vec<String>>();
         self.with_state(move || {
             CustomDispatcherStateBuilder::new()
                 .with_system(system, name, deps)
@@ -477,16 +483,18 @@ where
     /// * `system_desc`: Descriptor to instantiate the `System`.
     /// * `name`: Name to register the system with, used for dependency ordering.
     /// * `deps`: Names of systems that must run before this system.
-    pub fn with_system_desc_single<SD, S>(
-        self,
-        system_desc: SD,
-        name: &'static str,
-        deps: &'static [&'static str],
-    ) -> Self
+    pub fn with_system_desc_single<SD, S, N>(self, system_desc: SD, name: N, deps: &[N]) -> Self
     where
         SD: SystemDesc<'static, 'static, S> + Send + Sync + 'static,
         S: for<'sys_local> System<'sys_local> + Send + Sync + 'static,
+        N: Into<String> + Clone,
     {
+        let name = Into::<String>::into(name);
+        let deps = deps
+            .iter()
+            .map(Clone::clone)
+            .map(Into::<String>::into)
+            .collect::<Vec<String>>();
         self.with_state(move || {
             CustomDispatcherStateBuilder::new()
                 .with_system_desc(system_desc, name, deps)

--- a/amethyst_test/src/state/custom_dispatcher_state.rs
+++ b/amethyst_test/src/state/custom_dispatcher_state.rs
@@ -110,12 +110,7 @@ impl<'a, 'b: 'a> CustomDispatcherStateBuilder<'a, 'b> {
     /// * `system`: Function to instantiate the `System`.
     /// * `name`: Name to register the system with, used for dependency ordering.
     /// * `deps`: Names of systems that must run before this system.
-    pub fn with_system<S>(
-        mut self,
-        system: S,
-        name: &'static str,
-        dependencies: &'static [&'static str],
-    ) -> Self
+    pub fn with_system<S>(mut self, system: S, name: String, dependencies: Vec<String>) -> Self
     where
         S: for<'c> System<'c> + 'static + Send,
     {
@@ -138,8 +133,8 @@ impl<'a, 'b: 'a> CustomDispatcherStateBuilder<'a, 'b> {
     pub fn with_system_desc<SD, S>(
         mut self,
         system_desc: SD,
-        name: &'static str,
-        dependencies: &'static [&'static str],
+        name: String,
+        dependencies: Vec<String>,
     ) -> Self
     where
         SD: SystemDesc<'a, 'b, S> + 'a,

--- a/amethyst_test/src/system_desc_injection_bundle.rs
+++ b/amethyst_test/src/system_desc_injection_bundle.rs
@@ -18,9 +18,9 @@ where
     /// Function to instantiate `System` to add to the dispatcher.
     system_desc: SD,
     /// Name to register the system with.
-    system_name: &'static str,
+    system_name: String,
     /// Names of the system dependencies.
-    system_dependencies: &'static [&'static str],
+    system_dependencies: Vec<String>,
     /// Marker.
     system_marker: PhantomData<(&'a SD, &'b S)>,
 }
@@ -35,10 +35,15 @@ where
         world: &mut World,
         builder: &mut DispatcherBuilder<'a, 'b>,
     ) -> Result<(), Error> {
+        let system_dependencies = self
+            .system_dependencies
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<&str>>();
         builder.add(
             self.system_desc.build(world),
-            self.system_name,
-            self.system_dependencies,
+            &self.system_name,
+            &system_dependencies,
         );
         Ok(())
     }

--- a/amethyst_test/src/system_injection_bundle.rs
+++ b/amethyst_test/src/system_injection_bundle.rs
@@ -11,9 +11,9 @@ where
     /// Function to instantiate `System` to add to the dispatcher.
     system: S,
     /// Name to register the system with.
-    system_name: &'static str,
+    system_name: String,
     /// Names of the system dependencies.
-    system_dependencies: &'static [&'static str],
+    system_dependencies: Vec<String>,
 }
 
 impl<'a, 'b, S> SystemBundle<'a, 'b> for SystemInjectionBundle<S>
@@ -25,7 +25,12 @@ where
         _world: &mut World,
         builder: &mut DispatcherBuilder<'a, 'b>,
     ) -> Result<(), Error> {
-        builder.add(self.system, self.system_name, self.system_dependencies);
+        let system_dependencies = self
+            .system_dependencies
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<&str>>();
+        builder.add(self.system, &self.system_name, &system_dependencies);
         Ok(())
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * `AmethystApplication::with_thread_local` constraint relaxed to `RunNow` (previously `System`). ([#1882])
 * `SystemDesc` proc macro supports `#[system_desc(event_reader_id)]` to register event reader. ([#1883])
 * `SystemDesc` proc macro supports `#[system_desc(flagged_storage_reader(Component))]`. ([#1886])
+* `DispatcherOperation` stores system name and dependencies as `String`s. ([#1891])
 
 ### Fixed
 
@@ -43,6 +44,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1882]: https://github.com/amethyst/amethyst/pull/1882
 [#1883]: https://github.com/amethyst/amethyst/pull/1883
 [#1886]: https://github.com/amethyst/amethyst/pull/1886
+[#1891]: https://github.com/amethyst/amethyst/pull/1891
 
 ## [0.12.0] - 2019-07-30
 

--- a/src/game_data.rs
+++ b/src/game_data.rs
@@ -182,15 +182,17 @@ impl<'a, 'b> GameDataBuilder<'a, 'b> {
     ///     // It is legal to register a system with an empty name
     ///     .with(NopSystem, "", &[]);
     /// ~~~
-    pub fn with<S>(
-        mut self,
-        system: S,
-        name: &'static str,
-        dependencies: &'static [&'static str],
-    ) -> Self
+    pub fn with<S, N>(mut self, system: S, name: N, dependencies: &[N]) -> Self
     where
         S: for<'c> System<'c> + 'static + Send,
+        N: Into<String> + Clone,
     {
+        let name = Into::<String>::into(name);
+        let dependencies = dependencies
+            .iter()
+            .map(Clone::clone)
+            .map(Into::<String>::into)
+            .collect::<Vec<String>>();
         let dispatcher_operation = Box::new(AddSystem {
             system,
             name,
@@ -259,16 +261,23 @@ impl<'a, 'b> GameDataBuilder<'a, 'b> {
     ///     // It is legal to register a system with an empty name
     ///     .with_system_desc(NopSystem, "", &[]);
     /// ~~~
-    pub fn with_system_desc<SD, S>(
+    pub fn with_system_desc<SD, S, N>(
         mut self,
         system_desc: SD,
-        name: &'static str,
-        dependencies: &'static [&'static str],
+        name: N,
+        dependencies: &[N],
     ) -> Self
     where
         SD: SystemDesc<'a, 'b, S> + 'static,
         S: for<'c> System<'c> + 'static + Send,
+        N: Into<String> + Clone,
     {
+        let name = Into::<String>::into(name);
+        let dependencies = dependencies
+            .iter()
+            .map(Clone::clone)
+            .map(Into::<String>::into)
+            .collect::<Vec<String>>();
         let dispatcher_operation = Box::new(AddSystemDesc {
             system_desc,
             name,


### PR DESCRIPTION
## Description

Store system name and dependencies as `String`s in `DispatcherOperation`. #1882 broke backward compatibility in `amethyst_test` by requiring the name and dependencies to be `'static`.

cc: @AndreaCatania

## Modifications

* `DispatcherOperation` stores system name and dependencies as `String`s.

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
