### PR TITLE
Include note about `with_system_desc` in specs migration notes

### DIFF
--- a/book/src/appendices/b_migration_notes/specs_migration.md
+++ b/book/src/appendices/b_migration_notes/specs_migration.md
@@ -22,6 +22,7 @@
 
     - Find: `PrefabLoaderSystem::<([A-Za-z]+)>::default\(\)`,
     - Replace: `PrefabLoaderSystemDesc::<\1>::default()`
+    - don't forget to replace `with` with `with_system_desc` when adding to GameData.
 
 * `GltfSceneLoaderSystem` is initialized by `GltfSceneLoaderSystemDesc`.
 
@@ -29,6 +30,7 @@
 
     - Find: `GltfSceneLoaderSystem::<([A-Za-z]+)>::default\(\)`,
     - Replace: `GltfSceneLoaderSystemDesc::<\1>::default()`
+    - don't forget to replace `with` with `with_system_desc` when adding to GameData.
 
 * `AmethystApplication::with_setup` runs the function before the dispatcher.
 

--- a/book/src/appendices/b_migration_notes/specs_migration.md
+++ b/book/src/appendices/b_migration_notes/specs_migration.md
@@ -22,7 +22,7 @@
 
     - Find: `PrefabLoaderSystem::<([A-Za-z]+)>::default\(\)`,
     - Replace: `PrefabLoaderSystemDesc::<\1>::default()`
-    - don't forget to replace `with` with `with_system_desc` when adding to GameData.
+    - Don't forget to replace `with` with `with_system_desc` when adding to GameData.
 
 * `GltfSceneLoaderSystem` is initialized by `GltfSceneLoaderSystemDesc`.
 
@@ -30,7 +30,7 @@
 
     - Find: `GltfSceneLoaderSystem::<([A-Za-z]+)>::default\(\)`,
     - Replace: `GltfSceneLoaderSystemDesc::<\1>::default()`
-    - don't forget to replace `with` with `with_system_desc` when adding to GameData.
+    - Don't forget to replace `with` with `with_system_desc` when adding to GameData.
 
 * `AmethystApplication::with_setup` runs the function before the dispatcher.
 


### PR DESCRIPTION
## Description

Added a note about using `with_system_desc` instead of `with` in the specs migration notes, as the error is not obvious (or at least was not obvious to me).

## Additions

No Code Additions.

## Removals

No Code Removal.

## Modifications

- No changes to existing structures or functions

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files: 
- No, only added documentation.