### PR TITLE
Derive Debug for ProgressCounter and ProgressCounterTracker

### DIFF
--- a/amethyst_assets/src/progress.rs
+++ b/amethyst_assets/src/progress.rs
@@ -43,7 +43,7 @@ impl Progress for () {
 
 /// A progress tracker which is passed to the `Loader`
 /// in order to check how many assets are loaded.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct ProgressCounter {
     errors: Arc<Mutex<Vec<AssetErrorMeta>>>,
     num_assets: usize,
@@ -123,7 +123,7 @@ impl<'a> Progress for &'a mut ProgressCounter {
 }
 
 /// Progress tracker for `ProgressCounter`.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct ProgressCounterTracker {
     errors: Arc<Mutex<Vec<AssetErrorMeta>>>,
     num_failed: Arc<AtomicUsize>,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
  
 ### Added
 
+* Implement `Debug` for `ProgressCounter` and `ProgressCounterTracker`. ([#1973])
+
 ### Changed
 
 * Use a premultiplied view_proj matrix in vertex shaders. ([#1964])


### PR DESCRIPTION
## Description

Derive `Debug` for `ProgressCounter` and `ProgressCounterTracker`. I saw no obvious reason why they shouldn't impl `Debug`, but let me know if it's intended for them to not do so!

## Additions

- Implement `Debug` for `ProgressCounter` and `ProgressCounterTracker`.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR. (N/A)
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
