### PR TITLE
Fix Pong Tutorial background music

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-06.md
+++ b/book/src/pong-tutorial/pong-tutorial-06.md
@@ -361,7 +361,7 @@ pub fn initialise_audio(world: &mut World) {
 Finally, let's add a DJ System to our game to play the music. In `main.rs`:
 
 ```rust,ignore
-use amethyst::audio::DjSystem;
+use amethyst::audio::DjSystemDesc;
 use crate::audio::Music;
 
 fn main() -> amethyst::Result<()> {
@@ -370,7 +370,7 @@ fn main() -> amethyst::Result<()> {
     let game_data = GameDataBuilder::default()
         // ... bundles
         .with(
-            DjSystem::new(|music: &mut Music| music.music.next()),
+            DjSystemDesc::new(|music: &mut Music| music.music.next()),
             "dj_system",
             &[],
         )


### PR DESCRIPTION
## Description

Tracking 97d3d4f67ca51ef822c51c59f60e81e06cda86c3 for the tutorial. Without this change, no background music was heard with amethyst 0.13.2.

## Additions

- No API changes

## Removals

- No API changes

## Modifications

- List changes to existing structures and functions here if any

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [n/a] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [n/a] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
