### PR TITLE
[FIX] Fix dimensions assumption error with encoding

### DIFF
--- a/amethyst_tiles/src/lib.rs
+++ b/amethyst_tiles/src/lib.rs
@@ -26,7 +26,7 @@ use amethyst_core::math::Vector3;
 pub trait CoordinateEncoder: 'static + Clone + Default + Send + Sync {
     /// Constructor interface for `Self` which consumes the maps dimensions, which is required for some
     /// encoding types to fit within a given coordinate space.
-    fn from_dimensions(x: u32, y: u32, z: u32) -> Self;
+    fn from_dimensions(dimensions: &Vector3<u32>) -> Self;
 
     /// Encode the provided x, y and z 3-dimensional coordinates into a 1-dimensional array index.
     fn encode(&self, x: u32, y: u32, z: u32) -> Option<u32>;
@@ -53,9 +53,9 @@ impl Default for FlatEncoder {
     }
 }
 impl CoordinateEncoder for FlatEncoder {
-    fn from_dimensions(x: u32, y: u32, z: u32) -> Self {
+    fn from_dimensions(dimensions: &Vector3<u32>) -> Self {
         Self {
-            dimensions: Vector3::new(x, y, z),
+            dimensions: *dimensions,
         }
     }
 

--- a/amethyst_tiles/src/lib.rs
+++ b/amethyst_tiles/src/lib.rs
@@ -26,7 +26,7 @@ use amethyst_core::math::Vector3;
 pub trait CoordinateEncoder: 'static + Clone + Default + Send + Sync {
     /// Constructor interface for `Self` which consumes the maps dimensions, which is required for some
     /// encoding types to fit within a given coordinate space.
-    fn from_dimensions(dimensions: &Vector3<u32>) -> Self;
+    fn from_dimensions(dimensions: Vector3<u32>) -> Self;
 
     /// Encode the provided x, y and z 3-dimensional coordinates into a 1-dimensional array index.
     fn encode(&self, x: u32, y: u32, z: u32) -> Option<u32>;
@@ -53,10 +53,8 @@ impl Default for FlatEncoder {
     }
 }
 impl CoordinateEncoder for FlatEncoder {
-    fn from_dimensions(dimensions: &Vector3<u32>) -> Self {
-        Self {
-            dimensions: *dimensions,
-        }
+    fn from_dimensions(dimensions: Vector3<u32>) -> Self {
+        Self { dimensions }
     }
 
     #[inline]

--- a/amethyst_tiles/src/map.rs
+++ b/amethyst_tiles/src/map.rs
@@ -366,6 +366,7 @@ mod tests {
             pub fn get(&self) -> &TileMap<TestTile, E> {
                 unsafe { &*self.ptr }
             }
+            #[allow(clippy::mut_from_ref)]
             pub fn get_mut(&self) -> &mut TileMap<TestTile, E> {
                 unsafe { &mut *self.ptr }
             }

--- a/amethyst_tiles/src/map.rs
+++ b/amethyst_tiles/src/map.rs
@@ -336,20 +336,63 @@ mod tests {
     use amethyst_core::math::Point3;
     use rayon::prelude::*;
 
-    #[derive(Default, Clone)]
-    struct TestTile;
+    #[derive(Clone, Debug)]
+    struct TestTile {
+        point: Point3<u32>,
+    }
+    impl Default for TestTile {
+        fn default() -> Self {
+            Self {
+                point: Point3::new(0, 0, 0),
+            }
+        }
+    }
     impl Tile for TestTile {
         fn sprite(&self, _: Point3<u32>, _: &World) -> Option<usize> {
             None
         }
     }
 
+    use std::cell::RefCell;
+
     pub fn test_single_map<E: CoordinateEncoder>(dimensions: Vector3<u32>) {
-        let map = TileMap::<TestTile, E>::new(dimensions, Vector3::new(10, 10, 1), None);
+        struct UnsafeWrapper<E: CoordinateEncoder> {
+            ptr: *mut TileMap<TestTile, E>,
+        }
+        impl<E: CoordinateEncoder> UnsafeWrapper<E> {
+            pub fn new(map: &mut TileMap<TestTile, E>) -> Self {
+                Self {
+                    ptr: map as *mut TileMap<TestTile, E>,
+                }
+            }
+            pub fn get(&self) -> &TileMap<TestTile, E> {
+                unsafe { &*self.ptr }
+            }
+            pub fn get_mut(&self) -> &mut TileMap<TestTile, E> {
+                unsafe { &mut *self.ptr }
+            }
+        }
+        unsafe impl<E: CoordinateEncoder> Send for UnsafeWrapper<E> {}
+        unsafe impl<E: CoordinateEncoder> Sync for UnsafeWrapper<E> {}
+
+        let mut inner = TileMap::<TestTile, E>::new(dimensions, Vector3::new(10, 10, 1), None);
+        let mut map = UnsafeWrapper::new(&mut inner);
+
         (0..dimensions.x).into_par_iter().for_each(|x| {
             (0..dimensions.y).into_par_iter().for_each(|y| {
                 for z in 0..dimensions.z {
-                    let _ = map.get(&Point3::new(x, y, z)).unwrap();
+                    let point = Point3::new(x, y, z);
+
+                    *map.get_mut().get_mut(&point).unwrap() = TestTile { point };
+                }
+            });
+        });
+
+        (0..dimensions.x).into_par_iter().for_each(|x| {
+            (0..dimensions.y).into_par_iter().for_each(|y| {
+                for z in 0..dimensions.z {
+                    let point = Point3::new(x, y, z);
+                    assert_eq!(map.get().get(&Point3::new(x, y, z)).unwrap().point, point);
                 }
             });
         });
@@ -359,21 +402,21 @@ mod tests {
     pub fn asymmetric_maps() {
         let test_dimensions = [
             Vector3::new(10, 58, 54),
-            Vector3::new(66, 5, 200),
-            Vector3::new(199, 100, 1),
-            Vector3::new(5, 423, 6),
-            Vector3::new(15, 23, 1),
-            Vector3::new(20, 12, 12),
-            Vector3::new(48, 48, 12),
-            Vector3::new(12, 55, 12),
-            Vector3::new(26, 25, 1),
-            Vector3::new(1, 2, 5),
+            Vector3::new(66, 5, 20),
+            //Vector3::new(199, 100, 1),
+            Vector3::new(5, 55, 6),
+            //Vector3::new(15, 23, 1),
+            //Vector3::new(20, 12, 12),
+            //Vector3::new(48, 48, 12),
+            //Vector3::new(12, 55, 12),
+            //Vector3::new(26, 25, 1),
+            //Vector3::new(1, 2, 5),
         ];
 
         test_dimensions.par_iter().for_each(|dimensions| {
             test_single_map::<MortonEncoder>(*dimensions);
             test_single_map::<MortonEncoder2D>(*dimensions);
-            test_single_map::<FlatEncoder>(*dimensions);
+            //test_single_map::<FlatEncoder>(*dimensions);
         });
     }
 

--- a/amethyst_tiles/src/map.rs
+++ b/amethyst_tiles/src/map.rs
@@ -150,7 +150,7 @@ impl<T: Tile, E: CoordinateEncoder> TileMap<T, E> {
         let mut data = Vec::with_capacity(size);
         data.resize_with(size, T::default);
 
-        let encoder = E::from_dimensions(&encoder_dimensions);
+        let encoder = E::from_dimensions(encoder_dimensions);
 
         Self {
             data,

--- a/amethyst_tiles/src/map.rs
+++ b/amethyst_tiles/src/map.rs
@@ -143,7 +143,7 @@ impl<T: Tile, E: CoordinateEncoder> TileMap<T, E> {
         let mut data = Vec::with_capacity(size);
         data.resize_with(size, T::default);
 
-        let encoder = E::from_dimensions(dimensions.x, dimensions.y, dimensions.z);
+        let encoder = E::from_dimensions(&encoder_dimensions);
 
         Self {
             data,
@@ -353,8 +353,6 @@ mod tests {
         }
     }
 
-    use std::cell::RefCell;
-
     pub fn test_single_map<E: CoordinateEncoder>(dimensions: Vector3<u32>) {
         struct UnsafeWrapper<E: CoordinateEncoder> {
             ptr: *mut TileMap<TestTile, E>,
@@ -376,7 +374,7 @@ mod tests {
         unsafe impl<E: CoordinateEncoder> Sync for UnsafeWrapper<E> {}
 
         let mut inner = TileMap::<TestTile, E>::new(dimensions, Vector3::new(10, 10, 1), None);
-        let mut map = UnsafeWrapper::new(&mut inner);
+        let map = UnsafeWrapper::new(&mut inner);
 
         (0..dimensions.x).into_par_iter().for_each(|x| {
             (0..dimensions.y).into_par_iter().for_each(|y| {
@@ -403,20 +401,20 @@ mod tests {
         let test_dimensions = [
             Vector3::new(10, 58, 54),
             Vector3::new(66, 5, 20),
-            //Vector3::new(199, 100, 1),
+            Vector3::new(199, 100, 1),
             Vector3::new(5, 55, 6),
-            //Vector3::new(15, 23, 1),
-            //Vector3::new(20, 12, 12),
-            //Vector3::new(48, 48, 12),
-            //Vector3::new(12, 55, 12),
-            //Vector3::new(26, 25, 1),
-            //Vector3::new(1, 2, 5),
+            Vector3::new(15, 23, 1),
+            Vector3::new(20, 12, 12),
+            Vector3::new(48, 48, 12),
+            Vector3::new(12, 55, 12),
+            Vector3::new(26, 25, 1),
+            Vector3::new(1, 2, 5),
         ];
 
         test_dimensions.par_iter().for_each(|dimensions| {
             test_single_map::<MortonEncoder>(*dimensions);
             test_single_map::<MortonEncoder2D>(*dimensions);
-            //test_single_map::<FlatEncoder>(*dimensions);
+            test_single_map::<FlatEncoder>(*dimensions);
         });
     }
 

--- a/amethyst_tiles/src/morton/mod.rs
+++ b/amethyst_tiles/src/morton/mod.rs
@@ -92,7 +92,7 @@ pub fn morton_decode_intr_3d(morton: u32) -> (u32, u32, u32) {
 #[derive(Default, Clone)]
 pub struct MortonEncoder;
 impl CoordinateEncoder for MortonEncoder {
-    fn from_dimensions(_: &Vector3<u32>) -> Self {
+    fn from_dimensions(_: Vector3<u32>) -> Self {
         Self {}
     }
 
@@ -128,13 +128,11 @@ impl CoordinateEncoder for MortonEncoder {
 /// NOTE: This encoder requires allocation 2^n, equally in the X-Y axis.
 #[derive(Default, Clone)]
 pub struct MortonEncoder2D {
-    dimensions: (u32, u32, u32),
     len: u32,
 }
 impl CoordinateEncoder for MortonEncoder2D {
-    fn from_dimensions(dimensions: &Vector3<u32>) -> Self {
+    fn from_dimensions(dimensions: Vector3<u32>) -> Self {
         Self {
-            dimensions: (dimensions.x, dimensions.y, dimensions.z),
             len: dimensions.x * dimensions.y,
         }
     }

--- a/amethyst_tiles/src/morton/mod.rs
+++ b/amethyst_tiles/src/morton/mod.rs
@@ -67,6 +67,7 @@ pub fn morton_decode_lut(morton: u32) -> (u32, u32, u32) {
 #[inline]
 pub fn morton_encode_intr_3d(x: u32, y: u32, z: u32) -> u32 {
     use bitintr::Pdep;
+
     z.pdep(0x2492_4924) | y.pdep(0x1249_2492) | x.pdep(0x0924_9249)
 }
 

--- a/amethyst_tiles/src/morton/mod.rs
+++ b/amethyst_tiles/src/morton/mod.rs
@@ -92,7 +92,7 @@ pub fn morton_decode_intr_3d(morton: u32) -> (u32, u32, u32) {
 #[derive(Default, Clone)]
 pub struct MortonEncoder;
 impl CoordinateEncoder for MortonEncoder {
-    fn from_dimensions(_: u32, _: u32, _: u32) -> Self {
+    fn from_dimensions(_: &Vector3<u32>) -> Self {
         Self {}
     }
 
@@ -132,10 +132,10 @@ pub struct MortonEncoder2D {
     len: u32,
 }
 impl CoordinateEncoder for MortonEncoder2D {
-    fn from_dimensions(x: u32, y: u32, z: u32) -> Self {
+    fn from_dimensions(dimensions: &Vector3<u32>) -> Self {
         Self {
-            dimensions: (x, y, z),
-            len: x * y,
+            dimensions: (dimensions.x, dimensions.y, dimensions.z),
+            len: dimensions.x * dimensions.y,
         }
     }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 - Tilemap rotation was incorrect and not transposed. Fixed and uses component rotation. ([#1974])
 - `Config` types no longer require a `Default` impl ([#1989])
+- Fixed an incorrect dimensions being used in Tile Encoders, causing bad lookups in assymetric maps in any Z-level besides 0 ([#2017])
 
 ### Security
 
@@ -49,6 +50,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1984]: https://github.com/amethyst/amethyst/pull/1984
 [#1986]: https://github.com/amethyst/amethyst/pull/1986
 [#1989]: https://github.com/amethyst/amethyst/pull/1989
+[#2017]: https://github.com/amethyst/amethyst/pull/2017
 
 ## [0.13.3] - 2019-10-4
 

--- a/examples/tiles/main.rs
+++ b/examples/tiles/main.rs
@@ -20,7 +20,7 @@ use amethyst::{
         types::DefaultBackend,
         RenderDebugLines, RenderFlat2D, RenderToWindow, RenderingBundle, Texture,
     },
-    tiles::{RenderTiles2D, Tile, TileMap},
+    tiles::{MortonEncoder, RenderTiles2D, Tile, TileMap},
     utils::application_root_dir,
     window::ScreenDimensions,
     winit,
@@ -376,7 +376,7 @@ impl SimpleState for Example {
             .with(DebugLinesComponent::with_capacity(1))
             .build();
 
-        let map = TileMap::<ExampleTile>::new(
+        let map = TileMap::<ExampleTile, MortonEncoder>::new(
             Vector3::new(48, 48, 1),
             Vector3::new(20, 20, 1),
             Some(map_sprite_sheet_handle),
@@ -450,7 +450,7 @@ fn main() -> amethyst::Result<()> {
                 )
                 .with_plugin(RenderDebugLines::default())
                 .with_plugin(RenderFlat2D::default())
-                .with_plugin(RenderTiles2D::<ExampleTile>::default()),
+                .with_plugin(RenderTiles2D::<ExampleTile, MortonEncoder>::default()),
         )?;
 
     let mut game = Application::build(assets_directory, Example)?.build(game_data)?;


### PR DESCRIPTION
## Description

With the changes of pre-allocated dimensions, this change did not occur in the actual encoding schemes as well. Because of this, any encoding beyond z-level 0 was actually incorrect and did not work.

This fixes that, and adds the appropriate unit tests for that test case.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
