### PR TITLE
Fix TileArgs pod value tile_coordinate to be Rgb32Uint

### DIFF
--- a/amethyst_tiles/src/pod.rs
+++ b/amethyst_tiles/src/pod.rs
@@ -67,7 +67,7 @@ impl AsVertex for TileArgs {
             (Format::Rg32Sfloat, "u_offset"),
             (Format::Rg32Sfloat, "v_offset"),
             (Format::Rgba32Sfloat, "tint"),
-            (Format::Rgb32Sfloat, "tile_coordinate"),
+            (Format::Rgb32Uint, "tile_coordinate"),
         ))
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,10 +23,12 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * `TileMap` was not allocating enough space for to compensate for morton encoding alignment. This means that 
 all tilemap allocation must occur on 2^n boundary aligned on all axis (or x-y axis for Morton2D) ([#1950])
 * Add missing re-export for HideHierarchySystemDesc ([#1945])
+* `TileArgs` POD had incorrect format for `tile_coordinate` argument, caused a crash on metal backend. ([#1957])
 
 [#1945]: https://github.com/amethyst/amethyst/pull/1945
 [#1950]: https://github.com/amethyst/amethyst/pull/1950
 [#1952]: https://github.com/amethyst/amethyst/pull/1952
+[#1957]: https://github.com/amethyst/amethyst/pull/1957
 
 ## [0.13.0] - 2019-09-25
 


### PR DESCRIPTION
This caused a crash on macos but didnt trigger any validation errors for some reason.

This worked fine on linux/windows vulkan layers, but errors on macos metal backend. This changes it to the correct format of `Rgb32Uint`

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
