### PR TITLE
Fix fluent and unic-langid alignment

### DIFF
--- a/amethyst_locale/Cargo.toml
+++ b/amethyst_locale/Cargo.toml
@@ -24,8 +24,8 @@ amethyst_assets = { path = "../amethyst_assets", version = "0.9.1" }
 amethyst_core = { path = "../amethyst_core", version = "0.8.1" }
 amethyst_error = { path = "../amethyst_error", version = "0.3.0" }
 serde = { version = "1.0", features = ["derive"] }
-fluent = "0.7.2"
-unic-langid = { version = "0.5", features = ["macros"] }
+fluent = "0.8"
+unic-langid = { version = "0.6", features = ["macros"] }
 
 thread_profiler = { version = "0.3", optional = true }
 


### PR DESCRIPTION
Due to a mistake in https://github.com/zbraniecki/unic-locale/issues/18 I yanked too many revisions and ended up in a state where either amethyst_locale 0.7.0 or 0.7.1 doesn't work.

I updated all crates and this patch fixes amethyst_locale.

We may want to yank 0.7.1 and release 0.7.2 with this patch.