### PR TITLE
s/Point3/Vector3/ in tiles Map documentation.

### DIFF
--- a/amethyst_tiles/src/map.rs
+++ b/amethyst_tiles/src/map.rs
@@ -39,12 +39,12 @@ pub trait Map {
     /// Set the sprite sheet handle which the tile render pass should use for rendering this map.
     fn set_sprite_sheet(&mut self, sprite_sheet: Option<Handle<SpriteSheet>>);
 
-    /// Convert a tile coordinate `Point3<u32>` to an amethyst world-coordinate space coordinate `Point3<f32>`
+    /// Convert a tile coordinate `Point3<u32>` to an amethyst world-coordinate space coordinate `Vector3<f32>`
     /// This performs an inverse matrix transformation of the world coordinate, scaling and translating using this
     /// maps `origin` and `tile_dimensions` respectively.
     fn to_world(&self, coord: &Point3<u32>) -> Vector3<f32>;
 
-    /// Convert an amethyst world-coordinate space coordinate `Point3<f32>` to a tile coordinate `Point3<u32>`
+    /// Convert an amethyst world-coordinate space coordinate `Vector3<f32>` to a tile coordinate `Point3<u32>`
     /// This performs an inverse matrix transformation of the world coordinate, scaling and translating using this
     /// maps `origin` and `tile_dimensions` respectively.
     fn to_tile(&self, coord: &Vector3<f32>) -> Option<Point3<u32>>;


### PR DESCRIPTION
## Description

Replace (incorrect) claim in amethyst_tiles::Map of using `Point3<f32>` with the actual type, `Vector3<f32>`.

Map::to_tiles etc should probably actually use Point3 (because it is a point, not an offset), but I figure it's better at least for the docs to be accurate.

## Additions

None.

## Removals

None.

## Modifications

None.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`

I did not do those because I made this from the github web UI, but I am gambling that they wouldn't actually change anything. :)