### PR TITLE
Clarify UiImage:PartialTexture Coordinates

### DIFF
--- a/amethyst_ui/src/image.rs
+++ b/amethyst_ui/src/image.rs
@@ -1,6 +1,6 @@
 use amethyst_assets::Handle;
 use amethyst_core::ecs::{Component, DenseVecStorage};
-use amethyst_rendy::{sprite::TextureCoordinates, SpriteRender, Texture};
+use amethyst_rendy::{SpriteRender, Texture};
 
 /// Image used UI widgets, often as background.
 #[derive(Debug, Clone, PartialEq)]
@@ -8,7 +8,18 @@ pub enum UiImage {
     /// An image backed by texture handle
     Texture(Handle<Texture>),
     /// An image backed by a texture cropped to specified rectangle
-    PartialTexture(Handle<Texture>, TextureCoordinates),
+    PartialTexture {
+        /// Texture handle
+        tex: Handle<Texture>,
+        /// Left Texture Coordinate
+        left: f32,
+        /// Right Texture Coordinate
+        right: f32,
+        /// Bottom Texture Coordinate
+        bottom: f32,
+        /// Top Texture Coordinate
+        top: f32,
+    },
     /// An image backed by a Sprite
     Sprite(SpriteRender),
     /// An Image backed by a 9-sliced texture

--- a/amethyst_ui/src/pass.rs
+++ b/amethyst_ui/src/pass.rs
@@ -553,7 +553,13 @@ fn render_image<B: Backend>(
         UiImage::Sprite(sprite_renderer) => {
             let sprite_sheets = resources.fetch::<AssetStorage<SpriteSheet>>();
             if let Some(sprite_sheet) = sprite_sheets.get(&sprite_renderer.sprite_sheet) {
-                (&sprite_sheet.sprites[sprite_renderer.sprite_number].tex_coords).into()
+                let tex_coord = &sprite_sheet.sprites[sprite_renderer.sprite_number].tex_coords;
+                [
+                    tex_coord.left,
+                    tex_coord.top,
+                    tex_coord.right,
+                    tex_coord.bottom,
+                ]
             } else {
                 [0.0_f32, 0., 1., 1.]
             }

--- a/amethyst_ui/src/pass.rs
+++ b/amethyst_ui/src/pass.rs
@@ -558,7 +558,13 @@ fn render_image<B: Backend>(
                 [0.0_f32, 0., 1., 1.]
             }
         }
-        UiImage::PartialTexture(_, tex_coord) => tex_coord.into(),
+        UiImage::PartialTexture {
+            left,
+            right,
+            bottom,
+            top,
+            ..
+        } => [*left, *top, *right, *bottom],
         _ => [0.0_f32, 0., 1., 1.],
     };
 
@@ -584,7 +590,7 @@ fn render_image<B: Backend>(
                 false
             }
         }
