### PR TITLE
Feature/amethyst test wait for load state

### DIFF
--- a/amethyst_test/Cargo.toml
+++ b/amethyst_test/Cargo.toml
@@ -16,7 +16,11 @@ license = "MIT/Apache-2.0"
 amethyst = { path = "..", version = "0.12.0" }
 derivative = "1.0"
 derive-new = "0.5"
+derive_deref = "1.1.0"
 lazy_static = "1.3"
+
+[dev-dependencies]
+serde = "1.0"
 
 [features]
 default = []

--- a/amethyst_test/src/in_memory_source.rs
+++ b/amethyst_test/src/in_memory_source.rs
@@ -1,0 +1,29 @@
+use std::collections::HashMap;
+
+use amethyst::{assets::Source, error::format_err, Error};
+
+use derive_deref::{Deref, DerefMut};
+use derive_new::new;
+
+/// Identifies the in-memory asset source.
+pub const IN_MEMORY_SOURCE_ID: &str = "in_memory_asset_source";
+
+/// In-memory implementation of an asset `Source`, purely for tests.
+#[derive(Debug, Deref, DerefMut, new)]
+pub struct InMemorySource(#[new(default)] pub HashMap<String, Vec<u8>>);
+
+impl Source for InMemorySource {
+    fn modified(&self, _path: &str) -> Result<u64, Error> {
+        Ok(0)
+    }
+
+    fn load(&self, path: &str) -> Result<Vec<u8>, Error> {
+        let path = path.to_string();
+        self.0.get(&path).cloned().ok_or_else(|| {
+            format_err!(
+                "The `{}` asset is not registered in the `InMemorySource` asset source",
+                path
+            )
+        })
+    }
+}

--- a/amethyst_test/src/lib.rs
+++ b/amethyst_test/src/lib.rs
@@ -328,10 +328,12 @@ pub use crate::{
     effect_return::EffectReturn,
     fixture::{MaterialAnimationFixture, SpriteRenderAnimationFixture},
     game_update::GameUpdate,
+    in_memory_source::{InMemorySource, IN_MEMORY_SOURCE_ID},
     state::{
         CustomDispatcherState, CustomDispatcherStateBuilder, FunctionState, PopState,
         SequencerState,
     },
+    wait_for_load::WaitForLoad,
 };
 pub(crate) use crate::{
     system_desc_injection_bundle::SystemDescInjectionBundle,
@@ -343,8 +345,10 @@ mod amethyst_application;
 mod effect_return;
 mod fixture;
 mod game_update;
+mod in_memory_source;
 pub mod prelude;
 mod state;
 mod system_desc_injection_bundle;
 mod system_injection_bundle;
 mod thread_local_injection_bundle;
+mod wait_for_load;

--- a/amethyst_test/src/wait_for_load.rs
+++ b/amethyst_test/src/wait_for_load.rs
@@ -1,0 +1,99 @@
+use amethyst::{assets::ProgressCounter, ecs::WorldExt, State, StateData, Trans};
+use derive_new::new;
+
+use crate::GameUpdate;
+
+/// Reads a `ProgressCounter` resource and waits for it to be `complete()`.
+#[derive(Debug, new)]
+pub struct WaitForLoad;
+
+impl<T, E> State<T, E> for WaitForLoad
+where
+    T: GameUpdate,
+    E: Send + Sync + 'static,
+{
+    fn update(&mut self, data: StateData<'_, T>) -> Trans<T, E> {
+        data.data.update(&data.world);
+
+        let progress_counter = data.world.read_resource::<ProgressCounter>();
+        if !progress_counter.is_complete() {
+            Trans::None
+        } else {
+            Trans::Pop
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use amethyst::{
+        assets::{
+            Asset, AssetStorage, Handle, Loader, ProcessingState, Processor, ProgressCounter,
+            RonFormat,
+        },
+        ecs::{storage::VecStorage, WorldExt},
+        Error,
+    };
+    use serde::{Deserialize, Serialize};
+
+    use super::WaitForLoad;
+    use crate::{AmethystApplication, InMemorySource, IN_MEMORY_SOURCE_ID};
+
+    #[test]
+    fn pops_when_progress_counter_is_complete() -> Result<(), Error> {
+        AmethystApplication::blank()
+            .with_system(Processor::<TestAsset>::new(), "test_asset_processor", &[])
+            .with_effect(|world| {
+                let mut in_memory_source = InMemorySource::new();
+                in_memory_source.insert(String::from("file.ron"), "(val: 123)".as_bytes().to_vec());
+
+                let mut loader = world.write_resource::<Loader>();
+                loader.add_source(IN_MEMORY_SOURCE_ID, in_memory_source);
+            })
+            .with_effect(|world| {
+                let mut progress_counter = ProgressCounter::new();
+                let test_asset_handle = {
+                    let loader = world.read_resource::<Loader>();
+                    loader.load_from(
+                        "file.ron",
+                        RonFormat,
+                        IN_MEMORY_SOURCE_ID,
+                        &mut progress_counter,
+                        &world.read_resource::<AssetStorage<TestAsset>>(),
+                    )
+                };
+
+                world.insert(test_asset_handle);
+                world.insert(progress_counter);
+            })
+            .with_state(WaitForLoad::new)
+            .with_assertion(|world| {
+                let test_asset_handle = world.read_resource::<Handle<TestAsset>>();
+                let test_assets = world.read_resource::<AssetStorage<TestAsset>>();
+                let test_asset = test_assets
+                    .get(&test_asset_handle)
+                    .expect("Expected `TestAsset` to be loaded.");
+
+                assert_eq!(&TestAsset { val: 123 }, test_asset);
+            })
+            .run()
+    }
+
+    #[derive(Debug, Deserialize, PartialEq, Serialize)]
+    pub struct TestAsset {
+        val: u32,
+    }
+
+    impl Asset for TestAsset {
+        type Data = Self;
+        type HandleStorage = VecStorage<Handle<Self>>;
+
+        const NAME: &'static str = concat!(module_path!(), "::", stringify!(TestAsset));
+    }
+
+    impl From<TestAsset> for Result<ProcessingState<TestAsset>, Error> {
+        fn from(asset_data: TestAsset) -> Result<ProcessingState<TestAsset>, Error> {
+            Ok(ProcessingState::Loaded(asset_data))
+        }
+    }
+}

--- a/amethyst_test/src/wait_for_load.rs
+++ b/amethyst_test/src/wait_for_load.rs
@@ -45,7 +45,7 @@ mod tests {
             .with_system(Processor::<TestAsset>::new(), "test_asset_processor", &[])
             .with_effect(|world| {
                 let mut in_memory_source = InMemorySource::new();
-                in_memory_source.insert(String::from("file.ron"), "(val: 123)".as_bytes().to_vec());
+                in_memory_source.insert(String::from("file.ron"), b"(val: 123)".to_vec());
 
                 let mut loader = world.write_resource::<Loader>();
                 loader.add_source(IN_MEMORY_SOURCE_ID, in_memory_source);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * `RenderingBundle` for full manual control of the rendering pipeline via a custom `GraphCreator`. ([#1839])
 * `CameraOrtho::new` takes in `CameraOrthoWorldCoordinates`, which can be set to custom dimensions. ([#1916])
 * `Camera::screen_ray` method added, returning an appropriate `Ray` structure ([#1918]).
+* `amethyst_test`: `InMemorySource` and `WaitForLoad` helpers ([#1933]).
 
 ### Changed
 
@@ -64,6 +65,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1916]: https://github.com/amethyst/amethyst/pull/1916
 [#1919]: https://github.com/amethyst/amethyst/pull/1919
 [#1918]: https://github.com/amethyst/amethyst/pull/1918
+[#1933]: https://github.com/amethyst/amethyst/pull/1933
 
 ## [0.12.0] - 2019-07-30
 


### PR DESCRIPTION
## Description

Added `InMemorySource` and `WaitForLoad` to `amethyst_test`.

* `InMemorySource` allows assets to be loaded using `Loader` from memory.
* `WaitForLoad` is a state that waits for a `ProgressCounter` resource to be `complete()`.

## Additions

* `amethyst_test`: `InMemorySource` and `WaitForLoad` helpers.

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
