### PR TITLE
less verbose default logging for rendy/gfx-backend

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 ### Changed
 
 * Updated `syn`, `quote`, and `proc-macro2` to `1.0`. ([#1952])
+* Added less verbose default logging for rendy & gfx-backend
 
 ### Fixed
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -110,6 +110,19 @@ impl Logger {
             StdoutLog::Off => {}
         }
 
+        logger.dispatch = logger
+            .dispatch
+            .level_for("gfx_backend_empty", LevelFilter::Warn)
+            .level_for("gfx_backend_vulkan", LevelFilter::Warn)
+            .level_for("gfx_backend_dx12", LevelFilter::Warn)
+            .level_for("gfx_backend_metal", LevelFilter::Warn)
+            .level_for("rendy_factory::factory", LevelFilter::Warn)
+            .level_for("rendy_memory::allocator::dynamic", LevelFilter::Warn)
+            .level_for("rendy_graph::node::render::pass", LevelFilter::Warn)
+            .level_for("rendy_graph::graph", LevelFilter::Warn)
+            .level_for("rendy_memory::allocator::linear", LevelFilter::Warn)
+            .level_for("rendy_wsi", LevelFilter::Warn);
+
         if let Some(log_gfx_device_level) = config.log_gfx_device_level {
             logger.dispatch = logger
                 .dispatch


### PR DESCRIPTION
## Description

Altered the default logger to reduce the verbosity of gfx-backends and various rendy components

Addresses #1652 

The gfx-backends are all  set to the appropriate level. This does create a code location that will need to be modified for additional backends, but I couldn't see a solution for that which wasn't needlessly complex

## Modifications

- Modified Logger::new_with_config to reduce verbosity

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
