### PR TITLE
Improve SpriteSheetFormat::import_simple to support grids and lists

### DIFF
--- a/amethyst_rendy/src/error.rs
+++ b/amethyst_rendy/src/error.rs
@@ -6,7 +6,7 @@ use std::{error, fmt};
 #[derive(Debug)]
 pub(crate) enum Error {
     /// Failed to parse a Spritesheet from RON.
-    LoadSpritesheetError,
+    LoadSpritesheetError(ron::de::Error),
 }
 
 impl error::Error for Error {}
@@ -16,7 +16,7 @@ impl fmt::Display for Error {
         use self::Error::*;
 
         match *self {
-            LoadSpritesheetError => write!(fmt, "Failed to parse SpriteSheet"),
+            LoadSpritesheetError(..) => write!(fmt, "Failed to parse SpriteSheet"),
         }
     }
 }

--- a/amethyst_rendy/src/sprite/mod.rs
+++ b/amethyst_rendy/src/sprite/mod.rs
@@ -491,8 +491,8 @@ impl Format<SpriteSheet> for SpriteSheetFormat {
 #[cfg(test)]
 mod test {
     use super::{Sprite, SpriteSheetFormat, TextureCoordinates};
-    use amethyst_assets::Handle;
     use crate::types::Texture;
+    use amethyst_assets::Handle;
 
     #[test]
     fn texture_coordinates_from_tuple_maps_fields_correctly() {
@@ -578,10 +578,10 @@ mod test {
         );
     }
     fn create_texture() -> Handle<Texture> {
-        use amethyst_assets::{Loader, AssetStorage};
-        use std::sync::Arc;
-        use rayon::ThreadPoolBuilder;
         use crate::formats::texture::TextureGenerator;
+        use amethyst_assets::{AssetStorage, Loader};
+        use rayon::ThreadPoolBuilder;
+        use std::sync::Arc;
 
         let pool = Arc::new(ThreadPoolBuilder::new().build().expect("Invalid config"));
         let loader = Loader::new("/examples/assets", pool);
@@ -614,9 +614,10 @@ List((
             height: 16,
         ),
     ],
-))".to_string();
+))"
+        .to_string();
 
-        let sprite_list_reference : Vec<Sprite> = vec![
+        let sprite_list_reference: Vec<Sprite> = vec![
             Sprite {
                 width: 16.,
                 height: 16.,
@@ -640,7 +641,7 @@ List((
                 },
             },
         ];
-        
+
         let format = SpriteSheetFormat(create_texture());
         let sprite_list_loaded = format.import_simple(sprite_sheet_ron.into_bytes());
         let sprite_list = sprite_list_loaded.unwrap().sprites;
@@ -658,7 +659,8 @@ Grid((
     texture_height: 16,
     columns: 2,
     rows: 1
-))".to_string();
+))"
+        .to_string();
 
         let sprite_sheet_ron_cells: String = "
 #![enable(implicit_some)]
@@ -667,7 +669,8 @@ Grid((
     texture_height: 16,
     columns: 2,
     sprite_count: 2
-))".to_string();
+))"
+        .to_string();
 
         let sprite_sheet_ron_cell_size: String = "
 #![enable(implicit_some)]
@@ -676,9 +679,10 @@ Grid((
     texture_height: 16,
     columns: 2,
     cell_size: (24, 16)
-))".to_string();
+))"
+        .to_string();
 
