### PR TITLE
Fix incorrect circle point calculations

### DIFF
--- a/amethyst_rendy/src/debug_drawing.rs
+++ b/amethyst_rendy/src/debug_drawing.rs
@@ -250,7 +250,7 @@ impl DebugLinesComponent {
             let a = std::f32::consts::PI * 2.0 / (points as f32) * (i as f32);
             let x = radius * a.cos();
             let y = radius * a.sin();
-            let point = Vector3::new(x, y, 0);
+            let point = Vector3::new(x, y, 0.0);
             let point = center + rotation * point;
 
             if let Some(prev) = prev {

--- a/amethyst_rendy/src/debug_drawing.rs
+++ b/amethyst_rendy/src/debug_drawing.rs
@@ -250,8 +250,8 @@ impl DebugLinesComponent {
             let a = std::f32::consts::PI * 2.0 / (points as f32) * (i as f32);
             let x = radius * a.cos();
             let y = radius * a.sin();
-            let point = Vector3::new(x, y, center[2]);
-            let point = Point3::from(rotation * point);
+            let point = Vector3::new(x, y, 0);
+            let point = center + rotation * point;
 
             if let Some(prev) = prev {
                 self.add_line(prev, point, color);


### PR DESCRIPTION
## Description

Fix debug line drawing for incorrect point calculation in ```add_rotated_circle``` for issue #1924 

## Modifications

- ```add_rotated_circle```

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
