### PR TITLE
HOTFIX changes to amethyst_tiles 

### DIFF
--- a/amethyst_tiles/src/iters.rs
+++ b/amethyst_tiles/src/iters.rs
@@ -178,7 +178,7 @@ impl Iterator for RegionLinearIter {
             return Some(ret);
         }
 
-        if self.track.y >= self.region.max.y {
+        if self.track.y > self.region.max.y {
             self.track.z += 1;
 
             self.track.y = self.region.min.y;

--- a/amethyst_tiles/src/map.rs
+++ b/amethyst_tiles/src/map.rs
@@ -137,7 +137,9 @@ impl<T: Tile, E: CoordinateEncoder> TileMap<T, E> {
         let origin = Point3::new(0.0, 0.0, 0.0);
         let transform = create_transform(&dimensions, &tile_dimensions);
 
-        let size = (dimensions.x * dimensions.y * dimensions.z) as usize;
+        // Round the dimensions to the nearest multiplier for morton rounding
+        let encoder_dimensions = E::allocation_size(dimensions);
+        let size = (encoder_dimensions.x * encoder_dimensions.y * encoder_dimensions.z) as usize;
         let mut data = Vec::with_capacity(size);
         data.resize_with(size, T::default);
 

--- a/amethyst_tiles/src/map.rs
+++ b/amethyst_tiles/src/map.rs
@@ -356,7 +356,7 @@ mod tests {
     }
 
     #[test]
-    pub fn assymetric_maps() {
+    pub fn asymmetric_maps() {
         let test_dimensions = [
             Vector3::new(10, 58, 54),
             Vector3::new(66, 5, 200),

--- a/amethyst_tiles/src/morton/mod.rs
+++ b/amethyst_tiles/src/morton/mod.rs
@@ -81,16 +81,6 @@ pub fn morton_decode_intr_3d(morton: u32) -> (u32, u32, u32) {
     )
 }
 
-fn next_power_of_2(mut v: u32) -> u32 {
-    v -= 1;
-    v |= v >> 1;
-    v |= v >> 2;
-    v |= v >> 4;
-    v |= v >> 8;
-    v |= v >> 16;
-    v + 1
-}
-
 /// 3D Morton (Z-Order) encoding implementation.
 /// This implementation uses the `bmi2` CPU intrinsic if it is available via the `bitintr` crate. If this instruction
 /// set is not available, it falls back on simpler computation methods. Using these CPU instruction optimizations requires
@@ -115,12 +105,12 @@ impl CoordinateEncoder for MortonEncoder {
     }
 
     fn allocation_size(dimensions: Vector3<u32>) -> Vector3<u32> {
-        let max = dimensions.x.max(dimensions.y).max(dimensions.z);
-        Vector3::new(
-            next_power_of_2(max),
-            next_power_of_2(max),
-            next_power_of_2(max),
-        )
+        let max = dimensions
+            .x
+            .max(dimensions.y)
+            .max(dimensions.z)
+            .next_power_of_two();
+        Vector3::new(max, max, max)
     }
 }
 
@@ -177,8 +167,8 @@ impl CoordinateEncoder for MortonEncoder2D {
     }
 
     fn allocation_size(dimensions: Vector3<u32>) -> Vector3<u32> {
-        let max = dimensions.x.max(dimensions.y);
-        Vector3::new(next_power_of_2(max), next_power_of_2(max), dimensions.z)
+        let max = dimensions.x.max(dimensions.y).next_power_of_two();
+        Vector3::new(max, max, dimensions.z)
     }
 }
 

--- a/amethyst_tiles/src/morton/mod.rs
+++ b/amethyst_tiles/src/morton/mod.rs
@@ -82,7 +82,7 @@ pub fn morton_decode_intr_3d(morton: u32) -> (u32, u32, u32) {
 }
 
 fn next_power_of_2(mut v: u32) -> u32 {
-    v = v - 1;
+    v -= 1;
     v |= v >> 1;
     v |= v >> 2;
     v |= v >> 4;
@@ -113,10 +113,11 @@ impl CoordinateEncoder for MortonEncoder {
     }
 
     fn allocation_size(dimensions: Vector3<u32>) -> Vector3<u32> {
+        let max = dimensions.x.max(dimensions.y).max(dimensions.z);
         Vector3::new(
-            next_power_of_2(dimensions.x),
-            next_power_of_2(dimensions.y),
-            next_power_of_2(dimensions.z),
+            next_power_of_2(max),
+            next_power_of_2(max),
+            next_power_of_2(max),
         )
     }
 }
@@ -172,11 +173,8 @@ impl CoordinateEncoder for MortonEncoder2D {
     }
 
     fn allocation_size(dimensions: Vector3<u32>) -> Vector3<u32> {
-        Vector3::new(
-            next_power_of_2(dimensions.x),
-            next_power_of_2(dimensions.y),
-            dimensions.z,
-        )
+        let max = dimensions.x.max(dimensions.y);
+        Vector3::new(next_power_of_2(max), next_power_of_2(max), dimensions.z)
     }
 }
 

--- a/amethyst_tiles/src/morton/mod.rs
+++ b/amethyst_tiles/src/morton/mod.rs
@@ -96,6 +96,8 @@ fn next_power_of_2(mut v: u32) -> u32 {
 /// set is not available, it falls back on simpler computation methods. Using these CPU instruction optimizations requires
 /// `RUSTFLAGS=-C target-feature=+bmi2`. If this target feature is not provided, a LUT (Look Up Table) implementation
 /// of Morton encoding is used, considered extremely fast but still slightly slower than BMI2 intrinsics.
+///
+/// NOTE: This encoder requires allocation 2^n, equally in all dimensions.
 #[derive(Default, Clone)]
 pub struct MortonEncoder;
 impl CoordinateEncoder for MortonEncoder {
@@ -131,6 +133,8 @@ impl CoordinateEncoder for MortonEncoder {
 /// This implementation only performs 2D morton encoding on any given Z-level, while providing Z-levels ia a standard
 /// flat-array multiplicative manner. This means that each Z-level is contiguous in memory, but its inner coordinates
 /// are still Z-order encoded for some spatial locality.
+///
+/// NOTE: This encoder requires allocation 2^n, equally in the X-Y axis.
 #[derive(Default, Clone)]
 pub struct MortonEncoder2D {
     dimensions: (u32, u32, u32),

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ## [Unreleased]
 
+### Added 
+* `FlatEncoder` added to amethyst_tiles for flat linear encoding which is optimized for space. ([#1950])
+
+### Fixed 
+* `TileMap` was not allocating enough space for to compensate for morton encoding alignment. This means that 
+all tilemap allocation must occur on a 16-byte boundary ([#1950])
+
+[#1950]: https://github.com/amethyst/amethyst/pull/1950
+
 ### Major breaking changes
 
 * Systems needing initialization with world resources must go through a `SystemDesc` intermediate builder. ([#1780])

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ### Fixed 
 * `TileMap` was not allocating enough space for to compensate for morton encoding alignment. This means that 
-all tilemap allocation must occur on a 16-byte boundary ([#1950])
+all tilemap allocation must occur on 2^n boundary aligned on all axis (or x-y axis for Morton2D) ([#1950])
 
 [#1950]: https://github.com/amethyst/amethyst/pull/1950
 

--- a/examples/tiles/main.rs
+++ b/examples/tiles/main.rs
@@ -349,7 +349,7 @@ impl SimpleState for Example {
             .build();
 
         let map = TileMap::<ExampleTile>::new(
-            Vector3::new(32, 32, 1),
+            Vector3::new(48, 48, 1),
             Vector3::new(20, 20, 1),
             Some(map_sprite_sheet_handle),
         );


### PR DESCRIPTION
In a quick nutshell, this fixes the cases of:
- Allocation was incorrect for asymmetric map dimensions causing a panic on render. This is fixed by padding allocation for the morton encoder (2^n  boundary)
- Adds a FlatEncoder to optimize for space due to the padding needed for morton encoding (And I added it for testing)
- The iterator Ord was incorrect, causing hte y-axis to be one short.

This is a hotfix for these items.

Added: 
`FlatEncoder` added to amethyst_tiles for flat linear encoding which is optimized for space.

Fixed: 
- `TileMap` was not allocating enough space for to compensate for morton encoding alignment. This means that
all tilemap allocation must occur on a 2^n boundary on the correct dimensions boundary. This fixes the case of assemetric tilemaps.

- Fixed an iterator oppsy where the Ord was incorrect, causing the y-axis to be one tile short.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
