### PR TITLE
Add new derive to SpriteRenderPrefab

### DIFF
--- a/amethyst_rendy/src/sprite/prefab.rs
+++ b/amethyst_rendy/src/sprite/prefab.rs
@@ -10,6 +10,7 @@ use amethyst_core::{
 };
 use amethyst_error::Error;
 use derivative::Derivative;
+use derive_new::new;
 use serde::{Deserialize, Serialize};
 use std::sync::Mutex;
 
@@ -137,7 +138,7 @@ pub enum SpriteSheetReference {
 /// `SpriteSheetLoadedSet` by index during loading. Just like with `SpriteSheetPrefab` this means
 /// that this prefab should only be used as part of other prefabs or in specialised formats. Look at
 /// `SpriteScenePrefab` for an example.
-#[derive(Derivative, Clone, Debug, Deserialize, Serialize)]
+#[derive(new, Derivative, Clone, Debug, Deserialize, Serialize)]
 #[derivative(Default(bound = ""))]
 #[serde(bound = "")]
 pub struct SpriteRenderPrefab {
@@ -147,6 +148,7 @@ pub struct SpriteRenderPrefab {
     pub sprite_number: usize,
 
     #[serde(skip_deserializing, skip_serializing)]
+    #[new(default)]
     handle: Option<Handle<SpriteSheet>>,
 }
 
@@ -378,11 +380,7 @@ mod tests {
         let mut world = setup_sprite_world();
         let (sheet, handle) = add_sheet(&mut world);
         let entity = world.create_entity().build();
-        let mut prefab = SpriteRenderPrefab {
-            sheet: Some(sheet),
-            sprite_number: 0,
-            handle: None,
-        };
+        let mut prefab = SpriteRenderPrefab::new(Some(sheet), 0);
         prefab
             .load_sub_assets(&mut ProgressCounter::default(), &mut world.system_data())
             .unwrap();


### PR DESCRIPTION
## Description
Add new derive to `SpriteRenderPrefab`. Utilizing #[new(default)] for the private field `handle`

Reason:
Creating a `SpriteSheetPrefab` from another create is currently not possible because of the private `handle` field.
This approach was greenlit in #1585

fixes #1585 

## Additions

- SpriteRenderPrefab::new(Option<SpriteSheetReference>, usize) for creating a SpriteRenderPrefab with default `handle` field


## Modifications

- SpriteRenderPrefab

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
