### PR TITLE
Drop gfx dependency from amethyst_ui and amethyst_gltf

### DIFF
--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -24,7 +24,6 @@ err-derive = "0.1"
 base64 = "0.10"
 fnv = "1"
 gltf = "0.13"
-gfx = "0.17"
 hibitset = { version = "0.5.1", features = ["parallel"] }
 itertools = "0.7"
 log = "0.4.6"

--- a/amethyst_gltf/src/format/material.rs
+++ b/amethyst_gltf/src/format/material.rs
@@ -14,7 +14,6 @@ use amethyst_rendy::{
     },
 };
 
-// use gfx::texture::SamplerInfo;
 use gltf::{self, material::AlphaMode};
 use std::sync::Arc;
 

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -25,7 +25,6 @@ clipboard = "0.5"
 derivative = "1.0"
 derive-new = "0.5.6"
 fnv = "1"
-gfx = { version = "0.17", features = ["serialize"] }
 glsl-layout = "0.3"
 ron = "0.5"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Description

Currently the ui and gltfs crates depend on gfx 0.17. This is not needed as both crates don't use anything from gfx.
Removing the dep can also remove some sideeffects reported by Rybek 🐟#8316 in discord.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
