### PR TITLE
Add mention of how read_resource has moved

### DIFF
--- a/book/src/appendices/b_migration_notes/specs_migration.md
+++ b/book/src/appendices/b_migration_notes/specs_migration.md
@@ -6,6 +6,7 @@
 
     - Add `use amethyst::ecs::WorldExt` to imports.
     - Replace `world.add_resource` with `world.insert`.
+    - `use amethyst::ecs::WorldExt;` for `world.read_resource`.
     - Regex replace `\bResources\b` with `World`. Check for false replacements.
     - Replace `world.res` with `world`.
     - Regex replace `\bres\b` with `world`.


### PR DESCRIPTION
## Description
read_resource has moved from `World` to `WorldExt`, adding note to migration documentation.

## PR Checklist
By placing an x in the boxes I certify that I have:
- [x ] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.