### PR TITLE
Update link when no gfx backend is selected

### DIFF
--- a/amethyst_rendy/src/types.rs
+++ b/amethyst_rendy/src/types.rs
@@ -23,7 +23,7 @@ macro_rules! impl_backends {
 
         static_assertions::assert_cfg!(
             any($(feature = $feature),*),
-            concat!("You must specify at least one graphical backend feature: ", stringify!($($feature),* "See the wiki article https://github.com/amethyst/amethyst/wiki/GraphicalBackendError for more details."))
+            concat!("You must specify at least one graphical backend feature: ", stringify!($($feature),* "See the wiki article https://book.amethyst.rs/stable/appendices/c_feature_gates.html#graphics-features for more details."))
         );
 
         /// Backend wrapper.


### PR DESCRIPTION
## Description
Update the link in the error returned when no gfx backend is selected.
This change is needed because the wiki got disabled.


## Modifications

- URL Change

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [ ] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
