### PR TITLE
Feature/run setup fn before systems

### DIFF
--- a/amethyst_test/src/amethyst_application.rs
+++ b/amethyst_test/src/amethyst_application.rs
@@ -39,6 +39,7 @@ type BundleAddFn = Box<
 //   in a scope greater than the `AmethystApplication`'s lifetime, which detracts from the
 //   ergonomics of this test harness.
 type FnResourceAdd = Box<dyn FnMut(&mut World) + Send>;
+type FnSetup = Box<dyn FnOnce(&mut World) + Send>;
 type FnState<T, E> = Box<dyn FnOnce() -> Box<dyn State<T, E>>>;
 
 /// Screen width used in predefined display configuration.
@@ -84,6 +85,9 @@ where
     /// segfault caused by mesa and the software GL renderer.
     #[derivative(Debug = "ignore")]
     resource_add_fns: Vec<FnResourceAdd>,
+    /// Setup functions to run, in user specified order.
+    #[derivative(Debug = "ignore")]
+    setup_fns: Vec<FnSetup>,
     /// States to run, in user specified order.
     #[derivative(Debug = "ignore")]
     state_fns: Vec<FnState<T, E>>,
@@ -98,6 +102,7 @@ impl AmethystApplication<GameData<'static, 'static>, StateEvent, StateEventReade
         AmethystApplication {
             bundle_add_fns: Vec::new(),
             resource_add_fns: Vec::new(),
+            setup_fns: Vec::new(),
             state_fns: Vec::new(),
             state_data: PhantomData,
         }
@@ -134,7 +139,12 @@ where
     where
         for<'b> R: EventReader<'b, Event = E>,
     {
-        let params = (self.bundle_add_fns, self.resource_add_fns, self.state_fns);
+        let params = (
+            self.bundle_add_fns,
+            self.resource_add_fns,
+            self.setup_fns,
+            self.state_fns,
+        );
         Self::build_internal(params)
     }
 
@@ -147,9 +157,10 @@ where
     // parameters which causes a compilation failure.
     #[allow(unknown_lints, clippy::type_complexity)]
     fn build_internal(
-        (bundle_add_fns, resource_add_fns, state_fns): (
+        (bundle_add_fns, resource_add_fns, setup_fns, state_fns): (
             Vec<BundleAddFn>,
             Vec<FnResourceAdd>,
+            Vec<FnSetup>,
             Vec<FnState<GameData<'static, 'static>, E>>,
         ),
     ) -> Result<CoreApplication<'static, GameData<'static, 'static>, E, R>, Error>
@@ -168,13 +179,19 @@ where
             .into_iter()
             .rev()
             .for_each(|state_fn| states.push(state_fn()));
-        Self::build_application(SequencerState::new(states), game_data, resource_add_fns)
+        Self::build_application(
+            SequencerState::new(states),
+            game_data,
+            resource_add_fns,
+            setup_fns,
+        )
     }
 
     fn build_application<S>(
         first_state: S,
         game_data: GameDataBuilder<'static, 'static>,
         resource_add_fns: Vec<FnResourceAdd>,
+        setup_fns: Vec<FnSetup>,
     ) -> Result<CoreApplication<'static, GameData<'static, 'static>, E, R>, Error>
     where
         S: State<GameData<'static, 'static>, E> + 'static,
@@ -188,6 +205,9 @@ where
             for mut function in resource_add_fns {
                 function(world);
             }
+            for function in setup_fns {
+                function(world);
+            }
         }
         application_builder.build(game_data)
     }
