### PR TITLE
Update unic-langid to 0.5

### DIFF
--- a/amethyst_locale/Cargo.toml
+++ b/amethyst_locale/Cargo.toml
@@ -24,8 +24,8 @@ amethyst_assets = { path = "../amethyst_assets", version = "0.9.0" }
 amethyst_core = { path = "../amethyst_core", version = "0.8.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.3.0" }
 serde = { version = "1.0", features = ["derive"] }
-fluent = "0.7.0"
-unic-langid = { version = "0.4", features = ["macros"] }
+fluent = "0.7.2"
+unic-langid = { version = "0.5", features = ["macros"] }
 
 thread_profiler = { version = "0.3", optional = true }
 


### PR DESCRIPTION
## Description

I noticed that `amethyst_locale` uses `unic-langid` 0.4, but `fluent` 0.7 (which uses `unic-langid` 0.5).

I probably will want to re-export `langid` from fluent in the future to make it less likely to get desync, but for now, let's synchronize them!

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
