### PR TITLE
Fix regression caused by #1908

### DIFF
--- a/examples/assets/prefab/renderable.ron
+++ b/examples/assets/prefab/renderable.ron
@@ -57,6 +57,7 @@ Prefab (
                                     ),
                                     comparison: None,
                                     border: (0),
+                                    normalized: true,
                                     anisotropic: On(8),
                                 ),
                             )

--- a/examples/assets/prefab/rendy_example_scene.ron
+++ b/examples/assets/prefab/rendy_example_scene.ron
@@ -24,6 +24,7 @@ Prefab (
                                 ),
                                 comparison: None,
                                 border: (0),
+                                normalized: true,
                                 anisotropic: Off,
                             ),
                         )
@@ -78,6 +79,7 @@ Prefab (
                                 ),
                                 comparison: None,
                                 border: (0),
+                                normalized: true,
                                 anisotropic: Off,
                             ),
                         )
@@ -114,6 +116,7 @@ Prefab (
                                 ),
                                 comparison: None,
                                 border: (0),
+                                normalized: true,
                                 anisotropic: Off,
                             ),
                         )
@@ -161,6 +164,7 @@ Prefab (
                                 ),
                                 comparison: None,
                                 border: (0),
+                                normalized: true,
                                 anisotropic: Off,
                             ),
                         ),

--- a/examples/assets/prefab/sprite_animation.ron
+++ b/examples/assets/prefab/sprite_animation.ron
@@ -29,6 +29,7 @@ Prefab(
                                     ),
                                     comparison: None,
                                     border: (0),
+                                    normalized: true,
                                     anisotropic: Off,
                                 ),
                             ),

--- a/examples/assets/prefab/sprite_animation_test.ron
+++ b/examples/assets/prefab/sprite_animation_test.ron
@@ -29,6 +29,7 @@ Prefab(
                                     ),
                                     comparison: None,
                                     border: (0),
+                                    normalized: true,
                                     anisotropic: Off,
                                 ),
                             ),


### PR DESCRIPTION
Fix regression in the example RONs.

gfx-hal@0.3.0 added the `normalized` field to `SamplerInfo`. This change was not propagated to the prefabs. 


## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
