### PR TITLE
Maintenance/relax amethyst test fn constraint

### DIFF
--- a/amethyst_test/src/amethyst_application.rs
+++ b/amethyst_test/src/amethyst_application.rs
@@ -535,7 +535,7 @@ where
     /// * `func`: Function to execute.
     pub fn with_fn<F>(self, func: F) -> Self
     where
-        F: Fn(&mut World) + Send + Sync + 'static,
+        F: FnOnce(&mut World) + Send + Sync + 'static,
     {
         self.with_state(move || FunctionState::new(func))
     }
@@ -564,7 +564,7 @@ where
     /// * `effect_fn`: Function that executes an effect.
     pub fn with_effect<F>(self, effect_fn: F) -> Self
     where
-        F: Fn(&mut World) + Send + Sync + 'static,
+        F: FnOnce(&mut World) + Send + Sync + 'static,
     {
         self.with_fn(effect_fn)
     }
@@ -578,7 +578,7 @@ where
     /// * `assertion_fn`: Function that asserts the expected state.
     pub fn with_assertion<F>(self, assertion_fn: F) -> Self
     where
-        F: Fn(&mut World) + Send + Sync + 'static,
+        F: FnOnce(&mut World) + Send + Sync + 'static,
     {
         self.with_fn(assertion_fn)
     }

--- a/amethyst_test/src/state/function_state.rs
+++ b/amethyst_test/src/state/function_state.rs
@@ -1,31 +1,43 @@
 use amethyst::prelude::*;
 
-use derive_new::new;
-
 use crate::GameUpdate;
 
 /// Runs a function in `.update()` then `Pop`s itself.
 ///
 /// The function is run before `GameUpdate#update(world)` is called.
-#[derive(Debug, new)]
+#[derive(Debug)]
 pub struct FunctionState<F>
 where
-    F: Fn(&mut World),
+    F: FnOnce(&mut World),
 {
     /// Function to run in `update`.
-    function: F,
+    function: Option<F>,
+}
+
+impl<F> FunctionState<F>
+where
+    F: FnOnce(&mut World),
+{
+    /// Returns a new `FunctionState`
+    pub fn new(function: F) -> Self {
+        FunctionState {
+            function: Some(function),
+        }
+    }
 }
 
 impl<F, T, E> State<T, E> for FunctionState<F>
 where
-    F: Fn(&mut World),
+    F: FnOnce(&mut World),
     T: GameUpdate,
     E: Send + Sync + 'static,
 {
     fn update(&mut self, mut data: StateData<'_, T>) -> Trans<T, E> {
         data.data.update(&data.world);
 
-        (self.function)(&mut data.world);
+        if let Some(function) = self.function.take() {
+            (function)(&mut data.world);
+        }
 
         Trans::Pop
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,8 +20,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 - Use a premultiplied view_proj matrix in vertex shaders. ([#1964])
 - amethyst_network completely rewritten to provide a new baseline with which to build. ([#1917])
-- Cleaned up tiles example. Added rotation and translation tests, fixed raycast debug box. Added default zoom to PROJECT
-  perspective projection since no one knew to zoom out. ([#1974])
+- Cleaned up tiles example. Added rotation and translation tests, fixed raycast debug box. Added default zoom to `PROJECT` perspective projection since no one knew to zoom out. ([#1974])
+- `AmethystApplication::with_fn` constraint relaxed from `Fn` to `FnOnce`. ([#1983])
 
 ### Deprecated
 
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1973]: https://github.com/amethyst/amethyst/pull/1973
 [#1974]: https://github.com/amethyst/amethyst/pull/1974
 [#1978]: https://github.com/amethyst/amethyst/pull/1978
+[#1983]: https://github.com/amethyst/amethyst/pull/1983
 
 ## [0.13.3] - 2019-10-4
 


### PR DESCRIPTION
## Description

Users can pass in functions to run in `AmethystApplication::with_fn`. Since we only call the function once, we don't need it to be `Fn`, but `FnOnce`.

## Modifications

* `AmethystApplication::with_fn` constraint relaxed from `Fn` to `FnOnce`.

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
