### PR TITLE
Update gltf example with new config loading API

### DIFF
--- a/examples/gltf/main.rs
+++ b/examples/gltf/main.rs
@@ -220,7 +220,7 @@ fn main() -> Result<(), amethyst::Error> {
         // system is thread local as part of rendering, it runs after all of the systems anyway.
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
-                .with_plugin(RenderToWindow::from_config_path(display_config_path))
+                .with_plugin(RenderToWindow::from_config_path(display_config_path)?)
                 .with_plugin(RenderPbr3D::default().with_skinning())
                 .with_plugin(RenderSkybox::default()),
         )?;


### PR DESCRIPTION
Because since efd1e1c9, from_config_path returns a Result.

## Description

Add a brief summary of your PR here, between one sentence and two paragraphs

## Additions

- Detail API additions here if any
- Do not list changes or removals

## Removals

- List API removals here if any

## Modifications

- List changes to existing structures and functions here if any

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x ] Updated the content of the book if this PR would make the book outdated.
- [x ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x ] Added unit tests for new code added in this PR.
- [x ] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x ] Ran `cargo +stable fmt --all`
- [x ] Ran `cargo clippy --all --features "empty"`
- [x ] Ran `cargo test --all --features "empty"`
