### PR TITLE
Update pong-tutorial amethyst version to 0.13.

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-01.md
+++ b/book/src/pong-tutorial/pong-tutorial-01.md
@@ -19,7 +19,7 @@ authors = []
 edition = "2018"
 
 [dependencies.amethyst]
-version = "0.12"
+version = "0.13"
 features = ["vulkan"]
 ```
 
@@ -27,7 +27,7 @@ Alternatively, if you are developing on macOS, you might want to use the `metal`
 
 ```toml
 [dependencies.amethyst]
-version = "0.12"
+version = "0.13"
 features = ["metal"]
 ```
 


### PR DESCRIPTION
Updating the amethyst version in the pong-tutorial from 0.12 to 0.13.

The rest of the tutorial is written using 0.13, which causes some of the imports in the tutorial like `use amethyst::core::SystemDesc` to cause compile errors.