### PR TITLE
Allow disabling parallel support in amethyst_core (for WASM support)

### DIFF
--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -25,8 +25,8 @@ log = "0.4.6"
 num-traits = "0.2.0"
 rayon = "1.1.0"
 serde = { version = "1", features = ["derive"] }
-specs = { version = "0.15", features = ["shred-derive"] }
-specs-hierarchy = "0.5.1"
+specs = { version = "0.15", default-features = false, features = ["shred-derive"] }
+specs-hierarchy = { version = "0.5.1", default-features = false }
 getset = "0.0.7"
 derive-new = "0.5.6"
 derivative = "1.0"
@@ -38,6 +38,7 @@ amethyst = { path = "..", version = "0.12.0" }
 ron = "0.5.1"
 
 [features]
+default = ["specs/parallel", "specs-hierarchy/parallel"]
 profiler = ["thread_profiler/thread_profiler"]
 nightly = ["specs/nightly"]
 saveload = ["specs/serde"]


### PR DESCRIPTION
Hi all. This is both an intro and a tiny patch.

## Background / Intro

I'm using Amethyst (right now only `amethyst_core`) for a browser-based game written in Typescript and Rust. Along with `stdweb` it feels like a match made in heaven, and every day I'm more impressed by both Rust and Amethyst-spawned crates. 😍 Rendering is shelled out to `THREE.js` for now, until `wgpu-rs` or Amethyst are ready for WASM prime-time. Anyway, I figured I would hijack this PR to say hello 👋 and **inquire as to the WASM plan/timeline for Amethyst**. For example, Amethyst (including `core`) pulls in `rayon` directly but treading support isn't there just yet. I'm happy to help anywhere work overlaps! I'll need a few bleeding-edge things like a half decent UDP stack (so `WebRTC`). Would rather my efforts went to something shared than a private code base, if that's ever possible.

You're all awesome, keep up the great work 🍻

## Description
Threading support isn't there yet for browsers, and causes a panic when you try to use a `shred::DispatcherBuilder`:
_`backend.js:1 Panic error message: Invalid configuration: ThreadPoolBuildError { kind: IOError(Custom { kind: Other, error: "operation not supported on wasm yet" }) }`_

This PR continues piping the ability to disable parallel support in `shred` up through `amethyst_core` so that WASM consumers (like me) can disable it.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
