### PR TITLE
Changed Panic to return an error type

### DIFF
--- a/amethyst_tiles/Cargo.toml
+++ b/amethyst_tiles/Cargo.toml
@@ -33,6 +33,7 @@ lazy_static = "1.3"
 rayon = "1.0.2"
 bitintr = "0.3"
 glsl-layout = "0.3"
+err-derive = "0.1"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/amethyst_tiles/src/error.rs
+++ b/amethyst_tiles/src/error.rs
@@ -1,0 +1,19 @@
+//! Renderer error types.
+
+use amethyst_core::math::{Point3, Vector3};
+
+use err_derive::Error;
+
+/// Tile is out of bounds.
+#[derive(Debug, Error)]
+#[error(
+    display = "Requested coordinate is outside map dimensions: '{:?}', max dimensions=:{:?}",
+    point_dimensions,
+    max_dimensions
+)]
+pub struct TileOutOfBoundsError {
+    /// Calculated Point Dimension.
+    pub point_dimensions: Point3<i32>,
+    /// Map dimensions.
+    pub max_dimensions: Vector3<u32>,
+}

--- a/amethyst_tiles/src/error.rs
+++ b/amethyst_tiles/src/error.rs
@@ -7,7 +7,7 @@ use err_derive::Error;
 /// Tile is out of bounds.
 #[derive(Debug, Error)]
 #[error(
-    display = "Requested coordinate is outside map dimensions: '{:?}', max dimensions=:{:?}",
+    display = "Requested coordinate is outside map dimensions: '{:?}', max dimensions: '{:?}'",
     point_dimensions,
     max_dimensions
 )]

--- a/amethyst_tiles/src/lib.rs
+++ b/amethyst_tiles/src/lib.rs
@@ -8,10 +8,12 @@ mod map;
 mod morton;
 mod pass;
 
+pub mod error;
 pub mod iters;
 pub mod pod;
 pub mod prefab;
 
+pub use error::TileOutOfBoundsError;
 pub use iters::{MortonRegion, Region};
 pub use map::{Map, MapStorage, Tile, TileMap};
 pub use morton::{MortonEncoder, MortonEncoder2D};

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - Adds `get` methods to the underlying net::transport resources ([#2005])
 - Changed `SpriteSheetFormat::import_simple` to allow importing grid based `SpriteSheets` ([#2023])
   Migration Note: Rons need to wrap their content in either Grid() or List()
+- TileMap to_tile doesn't panic in debug mode. It instead return Result<Point<u32>,TileOutOfBounds>. ([#2020],[#2070])
 
 ### Deprecated
 
@@ -66,10 +67,12 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#2005]: https://github.com/amethyst/amethyst/pull/2005
 [#2004]: https://github.com/amethyst/amethyst/pull/2004
 [#2017]: https://github.com/amethyst/amethyst/pull/2017
+[#2020]: https://github.com/amethyst/amethyst/issue/2020
 [#2023]: https://github.com/amethyst/amethyst/pull/2023
 [#2029]: https://github.com/amethyst/amethyst/pull/2029
 [#2033]: https://github.com/amethyst/amethyst/pull/2033
 [#2041]: https://github.com/amethyst/amethyst/pull/2041
+[#2070]: https://github.com/amethyst/amethyst/pull/2070
 
 
 ## [0.13.3] - 2019-10-4


### PR DESCRIPTION
## Description

Resolves #2020 

by returning an error type rather than panic!() .

## Addition

- The error type TileOutOfBoundsError.


## Modification

- to_tile now returns Result<Point<u32>,TileOutOfBoundsError> 
## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x ] Ran `cargo test --all --features "empty"`
