### PR TITLE
Refer to `amethyst_rendy` via `amethyst::renderer`

### DIFF
--- a/examples/rendy/prefab_data.rs
+++ b/examples/rendy/prefab_data.rs
@@ -7,7 +7,7 @@ use amethyst::{
     utils::tag::Tag,
     Error,
 };
-use amethyst_rendy::{
+use amethyst::renderer::{
     camera::CameraPrefab,
     formats::{mesh::MeshPrefab, mtl::MaterialPrefab},
     light::LightPrefab,


### PR DESCRIPTION


## Description

This PR tweaks a "use" statement in the rendy example. This is necessary for the example to work when run outside of the amethyst repository

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
