### PR TITLE
[WIP] Rendy v0.5.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT/Apache-2.0"
 travis-ci = { repository = "amethyst/amethyst", branch = "master" }
 
 [features]
-default = ["animation", "audio", "locale", "network", "renderer"]
+default = ["animation", "locale", "network", "renderer"]
 
 vulkan = ["amethyst_rendy/vulkan"]
 metal = ["amethyst_rendy/metal"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ travis-ci = { repository = "amethyst/amethyst", branch = "master" }
 [features]
 default = ["animation", "audio", "locale", "network", "renderer"]
 
-vulkan = ["amethyst_rendy/vulkan", "amethyst_rendy/vulkan-x11"]
+vulkan = ["amethyst_rendy/vulkan"]
 metal = ["amethyst_rendy/metal"]
 empty = ["amethyst_rendy/empty"]
 
@@ -147,7 +147,7 @@ log = { version = "0.4.6", features = ["serde"] }
 rayon = "1.1.0"
 rustc_version_runtime = "0.1"
 sentry = { version = "0.17.0", optional = true }
-winit = { version = "0.19", features = ["serde", "icon_loading"] }
+winit = { version = "0.20.0-alpha4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 palette = { version = "0.4", features = ["serde"] }
 failure = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ log = { version = "0.4.6", features = ["serde"] }
 rayon = "1.1.0"
 rustc_version_runtime = "0.1"
 sentry = { version = "0.17.0", optional = true }
-winit = { version = "0.20.0-alpha4", features = ["serde"] }
+winit = { version = "0.20.0-alpha5", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 palette = { version = "0.4", features = ["serde"] }
 failure = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ log = { version = "0.4.6", features = ["serde"] }
 rayon = "1.1.0"
 rustc_version_runtime = "0.1"
 sentry = { version = "0.17.0", optional = true }
-winit = { version = "0.20.0-alpha5", features = ["serde"] }
+winit = { version = "0.20.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 palette = { version = "0.4", features = ["serde"] }
 failure = "0.1"

--- a/amethyst_controls/Cargo.toml
+++ b/amethyst_controls/Cargo.toml
@@ -22,7 +22,7 @@ amethyst_error = { path = "../amethyst_error", version = "0.3.0" }
 amethyst_input = { path = "../amethyst_input", version = "0.9.0" }
 derive-new = "0.5"
 serde = { version = "1.0", features = ["derive"] }
-winit = { version = "0.19", features = ["serde"] }
+winit = { version = "0.20.0-alpha4", features = ["serde"] }
 log = "0.4.6"
 
 thread_profiler = { version = "0.3", optional = true }

--- a/amethyst_controls/Cargo.toml
+++ b/amethyst_controls/Cargo.toml
@@ -22,7 +22,7 @@ amethyst_error = { path = "../amethyst_error", version = "0.3.0" }
 amethyst_input = { path = "../amethyst_input", version = "0.9.0" }
 derive-new = "0.5"
 serde = { version = "1.0", features = ["derive"] }
-winit = { version = "0.20.0-alpha5", features = ["serde"] }
+winit = { version = "0.20.0", features = ["serde"] }
 log = "0.4.6"
 
 thread_profiler = { version = "0.3", optional = true }

--- a/amethyst_controls/Cargo.toml
+++ b/amethyst_controls/Cargo.toml
@@ -22,7 +22,7 @@ amethyst_error = { path = "../amethyst_error", version = "0.3.0" }
 amethyst_input = { path = "../amethyst_input", version = "0.9.0" }
 derive-new = "0.5"
 serde = { version = "1.0", features = ["derive"] }
-winit = { version = "0.20.0-alpha4", features = ["serde"] }
+winit = { version = "0.20.0-alpha5", features = ["serde"] }
 log = "0.4.6"
 
 thread_profiler = { version = "0.3", optional = true }

--- a/amethyst_controls/src/bundles.rs
+++ b/amethyst_controls/src/bundles.rs
@@ -95,12 +95,8 @@ impl<'a, 'b, T: BindingTypes> SystemBundle<'a, 'b> for FlyControlBundle<T> {
             "free_rotation",
             &[],
         );
-        builder.add_thread_local(
-            MouseFocusUpdateSystemDesc::default().build(world)
-        );
-        builder.add_thread_local(
-            CursorHideSystemDesc::default().build(world)
-        );
+        builder.add_thread_local(MouseFocusUpdateSystemDesc::default().build(world));
+        builder.add_thread_local(CursorHideSystemDesc::default().build(world));
         Ok(())
     }
 }

--- a/amethyst_controls/src/bundles.rs
+++ b/amethyst_controls/src/bundles.rs
@@ -95,15 +95,11 @@ impl<'a, 'b, T: BindingTypes> SystemBundle<'a, 'b> for FlyControlBundle<T> {
             "free_rotation",
             &[],
         );
-        builder.add(
-            MouseFocusUpdateSystemDesc::default().build(world),
-            "mouse_focus",
-            &["free_rotation"],
+        builder.add_thread_local(
+            MouseFocusUpdateSystemDesc::default().build(world)
         );
-        builder.add(
-            CursorHideSystemDesc::default().build(world),
-            "cursor_hide",
-            &["mouse_focus"],
+        builder.add_thread_local(
+            CursorHideSystemDesc::default().build(world)
         );
         Ok(())
     }

--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -1,6 +1,6 @@
 use derive_new::new;
 use winit::{
-    event::{DeviceEvent, Event, WindowEvent}, 
+    event::{DeviceEvent, Event, WindowEvent},
     window::Window,
 };
 

--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -132,12 +132,12 @@ pub struct FreeRotationSystem {
     sensitivity_x: f32,
     sensitivity_y: f32,
     #[system_desc(event_channel_reader)]
-    event_reader: ReaderId<Event<()>>,
+    event_reader: ReaderId<Event<'static, ()>>,
 }
 
 impl<'a> System<'a> for FreeRotationSystem {
     type SystemData = (
-        Read<'a, EventChannel<Event<()>>>,
+        Read<'a, EventChannel<Event<'static, ()>>>,
         WriteStorage<'a, Transform>,
         ReadStorage<'a, FlyControlTag>,
         Read<'a, WindowFocus>,
@@ -173,11 +173,14 @@ impl<'a> System<'a> for FreeRotationSystem {
 #[system_desc(name(MouseFocusUpdateSystemDesc))]
 pub struct MouseFocusUpdateSystem {
     #[system_desc(event_channel_reader)]
-    event_reader: ReaderId<Event<()>>,
+    event_reader: ReaderId<Event<'static, ()>>,
 }
 
 impl<'a> System<'a> for MouseFocusUpdateSystem {
-    type SystemData = (Read<'a, EventChannel<Event<()>>>, Write<'a, WindowFocus>);
+    type SystemData = (
+        Read<'a, EventChannel<Event<'static, ()>>>,
+        Write<'a, WindowFocus>,
+    );
 
     fn run(&mut self, (events, mut focus): Self::SystemData) {
         #[cfg(feature = "profiler")]

--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -1,5 +1,8 @@
 use derive_new::new;
-use winit::{DeviceEvent, Event, Window, WindowEvent};
+use winit::{
+    event::{DeviceEvent, Event, WindowEvent}, 
+    window::Window,
+};
 
 #[cfg(feature = "profiler")]
 use thread_profiler::profile_scope;
@@ -129,12 +132,12 @@ pub struct FreeRotationSystem {
     sensitivity_x: f32,
     sensitivity_y: f32,
     #[system_desc(event_channel_reader)]
-    event_reader: ReaderId<Event>,
+    event_reader: ReaderId<Event<()>>,
 }
 
 impl<'a> System<'a> for FreeRotationSystem {
     type SystemData = (
-        Read<'a, EventChannel<Event>>,
+        Read<'a, EventChannel<Event<()>>>,
         WriteStorage<'a, Transform>,
         ReadStorage<'a, FlyControlTag>,
         Read<'a, WindowFocus>,
@@ -170,11 +173,11 @@ impl<'a> System<'a> for FreeRotationSystem {
 #[system_desc(name(MouseFocusUpdateSystemDesc))]
 pub struct MouseFocusUpdateSystem {
     #[system_desc(event_channel_reader)]
-    event_reader: ReaderId<Event>,
+    event_reader: ReaderId<Event<()>>,
 }
 
 impl<'a> System<'a> for MouseFocusUpdateSystem {
-    type SystemData = (Read<'a, EventChannel<Event>>, Write<'a, WindowFocus>);
+    type SystemData = (Read<'a, EventChannel<Event<()>>>, Write<'a, WindowFocus>);
 
     fn run(&mut self, (events, mut focus): Self::SystemData) {
         #[cfg(feature = "profiler")]
@@ -219,16 +222,16 @@ impl<'a> System<'a> for CursorHideSystem {
 
         let should_be_hidden = focus.is_focused && hide.hide;
         if !self.is_hidden && should_be_hidden {
-            if let Err(err) = win.grab_cursor(true) {
+            if let Err(err) = win.set_cursor_grab(true) {
                 log::error!("Unable to grab the cursor. Error: {:?}", err);
             }
-            win.hide_cursor(true);
+            win.set_cursor_visible(false);
             self.is_hidden = true;
         } else if self.is_hidden && !should_be_hidden {
-            if let Err(err) = win.grab_cursor(false) {
+            if let Err(err) = win.set_cursor_grab(false) {
                 log::error!("Unable to release the cursor. Error: {:?}", err);
             }
-            win.hide_cursor(false);
+            win.set_cursor_visible(true);
             self.is_hidden = false;
         }
     }

--- a/amethyst_gltf/src/format/material.rs
+++ b/amethyst_gltf/src/format/material.rs
@@ -158,7 +158,7 @@ fn load_texture(
         ..Default::default()
     };
 
-    load_from_image(std::io::Cursor::new(&data), metadata).map_err(|e| Error::new(e))
+    load_from_image(std::io::Cursor::new(&data), metadata).map_err(Error::new)
 }
 
 fn load_sampler_info(sampler: &gltf::texture::Sampler<'_>) -> hal::image::SamplerDesc {

--- a/amethyst_gltf/src/format/material.rs
+++ b/amethyst_gltf/src/format/material.rs
@@ -158,12 +158,12 @@ fn load_texture(
         ..Default::default()
     };
 
-    load_from_image(std::io::Cursor::new(&data), metadata).map_err(|e| e.compat().into())
+    load_from_image(std::io::Cursor::new(&data), metadata).map_err(|e| Error::new(e))
 }
 
-fn load_sampler_info(sampler: &gltf::texture::Sampler<'_>) -> hal::image::SamplerInfo {
+fn load_sampler_info(sampler: &gltf::texture::Sampler<'_>) -> hal::image::SamplerDesc {
     use gltf::texture::{MagFilter, MinFilter};
-    use hal::image::{Filter, SamplerInfo};
+    use hal::image::{Filter, SamplerDesc};
 
     let mag_filter = match sampler.mag_filter() {
         Some(MagFilter::Nearest) => Filter::Nearest,
@@ -184,7 +184,7 @@ fn load_sampler_info(sampler: &gltf::texture::Sampler<'_>) -> hal::image::Sample
     let wrap_s = map_wrapping(sampler.wrap_s());
     let wrap_t = map_wrapping(sampler.wrap_t());
 
-    let mut s = SamplerInfo::new(min_filter, wrap_s);
+    let mut s = SamplerDesc::new(min_filter, wrap_s);
     s.wrap_mode = (wrap_s, wrap_t, wrap_t);
     s.mag_filter = mag_filter;
     s.mip_filter = mip_filter;

--- a/amethyst_input/Cargo.toml
+++ b/amethyst_input/Cargo.toml
@@ -23,7 +23,7 @@ derivative = "1.0"
 derive-new = "0.5"
 fnv = "1"
 serde = { version = "1", features = ["derive"] }
-winit = { version = "0.19", features = ["serde"] }
+winit = { version = "0.20.0-alpha4", features = ["serde"] }
 sdl2 = { version = "0.32.2", optional = true }
 
 thread_profiler = { version = "0.3", optional = true }

--- a/amethyst_input/Cargo.toml
+++ b/amethyst_input/Cargo.toml
@@ -23,7 +23,7 @@ derivative = "1.0"
 derive-new = "0.5"
 fnv = "1"
 serde = { version = "1", features = ["derive"] }
-winit = { version = "0.20.0-alpha5", features = ["serde"] }
+winit = { version = "0.20.0", features = ["serde"] }
 sdl2 = { version = "0.32.2", optional = true }
 
 thread_profiler = { version = "0.3", optional = true }

--- a/amethyst_input/Cargo.toml
+++ b/amethyst_input/Cargo.toml
@@ -23,7 +23,7 @@ derivative = "1.0"
 derive-new = "0.5"
 fnv = "1"
 serde = { version = "1", features = ["derive"] }
-winit = { version = "0.20.0-alpha4", features = ["serde"] }
+winit = { version = "0.20.0-alpha5", features = ["serde"] }
 sdl2 = { version = "0.32.2", optional = true }
 
 thread_profiler = { version = "0.3", optional = true }

--- a/amethyst_input/src/bindings.rs
+++ b/amethyst_input/src/bindings.rs
@@ -522,7 +522,7 @@ impl<T: BindingTypes> Bindings<T> {
 mod tests {
     use super::*;
     use crate::{button::*, controller::ControllerAxis};
-    use winit::{MouseButton, VirtualKeyCode};
+    use winit::event::{MouseButton, VirtualKeyCode};
 
     #[test]
     fn add_and_remove_actions() {

--- a/amethyst_input/src/button.rs
+++ b/amethyst_input/src/button.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use winit::{MouseButton, VirtualKeyCode};
+use winit::event::{MouseButton, VirtualKeyCode};
 
 use super::{controller::ControllerButton, scroll_direction::ScrollDirection};
 

--- a/amethyst_input/src/event.rs
+++ b/amethyst_input/src/event.rs
@@ -1,6 +1,6 @@
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
-use winit::{MouseButton, VirtualKeyCode};
+use winit::event::{MouseButton, VirtualKeyCode};
 
 use super::{
     bindings::BindingTypes,

--- a/amethyst_input/src/input_handler.rs
+++ b/amethyst_input/src/input_handler.rs
@@ -11,11 +11,11 @@ use derivative::Derivative;
 use smallvec::SmallVec;
 use std::{borrow::Borrow, hash::Hash};
 use winit::{
-    dpi::LogicalPosition, 
+    dpi::LogicalPosition,
     event::{
-        DeviceEvent, ElementState, Event, KeyboardInput, MouseButton,
-        MouseScrollDelta, VirtualKeyCode, WindowEvent,
-    }
+        DeviceEvent, ElementState, Event, KeyboardInput, MouseButton, MouseScrollDelta,
+        VirtualKeyCode, WindowEvent,
+    },
 };
 
 /// This struct holds state information about input devices.

--- a/amethyst_input/src/input_handler.rs
+++ b/amethyst_input/src/input_handler.rs
@@ -11,8 +11,11 @@ use derivative::Derivative;
 use smallvec::SmallVec;
 use std::{borrow::Borrow, hash::Hash};
 use winit::{
-    dpi::LogicalPosition, DeviceEvent, ElementState, Event, KeyboardInput, MouseButton,
-    MouseScrollDelta, VirtualKeyCode, WindowEvent,
+    dpi::LogicalPosition, 
+    event::{
+        DeviceEvent, ElementState, Event, KeyboardInput, MouseButton,
+        MouseScrollDelta, VirtualKeyCode, WindowEvent,
+    }
 };
 
 /// This struct holds state information about input devices.
@@ -57,7 +60,7 @@ where
     /// the world as a resource.
     pub fn send_event(
         &mut self,
-        event: &Event,
+        event: &Event<()>,
         event_handler: &mut EventChannel<InputEvent<T>>,
         hidpi: f32,
     ) {

--- a/amethyst_input/src/input_handler.rs
+++ b/amethyst_input/src/input_handler.rs
@@ -11,7 +11,7 @@ use derivative::Derivative;
 use smallvec::SmallVec;
 use std::{borrow::Borrow, hash::Hash};
 use winit::{
-    dpi::LogicalPosition,
+    dpi::{LogicalPosition, PhysicalPosition},
     event::{
         DeviceEvent, ElementState, Event, KeyboardInput, MouseButton, MouseScrollDelta,
         VirtualKeyCode, WindowEvent,
@@ -61,7 +61,7 @@ where
     /// the world as a resource.
     pub fn send_event(
         &mut self,
-        event: &Event<()>,
+        event: &Event<'static, ()>,
         event_handler: &mut EventChannel<InputEvent<T>>,
         hidpi: f32,
     ) {
@@ -224,7 +224,7 @@ where
                     }
                 }
                 WindowEvent::CursorMoved {
-                    position: LogicalPosition { x, y },
+                    position: PhysicalPosition { x, y },
                     ..
                 } => {
                     if let Some((old_x, old_y)) = self.mouse_position {
@@ -782,8 +782,10 @@ mod tests {
 
     use super::*;
     use winit::{
-        DeviceId, ElementState, Event, KeyboardInput, ModifiersState, ScanCode, WindowEvent,
-        WindowId,
+        event::{
+            DeviceId, ElementState, Event, KeyboardInput, ModifiersState, ScanCode, WindowEvent,
+        },
+        window::WindowId,
     };
 
     const HIDPI: f32 = 1.0;
@@ -1263,19 +1265,20 @@ right: `{:?}`",
         }
     }
 
-    fn key_press(scancode: ScanCode, virtual_keycode: VirtualKeyCode) -> Event {
+    fn key_press(scancode: ScanCode, virtual_keycode: VirtualKeyCode) -> Event<'static, ()> {
         key_event(scancode, virtual_keycode, ElementState::Pressed)
     }
 
-    fn key_release(scancode: ScanCode, virtual_keycode: VirtualKeyCode) -> Event {
+    fn key_release(scancode: ScanCode, virtual_keycode: VirtualKeyCode) -> Event<'static, ()> {
         key_event(scancode, virtual_keycode, ElementState::Released)
     }
 
+    #[allow(deprecated)] // Needed for `ModifiersState`.
     fn key_event(
         scancode: ScanCode,
         virtual_keycode: VirtualKeyCode,
         state: ElementState,
-    ) -> Event {
+    ) -> Event<'static, ()> {
         Event::WindowEvent {
             window_id: unsafe { WindowId::dummy() },
             event: WindowEvent::KeyboardInput {
@@ -1284,43 +1287,34 @@ right: `{:?}`",
                     scancode,
                     state,
                     virtual_keycode: Some(virtual_keycode),
-                    modifiers: ModifiersState {
-                        shift: false,
-                        ctrl: false,
-                        alt: false,
-                        logo: false,
-                    },
+                    modifiers: ModifiersState::empty(),
                 },
+                is_synthetic: false,
             },
         }
     }
 
-    fn mouse_press(button: MouseButton) -> Event {
+    fn mouse_press(button: MouseButton) -> Event<'static, ()> {
         mouse_event(button, ElementState::Pressed)
     }
 
-    fn mouse_release(button: MouseButton) -> Event {
+    fn mouse_release(button: MouseButton) -> Event<'static, ()> {
         mouse_event(button, ElementState::Released)
     }
 
-    fn mouse_event(button: MouseButton, state: ElementState) -> Event {
+    fn mouse_event(button: MouseButton, state: ElementState) -> Event<'static, ()> {
         Event::WindowEvent {
             window_id: unsafe { WindowId::dummy() },
             event: WindowEvent::MouseInput {
                 device_id: unsafe { DeviceId::dummy() },
                 state,
                 button,
-                modifiers: ModifiersState {
-                    shift: false,
-                    ctrl: false,
-                    alt: false,
-                    logo: false,
-                },
+                modifiers: ModifiersState::empty(),
             },
         }
     }
 
-    fn mouse_wheel(x: f32, y: f32) -> Event {
+    fn mouse_wheel(x: f32, y: f32) -> Event<'static, ()> {
         Event::DeviceEvent {
             device_id: unsafe { DeviceId::dummy() },
             event: DeviceEvent::MouseWheel {

--- a/amethyst_input/src/lib.rs
+++ b/amethyst_input/src/lib.rs
@@ -26,7 +26,7 @@ pub use self::{
         is_key_up, is_mouse_button_down,
     },
 };
-pub use winit::{ElementState, VirtualKeyCode};
+pub use winit::event::{ElementState, VirtualKeyCode};
 
 use std::iter::Iterator;
 

--- a/amethyst_input/src/system.rs
+++ b/amethyst_input/src/system.rs
@@ -33,7 +33,7 @@ where
         <InputSystem<T> as System<'_>>::SystemData::setup(world);
 
         let reader = world
-            .fetch_mut::<EventChannel<Event<()>>>()
+            .fetch_mut::<EventChannel<Event<'static, ()>>>()
             .register_reader();
         if let Some(bindings) = self.bindings.as_ref() {
             world.fetch_mut::<InputHandler<T>>().bindings = bindings.clone();
@@ -52,18 +52,18 @@ pub struct InputSystem<T>
 where
     T: BindingTypes,
 {
-    reader: ReaderId<Event<()>>,
+    reader: ReaderId<Event<'static, ()>>,
     bindings: Option<Bindings<T>>,
 }
 
 impl<T: BindingTypes> InputSystem<T> {
     /// Create a new input system. Needs a reader id for `EventHandler<winit::Event>`.
-    pub fn new(reader: ReaderId<Event<()>>, bindings: Option<Bindings<T>>) -> Self {
+    pub fn new(reader: ReaderId<Event<'static, ()>>, bindings: Option<Bindings<T>>) -> Self {
         InputSystem { reader, bindings }
     }
 
     fn process_event(
-        event: &Event<()>,
+        event: &Event<'static, ()>,
         handler: &mut InputHandler<T>,
         output: &mut EventChannel<InputEvent<T>>,
         hidpi: f32,
@@ -74,7 +74,7 @@ impl<T: BindingTypes> InputSystem<T> {
 
 impl<'a, T: BindingTypes> System<'a> for InputSystem<T> {
     type SystemData = (
-        Read<'a, EventChannel<Event<()>>>,
+        Read<'a, EventChannel<Event<'static, ()>>>,
         Write<'a, InputHandler<T>>,
         Write<'a, EventChannel<InputEvent<T>>>,
         ReadExpect<'a, ScreenDimensions>,

--- a/amethyst_input/src/system.rs
+++ b/amethyst_input/src/system.rs
@@ -1,6 +1,6 @@
 //! Input system
 use derive_new::new;
-use winit::Event;
+use winit::event::Event;
 
 use crate::{BindingTypes, Bindings, InputEvent, InputHandler};
 use amethyst_core::{
@@ -32,7 +32,7 @@ where
     fn build(self, world: &mut World) -> InputSystem<T> {
         <InputSystem<T> as System<'_>>::SystemData::setup(world);
 
-        let reader = world.fetch_mut::<EventChannel<Event>>().register_reader();
+        let reader = world.fetch_mut::<EventChannel<Event<()>>>().register_reader();
         if let Some(bindings) = self.bindings.as_ref() {
             world.fetch_mut::<InputHandler<T>>().bindings = bindings.clone();
         }
@@ -50,18 +50,18 @@ pub struct InputSystem<T>
 where
     T: BindingTypes,
 {
-    reader: ReaderId<Event>,
+    reader: ReaderId<Event<()>>,
     bindings: Option<Bindings<T>>,
 }
 
 impl<T: BindingTypes> InputSystem<T> {
     /// Create a new input system. Needs a reader id for `EventHandler<winit::Event>`.
-    pub fn new(reader: ReaderId<Event>, bindings: Option<Bindings<T>>) -> Self {
+    pub fn new(reader: ReaderId<Event<()>>, bindings: Option<Bindings<T>>) -> Self {
         InputSystem { reader, bindings }
     }
 
     fn process_event(
-        event: &Event,
+        event: &Event<()>,
         handler: &mut InputHandler<T>,
         output: &mut EventChannel<InputEvent<T>>,
         hidpi: f32,
@@ -72,7 +72,7 @@ impl<T: BindingTypes> InputSystem<T> {
 
 impl<'a, T: BindingTypes> System<'a> for InputSystem<T> {
     type SystemData = (
-        Read<'a, EventChannel<Event>>,
+        Read<'a, EventChannel<Event<()>>>,
         Write<'a, InputHandler<T>>,
         Write<'a, EventChannel<InputEvent<T>>>,
         ReadExpect<'a, ScreenDimensions>,

--- a/amethyst_input/src/system.rs
+++ b/amethyst_input/src/system.rs
@@ -32,7 +32,9 @@ where
     fn build(self, world: &mut World) -> InputSystem<T> {
         <InputSystem<T> as System<'_>>::SystemData::setup(world);
 
-        let reader = world.fetch_mut::<EventChannel<Event<()>>>().register_reader();
+        let reader = world
+            .fetch_mut::<EventChannel<Event<()>>>()
+            .register_reader();
         if let Some(bindings) = self.bindings.as_ref() {
             world.fetch_mut::<InputHandler<T>>().bindings = bindings.clone();
         }

--- a/amethyst_input/src/util.rs
+++ b/amethyst_input/src/util.rs
@@ -3,7 +3,7 @@ use winit::event::{ElementState, Event, KeyboardInput, MouseButton, VirtualKeyCo
 
 /// If this event was for manipulating a keyboard key then this will return the `VirtualKeyCode`
 /// and the new state.
-pub fn get_key(event: &Event<()>) -> Option<(VirtualKeyCode, ElementState)> {
+pub fn get_key(event: &Event<'_, ()>) -> Option<(VirtualKeyCode, ElementState)> {
     match *event {
         Event::WindowEvent { ref event, .. } => match *event {
             WindowEvent::KeyboardInput {
@@ -23,7 +23,7 @@ pub fn get_key(event: &Event<()>) -> Option<(VirtualKeyCode, ElementState)> {
 
 /// Returns true if the event passed in is a key down event for the
 /// provided `VirtualKeyCode`.
-pub fn is_key_down(event: &Event<()>, key_code: VirtualKeyCode) -> bool {
+pub fn is_key_down(event: &Event<'_, ()>, key_code: VirtualKeyCode) -> bool {
     if let Some((key, state)) = get_key(event) {
         return key == key_code && state == ElementState::Pressed;
     }
@@ -33,7 +33,7 @@ pub fn is_key_down(event: &Event<()>, key_code: VirtualKeyCode) -> bool {
 
 /// Returns true if the event passed in is a key up event for the
 /// provided `VirtualKeyCode`.
-pub fn is_key_up(event: &Event<()>, key_code: VirtualKeyCode) -> bool {
+pub fn is_key_up(event: &Event<'_, ()>, key_code: VirtualKeyCode) -> bool {
     if let Some((key, state)) = get_key(event) {
         return key == key_code && state == ElementState::Released;
     }
@@ -42,7 +42,7 @@ pub fn is_key_up(event: &Event<()>, key_code: VirtualKeyCode) -> bool {
 }
 
 /// Returns true if the event passed in is a request to close the game window.
-pub fn is_close_requested(event: &Event<()>) -> bool {
+pub fn is_close_requested(event: &Event<'_, ()>) -> bool {
     match *event {
         Event::WindowEvent { ref event, .. } => match *event {
             WindowEvent::CloseRequested => true,
@@ -65,7 +65,7 @@ pub fn get_input_axis_simple<T: BindingTypes>(
 
 /// If this event was for manipulating a mouse button, this will return the `MouseButton`
 /// and the new state.
-pub fn get_mouse_button(event: &Event<()>) -> Option<(MouseButton, ElementState)> {
+pub fn get_mouse_button(event: &Event<'_, ()>) -> Option<(MouseButton, ElementState)> {
     match *event {
         Event::WindowEvent { ref event, .. } => match *event {
             WindowEvent::MouseInput { button, state, .. } => Some((button, state)),
@@ -77,7 +77,7 @@ pub fn get_mouse_button(event: &Event<()>) -> Option<(MouseButton, ElementState)
 
 /// Returns true if the event passed in is a mouse button down event for the
 /// provided `MouseButton`.
-pub fn is_mouse_button_down(event: &Event<()>, button: MouseButton) -> bool {
+pub fn is_mouse_button_down(event: &Event<'_, ()>, button: MouseButton) -> bool {
     if let Some((pressed_button, state)) = get_mouse_button(event) {
         pressed_button == button && state == ElementState::Pressed
     } else {

--- a/amethyst_input/src/util.rs
+++ b/amethyst_input/src/util.rs
@@ -1,9 +1,9 @@
 use crate::{input_handler::InputHandler, BindingTypes};
-use winit::{ElementState, Event, KeyboardInput, MouseButton, VirtualKeyCode, WindowEvent};
+use winit::event::{ElementState, Event, KeyboardInput, MouseButton, VirtualKeyCode, WindowEvent};
 
 /// If this event was for manipulating a keyboard key then this will return the `VirtualKeyCode`
 /// and the new state.
-pub fn get_key(event: &Event) -> Option<(VirtualKeyCode, ElementState)> {
+pub fn get_key(event: &Event<()>) -> Option<(VirtualKeyCode, ElementState)> {
     match *event {
         Event::WindowEvent { ref event, .. } => match *event {
             WindowEvent::KeyboardInput {
@@ -23,7 +23,7 @@ pub fn get_key(event: &Event) -> Option<(VirtualKeyCode, ElementState)> {
 
 /// Returns true if the event passed in is a key down event for the
 /// provided `VirtualKeyCode`.
-pub fn is_key_down(event: &Event, key_code: VirtualKeyCode) -> bool {
+pub fn is_key_down(event: &Event<()>, key_code: VirtualKeyCode) -> bool {
     if let Some((key, state)) = get_key(event) {
         return key == key_code && state == ElementState::Pressed;
     }
@@ -33,7 +33,7 @@ pub fn is_key_down(event: &Event, key_code: VirtualKeyCode) -> bool {
 
 /// Returns true if the event passed in is a key up event for the
 /// provided `VirtualKeyCode`.
-pub fn is_key_up(event: &Event, key_code: VirtualKeyCode) -> bool {
+pub fn is_key_up(event: &Event<()>, key_code: VirtualKeyCode) -> bool {
     if let Some((key, state)) = get_key(event) {
         return key == key_code && state == ElementState::Released;
     }
@@ -42,7 +42,7 @@ pub fn is_key_up(event: &Event, key_code: VirtualKeyCode) -> bool {
 }
 
 /// Returns true if the event passed in is a request to close the game window.
-pub fn is_close_requested(event: &Event) -> bool {
+pub fn is_close_requested(event: &Event<()>) -> bool {
     match *event {
         Event::WindowEvent { ref event, .. } => match *event {
             WindowEvent::CloseRequested => true,
@@ -65,7 +65,7 @@ pub fn get_input_axis_simple<T: BindingTypes>(
 
 /// If this event was for manipulating a mouse button, this will return the `MouseButton`
 /// and the new state.
-pub fn get_mouse_button(event: &Event) -> Option<(MouseButton, ElementState)> {
+pub fn get_mouse_button(event: &Event<()>) -> Option<(MouseButton, ElementState)> {
     match *event {
         Event::WindowEvent { ref event, .. } => match *event {
             WindowEvent::MouseInput { button, state, .. } => Some((button, state)),
@@ -77,7 +77,7 @@ pub fn get_mouse_button(event: &Event) -> Option<(MouseButton, ElementState)> {
 
 /// Returns true if the event passed in is a mouse button down event for the
 /// provided `MouseButton`.
-pub fn is_mouse_button_down(event: &Event, button: MouseButton) -> bool {
+pub fn is_mouse_button_down(event: &Event<()>, button: MouseButton) -> bool {
     if let Some((pressed_button, state)) = get_mouse_button(event) {
         pressed_button == button && state == ElementState::Pressed
     } else {

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -25,7 +25,7 @@ glsl-layout = "0.3"
 lazy_static = "1.3"
 log = "0.4"
 palette = { version = "0.4", features = ["serde"] }
-rendy = { version = "0.4.1", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1"] }
+rendy = { version = "0.5.1", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1", "init"] }
 ron = "0.5"
 serde = { version = "1", features = ["serde_derive"] }
 fnv = "1"
@@ -40,13 +40,12 @@ approx = "0.3.2"
 rayon = "1.1.0"
 more-asserts = "0.2.1"
 criterion = "0.3.0"
-winit = "0.19"
+winit = "0.20.0-alpha4"
 approx = "0.3"
 
 [features]
 metal = ["rendy/metal"]
 vulkan = ["rendy/vulkan"]
-vulkan-x11 = ["rendy/vulkan-x11"]
 empty = ["rendy/empty"]
 profiler = [ "thread_profiler/thread_profiler", "rendy/profiler" ]
 nightly = [ "amethyst_core/nightly" ]
@@ -54,7 +53,7 @@ no-slow-safety-checks = ["rendy/no-slow-safety-checks"]
 shader-compiler =  ["rendy/shader-compiler"]
 test-support =  []
 experimental-spirv-reflection = ["rendy/spirv-reflection"]
-window = ["rendy/wsi-winit", "amethyst_window"]
+window = ["rendy/init-winit", "amethyst_window"]
 
 [[bench]]
 name = "camera"

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -25,7 +25,7 @@ glsl-layout = "0.3"
 lazy_static = "1.3"
 log = "0.4"
 palette = { version = "0.4", features = ["serde"] }
-rendy = { version = "0.5.1", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1", "init"] }
+rendy = {git = "https://github.com/valkum/rendy", branch = "error_impl", version = "0.5.1", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1", "init"] }
 ron = "0.5"
 serde = { version = "1", features = ["serde_derive"] }
 fnv = "1"

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -25,7 +25,8 @@ glsl-layout = "0.3"
 lazy_static = "1.3"
 log = "0.4"
 palette = { version = "0.4", features = ["serde"] }
-rendy = {git = "https://github.com/valkum/rendy", branch = "error_impl", version = "0.5.1", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1", "init"] }
+# rendy = {version = "0.5.1", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1", "init"] }
+rendy = {git = "https://github.com/amethyst/rendy.git", rev = "cae226ff5988eee6debdfc520e34023368858b9b", version = "0.5.1", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1", "init"] }
 ron = "0.5"
 serde = { version = "1", features = ["serde_derive"] }
 fnv = "1"
@@ -40,7 +41,7 @@ approx = "0.3.2"
 rayon = "1.1.0"
 more-asserts = "0.2.1"
 criterion = "0.3.0"
-winit = "0.20.0-alpha4"
+winit = "0.20.0-alpha5"
 approx = "0.3"
 
 [features]

--- a/amethyst_rendy/src/bundle.rs
+++ b/amethyst_rendy/src/bundle.rs
@@ -492,7 +492,7 @@ impl TargetImage {
 }
 
 /// Set of options required to create an image node in render graph.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct ImageOptions {
     /// Image kind and size
     pub kind: hal::image::Kind,
@@ -647,8 +647,10 @@ impl<B: Backend> TargetPlan<B> {
         for (i, color) in outputs.colors.drain(..).enumerate() {
             match color {
                 OutputColor::Surface(surface, clear) => {
+                    let target_metadata = ctx.target_metadata[&self.key];
+                    let suggested_extend = hal::window::Extent2D { width: target_metadata.width, height: target_metadata.height };
                     subpass.add_color_surface();
-                    pass.add_surface(surface, clear);
+                    pass.add_surface(surface, suggested_extend, clear);
                 }
                 OutputColor::Image(opts) => {
                     let node = ctx.create_image(opts);

--- a/amethyst_rendy/src/formats/mesh.rs
+++ b/amethyst_rendy/src/formats/mesh.rs
@@ -33,7 +33,7 @@ impl Format<MeshData> for ObjFormat {
                 }
                 builder.0.into()
             })
-            .map_err(|e| Error::new(e))
+            .map_err(Error::new)
     }
 }
 

--- a/amethyst_rendy/src/formats/mesh.rs
+++ b/amethyst_rendy/src/formats/mesh.rs
@@ -33,7 +33,7 @@ impl Format<MeshData> for ObjFormat {
                 }
                 builder.0.into()
             })
-            .map_err(|e| e.compat().into())
+            .map_err(|e| Error::new(e))
     }
 }
 

--- a/amethyst_rendy/src/formats/texture.rs
+++ b/amethyst_rendy/src/formats/texture.rs
@@ -96,7 +96,7 @@ impl Format<TextureData> for ImageFormat {
     fn import_simple(&self, bytes: Vec<u8>) -> Result<TextureData, Error> {
         load_from_image(std::io::Cursor::new(&bytes), self.0.clone())
             .map(|builder| builder.into())
-            .map_err(|e| Error::new(e))
+            .map_err(Error::new)
     }
 }
 

--- a/amethyst_rendy/src/pass/base_3d.rs
+++ b/amethyst_rendy/src/pass/base_3d.rs
@@ -118,7 +118,8 @@ impl<B: Backend, T: Base3DPassDef> RenderGroupDesc<B, World> for DrawBase3DDesc<
                 hal::pso::ShaderStageFlags::VERTEX,
                 hal::pso::ShaderStageFlags::FRAGMENT,
             ],
-        ).map_err(|_| pso::CreationError::Other)?;
+        )
+        .map_err(|_| pso::CreationError::Other)?;
         let materials = MaterialSub::new(factory).map_err(|_| pso::CreationError::Other)?;
         let skinning = SkinningSub::new(factory).map_err(|_| pso::CreationError::Other)?;
 
@@ -438,7 +439,8 @@ impl<B: Backend, T: Base3DPassDef> RenderGroupDesc<B, World> for DrawBase3DTrans
                 hal::pso::ShaderStageFlags::VERTEX,
                 hal::pso::ShaderStageFlags::FRAGMENT,
             ],
-        ).map_err(|_| pso::CreationError::Other)?;
+        )
+        .map_err(|_| pso::CreationError::Other)?;
 
         let materials = MaterialSub::new(factory).map_err(|_| pso::CreationError::Other)?;
         let skinning = SkinningSub::new(factory).map_err(|_| pso::CreationError::Other)?;
@@ -788,7 +790,8 @@ fn build_pipelines<B: Backend, T: Base3DPassDef>(
     } else {
         PipelinesBuilder::new()
             .with_pipeline(pipe_desc)
-            .build(factory, None).map_err(|_| pso::CreationError::Other)
+            .build(factory, None)
+            .map_err(|_| pso::CreationError::Other)
     };
 
     unsafe {

--- a/amethyst_rendy/src/pass/debug_lines.rs
+++ b/amethyst_rendy/src/pass/debug_lines.rs
@@ -57,8 +57,10 @@ impl<B: Backend> RenderGroupDesc<B, World> for DrawDebugLinesDesc {
         #[cfg(feature = "profiler")]
         profile_scope!("build");
 
-        let env = DynamicUniform::new(factory, pso::ShaderStageFlags::VERTEX).map_err(|_| pso::CreationError::Other)?;
-        let args = DynamicUniform::new(factory, pso::ShaderStageFlags::VERTEX).map_err(|_| pso::CreationError::Other)?;
+        let env = DynamicUniform::new(factory, pso::ShaderStageFlags::VERTEX)
+            .map_err(|_| pso::CreationError::Other)?;
+        let args = DynamicUniform::new(factory, pso::ShaderStageFlags::VERTEX)
+            .map_err(|_| pso::CreationError::Other)?;
         let vertex = DynamicVertexBuffer::new();
 
         let (pipeline, pipeline_layout) = build_lines_pipeline(
@@ -226,7 +228,8 @@ fn build_lines_pipeline<B: Backend>(
                     write: true,
                 }),
         )
-        .build(factory, None).map_err(|_| pso::CreationError::Other);
+        .build(factory, None)
+        .map_err(|_| pso::CreationError::Other);
 
     unsafe {
         factory.destroy_shader_module(shader_vertex);

--- a/amethyst_rendy/src/pass/flat2d.rs
+++ b/amethyst_rendy/src/pass/flat2d.rs
@@ -434,7 +434,8 @@ fn build_sprite_pipeline<B: Backend>(
                     write: !transparent,
                 }),
         )
-        .build(factory, None).map_err(|_| pso::CreationError::Other);
+        .build(factory, None)
+        .map_err(|_| pso::CreationError::Other);
 
     unsafe {
         factory.destroy_shader_module(shader_vertex);

--- a/amethyst_rendy/src/pass/flat2d.rs
+++ b/amethyst_rendy/src/pass/flat2d.rs
@@ -55,12 +55,12 @@ impl<B: Backend> RenderGroupDesc<B, World> for DrawFlat2DDesc {
         subpass: hal::pass::Subpass<'_, B>,
         _buffers: Vec<NodeBuffer>,
         _images: Vec<NodeImage>,
-    ) -> Result<Box<dyn RenderGroup<B, World>>, failure::Error> {
+    ) -> Result<Box<dyn RenderGroup<B, World>>, pso::CreationError> {
         #[cfg(feature = "profiler")]
         profile_scope!("build");
 
-        let env = FlatEnvironmentSub::new(factory)?;
-        let textures = TextureSub::new(factory)?;
+        let env = FlatEnvironmentSub::new(factory).map_err(|_| pso::CreationError::Other)?;
+        let textures = TextureSub::new(factory).map_err(|_| pso::CreationError::Other)?;
         let vertex = DynamicVertexBuffer::new();
 
         let (pipeline, pipeline_layout) = build_sprite_pipeline(
@@ -240,12 +240,12 @@ impl<B: Backend> RenderGroupDesc<B, World> for DrawFlat2DTransparentDesc {
         subpass: hal::pass::Subpass<'_, B>,
         _buffers: Vec<NodeBuffer>,
         _images: Vec<NodeImage>,
-    ) -> Result<Box<dyn RenderGroup<B, World>>, failure::Error> {
+    ) -> Result<Box<dyn RenderGroup<B, World>>, pso::CreationError> {
         #[cfg(feature = "profiler")]
         profile_scope!("build_trans");
 
-        let env = FlatEnvironmentSub::new(factory)?;
-        let textures = TextureSub::new(factory)?;
+        let env = FlatEnvironmentSub::new(factory).map_err(|_| pso::CreationError::Other)?;
+        let textures = TextureSub::new(factory).map_err(|_| pso::CreationError::Other)?;
         let vertex = DynamicVertexBuffer::new();
 
         let (pipeline, pipeline_layout) = build_sprite_pipeline(
@@ -399,7 +399,7 @@ fn build_sprite_pipeline<B: Backend>(
     framebuffer_height: u32,
     transparent: bool,
     layouts: Vec<&B::DescriptorSetLayout>,
-) -> Result<(B::GraphicsPipeline, B::PipelineLayout), failure::Error> {
+) -> Result<(B::GraphicsPipeline, B::PipelineLayout), pso::CreationError> {
     let pipeline_layout = unsafe {
         factory
             .device()
@@ -413,7 +413,7 @@ fn build_sprite_pipeline<B: Backend>(
         .with_pipeline(
             PipelineDescBuilder::new()
                 .with_vertex_desc(&[(SpriteArgs::vertex(), pso::VertexInputRate::Instance(1))])
-                .with_input_assembler(pso::InputAssemblerDesc::new(hal::Primitive::TriangleStrip))
+                .with_input_assembler(pso::InputAssemblerDesc::new(pso::Primitive::TriangleStrip))
                 .with_shaders(util::simple_shader_set(
                     &shader_vertex,
                     Some(&shader_fragment),
@@ -434,7 +434,7 @@ fn build_sprite_pipeline<B: Backend>(
                     write: !transparent,
                 }),
         )
-        .build(factory, None);
+        .build(factory, None).map_err(|_| pso::CreationError::Other);
 
     unsafe {
         factory.destroy_shader_module(shader_vertex);

--- a/amethyst_rendy/src/pass/skybox.rs
+++ b/amethyst_rendy/src/pass/skybox.rs
@@ -97,10 +97,12 @@ impl<B: Backend> RenderGroupDesc<B, World> for DrawSkyboxDesc {
         profile_scope!("build");
 
         let env = FlatEnvironmentSub::new(factory).map_err(|_| pso::CreationError::Other)?;
-        let colors = DynamicUniform::new(factory, pso::ShaderStageFlags::FRAGMENT).map_err(|_| pso::CreationError::Other)?;
+        let colors = DynamicUniform::new(factory, pso::ShaderStageFlags::FRAGMENT)
+            .map_err(|_| pso::CreationError::Other)?;
         let mesh = Shape::Sphere(16, 16)
             .generate::<Vec<PosTex>>(None)
-            .build(queue, factory).map_err(|_| pso::CreationError::Other)?;
+            .build(queue, factory)
+            .map_err(|_| pso::CreationError::Other)?;
 
         let (pipeline, pipeline_layout) = build_skybox_pipeline(
             factory,
@@ -225,7 +227,8 @@ fn build_skybox_pipeline<B: Backend>(
                     blend: None,
                 }]),
         )
-        .build(factory, None).map_err(|_| pso::CreationError::Other);
+        .build(factory, None)
+        .map_err(|_| pso::CreationError::Other);
 
     unsafe {
         factory.destroy_shader_module(shader_vertex);

--- a/amethyst_rendy/src/pipeline.rs
+++ b/amethyst_rendy/src/pipeline.rs
@@ -9,10 +9,9 @@ use rendy::{
         pso::{
             AttributeDesc, BakedStates, BasePipeline, BlendDesc, ColorBlendDesc, DepthStencilDesc,
             DepthTest, Face, GraphicsPipelineDesc, GraphicsShaderSet, InputAssemblerDesc,
-            Multisampling, PipelineCreationFlags, Rasterizer, Rect, VertexBufferDesc,
+            Multisampling, PipelineCreationFlags, Primitive, Rasterizer, Rect, VertexBufferDesc,
             VertexInputRate, Viewport,
         },
-        Primitive,
     },
     mesh::VertexFormat,
 };

--- a/amethyst_rendy/src/plugins.rs
+++ b/amethyst_rendy/src/plugins.rs
@@ -104,7 +104,7 @@ mod window {
             self.dirty = false;
 
             let window = <ReadExpect<'_, Window>>::fetch(world);
-            let surface = factory.create_surface(&window);
+            let surface = factory.create_surface(&*window)?;
             let dimensions = self.dimensions.as_ref().unwrap();
             let window_kind = Kind::D2(dimensions.width() as u32, dimensions.height() as u32, 1, 1);
 
@@ -112,7 +112,12 @@ mod window {
                 kind: window_kind,
                 levels: 1,
                 format: Format::D32Sfloat,
-                clear: Some(ClearValue::DepthStencil(ClearDepthStencil(1.0, 0))),
+                clear: Some(ClearValue {
+                    depth_stencil: ClearDepthStencil {
+                        depth: 1.0, 
+                        stencil: 0
+                    }
+                }),
             };
 
             plan.add_root(Target::Main);
@@ -121,7 +126,9 @@ mod window {
                 crate::bundle::TargetPlanOutputs {
                     colors: vec![OutputColor::Surface(
                         surface,
-                        self.clear.map(ClearValue::Color),
+                        self.clear.map(|c|ClearValue {
+                            color: c
+                        }),
                     )],
                     depth: Some(depth_options),
                 },

--- a/amethyst_rendy/src/plugins.rs
+++ b/amethyst_rendy/src/plugins.rs
@@ -27,7 +27,7 @@ mod window {
         ecs::{ReadExpect, SystemData},
         SystemBundle,
     };
-    use amethyst_window::{DisplayConfig, ScreenDimensions, Window, WindowBundle};
+    use amethyst_window::{DisplayConfig, ScreenDimensions, Window, WindowBundle, EventLoop};
     use rendy::hal::command::{ClearColor, ClearDepthStencil, ClearValue};
     use std::path::Path;
 
@@ -37,24 +37,14 @@ mod window {
     #[derive(Default, Debug)]
     pub struct RenderToWindow {
         target: Target,
-        config: Option<DisplayConfig>,
         dimensions: Option<ScreenDimensions>,
         dirty: bool,
         clear: Option<ClearColor>,
     }
 
     impl RenderToWindow {
-        /// Create RenderToWindow plugin with [`WindowBundle`] using specified config path.
-        pub fn from_config_path(path: impl AsRef<Path>) -> Result<Self, ConfigError> {
-            Ok(Self::from_config(DisplayConfig::load(path)?))
-        }
-
-        /// Create RenderToWindow plugin with [`WindowBundle`] using specified config.
-        pub fn from_config(display_config: DisplayConfig) -> Self {
-            Self {
-                config: Some(display_config),
-                ..Default::default()
-            }
+        pub fn new() -> Self {
+            Self { ..Default::default() }
         }
 
         /// Select render target which will be presented to window.
@@ -70,16 +60,13 @@ mod window {
         }
     }
 
-    impl<B: Backend> RenderPlugin<B> for RenderToWindow {
+    impl< B: Backend> RenderPlugin<B> for RenderToWindow {
         fn on_build<'a, 'b>(
             &mut self,
             world: &mut World,
             builder: &mut DispatcherBuilder<'a, 'b>,
         ) -> Result<(), Error> {
-            if let Some(config) = self.config.take() {
-                WindowBundle::from_config(config).build(world, builder)?;
-            }
-
+            WindowBundle::new().build(world, builder)?;
             Ok(())
         }
 
@@ -102,7 +89,7 @@ mod window {
             world: &World,
         ) -> Result<(), Error> {
             self.dirty = false;
-
+            
             let window = <ReadExpect<'_, Window>>::fetch(world);
             let surface = factory.create_surface(&*window)?;
             let dimensions = self.dimensions.as_ref().unwrap();

--- a/amethyst_rendy/src/plugins.rs
+++ b/amethyst_rendy/src/plugins.rs
@@ -22,14 +22,12 @@ mod window {
         bundle::{ImageOptions, OutputColor},
         Format, Kind,
     };
-    use amethyst_config::{Config, ConfigError};
     use amethyst_core::{
         ecs::{ReadExpect, SystemData},
         SystemBundle,
     };
-    use amethyst_window::{DisplayConfig, ScreenDimensions, Window, WindowBundle, EventLoop};
+    use amethyst_window::{ScreenDimensions, Window, WindowBundle};
     use rendy::hal::command::{ClearColor, ClearDepthStencil, ClearValue};
-    use std::path::Path;
 
     /// A [RenderPlugin] for opening a window and displaying a render target to it.
     ///
@@ -43,8 +41,11 @@ mod window {
     }
 
     impl RenderToWindow {
+        /// Creates new RenderToWindow plugin
         pub fn new() -> Self {
-            Self { ..Default::default() }
+            Self {
+                ..Default::default()
+            }
         }
 
         /// Select render target which will be presented to window.
@@ -60,7 +61,7 @@ mod window {
         }
     }
 
-    impl< B: Backend> RenderPlugin<B> for RenderToWindow {
+    impl<B: Backend> RenderPlugin<B> for RenderToWindow {
         fn on_build<'a, 'b>(
             &mut self,
             world: &mut World,
@@ -89,7 +90,7 @@ mod window {
             world: &World,
         ) -> Result<(), Error> {
             self.dirty = false;
-            
+
             let window = <ReadExpect<'_, Window>>::fetch(world);
             let surface = factory.create_surface(&*window)?;
             let dimensions = self.dimensions.as_ref().unwrap();
@@ -101,9 +102,9 @@ mod window {
                 format: Format::D32Sfloat,
                 clear: Some(ClearValue {
                     depth_stencil: ClearDepthStencil {
-                        depth: 1.0, 
-                        stencil: 0
-                    }
+                        depth: 1.0,
+                        stencil: 0,
+                    },
                 }),
             };
 
@@ -113,9 +114,7 @@ mod window {
                 crate::bundle::TargetPlanOutputs {
                     colors: vec![OutputColor::Surface(
                         surface,
-                        self.clear.map(|c|ClearValue {
-                            color: c
-                        }),
+                        self.clear.map(|c| ClearValue { color: c }),
                     )],
                     depth: Some(depth_options),
                 },

--- a/amethyst_rendy/src/system.rs
+++ b/amethyst_rendy/src/system.rs
@@ -8,10 +8,11 @@ use crate::{
     skinning::JointTransforms,
     sprite::SpriteRender,
     transparent::Transparent,
-    types::{Backend, Mesh, Texture},
+    types::{SelectedBackend, Backend, Mesh, Texture},
     visibility::Visibility,
 };
 use amethyst_assets::{AssetStorage, Handle, HotReloadStrategy, ProcessingState, ThreadPool};
+use amethyst_error::Error;
 use amethyst_core::{
     components::Transform,
     ecs::{Read, ReadExpect, ReadStorage, RunNow, System, SystemData, World, Write, WriteExpect},
@@ -21,9 +22,12 @@ use amethyst_core::{
 use palette::{LinSrgba, Srgba};
 use rendy::{
     command::{Families, QueueId},
+    core::EnabledBackend,
+    init::{self, AnyRendy},
     factory::{Factory, ImageState},
     graph::{Graph, GraphBuilder},
     texture::palette::{load_from_linear_rgba, load_from_srgba},
+    with_any_rendy,
 };
 use std::{marker::PhantomData, sync::Arc};
 
@@ -145,7 +149,9 @@ where
 
     fn setup(&mut self, world: &mut World) {
         let config: rendy::factory::Config = Default::default();
-        let (factory, families): (Factory<B>, _) = rendy::factory::init(config).unwrap();
+        let backend = EnabledBackend::which::<B>();
+        let rendy = AnyRendy::init(backend, &config).expect("Failed to initialize graphics backend.");
+        let (factory, families): (Factory<B>, Families<B>) = with_any_rendy!((rendy) (factory, families) => {(factory, families)});
 
         let queue_id = QueueId {
             family: families.family_by_index(0).id(),
@@ -212,7 +218,7 @@ impl<'a, B: Backend> System<'a> for MeshProcessorSystem<B> {
                 b.0.build(*queue_id, &factory)
                     .map(B::wrap_mesh)
                     .map(ProcessingState::Loaded)
-                    .map_err(|e| e.compat().into())
+                    .map_err(|e| Error::new(e))
             },
             time.frame_number(),
             &**pool,
@@ -260,7 +266,7 @@ impl<'a, B: Backend> System<'a> for TextureProcessorSystem<B> {
                 )
                 .map(B::wrap_texture)
                 .map(ProcessingState::Loaded)
-                .map_err(|e| e.compat().into())
+                .map_err(|e| Error::new(e))
             },
             time.frame_number(),
             &**pool,

--- a/amethyst_rendy/src/system.rs
+++ b/amethyst_rendy/src/system.rs
@@ -12,22 +12,19 @@ use crate::{
     visibility::Visibility,
 };
 use amethyst_assets::{AssetStorage, Handle, HotReloadStrategy, ProcessingState, ThreadPool};
-use amethyst_error::Error;
 use amethyst_core::{
     components::Transform,
     ecs::{Read, ReadExpect, ReadStorage, RunNow, System, SystemData, World, Write, WriteExpect},
     timing::Time,
     Hidden, HiddenPropagate,
 };
+use amethyst_error::Error;
 use palette::{LinSrgba, Srgba};
 use rendy::{
     command::{Families, QueueId},
-    core::EnabledBackend,
-    init::{self, AnyRendy},
     factory::{Factory, ImageState},
     graph::{Graph, GraphBuilder},
     texture::palette::{load_from_linear_rgba, load_from_srgba},
-    with_any_rendy,
 };
 use std::{marker::PhantomData, sync::Arc};
 
@@ -125,6 +122,8 @@ where
     }
 
     fn run_graph(&mut self, world: &World) {
+        #[cfg(feature = "profiler")]
+        profile_scope!("run_graph");
         let mut factory = world.fetch_mut::<Factory<B>>();
         factory.maintain(&mut self.families);
         self.graph
@@ -140,6 +139,8 @@ where
     G: GraphCreator<B>,
 {
     fn run_now(&mut self, world: &'a World) {
+        #[cfg(feature = "profiler")]
+        profile_scope!("run_rendering_system");
         let rebuild = self.graph_creator.rebuild(world);
         if self.graph.is_none() || rebuild {
             self.rebuild_graph(world);
@@ -148,6 +149,8 @@ where
     }
 
     fn setup(&mut self, world: &mut World) {
+        #[cfg(feature = "profiler")]
+        profile_scope!("setup_rendering_system");
         SetupData::setup(world);
 
         let mat = create_default_mat::<B>(world);
@@ -155,6 +158,8 @@ where
     }
 
     fn dispose(mut self: Box<Self>, world: &mut World) {
+        #[cfg(feature = "profiler")]
+        profile_scope!("dispose_rendering_system");
         if let Some(graph) = self.graph.take() {
             let mut factory = world.fetch_mut::<Factory<B>>();
             log::debug!("Dispose graph");
@@ -202,7 +207,7 @@ impl<'a, B: Backend> System<'a> for MeshProcessorSystem<B> {
                 b.0.build(*queue_id, &factory)
                     .map(B::wrap_mesh)
                     .map(ProcessingState::Loaded)
-                    .map_err(|e| Error::new(e))
+                    .map_err(Error::new)
             },
             time.frame_number(),
             &**pool,
@@ -250,7 +255,7 @@ impl<'a, B: Backend> System<'a> for TextureProcessorSystem<B> {
                 )
                 .map(B::wrap_texture)
                 .map(ProcessingState::Loaded)
-                .map_err(|e| Error::new(e))
+                .map_err(Error::new)
             },
             time.frame_number(),
             &**pool,
@@ -260,6 +265,8 @@ impl<'a, B: Backend> System<'a> for TextureProcessorSystem<B> {
 }
 
 fn create_default_mat<B: Backend>(world: &mut World) -> Material {
+    #[cfg(feature = "profiler")]
+    profile_scope!("create_default_mat");
     use crate::mtl::TextureOffset;
 
     use amethyst_assets::Loader;

--- a/amethyst_rendy/src/types.rs
+++ b/amethyst_rendy/src/types.rs
@@ -118,6 +118,7 @@ impl_backends!(
     Empty, "empty", rendy::empty::Backend;
 );
 
+
 impl Asset for Mesh {
     const NAME: &'static str = "Mesh";
     type Data = MeshData;

--- a/amethyst_rendy/src/types.rs
+++ b/amethyst_rendy/src/types.rs
@@ -118,7 +118,6 @@ impl_backends!(
     Empty, "empty", rendy::empty::Backend;
 );
 
-
 impl Asset for Mesh {
     const NAME: &'static str = "Mesh";
     type Data = MeshData;

--- a/amethyst_tiles/src/pass.rs
+++ b/amethyst_tiles/src/pass.rs
@@ -125,7 +125,8 @@ impl<B: Backend, T: Tile, E: CoordinateEncoder, Z: DrawTiles2DBounds> RenderGrou
         #[cfg(feature = "profiler")]
         profile_scope!("build");
 
-        let env = DynamicUniform::new(factory, pso::ShaderStageFlags::VERTEX).map_err(|e| pso::CreationError::Other)?;
+        let env = DynamicUniform::new(factory, pso::ShaderStageFlags::VERTEX)
+            .map_err(|e| pso::CreationError::Other)?;
 
         let textures = TextureSub::new(factory).map_err(|_| pso::CreationError::Other)?;
         let vertex = DynamicVertexBuffer::new();
@@ -361,7 +362,9 @@ fn build_tiles_pipeline<B: Backend>(
             .create_pipeline_layout(layouts, None as Option<(_, _)>)
     }?;
 
-    let mut shaders = SHADERS.build(factory, Default::default()).map_err(|_| pso::CreationError::Other)?;
+    let mut shaders = SHADERS
+        .build(factory, Default::default())
+        .map_err(|_| pso::CreationError::Other)?;
 
     let pipes = PipelinesBuilder::new()
         .with_pipeline(
@@ -381,7 +384,8 @@ fn build_tiles_pipeline<B: Backend>(
                     write: false,
                 }),
         )
-        .build(factory, None).map_err(|_| pso::CreationError::Other);
+        .build(factory, None)
+        .map_err(|_| pso::CreationError::Other);
 
     shaders.dispose(factory);
 

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1.0", features = ["derive"] }
 smallvec = "0.6"
 unicode-normalization = "0.1"
 unicode-segmentation = "1.2"
-winit = { version = "0.19", features = ["serde"] }
+winit = { version = "0.20.0-alpha4", features = ["serde"] }
 log = "0.4.6"
 font-kit = "0.4"
 paste = "0.1"

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1.0", features = ["derive"] }
 smallvec = "0.6"
 unicode-normalization = "0.1"
 unicode-segmentation = "1.2"
-winit = { version = "0.20.0-alpha4", features = ["serde"] }
+winit = { version = "0.20.0-alpha5", features = ["serde"] }
 log = "0.4.6"
 font-kit = "0.4"
 paste = "0.1"

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1.0", features = ["derive"] }
 smallvec = "0.6"
 unicode-normalization = "0.1"
 unicode-segmentation = "1.2"
-winit = { version = "0.20.0-alpha5", features = ["serde"] }
+winit = { version = "0.20.0", features = ["serde"] }
 log = "0.4.6"
 font-kit = "0.4"
 paste = "0.1"

--- a/amethyst_ui/src/event.rs
+++ b/amethyst_ui/src/event.rs
@@ -13,7 +13,7 @@ use amethyst_input::{BindingTypes, InputHandler};
 use amethyst_window::ScreenDimensions;
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
-use winit::MouseButton;
+use winit::event::MouseButton;
 
 pub trait TargetedEvent {
     fn get_target(&self) -> Entity;

--- a/amethyst_ui/src/pass.rs
+++ b/amethyst_ui/src/pass.rs
@@ -157,7 +157,8 @@ impl<B: Backend> RenderGroupDesc<B, World> for DrawUiDesc {
         #[cfg(feature = "profiler")]
         profile_scope!("build");
 
-        let env = DynamicUniform::new(factory, pso::ShaderStageFlags::VERTEX).map_err(|_| pso::CreationError::Other)?;
+        let env = DynamicUniform::new(factory, pso::ShaderStageFlags::VERTEX)
+            .map_err(|_| pso::CreationError::Other)?;
         let textures = TextureSub::new(factory).map_err(|_| pso::CreationError::Other)?;
         let vertex = DynamicVertexBuffer::new();
 
@@ -510,7 +511,8 @@ fn build_ui_pipeline<B: Backend>(
                     blend: Some(pso::BlendState::ALPHA),
                 }]),
         )
-        .build(factory, None).map_err(|_| pso::CreationError::Other);
+        .build(factory, None)
+        .map_err(|_| pso::CreationError::Other);
 
     unsafe {
         factory.destroy_shader_module(shader_vertex);

--- a/amethyst_ui/src/selection.rs
+++ b/amethyst_ui/src/selection.rs
@@ -66,7 +66,7 @@ where
     G: Send + Sync + 'static + PartialEq,
 {
     #[system_desc(event_channel_reader)]
-    window_reader_id: ReaderId<Event<()>>,
+    window_reader_id: ReaderId<Event<'static, ()>>,
     phantom: PhantomData<G>,
 }
 
@@ -75,7 +75,7 @@ where
     G: Send + Sync + 'static + PartialEq,
 {
     /// Creates a new `SelectionKeyboardSystem`.
-    pub fn new(window_reader_id: ReaderId<Event<()>>) -> Self {
+    pub fn new(window_reader_id: ReaderId<Event<'static, ()>>) -> Self {
         Self {
             window_reader_id,
             phantom: PhantomData,
@@ -88,7 +88,7 @@ where
     G: Send + Sync + 'static + PartialEq,
 {
     type SystemData = (
-        Read<'a, EventChannel<Event<()>>>,
+        Read<'a, EventChannel<Event<'static, ()>>>,
         Read<'a, CachedSelectionOrder>,
         WriteStorage<'a, Selected>,
         Write<'a, EventChannel<UiEvent>>,
@@ -147,7 +147,7 @@ where
                     }
                     selecteds.clear();
 
-                    let target = if !modifiers.shift {
+                    let target = if !modifiers.shift() {
                         // Up
                         if highest > 0 {
                             cached.cache.get(highest - 1).unwrap_or_else(|| cached.cache.last()

--- a/amethyst_ui/src/selection.rs
+++ b/amethyst_ui/src/selection.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use derivative::Derivative;
 use derive_new::new;
 use serde::{Deserialize, Serialize};
-use winit::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent};
+use winit::event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent};
 
 use amethyst_core::{
     ecs::{
@@ -66,7 +66,7 @@ where
     G: Send + Sync + 'static + PartialEq,
 {
     #[system_desc(event_channel_reader)]
-    window_reader_id: ReaderId<Event>,
+    window_reader_id: ReaderId<Event<()>>,
     phantom: PhantomData<G>,
 }
 
@@ -75,7 +75,7 @@ where
     G: Send + Sync + 'static + PartialEq,
 {
     /// Creates a new `SelectionKeyboardSystem`.
-    pub fn new(window_reader_id: ReaderId<Event>) -> Self {
+    pub fn new(window_reader_id: ReaderId<Event<()>>) -> Self {
         Self {
             window_reader_id,
             phantom: PhantomData,
@@ -88,7 +88,7 @@ where
     G: Send + Sync + 'static + PartialEq,
 {
     type SystemData = (
-        Read<'a, EventChannel<Event>>,
+        Read<'a, EventChannel<Event<()>>>,
         Read<'a, CachedSelectionOrder>,
         WriteStorage<'a, Selected>,
         Write<'a, EventChannel<UiEvent>>,

--- a/amethyst_ui/src/text.rs
+++ b/amethyst_ui/src/text.rs
@@ -3,7 +3,7 @@
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 use unicode_normalization::{char::is_combining_mark, UnicodeNormalization};
-use winit::{ElementState, Event, MouseButton, WindowEvent};
+use winit::event::{ElementState, Event, MouseButton, WindowEvent};
 
 use amethyst_core::{
     ecs::prelude::{
@@ -141,7 +141,7 @@ impl Component for TextEditing {
 pub struct TextEditingMouseSystem {
     /// A reader for winit events.
     #[system_desc(event_channel_reader)]
-    reader: ReaderId<Event>,
+    reader: ReaderId<Event<()>>,
     /// This is set to true while the left mouse button is pressed.
     #[system_desc(skip)]
     left_mouse_button_pressed: bool,
@@ -152,7 +152,7 @@ pub struct TextEditingMouseSystem {
 
 impl TextEditingMouseSystem {
     /// Creates a new instance of this system
-    pub fn new(reader: ReaderId<Event>) -> Self {
+    pub fn new(reader: ReaderId<Event<()>>) -> Self {
         Self {
             reader,
             left_mouse_button_pressed: false,
@@ -166,7 +166,7 @@ impl<'a> System<'a> for TextEditingMouseSystem {
         WriteStorage<'a, UiText>,
         WriteStorage<'a, TextEditing>,
         ReadStorage<'a, Selected>,
-        Read<'a, EventChannel<Event>>,
+        Read<'a, EventChannel<Event<()>>>,
         ReadExpect<'a, ScreenDimensions>,
         Read<'a, Time>,
     );

--- a/amethyst_ui/src/text.rs
+++ b/amethyst_ui/src/text.rs
@@ -141,7 +141,7 @@ impl Component for TextEditing {
 pub struct TextEditingMouseSystem {
     /// A reader for winit events.
     #[system_desc(event_channel_reader)]
-    reader: ReaderId<Event<()>>,
+    reader: ReaderId<Event<'static, ()>>,
     /// This is set to true while the left mouse button is pressed.
     #[system_desc(skip)]
     left_mouse_button_pressed: bool,
@@ -152,7 +152,7 @@ pub struct TextEditingMouseSystem {
 
 impl TextEditingMouseSystem {
     /// Creates a new instance of this system
-    pub fn new(reader: ReaderId<Event<()>>) -> Self {
+    pub fn new(reader: ReaderId<Event<'static, ()>>) -> Self {
         Self {
             reader,
             left_mouse_button_pressed: false,
@@ -166,7 +166,7 @@ impl<'a> System<'a> for TextEditingMouseSystem {
         WriteStorage<'a, UiText>,
         WriteStorage<'a, TextEditing>,
         ReadStorage<'a, Selected>,
-        Read<'a, EventChannel<Event<()>>>,
+        Read<'a, EventChannel<Event<'static, ()>>>,
         ReadExpect<'a, ScreenDimensions>,
         Read<'a, Time>,
     );

--- a/amethyst_ui/src/text_editing.rs
+++ b/amethyst_ui/src/text_editing.rs
@@ -4,7 +4,9 @@ use clipboard::{ClipboardContext, ClipboardProvider};
 use log::error;
 use unicode_normalization::{char::is_combining_mark, UnicodeNormalization};
 use unicode_segmentation::UnicodeSegmentation;
-use winit::event::{ElementState, Event, KeyboardInput, ModifiersState, VirtualKeyCode, WindowEvent};
+use winit::event::{
+    ElementState, Event, KeyboardInput, ModifiersState, VirtualKeyCode, WindowEvent,
+};
 
 use amethyst_core::{
     ecs::prelude::{Entities, Join, Read, ReadStorage, System, SystemData, Write, WriteStorage},

--- a/amethyst_ui/src/text_editing.rs
+++ b/amethyst_ui/src/text_editing.rs
@@ -4,7 +4,7 @@ use clipboard::{ClipboardContext, ClipboardProvider};
 use log::error;
 use unicode_normalization::{char::is_combining_mark, UnicodeNormalization};
 use unicode_segmentation::UnicodeSegmentation;
-use winit::{ElementState, Event, KeyboardInput, ModifiersState, VirtualKeyCode, WindowEvent};
+use winit::event::{ElementState, Event, KeyboardInput, ModifiersState, VirtualKeyCode, WindowEvent};
 
 use amethyst_core::{
     ecs::prelude::{Entities, Join, Read, ReadStorage, System, SystemData, Write, WriteStorage},
@@ -24,12 +24,12 @@ use crate::{LineMode, Selected, TextEditing, UiEvent, UiEventType, UiText};
 pub struct TextEditingInputSystem {
     /// A reader for winit events.
     #[system_desc(event_channel_reader)]
-    reader: ReaderId<Event>,
+    reader: ReaderId<Event<()>>,
 }
 
 impl TextEditingInputSystem {
     /// Creates a new instance of this system
-    pub fn new(reader: ReaderId<Event>) -> Self {
+    pub fn new(reader: ReaderId<Event<()>>) -> Self {
         Self { reader }
     }
 }
@@ -40,7 +40,7 @@ impl<'a> System<'a> for TextEditingInputSystem {
         WriteStorage<'a, UiText>,
         WriteStorage<'a, TextEditing>,
         ReadStorage<'a, Selected>,
-        Read<'a, EventChannel<Event>>,
+        Read<'a, EventChannel<Event<()>>>,
         Write<'a, EventChannel<UiEvent>>,
     );
 

--- a/amethyst_window/Cargo.toml
+++ b/amethyst_window/Cargo.toml
@@ -20,7 +20,7 @@ amethyst_error = { path = "../amethyst_error/", version = "0.3.0" }
 log = "0.4.6"
 serde = { version = "1", features = ["derive"] }
 thread_profiler = { version = "0.3", optional = true }
-winit = { version = "0.19", features = ["serde", "icon_loading"] }
+winit = { version = "0.20.0-alpha4", features = ["serde"] }
 
 [features]
 profiler = [ "thread_profiler/thread_profiler" ]

--- a/amethyst_window/Cargo.toml
+++ b/amethyst_window/Cargo.toml
@@ -20,7 +20,7 @@ amethyst_error = { path = "../amethyst_error/", version = "0.3.0" }
 log = "0.4.6"
 serde = { version = "1", features = ["derive"] }
 thread_profiler = { version = "0.3", optional = true }
-winit = { version = "0.20.0-alpha5", features = ["serde"] }
+winit = { version = "0.20.0", features = ["serde"] }
 
 [features]
 profiler = [ "thread_profiler/thread_profiler" ]

--- a/amethyst_window/Cargo.toml
+++ b/amethyst_window/Cargo.toml
@@ -20,7 +20,7 @@ amethyst_error = { path = "../amethyst_error/", version = "0.3.0" }
 log = "0.4.6"
 serde = { version = "1", features = ["derive"] }
 thread_profiler = { version = "0.3", optional = true }
-winit = { version = "0.20.0-alpha4", features = ["serde"] }
+winit = { version = "0.20.0-alpha5", features = ["serde"] }
 
 [features]
 profiler = [ "thread_profiler/thread_profiler" ]

--- a/amethyst_window/src/bundle.rs
+++ b/amethyst_window/src/bundle.rs
@@ -2,7 +2,7 @@ use crate::{DisplayConfig, EventsLoopSystem, WindowSystem};
 use amethyst_config::{Config, ConfigError};
 use amethyst_core::{bundle::SystemBundle, ecs::World, shred::DispatcherBuilder};
 use amethyst_error::Error;
-use winit::EventsLoop;
+use winit::event_loop::EventLoop;
 
 /// Screen width used in predefined display configuration.
 #[cfg(feature = "test-support")]
@@ -55,7 +55,7 @@ impl<'a, 'b> SystemBundle<'a, 'b> for WindowBundle {
         world: &mut World,
         builder: &mut DispatcherBuilder<'a, 'b>,
     ) -> Result<(), Error> {
-        let event_loop = EventsLoop::new();
+        let event_loop = EventLoop::new();
         builder.add(
             WindowSystem::from_config(world, &event_loop, self.config),
             "window",

--- a/amethyst_window/src/bundle.rs
+++ b/amethyst_window/src/bundle.rs
@@ -1,10 +1,6 @@
-use crate::{DisplayConfig, WindowSystem, EventLoop};
-use amethyst_config::{Config, ConfigError};
+use crate::WindowSystem;
 use amethyst_core::{bundle::SystemBundle, ecs::World, shred::DispatcherBuilder};
 use amethyst_error::Error;
-use std::sync::{Arc, Mutex};
-use amethyst_core::shred::cell::TrustCell;
-
 
 /// Screen width used in predefined display configuration.
 #[cfg(feature = "test-support")]
@@ -13,30 +9,21 @@ pub const SCREEN_WIDTH: u32 = 800;
 #[cfg(feature = "test-support")]
 pub const SCREEN_HEIGHT: u32 = 600;
 
-/// Bundle providing easy initializing of the appopriate `Window`, `WindowSystem` `EventLoop` and
-/// `EventLoopSystem` constructs used for creating the rendering window of amethyst with `winit`
+/// Bundle providing easy initializing of the `WindowSystem` used for managing WindowDimensions
 #[derive(Debug)]
-pub struct WindowBundle {
-}
+pub struct WindowBundle {}
 
 impl WindowBundle {
+    /// Creates new WindowBundle
     pub fn new() -> Self {
-        Self { }
+        Self {}
     }
 }
 
 impl<'a, 'b> SystemBundle<'a, 'b> for WindowBundle {
-    fn build(
-        self,
-        world: &mut World,
-        builder: &mut DispatcherBuilder<'a, 'b>,
-    ) -> Result<(), Error> {
-        
-        builder.add_thread_local(
-            WindowSystem::new()
-        );
-        // world.insert(TrustCell::new(event_loop));
-        // builder.add_thread_local(EventsLoopSystem::new(event_loop));
+    fn build(self, _: &mut World, builder: &mut DispatcherBuilder<'a, 'b>) -> Result<(), Error> {
+        builder.add_thread_local(WindowSystem::new());
+
         Ok(())
     }
 }

--- a/amethyst_window/src/config.rs
+++ b/amethyst_window/src/config.rs
@@ -2,9 +2,9 @@ use std::path::PathBuf;
 
 use log::error;
 use serde::{Deserialize, Serialize};
-use winit::{Icon, WindowAttributes, WindowBuilder};
+use winit::window::{Icon, WindowAttributes, WindowBuilder};
 
-use crate::monitor::{MonitorIdent, MonitorsAccess};
+use crate::{MonitorIdent, MonitorsAccess};
 
 /// Configuration for a window display.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -15,7 +15,8 @@ pub struct DisplayConfig {
     /// Enables fullscreen mode on specific monitor when set.
     /// Defaults to `None`, which means fullscreen is off.
     #[serde(default)]
-    pub fullscreen: Option<MonitorIdent>,
+    // pub fullscreen: Option<MonitorIdent>,
+    pub fullscreen: Option<u32>,
     /// Current window dimensions, measured in pixels (px).
     #[serde(default)]
     pub dimensions: Option<(u32, u32)>,
@@ -124,9 +125,11 @@ impl DisplayConfig {
     /// The `MonitorsAccess` is needed to configure a fullscreen window.
     pub fn into_window_builder(self, monitors: &impl MonitorsAccess) -> WindowBuilder {
         let attrs = WindowAttributes {
-            dimensions: self.dimensions.map(Into::into),
-            max_dimensions: self.max_dimensions.map(Into::into),
-            min_dimensions: self.min_dimensions.map(Into::into),
+            inner_size: self.dimensions.map(Into::into),
+            max_inner_size: self.max_dimensions.map(Into::into),
+            min_inner_size: self.min_dimensions.map(Into::into),
+            resizable: self.resizable,
+            fullscreen: None,
             title: self.title,
             maximized: self.maximized,
             visible: self.visibility,
@@ -134,9 +137,6 @@ impl DisplayConfig {
             decorations: self.decorations,
             always_on_top: self.always_on_top,
             window_icon: None,
-            fullscreen: self.fullscreen.map(|ident| ident.monitor_id(monitors)),
-            resizable: self.resizable,
-            multitouch: self.multitouch,
         };
 
         let mut builder = WindowBuilder::new();
@@ -145,20 +145,20 @@ impl DisplayConfig {
         if self.loaded_icon.is_some() {
             builder = builder.with_window_icon(self.loaded_icon);
         } else if let Some(icon) = self.icon {
-            let icon = match Icon::from_path(&icon) {
-                Ok(x) => Some(x),
-                Err(e) => {
-                    error!(
-                        "Failed to load window icon from `{}`: {}",
-                        icon.display(),
-                        e
-                    );
+            // let icon = match Icon::from_path(&icon) {
+            //     Ok(x) => Some(x),
+            //     Err(e) => {
+            //         error!(
+            //             "Failed to load window icon from `{}`: {}",
+            //             icon.display(),
+            //             e
+            //         );
 
-                    None
-                }
-            };
+            //         None
+            //     }
+            // };
 
-            builder = builder.with_window_icon(icon);
+            // builder = builder.with_window_icon(icon);
         }
 
         builder

--- a/amethyst_window/src/display_config.rs
+++ b/amethyst_window/src/display_config.rs
@@ -123,7 +123,7 @@ impl DisplayConfig {
     /// Creates a `winit::WindowBuilder` using the values set in the `DisplayConfig`.
     ///
     /// The `MonitorsAccess` is needed to configure a fullscreen window.
-    pub fn into_window_builder(self, monitors: &impl MonitorsAccess) -> WindowBuilder {
+    pub fn into_window_builder(self) -> WindowBuilder {
         let attrs = WindowAttributes {
             inner_size: self.dimensions.map(Into::into),
             max_inner_size: self.max_dimensions.map(Into::into),

--- a/amethyst_window/src/display_config.rs
+++ b/amethyst_window/src/display_config.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-use log::error;
 use serde::{Deserialize, Serialize};
 use winit::window::{Icon, WindowAttributes, WindowBuilder};
 
@@ -15,7 +14,6 @@ pub struct DisplayConfig {
     /// Enables fullscreen mode on specific monitor when set.
     /// Defaults to `None`, which means fullscreen is off.
     #[serde(default)]
-    // pub fullscreen: Option<MonitorIdent>,
     pub fullscreen: Option<u32>,
     /// Current window dimensions, measured in pixels (px).
     #[serde(default)]
@@ -144,21 +142,8 @@ impl DisplayConfig {
 
         if self.loaded_icon.is_some() {
             builder = builder.with_window_icon(self.loaded_icon);
-        } else if let Some(icon) = self.icon {
-            // let icon = match Icon::from_path(&icon) {
-            //     Ok(x) => Some(x),
-            //     Err(e) => {
-            //         error!(
-            //             "Failed to load window icon from `{}`: {}",
-            //             icon.display(),
-            //             e
-            //         );
-
-            //         None
-            //     }
-            // };
-
-            // builder = builder.with_window_icon(icon);
+        } else if let Some(_icon) = self.icon {
+            // @todo: Icon::from_path got removed in winit v0.19.0 implement icon loading here
         }
 
         builder

--- a/amethyst_window/src/display_config.rs
+++ b/amethyst_window/src/display_config.rs
@@ -1,9 +1,10 @@
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
-use winit::window::{Icon, WindowAttributes, WindowBuilder};
-
-use crate::{MonitorIdent, MonitorsAccess};
+use winit::{
+    dpi::{LogicalSize, Size},
+    window::{Icon, WindowAttributes, WindowBuilder},
+};
 
 /// Configuration for a window display.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -123,9 +124,15 @@ impl DisplayConfig {
     /// The `MonitorsAccess` is needed to configure a fullscreen window.
     pub fn into_window_builder(self) -> WindowBuilder {
         let attrs = WindowAttributes {
-            inner_size: self.dimensions.map(Into::into),
-            max_inner_size: self.max_dimensions.map(Into::into),
-            min_inner_size: self.min_dimensions.map(Into::into),
+            inner_size: self
+                .dimensions
+                .map(|dimensions| Size::Logical(LogicalSize::from(dimensions))),
+            max_inner_size: self
+                .max_dimensions
+                .map(|dimensions| Size::Logical(LogicalSize::from(dimensions))),
+            min_inner_size: self
+                .min_dimensions
+                .map(|dimensions| Size::Logical(LogicalSize::from(dimensions))),
             resizable: self.resizable,
             fullscreen: None,
             title: self.title,

--- a/amethyst_window/src/lib.rs
+++ b/amethyst_window/src/lib.rs
@@ -25,4 +25,7 @@ pub use crate::{
     resources::ScreenDimensions,
     system::WindowSystem,
 };
-pub use winit::{event_loop::EventLoop, window::{Icon, Window}};
+pub use winit::{
+    event_loop::EventLoop,
+    window::{Icon, Window},
+};

--- a/amethyst_window/src/lib.rs
+++ b/amethyst_window/src/lib.rs
@@ -11,7 +11,7 @@
 #![allow(clippy::new_without_default)]
 
 mod bundle;
-mod config;
+mod display_config;
 mod monitor;
 mod resources;
 mod system;
@@ -20,9 +20,9 @@ mod system;
 pub use crate::bundle::{SCREEN_HEIGHT, SCREEN_WIDTH};
 pub use crate::{
     bundle::WindowBundle,
-    config::DisplayConfig,
+    display_config::DisplayConfig,
     monitor::{MonitorIdent, MonitorsAccess},
     resources::ScreenDimensions,
-    system::{EventsLoopSystem, WindowSystem},
+    system::WindowSystem,
 };
-pub use winit::window::{Icon, Window};
+pub use winit::{event_loop::EventLoop, window::{Icon, Window}};

--- a/amethyst_window/src/lib.rs
+++ b/amethyst_window/src/lib.rs
@@ -25,4 +25,4 @@ pub use crate::{
     resources::ScreenDimensions,
     system::{EventsLoopSystem, WindowSystem},
 };
-pub use winit::{Icon, Window};
+pub use winit::window::{Icon, Window};

--- a/amethyst_window/src/monitor.rs
+++ b/amethyst_window/src/monitor.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
-use winit::{event::Event, event_loop::EventLoop, monitor::MonitorHandle, window::Window};
+use winit::{event_loop::EventLoop, monitor::MonitorHandle, window::Window};
 
 /// A struct that can resolve monitors.
 /// Usually either a Window or an EventsLoop.
-pub trait MonitorsAccess {    
+pub trait MonitorsAccess {
     /// Returns an iterator over the available monitors
     fn iter(&self) -> Box<Iterator<Item = MonitorHandle>>;
     /// Returns the `MonitorHandle` of the primary display
@@ -45,7 +45,11 @@ impl MonitorIdent {
     }
 
     /// Get the identifier for specific monitor id.
-    pub fn from_monitor_id(monitors: &impl MonitorsAccess, monitor: MonitorHandle) -> Option<Self> {
+    pub fn from_monitor_id(
+        _monitors: &impl MonitorsAccess,
+        _monitor: MonitorHandle,
+    ) -> Option<Self> {
+        // @todo reimplement serializable monitor identification
         // #[cfg(target_os = "ios")]
         // use winit::platform::windows::MonitorIdExt;
         // #[cfg(target_os = "macos")]

--- a/amethyst_window/src/resources.rs
+++ b/amethyst_window/src/resources.rs
@@ -3,9 +3,9 @@ use amethyst_core::math::Vector2;
 /// World resource that stores screen dimensions.
 #[derive(Debug, PartialEq, Clone)]
 pub struct ScreenDimensions {
-    /// Screen width in physical pixels (px).
+    /// Screen width in logical pixels (px).
     pub(crate) w: f64,
-    /// Screen height in physical pixels (px).
+    /// Screen height in logical pixels (px).
     pub(crate) h: f64,
     /// Width divided by height.
     aspect_ratio: f32,

--- a/amethyst_window/src/system.rs
+++ b/amethyst_window/src/system.rs
@@ -1,19 +1,12 @@
-use crate::{DisplayConfig, ScreenDimensions};
-use amethyst_config::{Config, ConfigError};
-use amethyst_core::{
-    ecs::{ReadExpect, RunNow, System, SystemData, World, Write, WriteExpect},
-    shrev::EventChannel,
-};
-use std::path::Path;
-use winit::{event::Event, event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget}, window::Window};
-use winit::platform::desktop::EventLoopExtDesktop;
+use crate::ScreenDimensions;
+use amethyst_core::ecs::{ReadExpect, System, WriteExpect};
+use winit::window::Window;
 
 /// System for opening and managing the window.
 #[derive(Debug)]
 pub struct WindowSystem;
 
 impl WindowSystem {
-
     /// Create a new `WindowSystem` wrapping the provided `Window`
     pub fn new() -> Self {
         Self
@@ -56,4 +49,3 @@ impl<'a> System<'a> for WindowSystem {
         self.manage_dimensions(&mut screen_dimensions, &window);
     }
 }
-

--- a/amethyst_window/src/system.rs
+++ b/amethyst_window/src/system.rs
@@ -1,6 +1,9 @@
 use crate::ScreenDimensions;
 use amethyst_core::ecs::{ReadExpect, System, WriteExpect};
-use winit::window::Window;
+use winit::{
+    dpi::{LogicalSize, Size},
+    window::Window,
+};
 
 /// System for opening and managing the window.
 #[derive(Debug)]
@@ -18,14 +21,14 @@ impl WindowSystem {
 
         // Send resource size changes to the window
         if screen_dimensions.dirty {
-            window.set_inner_size((width, height).into());
+            window.set_inner_size(Size::Logical(LogicalSize::from((width, height))));
             screen_dimensions.dirty = false;
         }
 
-        let hidpi = window.hidpi_factor();
+        let hidpi = window.scale_factor();
 
         let size = window.inner_size();
-        let (window_width, window_height): (f64, f64) = size.to_physical(hidpi).into();
+        let (window_width, window_height): (f64, f64) = size.to_logical::<f64>(hidpi).into();
 
         // Send window size changes to the resource
         if (window_width, window_height) != (width, height) {

--- a/examples/assets/texture/crate_spritesheet.ron
+++ b/examples/assets/texture/crate_spritesheet.ron
@@ -4,7 +4,6 @@
 */
 
 #![enable(implicit_some)]
-
 // Used in the rendy example for sprite Tint
 Grid((
     texture_width: 32,

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -185,10 +185,10 @@ impl SimpleState for Example {
     }
 }
 
-fn main() {
+fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
 
-    let app_root = application_root_dir().expect("Could not create application root");
+    let app_root = application_root_dir()?;
 
     // Add our meshes directory to the asset loader.
     let assets_dir = app_root.join("examples").join("assets");
@@ -198,23 +198,17 @@ fn main() {
         .join("renderable")
         .join("config")
         .join("display.ron");
-    let display_config =
-        DisplayConfig::load(display_config_path).expect("Failed to load DisplayConfig");
+    let display_config = DisplayConfig::load(display_config_path)?;
 
     let event_loop = EventLoop::new();
     let game_data = GameDataBuilder::default()
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
         .with(ExampleSystem::default(), "example_system", &[])
-        .with_bundle(TransformBundle::new().with_dep(&["example_system"]))
-        .expect("Could not create Bundle")
-        .with_bundle(UiBundle::<StringBindings>::new())
-        .expect("Could not create Bundle")
-        .with_bundle(HotReloadBundle::default())
-        .expect("Could not create Bundle")
-        .with_bundle(FpsCounterBundle::default())
-        .expect("Could not create Bundle")
-        .with_bundle(InputBundle::<StringBindings>::new())
-        .expect("Could not create Bundle")
+        .with_bundle(TransformBundle::new().with_dep(&["example_system"]))?
+        .with_bundle(UiBundle::<StringBindings>::new())?
+        .with_bundle(HotReloadBundle::default())?
+        .with_bundle(FpsCounterBundle::default())?
+        .with_bundle(InputBundle::<StringBindings>::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new(display_config, &event_loop)
                 .with_plugin(RenderToWindow::new().with_clear(ClearColor {
@@ -222,10 +216,8 @@ fn main() {
                 }))
                 .with_plugin(RenderShaded3D::default())
                 .with_plugin(RenderUi::default()),
-        )
-        .expect("Could not create Bundle");
-    let mut game = Application::new(assets_dir, Loading::default(), game_data)
-        .expect("Failed to create CoreApplication");
+        )?;
+    let mut game = Application::new(assets_dir, Loading::default(), game_data)?;
     game.initialize();
     event_loop.run(move |event, _, control_flow| {
         #[cfg(feature = "profiler")]

--- a/examples/sprite_animation/main.rs
+++ b/examples/sprite_animation/main.rs
@@ -16,13 +16,13 @@ use amethyst::{
     renderer::{
         camera::Camera,
         plugins::{RenderFlat2D, RenderToWindow},
+        rendy,
         sprite::{prefab::SpriteScenePrefab, SpriteRender},
         types::DefaultBackend,
         RenderingBundle,
-        rendy
     },
     utils::application_root_dir,
-    window::{EventLoop, DisplayConfig, ScreenDimensions},
+    window::{DisplayConfig, EventLoop, ScreenDimensions},
     Application, GameData, GameDataBuilder, SimpleState, SimpleTrans, StateData, Trans,
 };
 use serde::{Deserialize, Serialize};
@@ -137,7 +137,8 @@ fn main() {
     let display_config_path = app_root.join("examples/sprite_animation/config/display.ron");
 
     let event_loop = EventLoop::new();
-    let display_config = DisplayConfig::load(display_config_path).expect("Failed to load DisplayConfig");
+    let display_config =
+        DisplayConfig::load(display_config_path).expect("Failed to load DisplayConfig");
     let game_data = GameDataBuilder::default()
         .with_system_desc(
             PrefabLoaderSystemDesc::<MyPrefabData>::default(),
@@ -147,21 +148,26 @@ fn main() {
         .with_bundle(AnimationBundle::<AnimationId, SpriteRender>::new(
             "sprite_animation_control",
             "sprite_sampler_interpolation",
-        )).expect("Could not create bundle")
+        ))
+        .expect("Could not create bundle")
         .with_bundle(
             TransformBundle::new()
                 .with_dep(&["sprite_animation_control", "sprite_sampler_interpolation"]),
-        ).expect("Could not create bundle")
+        )
+        .expect("Could not create bundle")
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new(display_config, &event_loop)
                 .with_plugin(
-                    RenderToWindow::new()
-                        .with_clear(rendy::hal::command::ClearColor{float32: [0.34, 0.36, 0.52, 1.0]}),
+                    RenderToWindow::new().with_clear(rendy::hal::command::ClearColor {
+                        float32: [0.34, 0.36, 0.52, 1.0],
+                    }),
                 )
                 .with_plugin(RenderFlat2D::default()),
-        ).expect("Could not create bundle");
+        )
+        .expect("Could not create bundle");
 
-    let mut game = Application::new(assets_dir, Example::default(), game_data).expect("Could not create CoreApplication");
+    let mut game = Application::new(assets_dir, Example::default(), game_data)
+        .expect("Could not create CoreApplication");
     game.initialize();
     event_loop.run(move |event, _, control_flow| {
         log::trace!("main loop run");

--- a/examples/sprite_animation/main.rs
+++ b/examples/sprite_animation/main.rs
@@ -129,16 +129,15 @@ fn initialise_camera(world: &mut World) {
         .build();
 }
 
-fn main() {
+fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
 
-    let app_root = application_root_dir().expect("Could not create application root");
+    let app_root = application_root_dir()?;
     let assets_dir = app_root.join("examples/assets/");
     let display_config_path = app_root.join("examples/sprite_animation/config/display.ron");
 
     let event_loop = EventLoop::new();
-    let display_config =
-        DisplayConfig::load(display_config_path).expect("Failed to load DisplayConfig");
+    let display_config = DisplayConfig::load(display_config_path)?;
     let game_data = GameDataBuilder::default()
         .with_system_desc(
             PrefabLoaderSystemDesc::<MyPrefabData>::default(),
@@ -148,13 +147,11 @@ fn main() {
         .with_bundle(AnimationBundle::<AnimationId, SpriteRender>::new(
             "sprite_animation_control",
             "sprite_sampler_interpolation",
-        ))
-        .expect("Could not create bundle")
+        ))?
         .with_bundle(
             TransformBundle::new()
                 .with_dep(&["sprite_animation_control", "sprite_sampler_interpolation"]),
-        )
-        .expect("Could not create bundle")
+        )?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new(display_config, &event_loop)
                 .with_plugin(
@@ -163,11 +160,9 @@ fn main() {
                     }),
                 )
                 .with_plugin(RenderFlat2D::default()),
-        )
-        .expect("Could not create bundle");
+        )?;
 
-    let mut game = Application::new(assets_dir, Example::default(), game_data)
-        .expect("Could not create CoreApplication");
+    let mut game = Application::new(assets_dir, Example::default(), game_data)?;
     game.initialize();
     event_loop.run(move |event, _, control_flow| {
         log::trace!("main loop run");

--- a/examples/sprite_camera_follow/main.rs
+++ b/examples/sprite_camera_follow/main.rs
@@ -6,17 +6,19 @@ use amethyst::{
         Component, Entity, Join, NullStorage, Read, ReadStorage, System, SystemData, WorldExt,
         WriteStorage,
     },
-    input::{is_close_requested, is_key_down, InputBundle, InputHandler, StringBindings},
+    input::{
+        is_close_requested, is_key_down, InputBundle, InputHandler, StringBindings, VirtualKeyCode,
+    },
     prelude::*,
     renderer::{
         plugins::{RenderFlat2D, RenderToWindow},
+        rendy::hal::command::ClearColor,
         types::DefaultBackend,
         Camera, ImageFormat, RenderingBundle, SpriteRender, SpriteSheet, SpriteSheetFormat,
         Texture, Transparent,
     },
     utils::application_root_dir,
-    window::ScreenDimensions,
-    winit,
+    window::{DisplayConfig, EventLoop, ScreenDimensions},
 };
 
 #[derive(Default)]
@@ -179,9 +181,9 @@ impl SimpleState for Example {
     ) -> SimpleTrans {
         let StateData { world, .. } = data;
         if let StateEvent::Window(event) = &event {
-            if is_close_requested(&event) || is_key_down(&event, winit::VirtualKeyCode::Escape) {
+            if is_close_requested(&event) || is_key_down(&event, VirtualKeyCode::Escape) {
                 Trans::Quit
-            } else if is_key_down(&event, winit::VirtualKeyCode::Space) {
+            } else if is_key_down(&event, VirtualKeyCode::Space) {
                 world.exec(
                     |(named, transforms): (ReadStorage<Named>, ReadStorage<Transform>)| {
                         for (name, transform) in (&named, &transforms).join() {
@@ -199,33 +201,45 @@ impl SimpleState for Example {
     }
 }
 
-fn main() -> amethyst::Result<()> {
+fn main() {
     amethyst::Logger::from_config(Default::default())
         .level_for("amethyst_assets", log::LevelFilter::Debug)
         .start();
 
-    let app_root = application_root_dir()?;
+    let app_root = application_root_dir().expect("Could not create application root");
     let assets_directory = app_root.join("examples/assets");
     let display_config_path = app_root.join("examples/sprite_camera_follow/config/display.ron");
+    let display_config =
+        DisplayConfig::load(display_config_path).expect("Failed to load DisplayConfig");
 
+    let event_loop = EventLoop::new();
     let game_data = GameDataBuilder::default()
-        .with_bundle(TransformBundle::new())?
+        .with_bundle(TransformBundle::new())
+        .expect("Could not create Bundle")
         .with_bundle(
-            InputBundle::<StringBindings>::new().with_bindings_from_file(
-                app_root.join("examples/sprite_camera_follow/config/input.ron"),
-            )?,
-        )?
+            InputBundle::<StringBindings>::new()
+                .with_bindings_from_file(
+                    app_root.join("examples/sprite_camera_follow/config/input.ron"),
+                )
+                .expect("Could not create Bundle"),
+        )
+        .expect("Could not create Bundle")
         .with(MovementSystem, "movement", &[])
         .with_bundle(
-            RenderingBundle::<DefaultBackend>::new()
-                .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.34, 0.36, 0.52, 1.0]),
-                )
+            RenderingBundle::<DefaultBackend>::new(display_config, &event_loop)
+                .with_plugin(RenderToWindow::new().with_clear(ClearColor {
+                    float32: [0.34, 0.36, 0.52, 1.0],
+                }))
                 .with_plugin(RenderFlat2D::default()),
-        )?;
+        )
+        .expect("Could not create Bundle");
 
-    let mut game = Application::build(assets_directory, Example)?.build(game_data)?;
-    game.run();
-    Ok(())
+    let mut game = Application::new(assets_directory, Example, game_data)
+        .expect("Failed to create CoreApplication");
+    game.initialize();
+    event_loop.run(move |event, _, control_flow| {
+        #[cfg(feature = "profiler")]
+        profile_scope!("run_event_loop");
+        game.run_winit_loop(event, control_flow)
+    })
 }

--- a/examples/sprite_camera_follow/main.rs
+++ b/examples/sprite_camera_follow/main.rs
@@ -201,29 +201,24 @@ impl SimpleState for Example {
     }
 }
 
-fn main() {
+fn main() -> amethyst::Result<()> {
     amethyst::Logger::from_config(Default::default())
         .level_for("amethyst_assets", log::LevelFilter::Debug)
         .start();
 
-    let app_root = application_root_dir().expect("Could not create application root");
+    let app_root = application_root_dir()?;
     let assets_directory = app_root.join("examples/assets");
     let display_config_path = app_root.join("examples/sprite_camera_follow/config/display.ron");
-    let display_config =
-        DisplayConfig::load(display_config_path).expect("Failed to load DisplayConfig");
+    let display_config = DisplayConfig::load(display_config_path)?;
 
     let event_loop = EventLoop::new();
     let game_data = GameDataBuilder::default()
-        .with_bundle(TransformBundle::new())
-        .expect("Could not create Bundle")
+        .with_bundle(TransformBundle::new())?
         .with_bundle(
-            InputBundle::<StringBindings>::new()
-                .with_bindings_from_file(
-                    app_root.join("examples/sprite_camera_follow/config/input.ron"),
-                )
-                .expect("Could not create Bundle"),
-        )
-        .expect("Could not create Bundle")
+            InputBundle::<StringBindings>::new().with_bindings_from_file(
+                app_root.join("examples/sprite_camera_follow/config/input.ron"),
+            )?,
+        )?
         .with(MovementSystem, "movement", &[])
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new(display_config, &event_loop)
@@ -231,11 +226,9 @@ fn main() {
                     float32: [0.34, 0.36, 0.52, 1.0],
                 }))
                 .with_plugin(RenderFlat2D::default()),
-        )
-        .expect("Could not create Bundle");
+        )?;
 
-    let mut game = Application::new(assets_directory, Example, game_data)
-        .expect("Failed to create CoreApplication");
+    let mut game = Application::new(assets_directory, Example, game_data)?;
     game.initialize();
     event_loop.run(move |event, _, control_flow| {
         #[cfg(feature = "profiler")]

--- a/examples/sprites_ordered/main.rs
+++ b/examples/sprites_ordered/main.rs
@@ -358,32 +358,28 @@ fn load_sprite_sheet(world: &mut World) -> LoadedSpriteSheet {
     }
 }
 
-fn main() {
+fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
 
-    let app_root = application_root_dir().expect("Could not create application root");
+    let app_root = application_root_dir()?;
 
     let display_config_path = app_root.join("examples/sprites_ordered/config/display.ron");
-    let display_config =
-        DisplayConfig::load(display_config_path).expect("Failed to load DisplayConfig");
+    let display_config = DisplayConfig::load(display_config_path)?;
 
     let assets_dir = app_root.join("examples/assets/");
 
     let event_loop = EventLoop::new();
     let game_data = GameDataBuilder::default()
-        .with_bundle(TransformBundle::new())
-        .expect("Could not create Bundle")
+        .with_bundle(TransformBundle::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new(display_config, &event_loop)
                 .with_plugin(RenderToWindow::new().with_clear(ClearColor {
                     float32: [0.34, 0.36, 0.52, 1.0],
                 }))
                 .with_plugin(RenderFlat2D::default()),
-        )
-        .expect("Could not create Bundle");
+        )?;
 
-    let mut game = Application::new(assets_dir, Example::new(), game_data)
-        .expect("Failed to create CoreApplication");
+    let mut game = Application::new(assets_dir, Example::new(), game_data)?;
     game.initialize();
     event_loop.run(move |event, _, control_flow| {
         #[cfg(feature = "profiler")]

--- a/examples/tiles/main.rs
+++ b/examples/tiles/main.rs
@@ -414,21 +414,18 @@ fn main() -> amethyst::Result<()> {
         .level_for("amethyst_tiles", log::LevelFilter::Warn)
         .start();
 
-    let app_root = application_root_dir().expect("Could not create application root");
+    let app_root = application_root_dir()?;
     let assets_directory = app_root.join("examples/assets");
     let display_config_path = app_root.join("examples/tiles/resources/display_config.ron");
-    let display_config =
-        DisplayConfig::load(display_config_path).expect("Failed to load DisplayConfig");
+    let display_config = DisplayConfig::load(display_config_path)?;
 
     let event_loop = EventLoop::new();
     let game_data = GameDataBuilder::default()
-        .with_bundle(TransformBundle::new())
-        .expect("Could not create Bundle")
+        .with_bundle(TransformBundle::new())?
         .with_bundle(
             InputBundle::<StringBindings>::new()
                 .with_bindings_from_file("examples/tiles/resources/input.ron")?,
-        )
-        .expect("Could not create Bundle")
+        )?
         .with(
             MapMovementSystem::default(),
             "MapMovementSystem",
@@ -457,11 +454,9 @@ fn main() -> amethyst::Result<()> {
                 .with_plugin(RenderDebugLines::default())
                 .with_plugin(RenderFlat2D::default())
                 .with_plugin(RenderTiles2D::<ExampleTile, MortonEncoder>::default()),
-        )
-        .expect("Could not create Bundle");
+        )?;
 
-    let mut game = Application::new(assets_directory, Example, game_data)
-        .expect("Failed to create CoreApplication");
+    let mut game = Application::new(assets_directory, Example, game_data)?;
     game.initialize();
     event_loop.run(move |event, _, control_flow| {
         #[cfg(feature = "profiler")]

--- a/src/app.rs
+++ b/src/app.rs
@@ -269,7 +269,7 @@ where
     ///
     /// ~~~no_run
     /// let event_loop = EventLoop::new();
-    /// let mut game = Application::new(assets_dir, Example::new(), game_data).expect("Failed to create CoreApplication");
+    /// let mut game = Application::new(assets_dir, Example::new(), game_data)?;
     /// game.initialize();
     /// event_loop.run(move |event, _, control_flow| {
     ///     #[cfg(feature = "profiler")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ pub use crate::core::{ecs, shred, shrev};
 pub use crate::derive::*;
 
 pub use self::{
-    app::{Application, ApplicationBuilder, CoreApplication, CoreApplicationWinitExt},
+    app::{Application, ApplicationBuilder, CoreApplication},
     callback_queue::{Callback, CallbackQueue},
     error::Error,
     game_data::{DataDispose, DataInit, GameData, GameDataBuilder},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ pub use crate::core::{ecs, shred, shrev};
 pub use crate::derive::*;
 
 pub use self::{
-    app::{Application, ApplicationBuilder, CoreApplication},
+    app::{Application, ApplicationBuilder, CoreApplication, CoreApplicationWinitExt},
     callback_queue::{Callback, CallbackQueue},
     error::Error,
     game_data::{DataDispose, DataInit, GameData, GameDataBuilder},

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,7 @@
 //! Contains common types that can be glob-imported (`*`) for convenience.
 
 pub use crate::{
-    app::{Application, ApplicationBuilder, CoreApplication, CoreApplicationWinitExt},
+    app::{Application, ApplicationBuilder, CoreApplication},
     callback_queue::{Callback, CallbackQueue},
     config::Config,
     core::{SystemDesc, SystemExt, WithNamed},

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,7 @@
 //! Contains common types that can be glob-imported (`*`) for convenience.
 
 pub use crate::{
-    app::{Application, ApplicationBuilder, CoreApplication},
+    app::{Application, ApplicationBuilder, CoreApplication, CoreApplicationWinitExt},
     callback_queue::{Callback, CallbackQueue},
     config::Config,
     core::{SystemDesc, SystemExt, WithNamed},

--- a/src/state_event.rs
+++ b/src/state_event.rs
@@ -1,5 +1,5 @@
 use derivative::Derivative;
-use winit::Event;
+use winit::event::Event;
 
 use crate::{
     core::{
@@ -22,7 +22,7 @@ where
     T: BindingTypes,
 {
     /// Events sent by the winit window.
-    Window(Event),
+    Window(Event<()>),
     /// Events sent by the ui system.
     Ui(UiEvent),
     /// Events sent by the input system.

--- a/src/state_event.rs
+++ b/src/state_event.rs
@@ -22,7 +22,7 @@ where
     T: BindingTypes,
 {
     /// Events sent by the winit window.
-    Window(Event<()>),
+    Window(Event<'static, ()>),
     /// Events sent by the ui system.
     Ui(UiEvent),
     /// Events sent by the input system.


### PR DESCRIPTION
## Description

Update to rendy v0.5.x and winit v0.20.0-alpha5
Feel free to contribute.

Currently an in place upgrade without any new features added. Might allow for OpenGL

## Status
Vulkan complains about the device being dropped before an object. Needs investigation.
Rest is working.
Not responding window might be an issue with our dispatcher blocking the main thread. Needs separate issue.

### Blockers

- [ ] https://github.com/rust-windowing/winit/issues/1255 (needs release)
- [ ] https://github.com/amethyst/rendy/pull/245 (revert https://github.com/amethyst/amethyst/commit/85ee2e80f6c30e05b205d925b0088201ea2401f7 when 0.5.2 released)
_Status: Waiting for 0.5.2_
- [ ] https://github.com/rust-windowing/winit/pull/1374 (needs merge and release)
    `WindowEvent` in `winit 0.20.0` is `!Clone`, which means we cannot read it from an event channel, then send it through `StateEvent` (which is what `StateEventReader` (generated by the `EventReader` derive) does).

### Todo:
- [x] Decide on Event<()> vs. Event<!>
Decided by rust-lang/rust#35121
- [ ] Rework MonitorIdent in amethyst_window
Monitor changed in winit. I added a `@todo`
- [ ] Better error propagation
Should we return underlying OOM Errors from submodules as `CreationError::OutOfMemory` or `CreationError::Other`
- [ ] Update all examples
- [ ] Fix tests

## Changes
See Changelog of rendy and winit

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [ ] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