-        let sprite_list_reference : Vec<Sprite> = vec![
+        let sprite_list_reference: Vec<Sprite> = vec![
             Sprite {
                 width: 24.,
                 height: 16.,
@@ -706,18 +710,33 @@ Grid((
         let format = SpriteSheetFormat(texture);
         {
             let sprite_list_loaded = format.import_simple(sprite_sheet_ron_rows.into_bytes());
-            let sprite_list = sprite_list_loaded.expect("failed to parse sprite_sheet_ron_rows").sprites;
-            assert_eq!(sprite_list_reference, sprite_list, "we are testing row based grids");
+            let sprite_list = sprite_list_loaded
+                .expect("failed to parse sprite_sheet_ron_rows")
+                .sprites;
+            assert_eq!(
+                sprite_list_reference, sprite_list,
+                "we are testing row based grids"
+            );
         }
         {
             let sprite_list_loaded = format.import_simple(sprite_sheet_ron_cells.into_bytes());
-            let sprite_list = sprite_list_loaded.expect("failed to parse sprite_sheet_ron_cells").sprites;
-            assert_eq!(sprite_list_reference, sprite_list, "we are testing number of cell based grids");
+            let sprite_list = sprite_list_loaded
+                .expect("failed to parse sprite_sheet_ron_cells")
+                .sprites;
+            assert_eq!(
+                sprite_list_reference, sprite_list,
+                "we are testing number of cell based grids"
+            );
         }
         {
             let sprite_list_loaded = format.import_simple(sprite_sheet_ron_cell_size.into_bytes());
-            let sprite_list = sprite_list_loaded.expect("failed to parse sprite_sheet_ron_cell_size").sprites;
-            assert_eq!(sprite_list_reference, sprite_list, "we are testing cell size based grids");
+            let sprite_list = sprite_list_loaded
+                .expect("failed to parse sprite_sheet_ron_cell_size")
+                .sprites;
+            assert_eq!(
+                sprite_list_reference, sprite_list,
+                "we are testing cell size based grids"
+            );
         }
     }
 }

--- a/amethyst_rendy/src/sprite/mod.rs
+++ b/amethyst_rendy/src/sprite/mod.rs
@@ -479,7 +479,7 @@ impl Format<SpriteSheet> for SpriteSheetFormat {
 
     fn import_simple(&self, bytes: Vec<u8>) -> Result<SpriteSheet, Error> {
         let sprites: Sprites =
-            from_ron_bytes(&bytes).map_err(|_| error::Error::LoadSpritesheetError)?;
+            from_ron_bytes(&bytes).map_err(|e| error::Error::LoadSpritesheetError(e))?;
 
         Ok(SpriteSheet {
             texture: self.0.clone(),

--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -495,7 +495,7 @@ are on the sheet. Let's create, right next to it, a file called
 `pong_spritesheet.ron`. It will contain the following sprite sheet definition:
 
 ```text,ignore
-(
+List((
     texture_width: 8,
     texture_height: 16,
     sprites: [
@@ -512,7 +512,7 @@ are on the sheet. Let's create, right next to it, a file called
             height: 4,
         ),
     ],
-)
+))
 ```
 
 > **Note:** Make sure to pay attention to the kind of parentheses in the ron file.

--- a/book/src/sprites/define_the_sprite_sheet.md
+++ b/book/src/sprites/define_the_sprite_sheet.md
@@ -6,10 +6,10 @@ There are two ways to load a sprite sheet definition: from a file or from code.
 ## Load the sheet from a file
 
 The easiest way to load your sprites is to use a sprite sheet definition ron file.
-Here is an example of such a definition file:
+Here is an example of such a definition file using a list of sprites:
 
 ```text,ignore
-(
+List((
     // Width of the texture used by the sprite sheet
     texture_width: 48,
     // Height of the texture used by the sprite sheet
@@ -36,9 +36,26 @@ Here is an example of such a definition file:
         ),
         // etc...
     ],
-)
+))
 ```
 `offsets: Some((0.0, 0.0)),` can be replaced by `offsets: (0.0, 0.0),` if the line `#![enable(implicit_some)]` is added at the top of the definition file.
+
+Or you can use a grid based definition, for example:
+
+```text,ignore
+Grid((
+    // Width of the texture used by the sprite sheet
+    texture_width: 48,
+    // Height of the texture used by the sprite sheet
+    texture_height: 16,
+    // Specifies the number of columns in the sprite sheet
+    columns: 2,
+    // Specifies the number of sprites in the spritesheet.
+    sprite_count: 2
+))
+```
+
+For more information about list and grid based sprite sheets see [`SpriteGrid`][doc_grid] or [`SpriteList`][doc_list].
 
 Then, you can load it using the texture handle of the sheet's image you loaded earlier:
 
@@ -121,3 +138,8 @@ pub fn load_sprite_sheet(texture: Handle<Texture>) -> SpriteSheet {
     }
 }
 ```
+
+
+
+[doc_grid]: https://docs.amethyst.rs/stable/amethyst_rendy/sprite/struct.SpriteGrid.html
+[doc_list]: https://docs.amethyst.rs/stable/amethyst_rendy/sprite/struct.SpriteList.html

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - ScreenDimensions now consistently reports window size in physical pixels. ([#1988])
 - `Config::load` now returns an error or failure rather than silently falling back to the default config. Same is true for the `from_config_file` methods on `RenderToWindow`, `WindowBundle`, and `WindowSystem` ([#1989])
 - Adds `get` methods to the underlying net::transport resources ([#2005])
-- Changed `SpriteSheetFormat::import_simple` to allow importing grid based `SpriteSheets` ([#0000])
+- Changed `SpriteSheetFormat::import_simple` to allow importing grid based `SpriteSheets` ([#2023])
   Migration Note: Rons need to wrap their content in either Grid() or List()
 
 ### Deprecated
@@ -60,6 +60,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#1989]: https://github.com/amethyst/amethyst/pull/1989
 [#2005]: https://github.com/amethyst/amethyst/pull/2005
 [#2004]: https://github.com/amethyst/amethyst/pull/2004
+[#2023]: https://github.com/amethyst/amethyst/pull/2023
 
 
 ## [0.13.3] - 2019-10-4

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - ScreenDimensions now consistently reports window size in physical pixels. ([#1988])
 - `Config::load` now returns an error or failure rather than silently falling back to the default config. Same is true for the `from_config_file` methods on `RenderToWindow`, `WindowBundle`, and `WindowSystem` ([#1989])
 - Adds `get` methods to the underlying net::transport resources ([#2005])
+- Changed `SpriteSheetFormat::import_simple` to allow importing grid based `SpriteSheets` ([#0000])
+  Migration Note: Rons need to wrap their content in either Grid() or List()
 
 ### Deprecated
 


### PR DESCRIPTION
## Description

Improve the loader of SpriteSheetFormat to allow loading of Grid definitions in ron files.
Currently you can only specify sprites as `SpriteList` in ron files.
Closes #1997 

## Modifications

- `SpriteSheetFormat::import_simple` now uses the `Sprites` enum instead of using `SpriteList` directly. This is a breaking change in current ron files loaded using SpriteSheetFormat.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
