### PR TITLE
Add immutable getters to the transport resources' underlying sockets/listeners

### DIFF
--- a/amethyst_network/src/simulation/transport/laminar.rs
+++ b/amethyst_network/src/simulation/transport/laminar.rs
@@ -169,6 +169,11 @@ impl LaminarSocketResource {
         Self { socket }
     }
 
+    /// Returns a reference to the socket if there is one configured.
+    pub fn get(&self) -> Option<&LaminarSocket> {
+        self.socket.as_ref()
+    }
+
     /// Returns a mutable reference to the socket if there is one configured.
     pub fn get_mut(&mut self) -> Option<&mut LaminarSocket> {
         self.socket.as_mut()

--- a/amethyst_network/src/simulation/transport/tcp.rs
+++ b/amethyst_network/src/simulation/transport/tcp.rs
@@ -261,6 +261,11 @@ impl TcpNetworkResource {
         }
     }
 
+    /// Returns an immutable reference to the listener if there is one configured.
+    pub fn get(&self) -> Option<&TcpListener> {
+        self.listener.as_ref()
+    }
+
     /// Returns a mutable reference to the listener if there is one configured.
     pub fn get_mut(&mut self) -> Option<&mut TcpListener> {
         self.listener.as_mut()

--- a/amethyst_network/src/simulation/transport/udp.rs
+++ b/amethyst_network/src/simulation/transport/udp.rs
@@ -145,6 +145,11 @@ impl UdpSocketResource {
         Self { socket }
     }
 
+    /// Returns an immutable reference to the socket if there is one configured.
+    pub fn get(&self) -> Option<&UdpSocket> {
+        self.socket.as_ref()
+    }
+
     /// Returns a mutable reference to the socket if there is one configured.
     pub fn get_mut(&mut self) -> Option<&mut UdpSocket> {
         self.socket.as_mut()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - `AmethystApplication::with_fn` constraint relaxed from `Fn` to `FnOnce`. ([#1983])
 - ScreenDimensions now consistently reports window size in physical pixels. ([#1988])
 - `Config::load` now returns an error or failure rather than silently falling back to the default config. Same is true for the `from_config_file` methods on `RenderToWindow`, `WindowBundle`, and `WindowSystem` ([#1989])
+- Adds `get` methods to the underlying net::transport resources ([#2005])
 
 ### Deprecated
 - `Config::load_no_fallback`, use `Config::load` instead ([#1989])


### PR DESCRIPTION
## Description

Implements https://github.com/amethyst/amethyst/issues/2005

## Additions

- Adds `get()` methods on each transport resource.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
