### PR TITLE
Consistently report screen dimensions in physical pixels

### DIFF
--- a/amethyst_window/src/resources.rs
+++ b/amethyst_window/src/resources.rs
@@ -3,9 +3,9 @@ use amethyst_core::math::Vector2;
 /// World resource that stores screen dimensions.
 #[derive(Debug, PartialEq, Clone)]
 pub struct ScreenDimensions {
-    /// Screen width in pixels (px).
+    /// Screen width in physical pixels (px).
     pub(crate) w: f64,
-    /// Screen height in pixels (px).
+    /// Screen height in physical pixels (px).
     pub(crate) h: f64,
     /// Width divided by height.
     aspect_ratio: f32,

--- a/amethyst_window/src/system.rs
+++ b/amethyst_window/src/system.rs
@@ -34,11 +34,12 @@ impl WindowSystem {
 
     /// Create a new `WindowSystem` wrapping the provided `Window`
     pub fn new(world: &mut World, window: Window) -> Self {
+        let hidpi = window.get_hidpi_factor();
         let (width, height) = window
             .get_inner_size()
             .expect("Window closed during initialization!")
+            .to_physical(hidpi)
             .into();
-        let hidpi = window.get_hidpi_factor();
         world.insert(ScreenDimensions::new(width, height, hidpi));
         world.insert(window);
         Self

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - amethyst_network completely rewritten to provide a new baseline with which to build. ([#1917])
 - Cleaned up tiles example. Added rotation and translation tests, fixed raycast debug box. Added default zoom to PROJECT
   perspective projection since no one knew to zoom out. ([#1974])
+- ScreenDimensions now consistently reports window size in physical pixels. ([#1988])
 
 ### Deprecated
 


### PR DESCRIPTION
## Description

Fix #1943

Docs and changelog updated for clarity.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [X] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.