### PR TITLE
Fix archlinux pkg name

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ If you are compiling on Linux, make sure to install the dependencies below.
 ### Arch Linux
 
 ```
-$ pacman -Syu grep gcc pkgconfig openssl alsa-lib cmake make python3 freetype2 awk libxcb
+$ pacman -Syu grep gcc pkgconf openssl alsa-lib cmake make python3 freetype2 awk libxcb
 ```
 
 ### Debian/Ubuntu


### PR DESCRIPTION
## [Minor] Change pkg name in README.md

(really a minor thing) The package compiler and linker has been renamed to `pkgconf` in the arch linux core package repository.

## Modifications

- Rename the package name in the readme

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
