### PR TITLE
Fix typo in pong-tutorial-06

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-06.md
+++ b/book/src/pong-tutorial/pong-tutorial-06.md
@@ -4,7 +4,7 @@ Now that we have a functional pong game, let's spice things up by adding some au
 
 ## Adding the Sounds Resource
 
-Let's get started by creating an `audio` subdirectory under `assets`. Then download [the bounce sound][bounce] and [the score sound][score] and put them in `audio/assets`.
+Let's get started by creating an `audio` subdirectory under `assets`. Then download [the bounce sound][bounce] and [the score sound][score] and put them in `assets/audio`.
 
 Next, we'll create a Resource to store our sound effects in. In `main.rs`, add:
 


### PR DESCRIPTION
## Description
Just a small typo I found while going through the pong tutorial.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
