### PR TITLE
Add missing re-export for HideHierarchySystemDesc

### DIFF
--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -38,7 +38,7 @@ pub use crate::{
 pub use self::{
     axis::{Axis2, Axis3},
     hidden::{Hidden, HiddenPropagate},
-    hide_system::HideHierarchySystem,
+    hide_system::{HideHierarchySystem, HideHierarchySystemDesc},
     named::{Named, WithNamed},
     system_desc::{RunNowDesc, SystemDesc},
 };

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 ### Changed
 
 ### Fixed
+- Add missing re-export for HideHierarchySystemDesc
 
 ## [0.13.0] - 2019-09-25
 


### PR DESCRIPTION
## Description

Added missing re-export for HideHierarchySystemDesc, as it's required in order to build game data since Amethyst 0.13.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
