### PR TITLE
Update system desc derive book chapter with note about passing exprs

### DIFF
--- a/book/src/concepts/system/system_desc_derive.md
+++ b/book/src/concepts/system/system_desc_derive.md
@@ -428,6 +428,10 @@ impl<'a, 'b> SystemDesc<'a, 'b, SystemName> for SystemNameDesc {
 
 ## Inserting a resource into the `World`
 
+**Note:** If the resource you wish to insert is the result of an expression,
+such as a function call, you must surround that expression in quotes, e.g.
+`#[system_desc(insert("MyResource::default()"))]`.
+
 ```rust,edition2018,no_run,noplaypen
 # extern crate amethyst;
 #


### PR DESCRIPTION
## Description

Minor addition to the book chapter on SystemDesc derives, noting the requirement for quotation marks if the resource to add in an `insert` macro is the result of an expression.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
