### PR TITLE
Improvement/wait for load improvements

### DIFF
--- a/amethyst_test/Cargo.toml
+++ b/amethyst_test/Cargo.toml
@@ -17,7 +17,9 @@ amethyst = { path = "..", version = "0.13.0" }
 derivative = "1.0"
 derive-new = "0.5"
 derive_deref = "1.1.0"
+humantime = "1.3.0"
 lazy_static = "1.3"
+log = "0.4"
 
 [dev-dependencies]
 serde = "1.0"

--- a/amethyst_test/Cargo.toml
+++ b/amethyst_test/Cargo.toml
@@ -17,7 +17,6 @@ amethyst = { path = "..", version = "0.13.0" }
 derivative = "1.0"
 derive-new = "0.5"
 derive_deref = "1.1.0"
-humantime = "1.3.0"
 lazy_static = "1.3"
 log = "0.4"
 

--- a/amethyst_test/src/wait_for_load.rs
+++ b/amethyst_test/src/wait_for_load.rs
@@ -72,12 +72,9 @@ where
                 if elapsed > LOADING_TIME_LIMIT {
                     self.stopwatch.stop();
 
-                    let duration = humantime::Duration::from(elapsed);
-
                     warn!(
-                        "Loading has not completed in {}, please ensure that you have registered \
-                         the relevant `Processor::<A>`s in the dispatcher.",
-                        duration
+                        "Loading has not completed in 10 seconds, please ensure that you have \
+                         registered the relevant `Processor::<A>`s in the dispatcher.",
                     );
                 }
             }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - Added a custom render pass Example. ([#1904])
 - Add an entry for `examples/tiles` to the examples readme. ([#1978])
 - Added UI states/menu example. [#1986]
+- Allow user to specify custom completion function in `amethyst_test::WaitForLoad`. ([#1984])
+- Log warning when `amethyst_test::WaitForLoad` has not completed in 10 seconds. ([#1984])
 
 ### Changed
 
@@ -26,6 +28,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - `Config::load` now returns an error or failure rather than silently falling back to the default config. Same is true for the `from_config_file` methods on `RenderToWindow`, `WindowBundle`, and `WindowSystem` ([#1989])
 
 ### Deprecated
+
 - `Config::load_no_fallback`, use `Config::load` instead ([#1989])
 
 ### Removed
@@ -43,6 +46,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1974]: https://github.com/amethyst/amethyst/pull/1974
 [#1978]: https://github.com/amethyst/amethyst/pull/1978
 [#1983]: https://github.com/amethyst/amethyst/pull/1983
+[#1984]: https://github.com/amethyst/amethyst/pull/1984
 [#1986]: https://github.com/amethyst/amethyst/pull/1986
 [#1989]: https://github.com/amethyst/amethyst/pull/1989
 


### PR DESCRIPTION
## Description

(based over #1983, can simply view [last 3 commits](https://github.com/amethyst/amethyst/pull/1984/files/3515aa0f531f920d5894d310f1bbd1b31566c7ab..f82b111bc04cd4dbb78735ede673894fe8ed3bea))

`amethyst_test::WaitForLoad` improvements.

## Additions

* Allow user to specify custom completion function in `amethyst_test::WaitForLoad`.
* Log warning when `amethyst_test::WaitForLoad` has not completed in 10 seconds.

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
