### PR TITLE
Support for tile u/v flipping with TileMap.

### DIFF
--- a/amethyst_tiles/src/map.rs
+++ b/amethyst_tiles/src/map.rs
@@ -20,6 +20,11 @@ pub trait Tile: 'static + Clone + Send + Sync + Default {
     fn tint(&self, coordinates: Point3<u32>, world: &World) -> Srgba {
         Srgba::new(1.0, 1.0, 1.0, 1.0)
     }
+
+    /// Takes an immutable reference to world to process this sprite and return its flip.
+    fn flip(&self, coordinates: Point3<u32>, world: &World) -> (bool, bool) {
+        (false, false)
+    }
 }
 
 /// Trait for providing access to an underlying storage type of a 3-dimensional Tile data. This is abstracted to provide

--- a/amethyst_tiles/src/pass.rs
+++ b/amethyst_tiles/src/pass.rs
@@ -274,6 +274,7 @@ impl<B: Backend, T: Tile, E: CoordinateEncoder, Z: DrawTiles2DBounds> RenderGrou
                             sprite_number,
                             Some(&TintComponent(tile.tint(coord, world))),
                             &coord,
+                            tile.flip(coord, world),
                         )?;
 
                         let (tex_id, this_changed) = textures_ref.insert(

--- a/amethyst_tiles/src/pod.rs
+++ b/amethyst_tiles/src/pod.rs
@@ -88,6 +88,7 @@ impl TileArgs {
         sprite_number: usize,
         tint: Option<&TintComponent>,
         tile_coordinate: &Point3<u32>,
+        flip: (bool, bool),
     ) -> Option<(Self, &'a Handle<Texture>)> {
         if !tex_storage.contains(&sprite_sheet.texture) {
             return None;
@@ -95,10 +96,20 @@ impl TileArgs {
 
         let sprite = &sprite_sheet.sprites[sprite_number];
 
+        let mut u_offset: vec2 = [sprite.tex_coords.left, sprite.tex_coords.right].into();
+        let mut v_offset: vec2 = [sprite.tex_coords.top, sprite.tex_coords.bottom].into();
+
+        if flip.0 {
+            u_offset = [sprite.tex_coords.right, sprite.tex_coords.left].into();
+        }
+        if flip.1 {
+            v_offset = [sprite.tex_coords.bottom, sprite.tex_coords.top].into();
+        }
+
         Some((
             Self {
-                u_offset: [sprite.tex_coords.left, sprite.tex_coords.right].into(),
-                v_offset: [sprite.tex_coords.top, sprite.tex_coords.bottom].into(),
+                u_offset,
+                v_offset,
                 tint: tint.map_or([1.0; 4].into(), |t| t.0.into_pod()),
                 tile_coordinate: [tile_coordinate.x, tile_coordinate.y, tile_coordinate.z].into(),
             },


### PR DESCRIPTION
## Description
Added the ability to flip the uv's for a tile map. This is useful for reusing tiles instead of duplicating them in your sprite sheet facing other ways.

## Additions

Tile trait now has a flip function which returns which dimension the tile should be flipped in.

## Modifications

TileArgs.from_data now flips uv's and accepts a new parameter.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
