### PR TITLE
Add errors to the types of events which can be sent on the EventChannel

### DIFF
--- a/amethyst_network/src/simulation/events.rs
+++ b/amethyst_network/src/simulation/events.rs
@@ -1,5 +1,6 @@
+use crate::simulation::Message;
 use bytes::Bytes;
-use std::net::SocketAddr;
+use std::{io, net::SocketAddr};
 
 /// Events which can be received from the network.
 #[derive(Debug)]
@@ -10,4 +11,10 @@ pub enum NetworkSimulationEvent {
     Connect(SocketAddr),
     // A host has disconnected from us
     Disconnect(SocketAddr),
+    // An error occurred while receiving a message.
+    RecvError(io::Error),
+    // An error occurred while sending a message.
+    SendError(io::Error, Message),
+    // An error occurred while managing connections.
+    ConnectionError(io::Error, Option<SocketAddr>),
 }

--- a/amethyst_network/src/simulation/message.rs
+++ b/amethyst_network/src/simulation/message.rs
@@ -7,13 +7,13 @@ use std::net::SocketAddr;
 #[derive(Debug, PartialEq, Eq)]
 pub struct Message {
     /// The destination to send the message.
-    pub(crate) destination: SocketAddr,
+    pub destination: SocketAddr,
     /// The serialized payload itself.
-    pub(crate) payload: Bytes,
+    pub payload: Bytes,
     /// The requirement around whether or not this message should be resent if lost.
-    pub(crate) delivery: DeliveryRequirement,
+    pub delivery: DeliveryRequirement,
     /// The requirement around when this message should be sent.
-    pub(crate) urgency: UrgencyRequirement,
+    pub urgency: UrgencyRequirement,
 }
 
 impl Message {

--- a/amethyst_network/src/simulation/transport/tcp.rs
+++ b/amethyst_network/src/simulation/transport/tcp.rs
@@ -2,13 +2,13 @@
 
 use crate::simulation::{
     events::NetworkSimulationEvent,
+    message::Message,
     requirements::DeliveryRequirement,
     timing::{NetworkSimulationTime, NetworkSimulationTimeSystem},
     transport::{
         TransportResource, NETWORK_RECV_SYSTEM_NAME, NETWORK_SEND_SYSTEM_NAME,
         NETWORK_SIM_TIME_SYSTEM_NAME,
     },
-    Message,
 };
 use amethyst_core::{
     bundle::SystemBundle,
@@ -17,7 +17,7 @@ use amethyst_core::{
 };
 use amethyst_error::Error;
 use bytes::Bytes;
-use log::{error, warn};
+use log::warn;
 use std::{
     collections::HashMap,
     io::{self, Read as IORead, Write as IOWrite},
@@ -97,10 +97,10 @@ impl<'s> System<'s> for TcpStreamManagementSystem {
                 let s = match TcpStream::connect(message.destination) {
                     Ok(s) => s,
                     Err(e) => {
-                        warn!(
-                            "Error attempting to connection to {}: {:?}",
-                            message.destination, e
-                        );
+                        event_channel.single_write(NetworkSimulationEvent::ConnectionError(
+                            e,
+                            Some(message.destination),
+                        ));
                         return;
                     }
                 };
@@ -146,7 +146,8 @@ impl<'s> System<'s> for TcpConnectionListenerSystem {
                         break;
                     }
                     Err(e) => {
-                        error!("Error listening for connections: {}", e);
+                        event_channel
+                            .single_write(NetworkSimulationEvent::ConnectionError(e, None));
                         break;
                     }
                 };
@@ -163,18 +164,19 @@ impl<'s> System<'s> for TcpNetworkSendSystem {
         Write<'s, TransportResource>,
         Write<'s, TcpNetworkResource>,
         Read<'s, NetworkSimulationTime>,
+        Write<'s, EventChannel<NetworkSimulationEvent>>,
     );
 
-    fn run(&mut self, (mut transport, mut net, sim_time): Self::SystemData) {
+    fn run(&mut self, (mut transport, mut net, sim_time, mut channel): Self::SystemData) {
         let messages = transport.drain_messages_to_send(|_| sim_time.should_send_message_now());
-        for message in messages.iter() {
+        for message in messages {
             match message.delivery {
                 DeliveryRequirement::ReliableOrdered(Some(_)) => {
                     warn!("Streams are not supported by TCP and will be ignored.");
-                    write_message(message, &mut net);
+                    write_message(message, &mut net, &mut channel);
                 }
                 DeliveryRequirement::ReliableOrdered(_) | DeliveryRequirement::Default => {
-                    write_message(message, &mut net);
+                    write_message(message, &mut net, &mut channel);
                 }
                 delivery => panic!(
                     "{:?} is unsupported. TCP only supports ReliableOrdered by design.",
@@ -185,13 +187,14 @@ impl<'s> System<'s> for TcpNetworkSendSystem {
     }
 }
 
-fn write_message(message: &Message, net: &mut TcpNetworkResource) {
+fn write_message(
+    message: Message,
+    net: &mut TcpNetworkResource,
+    channel: &mut EventChannel<NetworkSimulationEvent>,
+) {
     if let Some((_, stream)) = net.get_stream(message.destination) {
         if let Err(e) = stream.write(&message.payload) {
-            error!(
-                "There was an error when attempting to send message: {:?}",
-                e
-            );
+            channel.single_write(NetworkSimulationEvent::SendError(e, message));
         }
     }
 }
@@ -239,7 +242,9 @@ impl<'s> System<'s> for TcpNetworkRecvSystem {
                                 *active = false;
                             }
                             io::ErrorKind::WouldBlock => {}
-                            _ => error!("Encountered an error receiving data: {:?}", e),
+                            _ => {
+                                event_channel.single_write(NetworkSimulationEvent::RecvError(e));
+                            }
                         }
                         break;
                     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - Adds `get` methods to the underlying net::transport resources ([#2005])
 - Changed `SpriteSheetFormat::import_simple` to allow importing grid based `SpriteSheets` ([#2023])
   Migration Note: Rons need to wrap their content in either Grid() or List()
+- Added new Error options for `NetworkSimulationEvent`.
 
 ### Deprecated
 

--- a/examples/net_server/main.rs
+++ b/examples/net_server/main.rs
@@ -9,7 +9,7 @@ use amethyst::{
     utils::application_root_dir,
     Result,
 };
-use log::info;
+use log::{error, info};
 use std::net::TcpListener;
 
 fn main() -> Result<()> {
@@ -114,6 +114,10 @@ impl<'a> System<'a> for SpamReceiveSystem {
                 NetworkSimulationEvent::Disconnect(addr) => {
                     info!("Client Disconnected: {}", addr);
                 }
+                NetworkSimulationEvent::RecvError(e) => {
+                    error!("Recv Error: {:?}", e);
+                }
+                _ => {}
             }
         }
     }


### PR DESCRIPTION
## Description

Addresses issue https://github.com/amethyst/amethyst/issues/2000.

## Additions

- Adds new `NetworkSimulationEvent` errors.

## Modifications

- NetworkSimulationEvent has 3 more options for errors.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
