### PR TITLE
Docs: Fixing broken links to specs book in pong tutorial

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -678,8 +678,8 @@ If all is well, we should get something that looks like this:
 In the next chapter, we'll explore the "S" in ECS and actually get these paddles
 moving!
 
-[sb]: https://specs.amethyst.rs/docs/tutorials/
-[sb-storage]: https://slide-rs.github.io/specs/05_storages.html#densevecstorage
+[sb]: https://slide-rs.github.io/specs-website/docs/
+[sb-storage]: https://slide-rs.github.io/specs-website/docs/book/master/05_storages.html#densevecstorage
 [2d]: https://docs.amethyst.rs/stable/amethyst_renderer/struct.Camera.html#method.standard_2d
 [ss]: ../images/pong_tutorial/pong_spritesheet.png
 


### PR DESCRIPTION
## Description

I was working through the tutorial and found a broken link. This fixes it :-)

## Additions

- None

## Removals

- None

## Modifications

- Docs only

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.