### PR TITLE
Add animation support for UiTransform

### DIFF
--- a/amethyst_animation/Cargo.toml
+++ b/amethyst_animation/Cargo.toml
@@ -22,6 +22,7 @@ amethyst_core = { path = "../amethyst_core/", version = "0.7.0" }
 amethyst_error = { path = "../amethyst_error/", version = "0.2.0" }
 amethyst_derive = { path = "../amethyst_derive", version = "0.5.0" }
 amethyst_rendy = { path = "../amethyst_rendy", version = "0.2.0" }
+amethyst_ui = { path = "../amethyst_ui", version = "0.7.0" }
 derivative = "1.0"
 fnv = "1"
 itertools = "0.7.8"

--- a/amethyst_animation/src/lib.rs
+++ b/amethyst_animation/src/lib.rs
@@ -71,6 +71,7 @@ pub use self::{
         AnimationControlSystem, AnimationProcessor, SamplerInterpolationSystem, SamplerProcessor,
     },
     transform::TransformChannel,
+    ui_transform::UiTransformChannel,
     util::{get_animation_set, SamplerPrimitive},
 };
 
@@ -82,4 +83,5 @@ mod skinning;
 mod sprite;
 mod systems;
 mod transform;
+mod ui_transform;
 mod util;

--- a/amethyst_animation/src/ui_transform.rs
+++ b/amethyst_animation/src/ui_transform.rs
@@ -1,0 +1,56 @@
+use amethyst_core::math::zero;
+use amethyst_ui::UiTransform;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    resources::{AnimationSampling, ApplyData, BlendMethod},
+    util::SamplerPrimitive,
+};
+
+/// Channels that can be animated on `UiTransform`
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub enum UiTransformChannel {
+    /// The 2 dimensional position for an UI entity
+    Translation,
+}
+
+impl<'a> ApplyData<'a> for UiTransform {
+    type ApplyData = ();
+}
+
+impl AnimationSampling for UiTransform {
+    type Primitive = SamplerPrimitive<f32>;
+    type Channel = UiTransformChannel;
+
+    fn apply_sample(&mut self, channel: &Self::Channel, data: &SamplerPrimitive<f32>, _: &()) {
+        use crate::util::SamplerPrimitive::*;
+
+        use self::UiTransformChannel::*;
+
+        match (channel, *data) {
+            (&Translation, Vec2(ref d)) => {
+                self.local_x = d[0];
+                self.local_y = d[1];
+            }
+            _ => panic!("Attempt to apply invalid sample to UiTransform"),
+        }
+    }
+
+    fn current_sample(&self, channel: &Self::Channel, _: &()) -> SamplerPrimitive<f32> {
+        use self::UiTransformChannel::*;
+        match channel {
+            Translation => SamplerPrimitive::Vec2([self.local_x, self.local_y]),
+        }
+    }
+    fn default_primitive(channel: &Self::Channel) -> Self::Primitive {
+        use self::UiTransformChannel::*;
+        match channel {
+            Translation => SamplerPrimitive::Vec2([zero(); 2]),
+        }
+    }
+
+    fn blend_method(&self, _: &Self::Channel) -> Option<BlendMethod> {
+        Some(BlendMethod::Linear)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * `CameraOrtho::new` takes in `CameraOrthoWorldCoordinates`, which can be set to custom dimensions. ([#1916])
 * `Camera::screen_ray` method added, returning an appropriate `Ray` structure ([#1918]).
 * `amethyst_test`: `InMemorySource` and `WaitForLoad` helpers ([#1933]).
+* Animations are available with `UiTransform`s. ([#1935])
 
 ### Changed
 


### PR DESCRIPTION
## Description

Added basic animation support for UI elements. Code is copied from normal transform.

## Additions

`amethyst::animation::UiTransformChannel`, `impl AnimationSampling for UiTransform`

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [X] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