@@ -197,7 +217,12 @@ where
     where
         for<'b> R: EventReader<'b, Event = E>,
     {
-        let params = (self.bundle_add_fns, self.resource_add_fns, self.state_fns);
+        let params = (
+            self.bundle_add_fns,
+            self.resource_add_fns,
+            self.setup_fns,
+            self.state_fns,
+        );
 
         // `CoreApplication` is `!UnwindSafe`, but wrapping it in a `Mutex` allows us to
         // recover from a panic.
@@ -281,6 +306,7 @@ where
         AmethystApplication {
             bundle_add_fns: self.bundle_add_fns,
             resource_add_fns: self.resource_add_fns,
+            setup_fns: self.setup_fns,
             state_fns: Vec::new(),
             state_data: PhantomData,
         }
@@ -521,11 +547,12 @@ where
     /// # Parameters
     ///
     /// * `setup_fn`: Function to execute.
-    pub fn with_setup<F>(self, setup_fn: F) -> Self
+    pub fn with_setup<F>(mut self, setup_fn: F) -> Self
     where
-        F: Fn(&mut World) + Send + Sync + 'static,
+        F: FnOnce(&mut World) + Send + 'static,
     {
-        self.with_fn(setup_fn)
+        self.setup_fns.push(Box::new(setup_fn));
+        self
     }
 
     /// Registers a function that executes a desired effect.
@@ -902,6 +929,14 @@ mod test {
                     world.read_resource::<ApplicationResource>();
                 })
             })
+            .run()
+    }
+
+    #[test]
+    fn setup_runs_before_system() -> Result<(), Error> {
+        AmethystApplication::blank()
+            .with_setup(|world| world.insert(ApplicationResourceNonDefault))
+            .with_system(SystemNonDefault, "", &[])
             .run()
     }
 

--- a/amethyst_test/src/amethyst_application.rs
+++ b/amethyst_test/src/amethyst_application.rs
@@ -907,20 +907,6 @@ mod test {
     }
 
     #[test]
-    fn setup_can_be_invoked_after_with_state() -> Result<(), Error> {
-        AmethystApplication::blank()
-            .with_state(|| {
-                FunctionState::new(|world| {
-                    world.insert(ApplicationResource);
-                })
-            })
-            .with_setup(|world| {
-                world.read_resource::<ApplicationResource>();
-            })
-            .run()
-    }
-
-    #[test]
     fn with_state_invoked_after_with_resource_should_work() -> Result<(), Error> {
         AmethystApplication::blank()
             .with_resource(ApplicationResource)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,8 +33,10 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * `SystemDesc` proc macro supports `#[system_desc(event_reader_id)]` to register event reader. ([#1883])
 * `SystemDesc` proc macro supports `#[system_desc(flagged_storage_reader(Component))]`. ([#1886])
 * `DispatcherOperation` stores system name and dependencies as `String`s. ([#1891])
-* `TextureProcessor` renamed to `TextureProcessorSystem` ([#1839]).
-* `MeshProcessor` renamed to `MeshProcessorSystem` ([#1839]).
+* `TextureProcessor` renamed to `TextureProcessorSystem`. ([#1839])
+* `MeshProcessor` renamed to `MeshProcessorSystem`. ([#1839])
+* `AmethystApplication::with_setup` now takes in `FnOnce(&mut World) + Send + 'static`. ([#1912])
+* `AmethystApplication::with_setup` runs the function before the dispatcher. ([#1912])
 
 ### Fixed
 
@@ -51,6 +53,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1891]: https://github.com/amethyst/amethyst/pull/1891
 [#1896]: https://github.com/amethyst/amethyst/pull/1896
 [#1839]: https://github.com/amethyst/amethyst/pull/1839
+[#1912]: https://github.com/amethyst/amethyst/pull/1912
 
 ## [0.12.0] - 2019-07-30
 


### PR DESCRIPTION
## Description

In `amethyst_test`, changed `AmethystApplication::with_setup` to run before the dispatcher. This allows resources to be computed and inserted from other resources in the `World`.

Previously, if a `System` had `ReadExpect<'_, T>`, and `T ` needed to be computed from the `World`, it was impossible to insert the resource before the system runs.

## Modifications

* `AmethystApplication::with_setup` now takes in `FnOnce(&mut World) + Send + 'static`.
* `AmethystApplication::with_setup` runs the function before the dispatcher.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
