### PR TITLE
Fix minor grammatical error in pong tutorial

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -215,7 +215,7 @@ Now, we will create the `Paddle` component, all in `pong.rs`.
     By implementing `Component` for the `Paddle` struct, it can now be attached
     to entities in the game.
 
-    When implemented the `Component` trait, we must specify the storage type.
+    When implementing the `Component` trait, we must specify the storage type.
     Different storage types optimize for faster access, lower memory usage, or a
     balance between the two. For more information on storage types, check out the
     [Specs documentation][sb-storage].


### PR DESCRIPTION
## Description

The wrong form of "implementing" is used in the pong tutorial section of the book.

## Additions

None

## Removals

None

## Modifications

Changing one word in the book.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.