### PR TITLE
[BUGFIX] Fix encoders dimensional cases and optimize storage space

### DIFF
--- a/amethyst_tiles/src/lib.rs
+++ b/amethyst_tiles/src/lib.rs
@@ -34,9 +34,8 @@ pub trait CoordinateEncoder: 'static + Clone + Default + Send + Sync {
     /// Decode the provided 1-dimensional array index into its associated 3-dimensional coordinates.
     fn decode(&self, morton: u32) -> Option<(u32, u32, u32)>;
 
-    /// This function transforms the provided dimensions, performing any extra allocation needed for
-    /// padding our indexing method.
-    fn allocation_size(dimensions: Vector3<u32>) -> Vector3<u32>;
+    /// This function returns the actual number of elements allocated for a given dimension set and encoder.
+    fn allocation_size(dimensions: Vector3<u32>) -> usize;
 }
 
 /// The most basic encoder, which strictly flattens the 3d space into 1d coordinates in a linear fashion.
@@ -77,7 +76,7 @@ impl CoordinateEncoder for FlatEncoder {
     }
 
     #[must_use]
-    fn allocation_size(dimensions: Vector3<u32>) -> Vector3<u32> {
-        dimensions
+    fn allocation_size(dimensions: Vector3<u32>) -> usize {
+        (dimensions.x * dimensions.y * dimensions.z) as usize
     }
 }

--- a/amethyst_tiles/src/map.rs
+++ b/amethyst_tiles/src/map.rs
@@ -145,12 +145,11 @@ impl<T: Tile, E: CoordinateEncoder> TileMap<T, E> {
         let transform = create_transform(&dimensions, &tile_dimensions);
 
         // Round the dimensions to the nearest multiplier for morton rounding
-        let encoder_dimensions = E::allocation_size(dimensions);
-        let size = (encoder_dimensions.x * encoder_dimensions.y * encoder_dimensions.z) as usize;
+        let size = E::allocation_size(dimensions);
         let mut data = Vec::with_capacity(size);
         data.resize_with(size, T::default);
 
-        let encoder = E::from_dimensions(encoder_dimensions);
+        let encoder = E::from_dimensions(dimensions);
 
         Self {
             data,
@@ -409,8 +408,8 @@ mod tests {
         let mut inner = TileMap::<TestTile, E>::new(dimensions, Vector3::new(10, 10, 1), None);
         let map = UnsafeWrapper::new(&mut inner);
 
-        (0..dimensions.x).into_par_iter().for_each(|x| {
-            (0..dimensions.y).into_par_iter().for_each(|y| {
+        (0..dimensions.x).into_iter().for_each(|x| {
+            (0..dimensions.y).into_iter().for_each(|y| {
                 for z in 0..dimensions.z {
                     let point = Point3::new(x, y, z);
 
@@ -419,8 +418,8 @@ mod tests {
             });
         });
 
-        (0..dimensions.x).into_par_iter().for_each(|x| {
-            (0..dimensions.y).into_par_iter().for_each(|y| {
+        (0..dimensions.x).into_iter().for_each(|x| {
+            (0..dimensions.y).into_iter().for_each(|y| {
                 for z in 0..dimensions.z {
                     let point = Point3::new(x, y, z);
                     assert_eq!(map.get().get(&Point3::new(x, y, z)).unwrap().point, point);
@@ -444,7 +443,7 @@ mod tests {
             Vector3::new(1, 2, 5),
         ];
 
-        test_dimensions.par_iter().for_each(|dimensions| {
+        test_dimensions.into_par_iter().for_each(|dimensions| {
             test_single_map::<MortonEncoder>(*dimensions);
             test_single_map::<MortonEncoder2D>(*dimensions);
             test_single_map::<FlatEncoder>(*dimensions);


### PR DESCRIPTION
## Description

This fixes some edge cases with encoders.
- `MortonEncoder2D` was not correctly interopolating its dimensions size
    with its allocation size, causing tile overwrites
- `MortonEncoder2D` now bounds its size to actual min/max encoded
    dimensions, instead of power of 2.
    - Added test_encoders test sweeps to cover all encoder cases
- adds a upper-bound optimization to the classic
    `MortonEncoder`, limiting xyz size to the highest possible indexed value
    for the given dimensions

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
