### PR TITLE
Fix amethyst_derive syn feature

### DIFF
--- a/amethyst_derive/Cargo.toml
+++ b/amethyst_derive/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
 heck = "0.3.1"
-syn = { version = "0.15", features = ["visit"] }
+syn = { version = "0.15", features = ["full", "visit"] }
 quote = "0.6"
 proc-macro2 = "0.4"
 proc_macro_roids = "0.4"


### PR DESCRIPTION
## Description

Fixed an issue where compilation might fail with the following error:

```
Compiling amethyst_ui v0.7.0 (https://github.com/amethyst/amethyst#16841422)
error: proc-macro derive panicked
  --> ...\.cargo\git\checkouts\amethyst-fedb0a1032a075ce\1684142\amethyst_ui\src\glyphs.rs:90:10
   |
90 | #[derive(SystemDesc)]
   |          ^^^^^^^^^^
   |
   = help: message: Failed to parse `LitStr { token: Literal { lit: Lit { kind: Str, symbol: UiGlyphsResource { glyph_tex: None }, suffix: None }, span:
Span { lo: BytePos(52294), hi: BytePos(52332), ctxt: #0 } } }` as an expression. Error: unexpected token

error: aborting due to previous error

error: Could not compile `amethyst_ui`.
```

## PR Checklist

By placing an x in the boxes I certify that I have:

- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
