### PR TITLE
Use World::get_mut with amethyst_derive

### DIFF
--- a/amethyst_derive/src/system_desc.rs
+++ b/amethyst_derive/src/system_desc.rs
@@ -677,9 +677,14 @@ fn field_computation_expressions(system_desc_fields: &SystemDescFields<'_>) -> T
                         panic!("Expected `{}` field type to be `Type::Path`.", &field_name)
                     };
 
+                    let event_channel_error = format!(
+                        "Expected `EventChannel<{}>` to exist.",
+                        quote!(event_type_path).to_string()
+                    );
                     let tokens = quote! {
                         let #field_name = world
-                            .fetch_mut::<EventChannel<#event_type_path>>()
+                            .get_mut::<EventChannel<#event_type_path>>()
+                            .expect(#event_channel_error)
                             .register_reader();
                     };
                     token_stream.extend(tokens);


### PR DESCRIPTION
## Description

A slight tweak to exploit `&mut World` to reduce runtime borrow checks.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [X] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
