### PR TITLE
Implement `Copy` and `PartialEq` for `Tint`.

### DIFF
--- a/amethyst_rendy/src/resources.rs
+++ b/amethyst_rendy/src/resources.rs
@@ -32,7 +32,7 @@ impl<'a> PrefabData<'a> for AmbientColor {
 }
 
 /// A single object tinting applied in multiplicative mode (modulation)
-#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Tint(#[serde(with = "crate::serde_shim::srgba")] pub palette::Srgba);
 
 impl Component for Tint {

--- a/amethyst_rendy/src/serde_shim.rs
+++ b/amethyst_rendy/src/serde_shim.rs
@@ -43,7 +43,7 @@ pub mod srgb {
 /// ```
 pub mod srgba {
     use super::*;
-    #[derive(Serialize, Deserialize)]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
     struct Srgba(f32, f32, f32, f32);
 
     /// Serialize Srgba type as tuple struct with four floats

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - Added UI states/menu example. [#1986]
 - Allow user to specify custom completion function in `amethyst_test::WaitForLoad`. ([#1984])
 - Log warning when `amethyst_test::WaitForLoad` has not completed in 10 seconds. ([#1984])
+- Derive `Copy` and `PartialEq` for `amethyst::renderer::resources::Tint`. ([#2033])
 
 ### Changed
 
@@ -61,6 +62,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#2005]: https://github.com/amethyst/amethyst/pull/2005
 [#2004]: https://github.com/amethyst/amethyst/pull/2004
 [#2029]: https://github.com/amethyst/amethyst/pull/2029
+[#2033]: https://github.com/amethyst/amethyst/pull/2033
 
 
 ## [0.13.3] - 2019-10-4


### PR DESCRIPTION
## Description

Derive `Copy` and `PartialEq` for `amethyst::renderer::resources::Tint`.

## Additions

- Derive `Copy` and `PartialEq` for `amethyst::renderer::resources::Tint`.

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
