### PR TITLE
Instantiate the `AudioSink` resource and insert it

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-06.md
+++ b/book/src/pong-tutorial/pong-tutorial-06.md
@@ -329,11 +329,12 @@ use amethyst::{
 # }
 
 pub fn initialise_audio(world: &mut World) {
-    let (sound_effects, music) = {
+    let (sound_effects, music, audio_sink) = {
         let loader = world.read_resource::<Loader>();
 
-        let mut sink = world.write_resource::<AudioSink>();
-        sink.set_volume(0.25); // Music is a bit loud, reduce the volume.
+        let output = world.read_resource::<Output>();
+        let mut audio_sink = AudioSink::new(&output);
+        audio_sink.set_volume(0.25); // Music is a bit loud, reduce the volume.
 
         let music = MUSIC_TRACKS
             .iter()
@@ -348,13 +349,14 @@ pub fn initialise_audio(world: &mut World) {
             score_sfx: load_audio_track(&loader, &world, SCORE_SOUND),
         };
 
-        (sound, music)
+        (sound, music, audio_sink)
     };
 
     // Add sound effects and music to the world. We have to do this in another scope because
     // world won't let us insert new resources as long as `Loader` is borrowed.
     world.insert(sound_effects);
     world.insert(music);
+    world.insert(audio_sink);
 }
 ```
 


### PR DESCRIPTION
## Description

After going through the entire Pong tutorial over the weekend, I started getting this error after trying to add music to the game:

> thread 'main' panicked at 'Tried to fetch a resource of type "amethyst_audio::sink::AudioSink", but the resource does not exist.

I'm not sure if the proposed changes are the best way to correct this error message, but these changes did get my game to compile.

## Additions

N/A

## Removals

N/A

## Modifications

Instantiate the `AudioSink` resource and insert it into `world` instead of just calling `world.write_resource::<AudioSink>();`

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
