### PR TITLE
Update readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,24 +64,24 @@ Please visit the [features page][feat] for a list of features Amethyst provides.
 
 ## Navigation
 
-* [**Link to the book (0.11)**][bks11]
-* [**Link to the book (0.10)**][bks10]
+* [**Link to the book (0.13)**][bkstable]
+* [**Link to the book (0.12)**][bks12]
 * [**Link to the book (master)**][bkm]
-* [**Link to the examples (0.11)**][exr11]
-* [**Link to the examples (0.10)**][exr10]
+* [**Link to the examples (0.13)**][exr13]
+* [**Link to the examples (0.12)**][exr12]
 * [**Link to the examples (master)**][exm]
 
 ## Usage
 
-While the engine can be hard to use at times, we made a lot of [documentation][bks11] that will teach you everything you need to use Amethyst comfortably.
+While the engine can be hard to use at times, we made a lot of [documentation][bkstable] that will teach you everything you need to use Amethyst comfortably.
 
 If you don't understand a part of the documentation, please let us know. Join us on Discord or open an issue; we are always happy to help!
 
-[bks11]: https://book.amethyst.rs/stable/
-[bks10]: https://book.amethyst.rs/v0.10.0/
+[bkstable]: https://book.amethyst.rs/stable/
+[bks12]: https://book.amethyst.rs/v0.12.0/
 [bkm]: https://book.amethyst.rs/master/
-[exr11]: https://github.com/amethyst/amethyst/tree/v0.11.0/examples
-[exr10]: https://github.com/amethyst/amethyst/tree/v0.10.0/examples
+[exr13]: https://github.com/amethyst/amethyst/tree/v0.13.2/examples
+[exr12]: https://github.com/amethyst/amethyst/tree/v0.12.0/examples
 [exm]: https://github.com/amethyst/amethyst/tree/master/examples
 
 ## Getting started


### PR DESCRIPTION
## Description

Updated some links in README.md that pointed to really old versions of Amethyst.
~~Also removed the "Lines of Code" badge, since the server that hosts it seems to be down currently.~~ Seems to be up again, so I removed this commit and force-pushed.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
