### PR TITLE
Fix camera::Perspective::new documentation degrees -> radians

### DIFF
--- a/amethyst_rendy/src/camera.rs
+++ b/amethyst_rendy/src/camera.rs
@@ -272,7 +272,7 @@ impl Perspective {
     /// # Arguments
     ///
     /// * aspect - Aspect Ratio represented as a `f32` ratio.
-    /// * fov - Field of View represented in degrees
+    /// * fov - Field of View represented in radians
     /// * z_near - Near clip plane distance
     /// * z_far - Far clip plane distance
     ///


### PR DESCRIPTION
## Description

Minor doc fix. Fixes #2073

## Additions

None

## Removals

None

## Modifications

Docs for `Perspective::new`

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR. (n/a)
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`

(^ I just made this change in github's editor since it was a one-word doc comment change)