### PR TITLE
Fix copy/paste error in formats.rs

### DIFF
--- a/amethyst_assets/src/formats.rs
+++ b/amethyst_assets/src/formats.rs
@@ -2,7 +2,7 @@ use crate::Format;
 use amethyst_error::{format_err, Error, ResultExt};
 use serde::{Deserialize, Serialize};
 
-/// Format for loading from Ron files. Mostly useful for prefabs.
+/// Format for loading from RON files. Mostly useful for prefabs.
 /// This type cannot be used for tagged deserialization.
 /// It is meant to be used at top-level loading, manually specified to the loader.
 /// ```rust,ignore
@@ -32,7 +32,7 @@ where
     }
 }
 
-/// Format for loading from Ron files. Mostly useful for prefabs.
+/// Format for loading from JSON files. Mostly useful for prefabs.
 /// This type can only be used as manually specified to the loader.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct JsonFormat;


### PR DESCRIPTION
## Description

Fix a copy/paste error in the comments of `formats.rs`

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
   - Slight comment fix, book is not outdated
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
   - Does not apply.
- [x] Added unit tests for new code added in this PR.
   - No new code.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
