### PR TITLE
Fix pong tutorial background music

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-06.md
+++ b/book/src/pong-tutorial/pong-tutorial-06.md
@@ -369,7 +369,7 @@ fn main() -> amethyst::Result<()> {
 
     let game_data = GameDataBuilder::default()
         // ... bundles
-        .with(
+        .with_system_desc(
             DjSystemDesc::new(|music: &mut Music| music.music.next()),
             "dj_system",
             &[],


### PR DESCRIPTION
## Description

Use 'with_system_desc' func instead of 'with' func when adding
DjSystemDesc to the game data.

Should fix https://github.com/amethyst/amethyst/issues/1996

## Additions

- No API changes

## Removals

- No API changes

## Modifications

- No changes

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [n/a] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ n/a] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
