### PR TITLE
Fix #1976: Remove broken link from the Book

### DIFF
--- a/book/src/pong-tutorial/contribution.md
+++ b/book/src/pong-tutorial/contribution.md
@@ -19,10 +19,6 @@ An ecosystem-simulation game, 3D
 #### Showcase Game: [Space Menace](https://github.com/amethyst/space-menace/)
   
 An action 2D platformer
-  
-#### Showcase Game: [Survivor](https://github.com/jaynus/survival) 
-  
-(unannounced, 2D)
 
 For more examples from the community you can check out this list of [Games made with Amethyst](https://community.amethyst.rs/t/games-made-with-amethyst/134).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,11 +20,14 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ### Removed
 
+* Remove broken Survival link from the Call for Contribution chapter. ([#1977])
+
 ### Fixed
 
 ### Security
 
 [#1964]: https://github.com/amethyst/amethyst/pull/1964
+[#1977]: https://github.com/amethyst/amethyst/pull/1977
 
 
 ## [0.13.3] - 2019-10-4


### PR DESCRIPTION
Fixes #1976

## Description

This commit removes a [broken link to Survival](https://github.com/jaynus/survival) (a WIP showcase game) from
the Amethyst Book's [Call for Contribution chapter](https://book.amethyst.rs/master/pong-tutorial/contribution.html).

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files (it did not):

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
