### PR TITLE
Use global paths in SystemDesc derive

### DIFF
--- a/amethyst_animation/src/skinning/systems.rs
+++ b/amethyst_animation/src/skinning/systems.rs
@@ -1,10 +1,10 @@
 use amethyst_core::{
     ecs::prelude::{
-        BitSet, ComponentEvent, Join, ReadStorage, ReaderId, System, SystemData, World,
+        BitSet, ComponentEvent, Join, ReadStorage, ReaderId, System, SystemData,
         WriteStorage,
     },
     math::{convert, Matrix4},
-    SystemDesc, Transform,
+    Transform,
 };
 use amethyst_derive::SystemDesc;
 use amethyst_rendy::skinning::JointTransforms;

--- a/amethyst_animation/src/skinning/systems.rs
+++ b/amethyst_animation/src/skinning/systems.rs
@@ -1,7 +1,6 @@
 use amethyst_core::{
     ecs::prelude::{
-        BitSet, ComponentEvent, Join, ReadStorage, ReaderId, System, SystemData,
-        WriteStorage,
+        BitSet, ComponentEvent, Join, ReadStorage, ReaderId, System, SystemData, WriteStorage,
     },
     math::{convert, Matrix4},
     Transform,

--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -5,9 +5,7 @@ use winit::{DeviceEvent, Event, Window, WindowEvent};
 use thread_profiler::profile_scope;
 
 use amethyst_core::{
-    ecs::prelude::{
-        Join, Read, ReadExpect, ReadStorage, System, SystemData, Write, WriteStorage,
-    },
+    ecs::prelude::{Join, Read, ReadExpect, ReadStorage, System, SystemData, Write, WriteStorage},
     math::{convert, Unit, Vector3},
     shrev::{EventChannel, ReaderId},
     timing::Time,

--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -6,13 +6,12 @@ use thread_profiler::profile_scope;
 
 use amethyst_core::{
     ecs::prelude::{
-        Join, Read, ReadExpect, ReadStorage, System, SystemData, World, Write, WriteStorage,
+        Join, Read, ReadExpect, ReadStorage, System, SystemData, Write, WriteStorage,
     },
     math::{convert, Unit, Vector3},
     shrev::{EventChannel, ReaderId},
     timing::Time,
     transform::Transform,
-    SystemDesc,
 };
 use amethyst_derive::SystemDesc;
 use amethyst_input::{get_input_axis_simple, BindingTypes, InputHandler};

--- a/amethyst_derive/Cargo.toml
+++ b/amethyst_derive/Cargo.toml
@@ -20,6 +20,7 @@ syn = { version = "1.0", features = ["full", "visit"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 proc_macro_roids = "0.6"
+proc-macro-crate = "0.1"
 
 [dev-dependencies]
 amethyst_core = { path = "../amethyst_core", version = "0.8.1" }

--- a/amethyst_derive/src/system_desc.rs
+++ b/amethyst_derive/src/system_desc.rs
@@ -11,9 +11,13 @@ use syn::{
 };
 
 pub fn amethyst_core() -> TokenStream {
-    if let Ok(name) = proc_macro_crate::crate_name("amethyst_core").map(|x| Ident::new(&x, Span::call_site())) {
+    if let Ok(name) =
+        proc_macro_crate::crate_name("amethyst_core").map(|x| Ident::new(&x, Span::call_site()))
+    {
         quote!(::#name)
-    } else if let Ok(name) = proc_macro_crate::crate_name("amethyst").map(|x| Ident::new(&x, Span::call_site())) {
+    } else if let Ok(name) =
+        proc_macro_crate::crate_name("amethyst").map(|x| Ident::new(&x, Span::call_site()))
+    {
         quote!(::#name::core)
     } else {
         panic!("neither amethyst nor amethyst_core found");

--- a/amethyst_derive/src/system_desc.rs
+++ b/amethyst_derive/src/system_desc.rs
@@ -20,7 +20,7 @@ pub fn amethyst_core() -> TokenStream {
     {
         quote!(::#name::core)
     } else {
-        panic!("neither amethyst nor amethyst_core found");
+        quote!(::amethyst::core)
     }
 }
 

--- a/amethyst_derive/tests/system_desc.rs
+++ b/amethyst_derive/tests/system_desc.rs
@@ -337,7 +337,7 @@ fn struct_named_complex() -> Result<(), Error> {
 #[test]
 fn system_with_flagged_storage_reader() -> Result<(), Error> {
     use amethyst_core::{
-        ecs::{storage::ComponentEvent, WriteStorage},
+        ecs::storage::ComponentEvent,
         transform::Transform,
     };
 

--- a/amethyst_derive/tests/system_desc.rs
+++ b/amethyst_derive/tests/system_desc.rs
@@ -336,10 +336,7 @@ fn struct_named_complex() -> Result<(), Error> {
 
 #[test]
 fn system_with_flagged_storage_reader() -> Result<(), Error> {
-    use amethyst_core::{
-        ecs::storage::ComponentEvent,
-        transform::Transform,
-    };
+    use amethyst_core::{ecs::storage::ComponentEvent, transform::Transform};
 
     // Expects `System` to have a `new` constructor.
     #[derive(Debug, SystemDesc)]

--- a/amethyst_ui/src/button/system.rs
+++ b/amethyst_ui/src/button/system.rs
@@ -1,9 +1,9 @@
 use std::{collections::HashMap, fmt::Debug};
 
 use amethyst_core::{
-    ecs::{Entity, ReadExpect, System, SystemData, World, Write, WriteStorage},
+    ecs::{Entity, ReadExpect, System, SystemData, Write, WriteStorage},
     shrev::{EventChannel, ReaderId},
-    ParentHierarchy, SystemDesc,
+    ParentHierarchy,
 };
 use amethyst_derive::SystemDesc;
 

--- a/amethyst_ui/src/glyphs.rs
+++ b/amethyst_ui/src/glyphs.rs
@@ -7,8 +7,8 @@ use crate::{
 use amethyst_assets::{AssetStorage, Handle};
 use amethyst_core::{
     ecs::{
-        Component, DenseVecStorage, Entities, Join, Read, ReadStorage, System, SystemData,
-        Write, WriteExpect, WriteStorage,
+        Component, DenseVecStorage, Entities, Join, Read, ReadStorage, System, SystemData, Write,
+        WriteExpect, WriteStorage,
     },
     Hidden, HiddenPropagate,
 };

--- a/amethyst_ui/src/glyphs.rs
+++ b/amethyst_ui/src/glyphs.rs
@@ -7,10 +7,10 @@ use crate::{
 use amethyst_assets::{AssetStorage, Handle};
 use amethyst_core::{
     ecs::{
-        Component, DenseVecStorage, Entities, Join, Read, ReadStorage, System, SystemData, World,
+        Component, DenseVecStorage, Entities, Join, Read, ReadStorage, System, SystemData,
         Write, WriteExpect, WriteStorage,
     },
-    Hidden, HiddenPropagate, SystemDesc,
+    Hidden, HiddenPropagate,
 };
 use amethyst_derive::SystemDesc;
 use amethyst_rendy::{

--- a/amethyst_ui/src/resize.rs
+++ b/amethyst_ui/src/resize.rs
@@ -1,10 +1,9 @@
 use amethyst_core::{
     ecs::prelude::{
         BitSet, Component, ComponentEvent, FlaggedStorage, Join, ReadExpect, System, SystemData,
-        World, WriteStorage,
+        WriteStorage,
     },
     shrev::ReaderId,
-    SystemDesc,
 };
 use amethyst_derive::SystemDesc;
 use amethyst_window::ScreenDimensions;

--- a/amethyst_ui/src/sound.rs
+++ b/amethyst_ui/src/sound.rs
@@ -3,10 +3,9 @@ use amethyst_audio::{output::Output, Source, SourceHandle};
 use amethyst_core::{
     ecs::{
         prelude::{Component, DenseVecStorage},
-        Read, System, SystemData, World, Write,
+        Read, System, SystemData, Write,
     },
     shrev::{EventChannel, ReaderId},
-    SystemDesc,
 };
 use amethyst_derive::SystemDesc;
 

--- a/amethyst_ui/src/text.rs
+++ b/amethyst_ui/src/text.rs
@@ -7,12 +7,11 @@ use winit::{ElementState, Event, MouseButton, WindowEvent};
 
 use amethyst_core::{
     ecs::prelude::{
-        Component, DenseVecStorage, Join, Read, ReadExpect, ReadStorage, System, SystemData, World,
+        Component, DenseVecStorage, Join, Read, ReadExpect, ReadStorage, System, SystemData,
         WriteStorage,
     },
     shrev::{EventChannel, ReaderId},
     timing::Time,
-    SystemDesc,
 };
 use amethyst_derive::SystemDesc;
 use amethyst_window::ScreenDimensions;

--- a/amethyst_ui/src/text_editing.rs
+++ b/amethyst_ui/src/text_editing.rs
@@ -8,10 +8,9 @@ use winit::{ElementState, Event, KeyboardInput, ModifiersState, VirtualKeyCode, 
 
 use amethyst_core::{
     ecs::prelude::{
-        Entities, Join, Read, ReadStorage, System, SystemData, World, Write, WriteStorage,
+        Entities, Join, Read, ReadStorage, System, SystemData, Write, WriteStorage,
     },
     shrev::{EventChannel, ReaderId},
-    SystemDesc,
 };
 use amethyst_derive::SystemDesc;
 

--- a/amethyst_ui/src/text_editing.rs
+++ b/amethyst_ui/src/text_editing.rs
@@ -7,9 +7,7 @@ use unicode_segmentation::UnicodeSegmentation;
 use winit::{ElementState, Event, KeyboardInput, ModifiersState, VirtualKeyCode, WindowEvent};
 
 use amethyst_core::{
-    ecs::prelude::{
-        Entities, Join, Read, ReadStorage, System, SystemData, Write, WriteStorage,
-    },
+    ecs::prelude::{Entities, Join, Read, ReadStorage, System, SystemData, Write, WriteStorage},
     shrev::{EventChannel, ReaderId},
 };
 use amethyst_derive::SystemDesc;

--- a/amethyst_utils/src/auto_fov.rs
+++ b/amethyst_utils/src/auto_fov.rs
@@ -4,9 +4,8 @@ use amethyst_assets::PrefabData;
 use amethyst_core::{
     ecs::{
         Component, Entity, HashMapStorage, Join, ReadExpect, ReadStorage, System, SystemData,
-        World, WriteStorage,
+        WriteStorage,
     },
-    SystemDesc,
 };
 use amethyst_derive::{PrefabData, SystemDesc};
 use amethyst_error::Error;

--- a/amethyst_utils/src/auto_fov.rs
+++ b/amethyst_utils/src/auto_fov.rs
@@ -1,11 +1,9 @@
 //! Utility to adjust the aspect ratio of cameras automatically
 
 use amethyst_assets::PrefabData;
-use amethyst_core::{
-    ecs::{
-        Component, Entity, HashMapStorage, Join, ReadExpect, ReadStorage, System, SystemData,
-        WriteStorage,
-    },
+use amethyst_core::ecs::{
+    Component, Entity, HashMapStorage, Join, ReadExpect, ReadStorage, System, SystemData,
+    WriteStorage,
 };
 use amethyst_derive::{PrefabData, SystemDesc};
 use amethyst_error::Error;

--- a/book/src/concepts/system/system_desc_derive.md
+++ b/book/src/concepts/system/system_desc_derive.md
@@ -11,27 +11,14 @@ The `SystemDesc` derive supports the following cases when generating a `SystemDe
 If your system initialization use case is not covered, please see the
 [Implementing the `SystemDesc` Trait] page.
 
-In each of the following examples, make sure you have the following imports:
-
-```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
-#
-use amethyst::{
-    core::SystemDesc,
-    derive::SystemDesc,
-    ecs::{System, SystemData, World},
-};
-```
-
 ## Passing parameters to system constructor
 
 ```rust,edition2018,no_run,noplaypen
 # extern crate amethyst;
 #
 # use amethyst::{
-#     core::SystemDesc,
 #     derive::SystemDesc,
-#     ecs::{System, SystemData, World},
+#     ecs::{System, SystemData},
 # };
 #
 #[derive(SystemDesc)]
@@ -60,9 +47,8 @@ impl SystemName {
 # extern crate amethyst;
 #
 # use amethyst::{
-#     core::SystemDesc,
 #     derive::SystemDesc,
-#     ecs::{System, SystemData, World},
+#     ecs::{System, SystemData},
 # };
 #
 # pub struct SystemName {
@@ -94,9 +80,9 @@ impl SystemNameDesc {
     }
 }
 
-impl<'a, 'b> SystemDesc<'a, 'b, SystemName> for SystemNameDesc {
-    fn build(self, world: &mut World) -> SystemName {
-        <SystemName as System<'_>>::SystemData::setup(world);
+impl<'a, 'b> ::amethyst::core::SystemDesc<'a, 'b, SystemName> for SystemNameDesc {
+    fn build(self, world: &mut ::amethyst::ecs::World) -> SystemName {
+        <SystemName as ::amethyst::ecs::System<'_>>::SystemData::setup(world);
 
         SystemName::new(self.field_0, self.field_1)
     }
@@ -111,9 +97,8 @@ impl<'a, 'b> SystemDesc<'a, 'b, SystemName> for SystemNameDesc {
 # extern crate amethyst;
 #
 # use amethyst::{
-#     core::SystemDesc,
 #     derive::SystemDesc,
-#     ecs::{System, SystemData, World},
+#     ecs::{System, SystemData},
 # };
 #
 #[derive(SystemDesc)]
@@ -143,9 +128,8 @@ impl SystemName {
 # extern crate amethyst;
 #
 # use amethyst::{
-#     core::SystemDesc,
 #     derive::SystemDesc,
-#     ecs::{System, SystemData, World},
+#     ecs::{System, SystemData},
 # };
 #
 # pub struct SystemName {
@@ -176,9 +160,9 @@ impl SystemNameDesc {
     }
 }
 
-impl<'a, 'b> SystemDesc<'a, 'b, SystemName> for SystemNameDesc {
-    fn build(self, world: &mut World) -> SystemName {
-        <SystemName as System<'_>>::SystemData::setup(world);
+impl<'a, 'b> ::amethyst::core::SystemDesc<'a, 'b, SystemName> for SystemNameDesc {
+    fn build(self, world: &mut ::amethyst::ecs::World) -> SystemName {
+        <SystemName as ::amethyst::ecs::System<'_>>::SystemData::setup(world);
 
         SystemName::new(self.field_1)
     }
@@ -194,9 +178,8 @@ will call  `SystemName::default()`:
 # extern crate amethyst;
 #
 # use amethyst::{
-#     core::SystemDesc,
 #     derive::SystemDesc,
-#     ecs::{System, SystemData, World},
+#     ecs::{System, SystemData},
 # };
 #
 #[derive(Default, SystemDesc)]
@@ -219,9 +202,8 @@ pub struct SystemName {
 # extern crate amethyst;
 #
 # use amethyst::{
-#     core::SystemDesc,
 #     derive::SystemDesc,
-#     ecs::{System, SystemData, World},
+#     ecs::{System, SystemData},
 # };
 #
 # #[derive(Default)]
@@ -244,9 +226,9 @@ impl Default for SystemNameDesc {
     }
 }
 
-impl<'a, 'b> SystemDesc<'a, 'b, SystemName> for SystemNameDesc {
-    fn build(self, world: &mut World) -> SystemName {
-        <SystemName as System<'_>>::SystemData::setup(world);
+impl<'a, 'b> ::amethyst::core::SystemDesc<'a, 'b, SystemName> for SystemNameDesc {
+    fn build(self, world: &mut ::amethyst::ecs::World) -> SystemName {
+        <SystemName as ::amethyst::ecs::System<'_>>::SystemData::setup(world);
 
         SystemName::default()
     }
@@ -261,9 +243,8 @@ impl<'a, 'b> SystemDesc<'a, 'b, SystemName> for SystemNameDesc {
 # extern crate amethyst;
 #
 # use amethyst::{
-#     core::SystemDesc,
 #     derive::SystemDesc,
-#     ecs::{System, SystemData, World},
+#     ecs::{System, SystemData},
 #     shrev::{EventChannel, ReaderId},
 #     ui::UiEvent,
 # };
@@ -294,9 +275,8 @@ impl SystemName {
 # extern crate amethyst;
 #
 # use amethyst::{
-#     core::SystemDesc,
 #     derive::SystemDesc,
-#     ecs::{System, SystemData, World},
+#     ecs::{System, SystemData},
 #     shrev::{EventChannel, ReaderId},
 #     ui::UiEvent,
 # };
@@ -326,9 +306,9 @@ impl Default for SystemNameDesc {
     }
 }
 
-impl<'a, 'b> SystemDesc<'a, 'b, SystemName> for SystemNameDesc {
-    fn build(self, world: &mut World) -> SystemName {
-        <SystemName as System<'_>>::SystemData::setup(world);
+impl<'a, 'b> ::amethyst::core::SystemDesc<'a, 'b, SystemName> for SystemNameDesc {
+    fn build(self, world: &mut ::amethyst::ecs::World) -> SystemName {
+        <SystemName as ::amethyst::ecs::System<'_>>::SystemData::setup(world);
 
         let reader_id = world
             .fetch_mut::<EventChannel<UiEvent>>()
@@ -347,9 +327,8 @@ impl<'a, 'b> SystemDesc<'a, 'b, SystemName> for SystemNameDesc {
 # extern crate amethyst;
 #
 # use amethyst::{
-#     core::SystemDesc,
 #     derive::SystemDesc,
-#     ecs::{storage::ComponentEvent, System, SystemData, World, WriteStorage},
+#     ecs::{storage::ComponentEvent, System, SystemData, WriteStorage},
 #     shrev::{EventChannel, ReaderId},
 #     ui::UiResize,
 # };
@@ -380,9 +359,8 @@ impl SystemName {
 # extern crate amethyst;
 #
 # use amethyst::{
-#     core::SystemDesc,
 #     derive::SystemDesc,
-#     ecs::{storage::ComponentEvent, System, SystemData, World, WriteStorage},
+#     ecs::{storage::ComponentEvent, System, SystemData, WriteStorage},
 #     shrev::{EventChannel, ReaderId},
 #     ui::UiResize,
 # };
@@ -412,9 +390,9 @@ impl Default for SystemNameDesc {
     }
 }
 
-impl<'a, 'b> SystemDesc<'a, 'b, SystemName> for SystemNameDesc {
-    fn build(self, world: &mut World) -> SystemName {
-        <SystemName as System<'_>>::SystemData::setup(world);
+impl<'a, 'b> ::amethyst::core::SystemDesc<'a, 'b, SystemName> for SystemNameDesc {
+    fn build(self, world: &mut ::amethyst::ecs::World) -> SystemName {
+        <SystemName as ::amethyst::ecs::System<'_>>::SystemData::setup(world);
 
         let resize_events_id = WriteStorage::<UiResize>::fetch(&world)
                             .register_reader();
@@ -436,9 +414,8 @@ such as a function call, you must surround that expression in quotes, e.g.
 # extern crate amethyst;
 #
 # use amethyst::{
-#     core::SystemDesc,
 #     derive::SystemDesc,
-#     ecs::{ReadExpect, System, SystemData, World},
+#     ecs::{ReadExpect, System, SystemData},
 # };
 #
 pub struct NonDefault;
@@ -460,9 +437,8 @@ impl<'a> System<'a> for SystemName {
 # extern crate amethyst;
 #
 # use amethyst::{
-#     core::SystemDesc,
 #     derive::SystemDesc,
-#     ecs::{ReadExpect, System, SystemData, World},
+#     ecs::{ReadExpect, System, SystemData},
 # };
 #
 # pub struct NonDefault;
@@ -485,9 +461,9 @@ impl Default for SystemNameDesc {
     }
 }
 
-impl<'a, 'b> SystemDesc<'a, 'b, SystemName> for SystemNameDesc {
-    fn build(self, world: &mut World) -> SystemName {
-        <SystemName as System<'_>>::SystemData::setup(world);
+impl<'a, 'b> ::amethyst::core::SystemDesc<'a, 'b, SystemName> for SystemNameDesc {
+    fn build(self, world: &mut ::amethyst::ecs::World) -> SystemName {
+        <SystemName as ::amethyst::ecs::System<'_>>::SystemData::setup(world);
 
         world.insert(NonDefault);
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -72,6 +72,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 ### Added
 
 - `FlatEncoder` added to amethyst_tiles for flat linear encoding which is optimized for space. ([#1950])
+- `SystemDesc` derive no longer requires any imports. ([#1995])
 
 ### Changed
 
@@ -88,6 +89,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1950]: https://github.com/amethyst/amethyst/pull/1950
 [#1952]: https://github.com/amethyst/amethyst/pull/1952
 [#1957]: https://github.com/amethyst/amethyst/pull/1957
+[#1995]: https://github.com/amethyst/amethyst/pull/1995
 
 ## [0.13.0] - 2019-09-25
 

--- a/examples/arc_ball_camera/main.rs
+++ b/examples/arc_ball_camera/main.rs
@@ -6,10 +6,9 @@ use amethyst::{
     core::{
         shrev::{EventChannel, ReaderId},
         transform::{Transform, TransformBundle},
-        SystemDesc,
     },
     derive::SystemDesc,
-    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, World, WorldExt, WriteStorage},
+    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, WorldExt, WriteStorage},
     input::{
         is_key_down, InputBundle, InputEvent, ScrollDirection, StringBindings, VirtualKeyCode,
     },

--- a/examples/auto_fov/main.rs
+++ b/examples/auto_fov/main.rs
@@ -3,9 +3,9 @@ use amethyst::{
         Completion, Handle, Prefab, PrefabData, PrefabLoader, PrefabLoaderSystemDesc,
         ProgressCounter, RonFormat,
     },
-    core::{SystemDesc, Transform, TransformBundle},
+    core::{Transform, TransformBundle},
     derive::{PrefabData, SystemDesc},
-    ecs::{Entity, ReadExpect, ReadStorage, System, SystemData, World, WorldExt, WriteStorage},
+    ecs::{Entity, ReadExpect, ReadStorage, System, SystemData, WorldExt, WriteStorage},
     input::{is_close_requested, is_key_down, InputBundle, StringBindings},
     prelude::{
         Application, Builder, GameData, GameDataBuilder, SimpleState, SimpleTrans, StateData,

--- a/examples/custom_game_data/example_system.rs
+++ b/examples/custom_game_data/example_system.rs
@@ -2,11 +2,11 @@ use super::DemoState;
 use amethyst::{
     core::{
         math::{UnitQuaternion, Vector3},
-        SystemDesc, Time, Transform,
+        Time, Transform,
     },
     derive::SystemDesc,
     ecs::prelude::{
-        Entity, Join, Read, ReadStorage, System, SystemData, World, WriteExpect, WriteStorage,
+        Entity, Join, Read, ReadStorage, System, SystemData, WriteExpect, WriteStorage,
     },
     renderer::{camera::Camera, light::Light},
     ui::{UiFinder, UiText},

--- a/examples/debug_lines/main.rs
+++ b/examples/debug_lines/main.rs
@@ -5,10 +5,10 @@ use amethyst::{
     core::{
         math::{Point3, Vector3},
         transform::{Transform, TransformBundle},
-        SystemDesc, Time,
+        Time,
     },
     derive::SystemDesc,
-    ecs::{Read, System, SystemData, World, WorldExt, Write},
+    ecs::{Read, System, SystemData, WorldExt, Write},
     input::{is_close_requested, is_key_down, InputBundle, StringBindings},
     prelude::*,
     renderer::{

--- a/examples/debug_lines_ortho/main.rs
+++ b/examples/debug_lines_ortho/main.rs
@@ -3,10 +3,10 @@
 use amethyst::{
     core::{
         transform::{Transform, TransformBundle},
-        SystemDesc, Time,
+        Time,
     },
     derive::SystemDesc,
-    ecs::{Read, ReadExpect, System, SystemData, World, WorldExt, Write},
+    ecs::{Read, ReadExpect, System, SystemData, WorldExt, Write},
     prelude::*,
     renderer::{
         camera::Camera,

--- a/examples/mouse_raycast/main.rs
+++ b/examples/mouse_raycast/main.rs
@@ -8,7 +8,7 @@ use amethyst::{
         geometry::Plane,
         math::{Point2, Vector2, Vector3},
         transform::{Transform, TransformBundle},
-        Named, SystemDesc, WithNamed,
+        Named, WithNamed,
     },
     derive::SystemDesc,
     ecs::{

--- a/examples/pong/systems/bounce.rs
+++ b/examples/pong/systems/bounce.rs
@@ -5,9 +5,9 @@ use crate::{
 use amethyst::{
     assets::AssetStorage,
     audio::{output::Output, Source},
-    core::{transform::Transform, SystemDesc},
+    core::transform::Transform,
     derive::SystemDesc,
-    ecs::prelude::{Join, Read, ReadExpect, ReadStorage, System, SystemData, World, WriteStorage},
+    ecs::prelude::{Join, Read, ReadExpect, ReadStorage, System, SystemData, WriteStorage},
 };
 use std::ops::Deref;
 

--- a/examples/pong/systems/move_balls.rs
+++ b/examples/pong/systems/move_balls.rs
@@ -1,8 +1,8 @@
 use crate::Ball;
 use amethyst::{
-    core::{timing::Time, transform::Transform, SystemDesc},
+    core::{timing::Time, transform::Transform},
     derive::SystemDesc,
-    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, World, WriteStorage},
+    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
 };
 
 /// This system is responsible for moving all balls according to their speed

--- a/examples/pong/systems/paddle.rs
+++ b/examples/pong/systems/paddle.rs
@@ -1,8 +1,8 @@
 use crate::Paddle;
 use amethyst::{
-    core::{timing::Time, transform::Transform, SystemDesc},
+    core::{timing::Time, transform::Transform},
     derive::SystemDesc,
-    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, World, WriteStorage},
+    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
     input::{InputHandler, StringBindings},
 };
 

--- a/examples/pong/systems/winner.rs
+++ b/examples/pong/systems/winner.rs
@@ -2,11 +2,9 @@ use crate::{audio::Sounds, Ball, ScoreBoard};
 use amethyst::{
     assets::AssetStorage,
     audio::{output::Output, Source},
-    core::{SystemDesc, Transform},
+    core::Transform,
     derive::SystemDesc,
-    ecs::prelude::{
-        Entity, Join, Read, ReadExpect, System, SystemData, World, Write, WriteStorage,
-    },
+    ecs::prelude::{Entity, Join, Read, ReadExpect, System, SystemData, Write, WriteStorage},
     ui::UiText,
 };
 

--- a/examples/pong_tutorial_03/systems/paddle.rs
+++ b/examples/pong_tutorial_03/systems/paddle.rs
@@ -1,8 +1,8 @@
 use crate::pong::{Paddle, Side, ARENA_HEIGHT, PADDLE_HEIGHT};
 use amethyst::{
-    core::{transform::Transform, SystemDesc},
+    core::transform::Transform,
     derive::SystemDesc,
-    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, World, WriteStorage},
+    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
     input::{InputHandler, StringBindings},
 };
 

--- a/examples/pong_tutorial_04/systems/bounce.rs
+++ b/examples/pong_tutorial_04/systems/bounce.rs
@@ -1,7 +1,7 @@
 use amethyst::{
-    core::{transform::Transform, SystemDesc},
+    core::transform::Transform,
     derive::SystemDesc,
-    ecs::prelude::{Join, ReadStorage, System, SystemData, World, WriteStorage},
+    ecs::prelude::{Join, ReadStorage, System, SystemData, WriteStorage},
 };
 
 use crate::pong::{Ball, Paddle, Side, ARENA_HEIGHT};

--- a/examples/pong_tutorial_04/systems/move_balls.rs
+++ b/examples/pong_tutorial_04/systems/move_balls.rs
@@ -1,7 +1,7 @@
 use amethyst::{
-    core::{timing::Time, transform::Transform, SystemDesc},
+    core::{timing::Time, transform::Transform},
     derive::SystemDesc,
-    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, World, WriteStorage},
+    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
 };
 
 use crate::pong::Ball;

--- a/examples/pong_tutorial_04/systems/paddle.rs
+++ b/examples/pong_tutorial_04/systems/paddle.rs
@@ -1,8 +1,8 @@
 use crate::pong::{Paddle, Side, ARENA_HEIGHT, PADDLE_HEIGHT};
 use amethyst::{
-    core::{transform::Transform, SystemDesc},
+    core::transform::Transform,
     derive::SystemDesc,
-    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, World, WriteStorage},
+    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
     input::{InputHandler, StringBindings},
 };
 

--- a/examples/pong_tutorial_05/systems/bounce.rs
+++ b/examples/pong_tutorial_05/systems/bounce.rs
@@ -1,7 +1,7 @@
 use amethyst::{
-    core::{transform::Transform, SystemDesc},
+    core::transform::Transform,
     derive::SystemDesc,
-    ecs::prelude::{Join, ReadStorage, System, SystemData, World, WriteStorage},
+    ecs::prelude::{Join, ReadStorage, System, SystemData, WriteStorage},
 };
 
 use crate::pong::{Ball, Paddle, Side, ARENA_HEIGHT};

--- a/examples/pong_tutorial_05/systems/move_balls.rs
+++ b/examples/pong_tutorial_05/systems/move_balls.rs
@@ -1,7 +1,7 @@
 use amethyst::{
-    core::{timing::Time, transform::Transform, SystemDesc},
+    core::{timing::Time, transform::Transform},
     derive::SystemDesc,
-    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, World, WriteStorage},
+    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
 };
 
 use crate::pong::Ball;

--- a/examples/pong_tutorial_05/systems/paddle.rs
+++ b/examples/pong_tutorial_05/systems/paddle.rs
@@ -1,8 +1,8 @@
 use crate::pong::{Paddle, Side, ARENA_HEIGHT, PADDLE_HEIGHT};
 use amethyst::{
-    core::{transform::Transform, SystemDesc},
+    core::transform::Transform,
     derive::SystemDesc,
-    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, World, WriteStorage},
+    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
     input::{InputHandler, StringBindings},
 };
 

--- a/examples/pong_tutorial_05/systems/winner.rs
+++ b/examples/pong_tutorial_05/systems/winner.rs
@@ -1,7 +1,7 @@
 use amethyst::{
-    core::{SystemDesc, Transform},
+    core::Transform,
     derive::SystemDesc,
-    ecs::prelude::{Join, ReadExpect, System, SystemData, World, Write, WriteStorage},
+    ecs::prelude::{Join, ReadExpect, System, SystemData, Write, WriteStorage},
     ui::UiText,
 };
 

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -12,11 +12,10 @@ use amethyst::{
         math::{UnitQuaternion, Vector3},
         timing::Time,
         transform::{Transform, TransformBundle},
-        SystemDesc,
     },
     derive::SystemDesc,
     ecs::prelude::{
-        Entity, Join, Read, ReadStorage, System, SystemData, World, WorldExt, Write, WriteStorage,
+        Entity, Join, Read, ReadStorage, System, SystemData, WorldExt, Write, WriteStorage,
     },
     input::{
         get_key, is_close_requested, is_key_down, ElementState, InputBundle, StringBindings,

--- a/examples/sprite_camera_follow/main.rs
+++ b/examples/sprite_camera_follow/main.rs
@@ -1,10 +1,10 @@
 use amethyst::{
     assets::{AssetStorage, Handle, Loader},
-    core::{Named, Parent, SystemDesc, Transform, TransformBundle},
+    core::{Named, Parent, Transform, TransformBundle},
     derive::SystemDesc,
     ecs::{
-        Component, Entity, Join, NullStorage, Read, ReadStorage, System, SystemData, World,
-        WorldExt, WriteStorage,
+        Component, Entity, Join, NullStorage, Read, ReadStorage, System, SystemData, WorldExt,
+        WriteStorage,
     },
     input::{is_close_requested, is_key_down, InputBundle, InputHandler, StringBindings},
     prelude::*,

--- a/examples/states_ui/events.rs
+++ b/examples/states_ui/events.rs
@@ -1,7 +1,6 @@
 use amethyst::{
-    core::SystemDesc,
     derive::SystemDesc,
-    ecs::prelude::{System, SystemData, World, Write},
+    ecs::prelude::{System, SystemData, Write},
     shrev::{EventChannel, ReaderId},
     ui::UiEvent,
 };

--- a/examples/ui/main.rs
+++ b/examples/ui/main.rs
@@ -3,9 +3,9 @@
 use amethyst::{
     assets::{PrefabLoader, PrefabLoaderSystemDesc, Processor, RonFormat},
     audio::{output::init_output, Source},
-    core::{frame_limiter::FrameRateLimitStrategy, transform::TransformBundle, SystemDesc, Time},
+    core::{frame_limiter::FrameRateLimitStrategy, transform::TransformBundle, Time},
     derive::SystemDesc,
-    ecs::prelude::{Entity, System, SystemData, World, WorldExt, Write},
+    ecs::prelude::{Entity, System, SystemData, WorldExt, Write},
     input::{is_close_requested, is_key_down, InputBundle, StringBindings},
     prelude::*,
     renderer::{


### PR DESCRIPTION
## Description

Use `::amethyst::core::` or `::amethyst_core::` for paths to `SystemDesc`, `World`, `System`, etc. Also use absolute paths where possible.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
