### PR TITLE
Add Draggable component + system for Ui widgets that use UiTransform

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ travis-ci = { repository = "amethyst/amethyst", branch = "master" }
 [features]
 default = ["animation", "audio", "locale", "network", "renderer"]
 
-vulkan = ["amethyst_rendy/vulkan", "amethyst_rendy/vulkan-x11"]
+vulkan = ["amethyst_rendy/vulkan"]
 metal = ["amethyst_rendy/metal"]
 empty = ["amethyst_rendy/empty"]
 
@@ -134,7 +134,7 @@ amethyst_derive = { path = "amethyst_derive", version = "0.6.1" }
 amethyst_gltf = { path = "amethyst_gltf", version = "0.8.1", optional = true }
 amethyst_network = { path = "amethyst_network", version = "0.6.1", optional = true }
 amethyst_locale = { path = "amethyst_locale", version = "0.7.2", optional = true }
-amethyst_rendy = { path = "amethyst_rendy", version = "0.3.0", features = ["window", "vulkan"], optional = true }
+amethyst_rendy = { path = "amethyst_rendy", version = "0.3.0", features = ["window"], optional = true }
 amethyst_input = { path = "amethyst_input", version = "0.9.1" }
 amethyst_ui = { path = "amethyst_ui", version = "0.8.1" }
 amethyst_utils = { path = "amethyst_utils", version = "0.8.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ travis-ci = { repository = "amethyst/amethyst", branch = "master" }
 [features]
 default = ["animation", "audio", "locale", "network", "renderer"]
 
-vulkan = ["amethyst_rendy/vulkan"]
+vulkan = ["amethyst_rendy/vulkan", "amethyst_rendy/vulkan-x11"]
 metal = ["amethyst_rendy/metal"]
 empty = ["amethyst_rendy/empty"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ amethyst_derive = { path = "amethyst_derive", version = "0.6.1" }
 amethyst_gltf = { path = "amethyst_gltf", version = "0.8.1", optional = true }
 amethyst_network = { path = "amethyst_network", version = "0.6.1", optional = true }
 amethyst_locale = { path = "amethyst_locale", version = "0.7.2", optional = true }
-amethyst_rendy = { path = "amethyst_rendy", version = "0.3.0", features = ["window"], optional = true }
+amethyst_rendy = { path = "amethyst_rendy", version = "0.3.0", features = ["window", "vulkan"], optional = true }
 amethyst_input = { path = "amethyst_input", version = "0.9.1" }
 amethyst_ui = { path = "amethyst_ui", version = "0.8.1" }
 amethyst_utils = { path = "amethyst_utils", version = "0.8.0" }

--- a/amethyst_ui/src/bundle.rs
+++ b/amethyst_ui/src/bundle.rs
@@ -1,12 +1,11 @@
 //! ECS rendering bundle
 
 use crate::{
-    BlinkSystem, CacheSelectionOrderSystem, FontAsset, NoCustomUi, ResizeSystemDesc,
-    SelectionKeyboardSystemDesc, SelectionMouseSystemDesc, TextEditingInputSystemDesc,
-    TextEditingMouseSystemDesc, ToNativeWidget, UiButtonActionRetriggerSystemDesc,
-    UiButtonSystemDesc, UiLoaderSystemDesc, UiMouseSystem, UiSoundRetriggerSystemDesc,
-    UiSoundSystemDesc, UiTransformSystemDesc, WidgetId,
-    DragWidgetSystemDesc,
+    BlinkSystem, CacheSelectionOrderSystem, DragWidgetSystemDesc, FontAsset, NoCustomUi,
+    ResizeSystemDesc, SelectionKeyboardSystemDesc, SelectionMouseSystemDesc,
+    TextEditingInputSystemDesc, TextEditingMouseSystemDesc, ToNativeWidget,
+    UiButtonActionRetriggerSystemDesc, UiButtonSystemDesc, UiLoaderSystemDesc, UiMouseSystem,
+    UiSoundRetriggerSystemDesc, UiSoundSystemDesc, UiTransformSystemDesc, WidgetId,
 };
 use amethyst_assets::Processor;
 use amethyst_core::{

--- a/amethyst_ui/src/bundle.rs
+++ b/amethyst_ui/src/bundle.rs
@@ -47,10 +47,17 @@ where
             "ui_loader",
             &[],
         );
+
+        builder.add(
+            DragWidgetSystemDesc::<T>::default().build(world),
+            "ui_drag_system",
+            &[],
+        );
+
         builder.add(
             UiTransformSystemDesc::default().build(world),
             "ui_transform",
-            &["transform_system"],
+            &["transform_system", "ui_drag_system"],
         );
         builder.add(
             Processor::<FontAsset>::new(),
@@ -97,11 +104,6 @@ where
         builder.add(
             UiButtonSystemDesc::default().build(world),
             "ui_button_system",
-            &["ui_mouse_system"],
-        );
-        builder.add(
-            DragWidgetSystemDesc::<T>::default().build(world),
-            "ui_drag_system",
             &["ui_mouse_system"],
         );
 

--- a/amethyst_ui/src/bundle.rs
+++ b/amethyst_ui/src/bundle.rs
@@ -6,6 +6,7 @@ use crate::{
     TextEditingMouseSystemDesc, ToNativeWidget, UiButtonActionRetriggerSystemDesc,
     UiButtonSystemDesc, UiLoaderSystemDesc, UiMouseSystem, UiSoundRetriggerSystemDesc,
     UiSoundSystemDesc, UiTransformSystemDesc, WidgetId,
+    DragSelectedSystemDesc,
 };
 use amethyst_assets::Processor;
 use amethyst_core::{
@@ -97,6 +98,11 @@ where
         builder.add(
             UiButtonSystemDesc::default().build(world),
             "ui_button_system",
+            &["ui_mouse_system"],
+        );
+        builder.add(
+            DragSelectedSystemDesc::<T>::default().build(world),
+            "ui_drag_system",
             &["ui_mouse_system"],
         );
 

--- a/amethyst_ui/src/bundle.rs
+++ b/amethyst_ui/src/bundle.rs
@@ -47,17 +47,10 @@ where
             "ui_loader",
             &[],
         );
-
-        builder.add(
-            DragWidgetSystemDesc::<T>::default().build(world),
-            "ui_drag_system",
-            &[],
-        );
-
         builder.add(
             UiTransformSystemDesc::default().build(world),
             "ui_transform",
-            &["transform_system", "ui_drag_system"],
+            &["transform_system"],
         );
         builder.add(
             Processor::<FontAsset>::new(),
@@ -104,6 +97,11 @@ where
         builder.add(
             UiButtonSystemDesc::default().build(world),
             "ui_button_system",
+            &["ui_mouse_system"],
+        );
+        builder.add(
+            DragWidgetSystemDesc::<T>::default().build(world),
+            "ui_drag_system",
             &["ui_mouse_system"],
         );
 

--- a/amethyst_ui/src/bundle.rs
+++ b/amethyst_ui/src/bundle.rs
@@ -6,7 +6,7 @@ use crate::{
     TextEditingMouseSystemDesc, ToNativeWidget, UiButtonActionRetriggerSystemDesc,
     UiButtonSystemDesc, UiLoaderSystemDesc, UiMouseSystem, UiSoundRetriggerSystemDesc,
     UiSoundSystemDesc, UiTransformSystemDesc, WidgetId,
-    DragSelectedSystemDesc,
+    DragWidgetSystemDesc,
 };
 use amethyst_assets::Processor;
 use amethyst_core::{
@@ -101,7 +101,7 @@ where
             &["ui_mouse_system"],
         );
         builder.add(
-            DragSelectedSystemDesc::<T>::default().build(world),
+            DragWidgetSystemDesc::<T>::default().build(world),
             "ui_drag_system",
             &["ui_mouse_system"],
         );

--- a/amethyst_ui/src/drag.rs
+++ b/amethyst_ui/src/drag.rs
@@ -3,8 +3,8 @@ use std::marker::PhantomData;
 
 use amethyst_core::{
     ecs::{
-        Component, DenseVecStorage, Entities, Entity, Join, Read, ReaderId,
-        System, SystemData, Write, WriteStorage,
+        Component, DenseVecStorage, Entities, Entity, Join, Read, ReaderId, System, SystemData,
+        Write, WriteStorage,
     },
     math::Vector2,
     shrev::EventChannel,
@@ -39,7 +39,7 @@ pub struct DragWidgetSystem<T: BindingTypes> {
     phantom: PhantomData<T>,
 }
 
-impl<T> DragWidgetSystem<T> 
+impl<T> DragWidgetSystem<T>
 where
     T: BindingTypes,
 {
@@ -52,7 +52,7 @@ where
     }
 }
 
-impl<'s, T> System<'s> for DragWidgetSystem<T> 
+impl<'s, T> System<'s> for DragWidgetSystem<T>
 where
     T: BindingTypes,
 {
@@ -62,9 +62,12 @@ where
         Write<'s, EventChannel<UiEvent>>,
         WriteStorage<'s, Draggable>,
         WriteStorage<'s, UiTransform>,
-    ); 
+    );
 
-    fn run(&mut self, (entities, input_events, mut ui_events, mut draggables, mut ui_transforms): Self::SystemData) {
+    fn run(
+        &mut self,
+        (entities, input_events, mut ui_events, mut draggables, mut ui_transforms): Self::SystemData,
+    ) {
         let mut click_stopped: Vec<Entity> = Vec::new();
 
         for event in ui_events.read(&mut self.ui_reader_id) {
@@ -73,39 +76,48 @@ where
                     if let Some(draggable) = draggables.get_mut(event.target) {
                         draggable.being_dragged = true;
                     }
-                },
+                }
                 UiEventType::ClickStop => {
                     if let Some(draggable) = draggables.get(event.target) {
                         if draggable.being_dragged {
                             click_stopped.push(event.target);
                         }
                     }
-                },
+                }
                 _ => (),
             }
         }
 
         for event in input_events.read(&mut self.input_reader_id) {
-            match event {
-                InputEvent::CursorMoved { delta_x, delta_y } => {
-                    for (entity, draggable, mut ui_transforms) in (&entities, &draggables, &mut ui_transforms.restrict_mut()).join() {
-                        if draggable.being_dragged {
-                            let ui_transform = ui_transforms.get_mut_unchecked();
+            if let InputEvent::CursorMoved { delta_x, delta_y } = event {
+                for (entity, draggable, mut ui_transforms) in
+                    (&entities, &draggables, &mut ui_transforms.restrict_mut()).join()
+                {
+                    if draggable.being_dragged {
+                        let ui_transform = ui_transforms.get_mut_unchecked();
 
-                            ui_events.single_write(UiEvent::new(UiEventType::Dragging { element_offset: Vector2::new(*delta_x, -*delta_y) }, entity));
-                            ui_transform.local_x += delta_x;
-                            ui_transform.local_y -= delta_y;
-                        }
+                        ui_events.single_write(UiEvent::new(
+                            UiEventType::Dragging {
+                                element_offset: Vector2::new(*delta_x, -*delta_y),
+                            },
+                            entity,
+                        ));
+                        ui_transform.local_x += delta_x;
+                        ui_transform.local_y -= delta_y;
                     }
-                },
-                _ => (),
+                }
             }
         }
 
         for entity in click_stopped.iter() {
             draggables.get_mut(*entity).unwrap().being_dragged = false;
 
-            ui_events.single_write(UiEvent::new(UiEventType::Dropped { dropped_on: *entity }, *entity));
+            ui_events.single_write(UiEvent::new(
+                UiEventType::Dropped {
+                    dropped_on: *entity,
+                },
+                *entity,
+            ));
         }
     }
 }

--- a/amethyst_ui/src/drag.rs
+++ b/amethyst_ui/src/drag.rs
@@ -32,6 +32,10 @@ pub struct DragWidgetSystem<T: BindingTypes> {
     #[system_desc(event_channel_reader)]
     ui_reader_id: ReaderId<UiEvent>,
 
+    /// hashmap whose keys are every entities being dragged, 
+    /// and whose element is a tuple whose first element is 
+    /// the original mouse position when drag first started, 
+    /// and second element the mouse position one frame ago
     #[system_desc(skip)]
     record: HashMap<Entity, (Vector2<f32>, Vector2<f32>)>,
 

--- a/amethyst_ui/src/drag.rs
+++ b/amethyst_ui/src/drag.rs
@@ -17,7 +17,7 @@ use crate::{UiEvent, UiEventType, Selected, UiTransform};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Draggable {
-    being_dragged: bool,
+    pub being_dragged: bool,
 }
 
 impl Component for Draggable {

--- a/amethyst_ui/src/drag.rs
+++ b/amethyst_ui/src/drag.rs
@@ -102,6 +102,8 @@ where
 
         for entity in click_stopped.iter() {
             draggables.get_mut(*entity).unwrap().being_dragged = false;
+
+            ui_events.single_write(UiEvent::new(UiEventType::Dropped { dropped_on: *entity }, *entity));
         }
     }
 }

--- a/amethyst_ui/src/drag.rs
+++ b/amethyst_ui/src/drag.rs
@@ -1,0 +1,107 @@
+use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
+
+use amethyst_core::{
+    ecs::{
+        Component, DenseVecStorage, Entities, Entity, Join, Read, ReadStorage, ReaderId,
+        System, SystemData, Write, WriteStorage,
+    },
+    math::Vector2,
+    shrev::EventChannel,
+    SystemDesc,
+};
+use amethyst_derive::SystemDesc;
+use amethyst_input::{BindingTypes, InputEvent};
+
+use crate::{UiEvent, UiEventType, Selected, UiTransform};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Draggable {
+    being_dragged: bool,
+}
+
+impl Component for Draggable {
+    type Storage = DenseVecStorage<Self>;
+}
+
+#[derive(Debug, SystemDesc)]
+#[system_desc(name(DragSelectedSystemDesc))]
+pub struct DragSelectedSystem<T: BindingTypes> {
+    #[system_desc(event_channel_reader)]
+    input_reader_id: ReaderId<InputEvent<T>>,
+
+    #[system_desc(event_channel_reader)]
+    ui_reader_id: ReaderId<UiEvent>,
+
+    phantom: PhantomData<T>,
+}
+
+impl<T> DragSelectedSystem<T> 
+where
+    T: BindingTypes,
+{
+    pub fn new(input_reader_id: ReaderId<InputEvent<T>>, ui_reader_id: ReaderId<UiEvent>) -> Self {
+        Self {
+            input_reader_id,
+            ui_reader_id,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<'s, T> System<'s> for DragSelectedSystem<T> 
+where
+    T: BindingTypes,
+{
+    type SystemData = (
+        Entities<'s>,
+        Read<'s, EventChannel<InputEvent<T>>>,
+        ReadStorage<'s, Selected>,
+        Write<'s, EventChannel<UiEvent>>,
+        WriteStorage<'s, Draggable>,
+        WriteStorage<'s, UiTransform>,
+    ); 
+
+    fn run(&mut self, (entities, input_events, selects, mut ui_events, mut draggables, mut ui_transforms): Self::SystemData) {
+        let mut click_stopped: Vec<Entity> = Vec::new();
+
+        for event in ui_events.read(&mut self.ui_reader_id) {
+            match event.event_type {
+                UiEventType::ClickStart => {
+                    if let Some(draggable) = draggables.get_mut(event.target) {
+                        draggable.being_dragged = true;
+                    }
+                },
+                UiEventType::ClickStop => {
+                    if let Some(draggable) = draggables.get(event.target) {
+                        if draggable.being_dragged {
+                            click_stopped.push(event.target);
+                        }
+                    }
+                },
+                _ => (),
+            }
+        }
+
+        for event in input_events.read(&mut self.input_reader_id) {
+            match event {
+                InputEvent::CursorMoved { delta_x, delta_y } => {
+                    for (entity, draggable, mut ui_transforms) in (&entities, &draggables, &mut ui_transforms.restrict_mut()).join() {
+                        if draggable.being_dragged {
+                            let ui_transform = ui_transforms.get_mut_unchecked();
+
+                            ui_events.single_write(UiEvent::new(UiEventType::Dragging { element_offset: Vector2::new(*delta_x, *delta_y) }, entity));
+                            ui_transform.local_x += delta_x;
+                            ui_transform.local_y += delta_y;
+                        }
+                    }
+                },
+                _ => (),
+            }
+        }
+
+        for entity in click_stopped.iter() {
+            draggables.get_mut(*entity).unwrap().being_dragged = false;
+        }
+    }
+}

--- a/amethyst_ui/src/drag.rs
+++ b/amethyst_ui/src/drag.rs
@@ -3,20 +3,23 @@ use std::marker::PhantomData;
 
 use amethyst_core::{
     ecs::{
-        Component, DenseVecStorage, Entities, Entity, Join, Read, ReadStorage, ReaderId,
+        Component, DenseVecStorage, Entities, Entity, Join, Read, ReaderId,
         System, SystemData, Write, WriteStorage,
     },
     math::Vector2,
     shrev::EventChannel,
-    SystemDesc,
 };
 use amethyst_derive::SystemDesc;
 use amethyst_input::{BindingTypes, InputEvent};
 
-use crate::{UiEvent, UiEventType, Selected, UiTransform};
+use crate::{UiEvent, UiEventType, UiTransform};
 
+/// Component that denotes whether a given ui widget is draggable.
+/// Requires UiTransform to work, and its expected way of usage is
+/// through UiTransformData prefab.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Draggable {
+    /// When true, the widget is being dragged. When false, it's not.
     pub being_dragged: bool,
 }
 
@@ -25,8 +28,8 @@ impl Component for Draggable {
 }
 
 #[derive(Debug, SystemDesc)]
-#[system_desc(name(DragSelectedSystemDesc))]
-pub struct DragSelectedSystem<T: BindingTypes> {
+#[system_desc(name(DragWidgetSystemDesc))]
+pub struct DragWidgetSystem<T: BindingTypes> {
     #[system_desc(event_channel_reader)]
     input_reader_id: ReaderId<InputEvent<T>>,
 
@@ -36,7 +39,7 @@ pub struct DragSelectedSystem<T: BindingTypes> {
     phantom: PhantomData<T>,
 }
 
-impl<T> DragSelectedSystem<T> 
+impl<T> DragWidgetSystem<T> 
 where
     T: BindingTypes,
 {
@@ -49,20 +52,19 @@ where
     }
 }
 
-impl<'s, T> System<'s> for DragSelectedSystem<T> 
+impl<'s, T> System<'s> for DragWidgetSystem<T> 
 where
     T: BindingTypes,
 {
     type SystemData = (
         Entities<'s>,
         Read<'s, EventChannel<InputEvent<T>>>,
-        ReadStorage<'s, Selected>,
         Write<'s, EventChannel<UiEvent>>,
         WriteStorage<'s, Draggable>,
         WriteStorage<'s, UiTransform>,
     ); 
 
-    fn run(&mut self, (entities, input_events, selects, mut ui_events, mut draggables, mut ui_transforms): Self::SystemData) {
+    fn run(&mut self, (entities, input_events, mut ui_events, mut draggables, mut ui_transforms): Self::SystemData) {
         let mut click_stopped: Vec<Entity> = Vec::new();
 
         for event in ui_events.read(&mut self.ui_reader_id) {
@@ -90,9 +92,9 @@ where
                         if draggable.being_dragged {
                             let ui_transform = ui_transforms.get_mut_unchecked();
 
-                            ui_events.single_write(UiEvent::new(UiEventType::Dragging { element_offset: Vector2::new(*delta_x, *delta_y) }, entity));
+                            ui_events.single_write(UiEvent::new(UiEventType::Dragging { element_offset: Vector2::new(*delta_x, -*delta_y) }, entity));
                             ui_transform.local_x += delta_x;
-                            ui_transform.local_y += delta_y;
+                            ui_transform.local_y -= delta_y;
                         }
                     }
                 },

--- a/amethyst_ui/src/drag.rs
+++ b/amethyst_ui/src/drag.rs
@@ -98,12 +98,12 @@ where
 
                         ui_events.single_write(UiEvent::new(
                             UiEventType::Dragging {
-                                element_offset: Vector2::new(*delta_x, -*delta_y),
+                                element_offset: Vector2::new(*delta_x, *delta_y),
                             },
                             entity,
                         ));
                         ui_transform.local_x += delta_x;
-                        ui_transform.local_y -= delta_y;
+                        ui_transform.local_y += delta_y;
                     }
                 }
             }

--- a/amethyst_ui/src/drag.rs
+++ b/amethyst_ui/src/drag.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::marker::PhantomData;
 
 use amethyst_core::{
@@ -89,7 +89,7 @@ where
         if let Some((mouse_x, mouse_y)) = input_handler.mouse_position() {
             let mouse_pos = Vector2::new(mouse_x, screen_dimensions.height() - mouse_y);
 
-            let mut click_stopped: Vec<Entity> = Vec::new();
+            let mut click_stopped: HashSet<Entity> = HashSet::new();
 
             for event in ui_events.read(&mut self.ui_reader_id) {
                 match event.event_type {
@@ -98,12 +98,18 @@ where
                             self.record.insert(event.target, (mouse_pos, mouse_pos));
                         }
                     }
-                    UiEventType::ClickStop | UiEventType::HoverStop => {
+                    UiEventType::ClickStop => {
                         if self.record.contains_key(&event.target) {
-                            click_stopped.push(event.target);
+                            click_stopped.insert(event.target);
                         }
                     }
                     _ => (),
+                }
+            }
+
+            for (entity, _) in self.record.iter() {
+                if hiddens.get(*entity).is_some() || hidden_props.get(*entity).is_some() {
+                    click_stopped.insert(*entity);
                 }
             }
 

--- a/amethyst_ui/src/drag.rs
+++ b/amethyst_ui/src/drag.rs
@@ -98,12 +98,12 @@ where
 
                         ui_events.single_write(UiEvent::new(
                             UiEventType::Dragging {
-                                element_offset: Vector2::new(*delta_x, *delta_y),
+                                element_offset: Vector2::new(*delta_x, -*delta_y),
                             },
                             entity,
                         ));
                         ui_transform.local_x += delta_x;
-                        ui_transform.local_y += delta_y;
+                        ui_transform.local_y -= delta_y;
                     }
                 }
             }

--- a/amethyst_ui/src/event.rs
+++ b/amethyst_ui/src/event.rs
@@ -40,7 +40,7 @@ pub enum UiEventType {
     Dragging {
         /// The position of the mouse relative to the center of the transform when the drag started.
         offset_from_mouse: Vector2<f32>,
-       /// Position at which the mouse is currently. Absolute value; not relative to the parent of the dragged entity.
+        /// Position at which the mouse is currently. Absolute value; not relative to the parent of the dragged entity.
         new_position: Vector2<f32>,
     },
     /// When stopping to drag a `Draggable` Ui element.
@@ -196,14 +196,14 @@ where
 /// on if `pos` is over the non-interactable one or not.
 pub fn targeted_below<'a, I>(pos: (f32, f32), height: f32, transforms: I) -> Option<Entity>
 where
-I: Iterator<Item = (Entity, &'a UiTransform, Option<&'a Interactable>)> + 'a,
+    I: Iterator<Item = (Entity, &'a UiTransform, Option<&'a Interactable>)> + 'a,
 {
-transforms
-    .filter(|(_e, t, _m)| t.opaque && t.position_inside(pos.0, pos.1) && t.global_z < height)
-    .max_by(|(_e1, t1, _m1), (_e2, t2, _m2)| {
-        t1.global_z
-            .partial_cmp(&t2.global_z)
-            .expect("Unexpected NaN")
-    })
-    .and_then(|(e, _, m)| m.map(|_m| e))
+    transforms
+        .filter(|(_e, t, _m)| t.opaque && t.position_inside(pos.0, pos.1) && t.global_z < height)
+        .max_by(|(_e1, t1, _m1), (_e2, t2, _m2)| {
+            t1.global_z
+                .partial_cmp(&t2.global_z)
+                .expect("Unexpected NaN")
+        })
+        .and_then(|(e, _, m)| m.map(|_m| e))
 }

--- a/amethyst_ui/src/event_retrigger.rs
+++ b/amethyst_ui/src/event_retrigger.rs
@@ -37,10 +37,14 @@ where
     }
 }
 