-        UiImage::PartialTexture(tex, _) => {
+        UiImage::PartialTexture { tex, .. } => {
             if let Some((tex_id, this_changed)) = textures.insert(
                 factory,
                 resources,

--- a/amethyst_ui/src/prefab.rs
+++ b/amethyst_ui/src/prefab.rs
@@ -340,7 +340,13 @@ pub enum UiImageLoadPrefab {
     /// A textured image
     Texture(TexturePrefab),
     /// A partial textured image
-    PartialTexture(TexturePrefab, f32, f32, f32, f32),
+    PartialTexture {
+        tex: TexturePrefab,
+        left: f32,
+        right: f32,
+        bottom: f32,
+        top: f32,
+    },
     /// Solid color image
     SolidColor(f32, f32, f32, f32),
     /// 9-Slice image
@@ -401,12 +407,19 @@ impl<'a> PrefabData<'a> for UiImageLoadPrefab {
             UiImageLoadPrefab::Texture(tex) => {
                 UiImage::Texture(tex.add_to_entity(entity, textures, entities, children)?)
             }
-            UiImageLoadPrefab::PartialTexture(tex, left, right, bottom, top) => {
-                UiImage::PartialTexture(
-                    tex.add_to_entity(entity, textures, entities, children)?,
-                    [*left, *right, *bottom, *top].into(),
-                )
-            }
+            UiImageLoadPrefab::PartialTexture {
+                tex,
+                left,
+                right,
+                bottom,
+                top,
+            } => UiImage::PartialTexture {
+                tex: tex.add_to_entity(entity, textures, entities, children)?,
+                left: *left,
+                right: *right,
+                bottom: *bottom,
+                top: *top,
+            },
             UiImageLoadPrefab::NineSlice {
                 x_start,
                 y_start,
@@ -442,7 +455,9 @@ impl<'a> PrefabData<'a> for UiImageLoadPrefab {
     ) -> Result<bool, Error> {
         match self {
             UiImageLoadPrefab::Texture(tex) => tex.load_sub_assets(progress, textures),
-            UiImageLoadPrefab::PartialTexture(tex, ..) => tex.load_sub_assets(progress, textures),
+            UiImageLoadPrefab::PartialTexture { tex, .. } => {
+                tex.load_sub_assets(progress, textures)
+            }
             UiImageLoadPrefab::NineSlice { tex, .. } => tex.load_sub_assets(progress, textures),
             UiImageLoadPrefab::SolidColor(..) => Ok(false),
         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,7 +39,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * `MeshProcessor` renamed to `MeshProcessorSystem`. ([#1839])
 * `AmethystApplication::with_setup` now takes in `FnOnce(&mut World) + Send + 'static`. ([#1912])
 * `AmethystApplication::with_setup` runs the function before the dispatcher. ([#1912])
-* `UiImage:PartialTexture` texture coordinates are correct and is now a struct enum. ([#1906])
+* `UiImage:PartialTexture` texture coordinates are correct and is now a struct enum. ([#1906],[#1919])
 
 ### Fixed
 
@@ -60,6 +60,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1906]: https://github.com/amethyst/amethyst/issues/1906
 [#1912]: https://github.com/amethyst/amethyst/pull/1912
 [#1916]: https://github.com/amethyst/amethyst/pull/1916
+[#1919]: https://github.com/amethyst/amethyst/pull/1919
 
 ## [0.12.0] - 2019-07-30
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * `AmethystApplication` takes in `SystemDesc`s through `with_system_desc`. ([#1882])
 * `AmethystApplication::with_thread_local_desc` takes in `RunNowDesc`. ([#1882])
 * Add `NineSlice` support to `UiImage`. ([#1896])
-* `RenderingBundle` for full manual control of the rendering pipeline via a custom `GraphCreator` ([#1839]).
+* `RenderingBundle` for full manual control of the rendering pipeline via a custom `GraphCreator`. ([#1839])
 * `CameraOrtho::new` takes in `CameraOrthoWorldCoordinates`, which can be set to custom dimensions. ([#1916])
 
 ### Changed
@@ -39,7 +39,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * `MeshProcessor` renamed to `MeshProcessorSystem`. ([#1839])
 * `AmethystApplication::with_setup` now takes in `FnOnce(&mut World) + Send + 'static`. ([#1912])
 * `AmethystApplication::with_setup` runs the function before the dispatcher. ([#1912])
-* `UiImage:PartialTexture` texture coordinates are correct and is now a struct enum. ([#1906],[#1919])
+* `UiImage:PartialTexture` & `UiImage:Sprite` texture coordinates are correct. Clarified types. ([#1906],[#1919])
 
 ### Fixed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * `MeshProcessor` renamed to `MeshProcessorSystem`. ([#1839])
 * `AmethystApplication::with_setup` now takes in `FnOnce(&mut World) + Send + 'static`. ([#1912])
 * `AmethystApplication::with_setup` runs the function before the dispatcher. ([#1912])
+* `UiImage:PartialTexture` texture coordinates are correct and is now a struct enum. ([#1906])
 
 ### Fixed
 
@@ -56,6 +57,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1891]: https://github.com/amethyst/amethyst/pull/1891
 [#1896]: https://github.com/amethyst/amethyst/pull/1896
 [#1839]: https://github.com/amethyst/amethyst/pull/1839
+[#1906]: https://github.com/amethyst/amethyst/issues/1906
 [#1912]: https://github.com/amethyst/amethyst/pull/1912
 [#1916]: https://github.com/amethyst/amethyst/pull/1916
 

--- a/examples/assets/ui/example.ron
+++ b/examples/assets/ui/example.ron
@@ -59,7 +59,12 @@ Container(
                 anchor: TopRight,
                 mouse_reactive: true,
             ),
-            image: PartialTexture(File("texture/test_texture.png", ("IMAGE", ())),0.34,0.0,1.0,0.333),
+            image: PartialTexture(
+                tex: File("texture/test_texture.png", ("IMAGE", ())),
+                left : 0.34,
+                right : 1.0,
+                bottom: 0.333,
+                top: 0.0),
         ),
         //9-Slice
         Image(


### PR DESCRIPTION

Fixes #1906 

## Description

Fixes the texture coordinates issue and makes UiImage:PartialTexture a struct enum so the members are explicit. 

## Modifications

-  UiImage:PartialTexture update
-  Prefab updated to match
## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
