### PR TITLE
rendy -> 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ travis-ci = { repository = "amethyst/amethyst", branch = "master" }
 [features]
 default = ["animation", "audio", "locale", "network", "renderer"]
 
-vulkan = ["amethyst_rendy/vulkan"]
+vulkan = ["amethyst_rendy/vulkan", "amethyst_rendy/vulkan-x11"]
 metal = ["amethyst_rendy/metal"]
 empty = ["amethyst_rendy/empty"]
 

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -25,7 +25,7 @@ glsl-layout = "0.3"
 lazy_static = "1.3"
 log = "0.4"
 palette = { version = "0.4", features = ["serde"] }
-rendy = { version = "^0.3.2", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1"] }
+rendy = { version = "0.4.1", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1"] }
 ron = "0.5"
 serde = { version = "1", features = ["serde_derive"] }
 fnv = "1"
@@ -46,6 +46,7 @@ approx = "0.3"
 [features]
 metal = ["rendy/metal"]
 vulkan = ["rendy/vulkan"]
+vulkan-x11 = ["rendy/vulkan-x11"]
 empty = ["rendy/empty"]
 profiler = [ "thread_profiler/thread_profiler", "rendy/profiler" ]
 nightly = [ "amethyst_core/nightly" ]

--- a/amethyst_rendy/src/formats/texture.rs
+++ b/amethyst_rendy/src/formats/texture.rs
@@ -76,6 +76,7 @@ impl Default for ImageFormat {
                 },
                 comparison: None,
                 border: PackedColor(0),
+                normalized: true,
                 anisotropic: Anisotropic::Off,
             },
             generate_mips: false,

--- a/amethyst_rendy/src/pass/base_3d.rs
+++ b/amethyst_rendy/src/pass/base_3d.rs
@@ -742,18 +742,18 @@ fn build_pipelines<B: Backend, T: Base3DPassDef>(
         .with_subpass(subpass)
         .with_framebuffer_size(framebuffer_width, framebuffer_height)
         .with_face_culling(pso::Face::BACK)
-        .with_depth_test(pso::DepthTest::On {
+        .with_depth_test(pso::DepthTest {
             fun: pso::Comparison::Less,
             write: !transparent,
         })
-        .with_blend_targets(vec![pso::ColorBlendDesc(
-            pso::ColorMask::ALL,
-            if transparent {
-                pso::BlendState::PREMULTIPLIED_ALPHA
+        .with_blend_targets(vec![pso::ColorBlendDesc {
+            mask: pso::ColorMask::ALL,
+            blend: if transparent {
+                Some(pso::BlendState::PREMULTIPLIED_ALPHA)
             } else {
-                pso::BlendState::Off
+                None
             },
-        )]);
+        }]);
 
     let pipelines = if skinning {
         let shader_vertex_skinned = unsafe { T::vertex_skinned_shader().module(factory).unwrap() };

--- a/amethyst_rendy/src/pass/debug_lines.rs
+++ b/amethyst_rendy/src/pass/debug_lines.rs
@@ -217,11 +217,11 @@ fn build_lines_pipeline<B: Backend>(
                 .with_layout(&pipeline_layout)
                 .with_subpass(subpass)
                 .with_framebuffer_size(framebuffer_width, framebuffer_height)
-                .with_blend_targets(vec![pso::ColorBlendDesc(
-                    pso::ColorMask::ALL,
-                    pso::BlendState::ALPHA,
-                )])
-                .with_depth_test(pso::DepthTest::On {
+                .with_blend_targets(vec![pso::ColorBlendDesc {
+                    mask: pso::ColorMask::ALL,
+                    blend: Some(pso::BlendState::ALPHA),
+                }])
+                .with_depth_test(pso::DepthTest {
                     fun: pso::Comparison::LessEqual,
                     write: true,
                 }),

--- a/amethyst_rendy/src/pass/flat2d.rs
+++ b/amethyst_rendy/src/pass/flat2d.rs
@@ -421,15 +421,15 @@ fn build_sprite_pipeline<B: Backend>(
                 .with_layout(&pipeline_layout)
                 .with_subpass(subpass)
                 .with_framebuffer_size(framebuffer_width, framebuffer_height)
-                .with_blend_targets(vec![pso::ColorBlendDesc(
-                    pso::ColorMask::ALL,
-                    if transparent {
-                        pso::BlendState::PREMULTIPLIED_ALPHA
+                .with_blend_targets(vec![pso::ColorBlendDesc {
+                    mask: pso::ColorMask::ALL,
+                    blend: if transparent {
+                        Some(pso::BlendState::PREMULTIPLIED_ALPHA)
                     } else {
-                        pso::BlendState::Off
+                        None
                     },
-                )])
-                .with_depth_test(pso::DepthTest::On {
+                }])
+                .with_depth_test(pso::DepthTest {
                     fun: pso::Comparison::Less,
                     write: !transparent,
                 }),

--- a/amethyst_rendy/src/pass/mod.rs
+++ b/amethyst_rendy/src/pass/mod.rs
@@ -13,93 +13,93 @@ pub use self::{base_3d::*, debug_lines::*, flat::*, flat2d::*, pbr::*, shaded::*
 use rendy::{hal::pso::ShaderStageFlags, shader::SpirvShader};
 
 lazy_static::lazy_static! {
-    static ref POS_TEX_VERTEX: SpirvShader = SpirvShader::new(
-        include_bytes!("../../compiled/vertex/pos_tex.vert.spv").to_vec(),
+    static ref POS_TEX_VERTEX: SpirvShader = SpirvShader::from_bytes(
+        include_bytes!("../../compiled/vertex/pos_tex.vert.spv"),
         ShaderStageFlags::VERTEX,
         "main",
-    );
+    ).unwrap();
 
-    static ref POS_TEX_SKIN_VERTEX: SpirvShader = SpirvShader::new(
-        include_bytes!("../../compiled/vertex/pos_tex_skin.vert.spv").to_vec(),
+    static ref POS_TEX_SKIN_VERTEX: SpirvShader = SpirvShader::from_bytes(
+        include_bytes!("../../compiled/vertex/pos_tex_skin.vert.spv"),
         ShaderStageFlags::VERTEX,
         "main",
-    );
+    ).unwrap();
 
-    static ref POS_NORM_TEX_VERTEX: SpirvShader = SpirvShader::new(
-        include_bytes!("../../compiled/vertex/pos_norm_tex.vert.spv").to_vec(),
+    static ref POS_NORM_TEX_VERTEX: SpirvShader = SpirvShader::from_bytes(
+        include_bytes!("../../compiled/vertex/pos_norm_tex.vert.spv"),
         ShaderStageFlags::VERTEX,
         "main",
-    );
+    ).unwrap();
 
-    static ref POS_NORM_TEX_SKIN_VERTEX: SpirvShader = SpirvShader::new(
-        include_bytes!("../../compiled/vertex/pos_norm_tex_skin.vert.spv").to_vec(),
+    static ref POS_NORM_TEX_SKIN_VERTEX: SpirvShader = SpirvShader::from_bytes(
+        include_bytes!("../../compiled/vertex/pos_norm_tex_skin.vert.spv"),
         ShaderStageFlags::VERTEX,
         "main",
-    );
+    ).unwrap();
 
-    static ref POS_NORM_TANG_TEX_VERTEX: SpirvShader = SpirvShader::new(
-        include_bytes!("../../compiled/vertex/pos_norm_tang_tex.vert.spv").to_vec(),
+    static ref POS_NORM_TANG_TEX_VERTEX: SpirvShader = SpirvShader::from_bytes(
+        include_bytes!("../../compiled/vertex/pos_norm_tang_tex.vert.spv"),
         ShaderStageFlags::VERTEX,
         "main",
-    );
+    ).unwrap();
 
-    static ref POS_NORM_TANG_TEX_SKIN_VERTEX: SpirvShader = SpirvShader::new(
-        include_bytes!("../../compiled/vertex/pos_norm_tang_tex_skin.vert.spv").to_vec(),
+    static ref POS_NORM_TANG_TEX_SKIN_VERTEX: SpirvShader = SpirvShader::from_bytes(
+        include_bytes!("../../compiled/vertex/pos_norm_tang_tex_skin.vert.spv"),
         ShaderStageFlags::VERTEX,
         "main",
-    );
+    ).unwrap();
 
-    static ref FLAT_FRAGMENT: SpirvShader = SpirvShader::new(
-        include_bytes!("../../compiled/fragment/flat.frag.spv").to_vec(),
+    static ref FLAT_FRAGMENT: SpirvShader = SpirvShader::from_bytes(
+        include_bytes!("../../compiled/fragment/flat.frag.spv"),
         ShaderStageFlags::FRAGMENT,
         "main",
-    );
+    ).unwrap();
 
-    static ref SHADED_FRAGMENT: SpirvShader = SpirvShader::new(
-        include_bytes!("../../compiled/fragment/shaded.frag.spv").to_vec(),
+    static ref SHADED_FRAGMENT: SpirvShader = SpirvShader::from_bytes(
+        include_bytes!("../../compiled/fragment/shaded.frag.spv"),
         ShaderStageFlags::FRAGMENT,
         "main",
-    );
+    ).unwrap();
 
-    static ref PBR_FRAGMENT: SpirvShader = SpirvShader::new(
-        include_bytes!("../../compiled/fragment/pbr.frag.spv").to_vec(),
+    static ref PBR_FRAGMENT: SpirvShader = SpirvShader::from_bytes(
+        include_bytes!("../../compiled/fragment/pbr.frag.spv"),
         ShaderStageFlags::FRAGMENT,
         "main",
-    );
+    ).unwrap();
 
-    static ref SPRITE_VERTEX: SpirvShader = SpirvShader::new(
-        include_bytes!("../../compiled/vertex/sprite.vert.spv").to_vec(),
+    static ref SPRITE_VERTEX: SpirvShader = SpirvShader::from_bytes(
+        include_bytes!("../../compiled/vertex/sprite.vert.spv"),
         ShaderStageFlags::VERTEX,
         "main",
-    );
+    ).unwrap();
 
-    static ref SPRITE_FRAGMENT: SpirvShader = SpirvShader::new(
-        include_bytes!("../../compiled/fragment/sprite.frag.spv").to_vec(),
+    static ref SPRITE_FRAGMENT: SpirvShader = SpirvShader::from_bytes(
+        include_bytes!("../../compiled/fragment/sprite.frag.spv"),
         ShaderStageFlags::FRAGMENT,
         "main",
-    );
+    ).unwrap();
 
-    static ref SKYBOX_VERTEX: SpirvShader = SpirvShader::new(
-        include_bytes!("../../compiled/vertex/skybox.vert.spv").to_vec(),
+    static ref SKYBOX_VERTEX: SpirvShader = SpirvShader::from_bytes(
+        include_bytes!("../../compiled/vertex/skybox.vert.spv"),
         ShaderStageFlags::VERTEX,
         "main",
-    );
+    ).unwrap();
 
-    static ref SKYBOX_FRAGMENT: SpirvShader = SpirvShader::new(
-        include_bytes!("../../compiled/fragment/skybox.frag.spv").to_vec(),
+    static ref SKYBOX_FRAGMENT: SpirvShader = SpirvShader::from_bytes(
+        include_bytes!("../../compiled/fragment/skybox.frag.spv"),
         ShaderStageFlags::FRAGMENT,
         "main",
-    );
+    ).unwrap();
 
-    static ref DEBUG_LINES_VERTEX: SpirvShader = SpirvShader::new(
-        include_bytes!("../../compiled/vertex/debug_lines.vert.spv").to_vec(),
+    static ref DEBUG_LINES_VERTEX: SpirvShader = SpirvShader::from_bytes(
+        include_bytes!("../../compiled/vertex/debug_lines.vert.spv"),
         ShaderStageFlags::VERTEX,
         "main",
-    );
+    ).unwrap();
 
-    static ref DEBUG_LINES_FRAGMENT: SpirvShader = SpirvShader::new(
-        include_bytes!("../../compiled/fragment/debug_lines.frag.spv").to_vec(),
+    static ref DEBUG_LINES_FRAGMENT: SpirvShader = SpirvShader::from_bytes(
+        include_bytes!("../../compiled/fragment/debug_lines.frag.spv"),
         ShaderStageFlags::FRAGMENT,
         "main",
-    );
+    ).unwrap();
 }

--- a/amethyst_rendy/src/pass/skybox.rs
+++ b/amethyst_rendy/src/pass/skybox.rs
@@ -216,14 +216,14 @@ fn build_skybox_pipeline<B: Backend>(
                 .with_layout(&pipeline_layout)
                 .with_subpass(subpass)
                 .with_framebuffer_size(framebuffer_width, framebuffer_height)
-                .with_depth_test(pso::DepthTest::On {
+                .with_depth_test(pso::DepthTest {
                     fun: pso::Comparison::LessEqual,
                     write: false,
                 })
-                .with_blend_targets(vec![pso::ColorBlendDesc(
-                    pso::ColorMask::ALL,
-                    pso::BlendState::Off,
-                )]),
+                .with_blend_targets(vec![pso::ColorBlendDesc {
+                    mask: pso::ColorMask::ALL,
+                    blend: None,
+                }]),
         )
         .build(factory, None);
 

--- a/amethyst_rendy/src/pipeline.rs
+++ b/amethyst_rendy/src/pipeline.rs
@@ -220,7 +220,7 @@ impl<'a, B: Backend> PipelineDescBuilder<'a, B> {
     }
     /// Set to use the provided `DepthTest`
     pub fn set_depth_test(&mut self, depth_test: DepthTest) {
-        self.depth_stencil.depth = depth_test;
+        self.depth_stencil.depth = Some(depth_test);
     }
 
     /// Build with the provided `Face` culling.

--- a/amethyst_tiles/src/pass.rs
+++ b/amethyst_tiles/src/pass.rs
@@ -59,17 +59,17 @@ use crate::{
 use thread_profiler::profile_scope;
 
 lazy_static::lazy_static! {
-    static ref VERTEX: SpirvShader = SpirvShader::new(
-        include_bytes!("../compiled/tiles.vert.spv").to_vec(),
+    static ref VERTEX: SpirvShader = SpirvShader::from_bytes(
+        include_bytes!("../compiled/tiles.vert.spv"),
         ShaderStageFlags::VERTEX,
         "main",
-    );
+    ).unwrap();
 
-    static ref FRAGMENT: SpirvShader = SpirvShader::new(
-        include_bytes!("../compiled/tiles.frag.spv").to_vec(),
+    static ref FRAGMENT: SpirvShader = SpirvShader::from_bytes(
+        include_bytes!("../compiled/tiles.frag.spv"),
         ShaderStageFlags::FRAGMENT,
         "main",
-    );
+    ).unwrap();
 
     static ref SHADERS: ShaderSetBuilder = ShaderSetBuilder::default()
         .with_vertex(&*VERTEX).unwrap()
@@ -372,11 +372,11 @@ fn build_tiles_pipeline<B: Backend>(
                 .with_layout(&pipeline_layout)
                 .with_subpass(subpass)
                 .with_framebuffer_size(framebuffer_width, framebuffer_height)
-                .with_blend_targets(vec![pso::ColorBlendDesc(
-                    pso::ColorMask::ALL,
-                    pso::BlendState::PREMULTIPLIED_ALPHA,
-                )])
-                .with_depth_test(pso::DepthTest::On {
+                .with_blend_targets(vec![pso::ColorBlendDesc {
+                    mask: pso::ColorMask::ALL,
+                    blend: Some(pso::BlendState::PREMULTIPLIED_ALPHA),
+                }])
+                .with_depth_test(pso::DepthTest {
                     fun: pso::Comparison::Less,
                     write: false,
                 }),

--- a/amethyst_ui/src/pass.rs
+++ b/amethyst_ui/src/pass.rs
@@ -117,17 +117,17 @@ struct UiViewArgs {
 }
 
 lazy_static::lazy_static! {
-    static ref UI_VERTEX: SpirvShader = SpirvShader::new(
-        include_bytes!("../compiled/ui.vert.spv").to_vec(),
+    static ref UI_VERTEX: SpirvShader = SpirvShader::from_bytes(
+        include_bytes!("../compiled/ui.vert.spv"),
         ShaderStageFlags::VERTEX,
         "main",
-    );
+    ).unwrap();
 
-    static ref UI_FRAGMENT: SpirvShader = SpirvShader::new(
-        include_bytes!("../compiled/ui.frag.spv").to_vec(),
+    static ref UI_FRAGMENT: SpirvShader = SpirvShader::from_bytes(
+        include_bytes!("../compiled/ui.frag.spv"),
         ShaderStageFlags::FRAGMENT,
         "main",
-    );
+    ).unwrap();
 }
 
 /// A UI drawing pass that draws UI elements and text in screen-space
@@ -505,10 +505,10 @@ fn build_ui_pipeline<B: Backend>(
                 .with_layout(&pipeline_layout)
                 .with_subpass(subpass)
                 .with_framebuffer_size(framebuffer_width, framebuffer_height)
-                .with_blend_targets(vec![pso::ColorBlendDesc(
-                    pso::ColorMask::ALL,
-                    pso::BlendState::ALPHA,
-                )]),
+                .with_blend_targets(vec![pso::ColorBlendDesc {
+                    mask: pso::ColorMask::ALL,
+                    blend: Some(pso::BlendState::ALPHA),
+                }]),
         )
         .build(factory, None);
 

--- a/examples/custom_render_pass/custom_pass.rs
+++ b/examples/custom_render_pass/custom_pass.rs
@@ -31,17 +31,17 @@ use glsl_layout::*;
 lazy_static::lazy_static! {
     // These uses the precompiled shaders.
     // These can be obtained using glslc.exe in the vulkan sdk.
-    static ref VERTEX: SpirvShader = SpirvShader::new(
-        include_bytes!("../assets/shaders/compiled/vertex/custom.vert.spv").to_vec(),
+    static ref VERTEX: SpirvShader = SpirvShader::from_bytes(
+        include_bytes!("../assets/shaders/compiled/vertex/custom.vert.spv"),
         ShaderStageFlags::VERTEX,
         "main",
-    );
+    ).unwrap();
 
-    static ref FRAGMENT: SpirvShader = SpirvShader::new(
-        include_bytes!("../assets/shaders/compiled/fragment/custom.frag.spv").to_vec(),
+    static ref FRAGMENT: SpirvShader = SpirvShader::from_bytes(
+        include_bytes!("../assets/shaders/compiled/fragment/custom.frag.spv"),
         ShaderStageFlags::FRAGMENT,
         "main",
-    );
+    ).unwrap();
 }
 
 /// Example code of using a custom shader
@@ -234,10 +234,10 @@ fn build_custom_pipeline<B: Backend>(
                 .with_subpass(subpass)
                 .with_framebuffer_size(framebuffer_width, framebuffer_height)
                 // We are using alpha blending
-                .with_blend_targets(vec![pso::ColorBlendDesc(
-                    pso::ColorMask::ALL,
-                    pso::BlendState::ALPHA,
-                )]),
+                .with_blend_targets(vec![pso::ColorBlendDesc {
+                    mask: pso::ColorMask::ALL,
+                    blend: Some(pso::BlendState::ALPHA),
+                }]),
         )
         .build(factory, None);
 


### PR DESCRIPTION
## Description

Upgrade rendy -> 0.4.1. Includes gfx-hal -> 0.3.

## Additions

`amethyst::renderer::pass::validate_spirv` - can somebody suggest a better name?

## Modifications

gfx-hal breaking changes for anyone playing with custom passes.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [X] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
