### PR TITLE
[Maintenance] Bump a bunch of dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ ron = "0.5"
 specs-derive = "0.4"
 
 [build-dependencies]
-dirs = "1.0.5"
+dirs = "2.0.2"
 vergen = "3.0"
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ fern = { version = "0.5", features = ["colored"] }
 log = { version = "0.4.6", features = ["serde"] }
 rayon = "1.1.0"
 rustc_version_runtime = "0.1"
-sentry = { version = "0.15.4", optional = true }
+sentry = { version = "0.17.0", optional = true }
 winit = { version = "0.19", features = ["serde", "icon_loading"] }
 serde = { version = "1.0", features = ["derive"] }
 palette = { version = "0.4", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ glsl-layout = "0.3"
 
 [dev-dependencies]
 derive-new = "0.5"
-env_logger = "0.6.1"
+env_logger = "0.7.1"
 genmesh = "0.6"
 ron = "0.5"
 specs-derive = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,8 +102,23 @@ experimental-spirv-reflection = ["amethyst_rendy/experimental-spirv-reflection"]
 
 [workspace]
 members = [
-  "amethyst_test",
+  "amethyst_animation",
+  "amethyst_assets",
+  "amethyst_audio",
+  "amethyst_config",
+  "amethyst_core",
+  "amethyst_error",
+  "amethyst_controls",
+  "amethyst_derive",
+  "amethyst_gltf",
+  "amethyst_network",
+  "amethyst_locale",
   "amethyst_rendy",
+  "amethyst_input",
+  "amethyst_ui",
+  "amethyst_utils",
+  "amethyst_test",
+  "amethyst_tiles",
   "amethyst_window",
 ]
 

--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -21,7 +21,7 @@ amethyst_core = { path = "../amethyst_core/", version = "0.8.1" }
 amethyst_error = { path = "../amethyst_error/", version = "0.3.0" }
 amethyst_rendy = { path = "../amethyst_rendy", version = "0.3.0" }
 err-derive = "0.1"
-base64 = "0.10"
+base64 = "0.11"
 fnv = "1"
 gltf = "0.14"
 hibitset = { version = "0.6.2", features = ["parallel"] }

--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -23,7 +23,7 @@ amethyst_rendy = { path = "../amethyst_rendy", version = "0.3.0" }
 err-derive = "0.1"
 base64 = "0.10"
 fnv = "1"
-gltf = "0.13"
+gltf = "0.14"
 hibitset = { version = "0.6.2", features = ["parallel"] }
 itertools = "0.8"
 log = "0.4.6"

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -39,7 +39,7 @@ approx = "0.3.2"
 [dev-dependencies]
 rayon = "1.1.0"
 more-asserts = "0.2.1"
-criterion = "0.2.11"
+criterion = "0.3.0"
 winit = "0.19"
 approx = "0.3"
 

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1", features = ["serde_derive"] }
 fnv = "1"
 derivative = "1.0"
 smallvec = "0.6.9"
-static_assertions = "0.3"
+static_assertions = "1.0"
 
 thread_profiler = { version = "0.3", optional = true }
 approx = "0.3.2"


### PR DESCRIPTION
Bump a bunch of dependencies

| Crate | Dependency |
| ------ | --- |
| amethyst | sentry 0.15.4 -> 0.17.0 |
| amethyst | env_logger 0.6.1-> 0.7.1 |
| amethyst | dirs 1.0.5 -> 2.0.2 |
| amethyst_gltf | gltf 0.13 -> 0.14 |
| amethyst_gltf | base64 0.10 -> 0.11 |
| amethyst_rendy | static_assertions 0.3 -> 1.0 |
| amethyst_rendy | criterion 0.2.11 -> 0.3.0 |



## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