+/// Trait that denotes which event gets retriggered to which other event and how
 pub trait EventRetrigger: Component {
+    /// Event type that causes retrigger
     type In: Clone + Send + Sync + TargetedEvent;
+    /// Event type that gets retriggered
     type Out: Clone + Send + Sync;
 
+    /// Denotes how In events retriggers Out events
     fn apply<R>(&self, event: &Self::In, out: &mut R)
     where
         R: EventReceiver<Self::Out>;

--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -19,7 +19,9 @@ pub use self::{
     },
     drag::{DragWidgetSystemDesc, Draggable},
     event::{targeted, targeted_below, Interactable, UiEvent, UiEventType, UiMouseSystem},
-    event_retrigger::{EventReceiver, EventRetrigger, EventRetriggerSystem, EventRetriggerSystemDesc},
+    event_retrigger::{
+        EventReceiver, EventRetrigger, EventRetriggerSystem, EventRetriggerSystemDesc,
+    },
     font::{
         default::get_default_font,
         systemfont::{default_system_font, get_all_font_handles, list_system_font_families},

--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -47,7 +47,7 @@ pub use self::{
     text_editing::{TextEditingInputSystem, TextEditingInputSystemDesc},
     transform::{UiFinder, UiTransform},
     widgets::{Widget, WidgetId, Widgets},
-    drag::{Draggable, DragSelectedSystemDesc},
+    drag::{Draggable, DragWidgetSystemDesc},
 };
 
 pub(crate) use amethyst_core::ecs::prelude::Entity;

--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -47,6 +47,7 @@ pub use self::{
     text_editing::{TextEditingInputSystem, TextEditingInputSystemDesc},
     transform::{UiFinder, UiTransform},
     widgets::{Widget, WidgetId, Widgets},
+    drag::{Draggable, DragSelectedSystemDesc},
 };
 
 pub(crate) use amethyst_core::ecs::prelude::Entity;
@@ -73,3 +74,4 @@ mod text;
 mod text_editing;
 mod transform;
 mod widgets;
+mod drag;

--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -18,7 +18,7 @@ pub use self::{
         UiButtonBuilderResources, UiButtonSystem, UiButtonSystemDesc,
     },
     drag::{DragWidgetSystemDesc, Draggable},
-    event::{targeted, Interactable, UiEvent, UiEventType, UiMouseSystem},
+    event::{targeted, targeted_below, Interactable, UiEvent, UiEventType, UiMouseSystem},
     event_retrigger::{EventReceiver, EventRetriggerSystem, EventRetriggerSystemDesc},
     font::{
         default::get_default_font,

--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -19,7 +19,7 @@ pub use self::{
     },
     drag::{DragWidgetSystemDesc, Draggable},
     event::{targeted, targeted_below, Interactable, UiEvent, UiEventType, UiMouseSystem},
-    event_retrigger::{EventReceiver, EventRetriggerSystem, EventRetriggerSystemDesc},
+    event_retrigger::{EventReceiver, EventRetrigger, EventRetriggerSystem, EventRetriggerSystemDesc},
     font::{
         default::get_default_font,
         systemfont::{default_system_font, get_all_font_handles, list_system_font_families},

--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -17,6 +17,7 @@ pub use self::{
         UiButtonActionRetriggerSystemDesc, UiButtonActionType, UiButtonBuilder,
         UiButtonBuilderResources, UiButtonSystem, UiButtonSystemDesc,
     },
+    drag::{DragWidgetSystemDesc, Draggable},
     event::{targeted, Interactable, UiEvent, UiEventType, UiMouseSystem},
     event_retrigger::{EventReceiver, EventRetriggerSystem, EventRetriggerSystemDesc},
     font::{
@@ -47,7 +48,6 @@ pub use self::{
     text_editing::{TextEditingInputSystem, TextEditingInputSystemDesc},
     transform::{UiFinder, UiTransform},
     widgets::{Widget, WidgetId, Widgets},
-    drag::{Draggable, DragWidgetSystemDesc},
 };
 
 pub(crate) use amethyst_core::ecs::prelude::Entity;
@@ -56,6 +56,7 @@ pub(crate) use paste;
 mod blink;
 mod bundle;
 mod button;
+mod drag;
 mod event;
 mod event_retrigger;
 mod font;
@@ -74,4 +75,3 @@ mod text;
 mod text_editing;
 mod transform;
 mod widgets;
-mod drag;

--- a/amethyst_ui/src/prefab.rs
+++ b/amethyst_ui/src/prefab.rs
@@ -190,10 +190,7 @@ where
         }
 
         if self.draggable {
-            system_data.4.insert(
-                entity,
-                Draggable,
-            )?;
+            system_data.4.insert(entity, Draggable)?;
         }
 
         Ok(())

--- a/amethyst_ui/src/prefab.rs
+++ b/amethyst_ui/src/prefab.rs
@@ -192,9 +192,7 @@ where
         if self.draggable {
             system_data.4.insert(
                 entity,
-                Draggable {
-                    being_dragged: false,
-                },
+                Draggable,
             )?;
         }
 

--- a/amethyst_ui/src/prefab.rs
+++ b/amethyst_ui/src/prefab.rs
@@ -26,6 +26,7 @@ use crate::{
     get_default_font, Anchor, FontAsset, Interactable, LineMode, Selectable, Stretch, TextEditing,
     UiButton, UiButtonAction, UiButtonActionRetrigger, UiButtonActionType, UiImage,
     UiPlaySoundAction, UiSoundRetrigger, UiText, UiTransform, WidgetId, Widgets,
+    Draggable,
 };
 
 /// Loadable `UiTransform` data.
@@ -75,6 +76,8 @@ pub struct UiTransformData<G> {
     /// this ordering backwards.
     // TODO: Make full prefab for Selectable.
     pub selectable: Option<u32>,
+    /// Makes the UiTransform draggable through mouse inputs.
+    pub draggable: bool,
     #[serde(skip)]
     _phantom: PhantomData<G>,
 }
@@ -144,6 +147,7 @@ where
         WriteStorage<'a, Interactable>,
         WriteStorage<'a, HiddenPropagate>,
         WriteStorage<'a, Selectable<G>>,
+        WriteStorage<'a, Draggable>,
     );
     type Result = ();
 
@@ -184,6 +188,10 @@ where
 
         if let Some(u) = self.selectable {
             system_data.3.insert(entity, Selectable::<G>::new(u))?;
+        }
+
+        if self.draggable {
+            system_data.4.insert(entity, Draggable { being_dragged: false })?;
         }
 
         Ok(())

--- a/amethyst_ui/src/prefab.rs
+++ b/amethyst_ui/src/prefab.rs
@@ -23,10 +23,9 @@ use amethyst_rendy::TexturePrefab;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    get_default_font, Anchor, FontAsset, Interactable, LineMode, Selectable, Stretch, TextEditing,
-    UiButton, UiButtonAction, UiButtonActionRetrigger, UiButtonActionType, UiImage,
+    get_default_font, Anchor, Draggable, FontAsset, Interactable, LineMode, Selectable, Stretch,
+    TextEditing, UiButton, UiButtonAction, UiButtonActionRetrigger, UiButtonActionType, UiImage,
     UiPlaySoundAction, UiSoundRetrigger, UiText, UiTransform, WidgetId, Widgets,
-    Draggable,
 };
 
 /// Loadable `UiTransform` data.
@@ -191,7 +190,12 @@ where
         }
 
         if self.draggable {
-            system_data.4.insert(entity, Draggable { being_dragged: false })?;
+            system_data.4.insert(
+                entity,
+                Draggable {
+                    being_dragged: false,
+                },
+            )?;
         }
 
         Ok(())

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - Log warning when `amethyst_test::WaitForLoad` has not completed in 10 seconds. ([#1984])
 - Derive `Copy` and `PartialEq` for `amethyst::renderer::resources::Tint`. ([#2033])
 - Derive `Hash` for `amethyst::input::{Button, ControllerButton, ScrollDirection}`. ([#2041])
-- Add `Draggable` component that can be used with `UiTransform` to make widgets draggable. 
+- Add `Draggable` component that can be used with `UiTransform` to make widgets draggable.  ([#2080])
 
 ### Changed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - Log warning when `amethyst_test::WaitForLoad` has not completed in 10 seconds. ([#1984])
 - Derive `Copy` and `PartialEq` for `amethyst::renderer::resources::Tint`. ([#2033])
 - Derive `Hash` for `amethyst::input::{Button, ControllerButton, ScrollDirection}`. ([#2041])
+- Add `Draggable` component that can be used with `UiTransform` to make widgets draggable. 
 
 ### Changed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -72,6 +72,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#2029]: https://github.com/amethyst/amethyst/pull/2029
 [#2033]: https://github.com/amethyst/amethyst/pull/2033
 [#2041]: https://github.com/amethyst/amethyst/pull/2041
+[#2080]: https://github.com/amethyst/amethyst/pull/2080
 
 
 ## [0.13.3] - 2019-10-4

--- a/examples/assets/ui/example.ron
+++ b/examples/assets/ui/example.ron
@@ -163,7 +163,7 @@ Container(
             transform: (
                 id: "simple_button",
                 x: 250.,
-                y: -80., // -64-16
+                y: -40., // -64-16
                 width: 128.,
                 height: 64.,
                 tab_order: 9,
@@ -178,6 +178,29 @@ Container(
                 normal_image: SolidColor(0.82, 0.83, 0.83, 1.0),
             )
         ),
+
+        // Draggable Button
+        Button(
+            transform: (
+                id: "draggable_button",
+                x: 250.,
+                y: -120., // -64-16
+                width: 128.,
+                height: 64.,
+                tab_order: 9,
+                anchor: TopLeft,
+                mouse_reactive: true,
+                draggable: true,
+            ),
+            button: (
+                text: "Draggable",
+                font: File("font/square.ttf", ("TTF", ())),
+                font_size: 20.,
+                normal_text_color: (0.0, 0.0, 0.0, 1.0),
+                normal_image: SolidColor(0.82, 0.83, 0.83, 1.0),
+            )
+        ),
+
         Label(
             transform: (
                 id: "fps",

--- a/examples/assets/ui/example.ron
+++ b/examples/assets/ui/example.ron
@@ -164,6 +164,7 @@ Container(
                 id: "simple_button",
                 x: 250.,
                 y: -40., // -64-16
+                z: 11.,
                 width: 128.,
                 height: 64.,
                 tab_order: 9,
@@ -185,6 +186,7 @@ Container(
                 id: "draggable_button",
                 x: 250.,
                 y: -120., // -64-16
+                z: 12.,
                 width: 128.,
                 height: 64.,
                 tab_order: 9,

--- a/examples/assets/ui/example.ron
+++ b/examples/assets/ui/example.ron
@@ -163,7 +163,7 @@ Container(
             transform: (
                 id: "simple_button",
                 x: 250.,
-                y: -40., // -64-16
+                y: -40.,
                 z: 11.,
                 width: 128.,
                 height: 64.,
@@ -185,7 +185,7 @@ Container(
             transform: (
                 id: "draggable_button",
                 x: 250.,
-                y: -120., // -64-16
+                y: -120.,
                 z: 12.,
                 width: 128.,
                 height: 64.,


### PR DESCRIPTION
## Description
Ui widgets that use UiTransform didn't have an easy to use draggable component that's integrated in its prefab definition and comes bundled with UiBundle. So, I decided to make one.

## Additions
Ui widgets can become draggable by setting 'draggable' field in UiTransformData to be true. You can also manually add or remove Draggable component to any ui widget entity that also has UiTransform component.

## Removals

None

## Modifications

Included dragging SystemDesc to UiBundle.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
