### PR TITLE
Store sentry_status.txt in $XDG_CONFIG_HOME/amethyst

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-use dirs::home_dir;
+use dirs::config_dir;
 use std::{
     fs::{create_dir_all, read_to_string, remove_file, File},
     io::{stderr, stdin, Write},
@@ -8,7 +8,7 @@ use vergen::{self, ConstantsFlags};
 
 fn main() {
     let amethyst_home =
-        Path::new(&home_dir().expect("Failed to find home directory")).join(".amethyst");
+        Path::new(&config_dir().expect("Failed to find home directory")).join("amethyst");
     match amethyst_home.exists() {
         true => match check_sentry_allowed(&amethyst_home) {
             Some(true) => {
@@ -34,7 +34,7 @@ fn main() {
 }
 
 fn check_sentry_allowed(amethyst_home: &Path) -> Option<bool> {
-    let sentry_status_file = amethyst_home.join(".sentry_status.txt");
+    let sentry_status_file = amethyst_home.join("sentry_status.txt");
     if sentry_status_file.exists() {
         match read_to_string(&sentry_status_file) {
             Ok(result) => match result.as_str().trim() {
@@ -68,7 +68,7 @@ fn ask_user_data_collection() -> bool {
 }
 
 fn ask_write_user_data_collection(amethyst_home: &Path) -> bool {
-    let mut file = File::create(amethyst_home.join(".sentry_status.txt"))
+    let mut file = File::create(amethyst_home.join("sentry_status.txt"))
         .expect("Error writing Sentry status file");
     match ask_user_data_collection() {
         true => {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - Changed `SpriteSheetFormat::import_simple` to allow importing grid based `SpriteSheets` ([#2023])
   Migration Note: Rons need to wrap their content in either Grid() or List()
 - Added new Error options for `NetworkSimulationEvent`.
+- Changed amethyst config directory from `$HOME/.amethyst` to `$HOME/.config/amethyst` ([#2079])
 
 ### Deprecated
 
@@ -71,6 +72,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#2029]: https://github.com/amethyst/amethyst/pull/2029
 [#2033]: https://github.com/amethyst/amethyst/pull/2033
 [#2041]: https://github.com/amethyst/amethyst/pull/2041
+[#2079]: https://github.com/amethyst/amethyst/pull/2079
 
 
 ## [0.13.3] - 2019-10-4


### PR DESCRIPTION
## Description

#2007 was abandoned and can't be merged because the author deleted their repo. This is just a new pr with their commit and some minor fixes.

This pr fixes a few clippy warnings, and an issue where the build would crash if `$HOME/.config` did not exist.
It also removes a function that tried to ask the user for consent to collect data. This function didn't actually work, as mentioned in the comment, and I think asking for user input in the middle of the build process is a really bad idea regardless. But if this is controversial I can remove that commit.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
