### PR TITLE
Trans Updates - Replace,New Stack, and Sequence

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - Log warning when `amethyst_test::WaitForLoad` has not completed in 10 seconds. ([#1984])
 - Derive `Copy` and `PartialEq` for `amethyst::renderer::resources::Tint`. ([#2033])
 - Derive `Hash` for `amethyst::input::{Button, ControllerButton, ScrollDirection}`. ([#2041])
+- Added Trans::Replace, Trans::NewStack, and Trans::Sequence to the State Machine Transitions. ([#2067])
 
 ### Changed
 
@@ -70,6 +71,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#2029]: https://github.com/amethyst/amethyst/pull/2029
 [#2033]: https://github.com/amethyst/amethyst/pull/2033
 [#2041]: https://github.com/amethyst/amethyst/pull/2041
+[#2067]: https://github.com/amethyst/amethyst/issue/2067
 
 
 ## [0.13.3] - 2019-10-4

--- a/src/state.rs
+++ b/src/state.rs
@@ -60,16 +60,25 @@ pub enum Trans<T, E> {
     Push(Box<dyn State<T, E>>),
     /// Remove the current state on the stack and insert a different one.
     Switch(Box<dyn State<T, E>>),
+    /// Remove all states on the stack and insert a different one.
+    Replace(Box<dyn State<T, E>>),
+    /// Remove all states on the stack and insert new stack.
+    NewStack(Vec<Box<dyn State<T, E>>>),
+    /// Execute a series of Trans's.
+    Sequence(Vec<Trans<T, E>>),
     /// Stop and remove all states and shut down the engine.
     Quit,
 }
 impl<T, E> Debug for Trans<T, E> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match *self {
+        match self {
             Trans::None => f.write_str("None"),
             Trans::Pop => f.write_str("Pop"),
             Trans::Push(_) => f.write_str("Push"),
             Trans::Switch(_) => f.write_str("Switch"),
+            Trans::Replace(_) => f.write_str("Replace"),
+            Trans::NewStack(_) => f.write_str("NewStack"),
+            Trans::Sequence(sequence) => f.write_str(&format!("Sequence {:?}", sequence)),
             Trans::Quit => f.write_str("Quit"),
         }
     }
@@ -465,6 +474,17 @@ impl<'a, T, E: Send + Sync + 'static> StateMachine<'a, T, E> {
                 Trans::Pop => self.pop(data),
                 Trans::Push(state) => self.push(state, data),
                 Trans::Switch(state) => self.switch(state, data),
+                Trans::Replace(state) => self.replace(state, data),
+                Trans::NewStack(states) => self.new_stack(states, data),
+                Trans::Sequence(sequence) => {
+                    for trans in sequence {
+                        let temp_data = StateData {
+                            world: data.world,
+                            data: data.data,
+                        };
+                        self.transition(trans, temp_data);
+                    }
+                }
                 Trans::Quit => self.stop(data),
             }
         }
@@ -515,6 +535,49 @@ impl<'a, T, E: Send + Sync + 'static> StateMachine<'a, T, E> {
                 state.on_resume(StateData { world, data });
             } else {
                 self.running = false;
+            }
+        }
+    }
+
+    /// Removes all states from the stack and replaces it with a new state.
+    pub(crate) fn replace(&mut self, state: Box<dyn State<T, E>>, data: StateData<'_, T>) {
+        if self.running {
+            //Pemove all current states
+            let StateData { world, data } = data;
+            while let Some(mut state) = self.state_stack.pop() {
+                state.on_stop(StateData { world, data });
+            }
+
+            //Push the new state
+            self.state_stack.push(state);
+
+            //State was just pushed, thus pop will always succeed
+            let new_state = self.state_stack.last_mut().unwrap();
+            new_state.on_start(StateData { world, data });
+        }
+    }
+
+    /// Removes all states from the stack and replaces it with a new stack.
+    pub(crate) fn new_stack(&mut self, states: Vec<Box<dyn State<T, E>>>, data: StateData<'_, T>) {
+        if self.running {
+            //revome all current states
+            let StateData { world, data } = data;
+            while let Some(mut state) = self.state_stack.pop() {
+                state.on_stop(StateData { world, data });
+            }
+
+            //push the new states
+            let state_count = states.len();
+            for (count, state) in states.into_iter().enumerate() {
+                self.state_stack.push(state);
+
+                //State was just pushed, thus pop will always succeed
+                let new_state = self.state_stack.last_mut().unwrap();
+                new_state.on_start(StateData { world, data });
+                if count != state_count - 1 {
+                    //pause on each state but the last
+                    new_state.on_pause(StateData { world, data });
+                }
             }
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -560,7 +560,7 @@ impl<'a, T, E: Send + Sync + 'static> StateMachine<'a, T, E> {
     /// Removes all states from the stack and replaces it with a new stack.
     pub(crate) fn new_stack(&mut self, states: Vec<Box<dyn State<T, E>>>, data: StateData<'_, T>) {
         if self.running {
-            //revome all current states
+            //remove all current states
             let StateData { world, data } = data;
             while let Some(mut state) = self.state_stack.pop() {
                 state.on_stop(StateData { world, data });

--- a/src/state.rs
+++ b/src/state.rs
@@ -599,15 +599,11 @@ impl<'a, T, E: Send + Sync + 'static> StateMachine<'a, T, E> {
 mod tests {
     use super::*;
 
-    #[derive(PartialEq,Eq)]
     struct State0;
     struct State1(u8);
     struct State2;
-    #[derive(PartialEq,Eq)]
     struct StateNewStack;
-    #[derive(PartialEq,Eq)]
     struct StateSequence;
-    #[derive(PartialEq,Eq)]
     struct StateReplace(u8);
 
     impl State<(), ()> for State0 {
@@ -722,7 +718,7 @@ mod tests {
 
         for i in 0..3 {
             sm.update(StateData::new(&mut world, &mut ()));
-            assert_eq!(sm.state_stack.len(), i+2);
+            assert_eq!(sm.state_stack.len(), i + 2);
         }
 
         sm.update(StateData::new(&mut world, &mut ()));


### PR DESCRIPTION
## Description

Added new values to the Trans Enum for Transitioning States.

Closes #2067 

## Additions

- Trans::Replace(new_state): Delete the stack and replace with the new state.

- Trans::Sequence(Trans[]): Execute a sequence of transitions.

- Trans::NewState(New_States[]): Remove the existing stack and replace with New_States.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
