### PR TITLE
Feature/construct camera ortho with custom dimensions

### DIFF
--- a/amethyst_utils/Cargo.toml
+++ b/amethyst_utils/Cargo.toml
@@ -22,6 +22,7 @@ amethyst_error = { path = "../amethyst_error", version = "0.2.0" }
 amethyst_derive = { path = "../amethyst_derive", version = "0.5.0" }
 amethyst_rendy = { path = "../amethyst_rendy", version = "0.2.0" }
 amethyst_window = { path = "../amethyst_window", version = "0.2.0" }
+derive-new = "0.5.8"
 log = "0.4.6"
 serde = { version = "1.0", features = ["derive"] }
 specs-derive = "0.4.0"

--- a/amethyst_utils/src/ortho_camera.rs
+++ b/amethyst_utils/src/ortho_camera.rs
@@ -9,6 +9,7 @@ use amethyst_derive::PrefabData;
 use amethyst_error::Error;
 use amethyst_rendy::camera::{Camera, Orthographic};
 use amethyst_window::ScreenDimensions;
+use derive_new::new;
 
 use serde::{Deserialize, Serialize};
 
@@ -86,7 +87,7 @@ impl Default for CameraOrthoWorldCoordinates {
 ///     .with(CameraOrtho::normalized(CameraNormalizeMode::Contain))
 ///     .build();
 /// ```
-#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, PrefabData)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, PrefabData, new)]
 #[prefab(Component)]
 pub struct CameraOrtho {
     /// How the camera's matrix is changed when the window's aspect ratio changes.
@@ -94,6 +95,7 @@ pub struct CameraOrtho {
     pub mode: CameraNormalizeMode,
     /// The world coordinates that this camera will keep visible as the window size changes
     pub world_coordinates: CameraOrthoWorldCoordinates,
+    #[new(default)]
     aspect_ratio_cache: f32,
 }
 
@@ -364,6 +366,19 @@ mod test {
         let aspect = 1.0;
         let cam = CameraOrtho::normalized(CameraNormalizeMode::Contain);
         assert_eq!((0.0, 1.0, 0.0, 1.0), cam.camera_offsets(aspect));
+    }
+
+    #[test]
+    fn custom_camera_large_contain() {
+        let aspect = 2.0 / 1.0;
+        let camera_ortho_world_coordinates = CameraOrthoWorldCoordinates {
+            left: 0.,
+            right: 800.,
+            bottom: 0.,
+            top: 600.,
+        };
+        let cam = CameraOrtho::new(CameraNormalizeMode::Contain, camera_ortho_world_coordinates);
+        assert_eq!((-200.0, 1000.0, 0.0, 600.0), cam.camera_offsets(aspect));
     }
 
     #[test]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * `AmethystApplication::with_thread_local_desc` takes in `RunNowDesc`. ([#1882])
 * Add `NineSlice` support to `UiImage`. ([#1896])
 * `RenderingBundle` for full manual control of the rendering pipeline via a custom `GraphCreator` ([#1839]).
+* `CameraOrtho::new` takes in `CameraOrthoWorldCoordinates`, which can be set to custom dimensions. ([#1916])
 
 ### Changed
 
@@ -54,6 +55,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1896]: https://github.com/amethyst/amethyst/pull/1896
 [#1839]: https://github.com/amethyst/amethyst/pull/1839
 [#1912]: https://github.com/amethyst/amethyst/pull/1912
+[#1916]: https://github.com/amethyst/amethyst/pull/1916
 
 ## [0.12.0] - 2019-07-30
 


### PR DESCRIPTION
## Description

Allow `CameraOrtho` to be constructed with custom dimensions.

Previously:

```rust
let mut camera_ortho = CameraOrtho::normalized(mode);
camera_ortho.world_coordinates.left = left;
camera_ortho.world_coordinates.right = right;
camera_ortho.world_coordinates.bottom = bottom;
camera_ortho.world_coordinates.top = top;
```

Now:

```rust
let world_coordinates = CameraOrthoWorldCoordinates {
    left, right, bottom, top
};
let mut camera_ortho = CameraOrtho::new(mode, world_coordinates);
```

## Additions

* `CameraOrtho::new` takes in `CameraOrthoWorldCoordinates`, which can be set to custom dimensions.

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
