### PR TITLE
[FEATURE]1652 Adding configurable verbosity for gfx-backend and rendy, removing log_gfx_device_level

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - Log warning when `amethyst_test::WaitForLoad` has not completed in 10 seconds. ([#1984])
 - Derive `Copy` and `PartialEq` for `amethyst::renderer::resources::Tint`. ([#2033])
 - Derive `Hash` for `amethyst::input::{Button, ControllerButton, ScrollDirection}`. ([#2041])
+- Add rendy/gfx-backend log verbosity through configuration. ([#1652])
 
 ### Changed
 
@@ -70,6 +71,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#2029]: https://github.com/amethyst/amethyst/pull/2029
 [#2033]: https://github.com/amethyst/amethyst/pull/2033
 [#2041]: https://github.com/amethyst/amethyst/pull/2041
+[#1652]: https://github.com/amethyst/amethyst/issues/1652
 
 
 ## [0.13.3] - 2019-10-4

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -118,7 +118,7 @@ impl Logger {
 
         logger.dispatch = logger
             .dispatch
-            .level_for("gfx_backend_empty", log_gfx_backend_le  vel)
+            .level_for("gfx_backend_empty", log_gfx_backend_level)
             .level_for("gfx_backend_vulkan", log_gfx_backend_level)
             .level_for("gfx_backend_dx12", log_gfx_backend_level)
             .level_for("gfx_backend_metal", log_gfx_backend_level)

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -113,21 +113,41 @@ impl Logger {
             StdoutLog::Off => {}
         }
 
-        let log_gfx_backend_level = config.log_gfx_backend_level.unwrap();
-        let log_gfx_rendy_level = config.log_gfx_rendy_level.unwrap();
+        if let Some(log_gfx_backend_level) = config.log_gfx_backend_level {
+            logger.dispatch = logger
+                .dispatch
+                .level_for("gfx_backend_empty", log_gfx_backend_level)
+                .level_for("gfx_backend_vulkan", log_gfx_backend_level)
+                .level_for("gfx_backend_dx12", log_gfx_backend_level)
+                .level_for("gfx_backend_metal", log_gfx_backend_level)
+        } else {
+            logger.dispatch = logger
+                .dispatch
+                .level_for("gfx_backend_empty", LevelFilter::Warn)
+                .level_for("gfx_backend_vulkan", LevelFilter::Warn)
+                .level_for("gfx_backend_dx12", LevelFilter::Warn)
+                .level_for("gfx_backend_metal", LevelFilter::Warn)
+        }
 
-        logger.dispatch = logger
-            .dispatch
-            .level_for("gfx_backend_empty", log_gfx_backend_level)
-            .level_for("gfx_backend_vulkan", log_gfx_backend_level)
-            .level_for("gfx_backend_dx12", log_gfx_backend_level)
-            .level_for("gfx_backend_metal", log_gfx_backend_level)
-            .level_for("rendy_factory::factory", log_gfx_rendy_level)
-            .level_for("rendy_memory::allocator::dynamic", log_gfx_rendy_level)
-            .level_for("rendy_graph::node::render::pass", log_gfx_rendy_level)
-            .level_for("rendy_graph::graph", log_gfx_rendy_level)
-            .level_for("rendy_memory::allocator::linear", log_gfx_rendy_level)
-            .level_for("rendy_wsi", log_gfx_rendy_level);
+        if let Some(log_gfx_rendy_level) = config.log_gfx_rendy_level {
+            logger.dispatch = logger
+                .dispatch
+                .level_for("rendy_factory::factory", log_gfx_rendy_level)
+                .level_for("rendy_memory::allocator::dynamic", log_gfx_rendy_level)
+                .level_for("rendy_graph::node::render::pass", log_gfx_rendy_level)
+                .level_for("rendy_graph::graph", log_gfx_rendy_level)
+                .level_for("rendy_memory::allocator::linear", log_gfx_rendy_level)
+                .level_for("rendy_wsi", log_gfx_rendy_level);
+        } else {
+            logger.dispatch = logger
+                .dispatch
+                .level_for("rendy_factory::factory", LevelFilter::Warn)
+                .level_for("rendy_memory::allocator::dynamic", LevelFilter::Warn)
+                .level_for("rendy_graph::node::render::pass", LevelFilter::Warn)
+                .level_for("rendy_graph::graph", LevelFilter::Warn)
+                .level_for("rendy_memory::allocator::linear", LevelFilter::Warn)
+                .level_for("rendy_wsi", LevelFilter::Warn);
+        }
 
         if let Some(path) = config.log_file {
             if let Ok(log_file) = fern::log_file(path) {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -27,8 +27,10 @@ pub struct LoggerConfig {
     pub log_file: Option<PathBuf>,
     /// If set, allows the config values to be overriden via the corresponding environmental variables.
     pub allow_env_override: bool,
-    /// Sets a different level for gfx_device_gl if Some
-    pub log_gfx_device_level: Option<LevelFilter>,
+    /// Sets a different level for gfx_backend if Some
+    pub log_gfx_backend_level: Option<LevelFilter>,
+    /// Sets a different level for gfx_rendy if Some
+    pub log_gfx_rendy_level: Option<LevelFilter>,
 }
 
 impl Default for LoggerConfig {
@@ -38,7 +40,8 @@ impl Default for LoggerConfig {
             level_filter: LevelFilter::Info,
             log_file: None,
             allow_env_override: true,
-            log_gfx_device_level: Some(LevelFilter::Warn),
+            log_gfx_backend_level: Some(LevelFilter::Warn),
+            log_gfx_rendy_level: Some(LevelFilter::Warn),
         }
     }
 }
@@ -110,11 +113,21 @@ impl Logger {
             StdoutLog::Off => {}
         }
 
-        if let Some(log_gfx_device_level) = config.log_gfx_device_level {
-            logger.dispatch = logger
-                .dispatch
-                .level_for("gfx_device_gl", log_gfx_device_level);
-        }
+        let log_gfx_backend_level = config.log_gfx_backend_level.unwrap();
+        let log_gfx_rendy_level = config.log_gfx_rendy_level.unwrap();
+
+        logger.dispatch = logger
+            .dispatch
+            .level_for("gfx_backend_empty", log_gfx_backend_le  vel)
+            .level_for("gfx_backend_vulkan", log_gfx_backend_level)
+            .level_for("gfx_backend_dx12", log_gfx_backend_level)
+            .level_for("gfx_backend_metal", log_gfx_backend_level)
+            .level_for("rendy_factory::factory", log_gfx_rendy_level)
+            .level_for("rendy_memory::allocator::dynamic", log_gfx_rendy_level)
+            .level_for("rendy_graph::node::render::pass", log_gfx_rendy_level)
+            .level_for("rendy_graph::graph", log_gfx_rendy_level)
+            .level_for("rendy_memory::allocator::linear", log_gfx_rendy_level)
+            .level_for("rendy_wsi", log_gfx_rendy_level);
 
         if let Some(path) = config.log_file {
             if let Ok(log_file) = fern::log_file(path) {


### PR DESCRIPTION
## Description

This pr removes the, as I understand, now obsolete `log_gfx_device_level` from logger.rs, and instead provides two new optional config entries: `log_gfx_backend_level` and `log_gfx_rendy_level` which default to Warn.

## Additions

- Added optional `log_gfx_backend_level` and `log_gfx_rendy_level` to configuration

## Removals

- Removed obsolete `log_gfx_device_level` from configuration

## PR Checklist

By placing an x in the boxes I certify that I have:

- [X] Updated the content of the book if this PR would make the book outdated.
- [X] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [X] Added unit tests for new code added in this PR.
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [X] Ran `cargo +stable fmt --all`
- [X] Ran `cargo clippy --all --features "empty"`
- [X] Ran `cargo test --all --features "empty"`
