### PR TITLE
Fix dead link in pong tutorial

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -679,7 +679,7 @@ In the next chapter, we'll explore the "S" in ECS and actually get these paddles
 moving!
 
 [sb]: https://specs.amethyst.rs/docs/tutorials/
-[sb-storage]: https://slide-rs.github.io/specs/05_storages.html#densevecstorage
+[sb-storage]: https://specs.amethyst.rs/docs/tutorials/05_storages.html#densevecstorage
 [2d]: https://docs.amethyst.rs/stable/amethyst_renderer/struct.Camera.html#method.standard_2d
 [ss]: ../images/pong_tutorial/pong_spritesheet.png
 


### PR DESCRIPTION
## Description

In [pong-tutorial-02.md](https://github.com/amethyst/amethyst/blob/master/book/src/pong-tutorial/pong-tutorial-02.md#our-first-component) at the very end of "Our first Component", the link to the Specs documentation about `DenseVecStorage` is broken. This PR updates the link to the new location of the doc.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

Resolves #2077 