### PR TITLE
Update to a newer, Rusty version of mikktspace

### DIFF
--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -27,7 +27,7 @@ gltf = "0.14"
 hibitset = { version = "0.6.2", features = ["parallel"] }
 itertools = "0.8"
 log = "0.4.6"
-mikktspace = { version = "0.1" }
+mikktspace = { git = "https://github.com/gltf-rs/mikktspace", rev = "abbae9b486f280ce6e331821e2454c2cfd746d5b" }
 serde = { version = "1.0", features = ["derive"] }
 
 thread_profiler = { version = "0.3", optional = true }

--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -27,7 +27,7 @@ gltf = "0.14"
 hibitset = { version = "0.6.2", features = ["parallel"] }
 itertools = "0.8"
 log = "0.4.6"
-mikktspace = { git = "https://github.com/gltf-rs/mikktspace", rev = "abbae9b486f280ce6e331821e2454c2cfd746d5b" }
+mikktspace = "0.2.0"
 serde = { version = "1.0", features = ["derive"] }
 
 thread_profiler = { version = "0.3", optional = true }

--- a/amethyst_gltf/src/format/mesh.rs
+++ b/amethyst_gltf/src/format/mesh.rs
@@ -7,8 +7,8 @@ use amethyst_rendy::{
     skinning::JointCombined,
 };
 use log::{trace, warn};
-use std::{iter::repeat, ops::Range};
 use mikktspace::{generate_tangents_default, Geometry};
+use std::{iter::repeat, ops::Range};
 
 fn compute_if<T, F: Fn() -> T>(predicate: bool, func: F) -> Option<T> {
     if predicate {

--- a/amethyst_gltf/src/format/mesh.rs
+++ b/amethyst_gltf/src/format/mesh.rs
@@ -6,8 +6,9 @@ use amethyst_rendy::{
     rendy::mesh::{Color, MeshBuilder, Normal, Position, Tangent, TexCoord},
     skinning::JointCombined,
 };
-use log::trace;
+use log::{trace, warn};
 use std::{iter::repeat, ops::Range};
+use mikktspace::{generate_tangents_default, Geometry};
 
 fn compute_if<T, F: Fn() -> T>(predicate: bool, func: F) -> Option<T> {
     if predicate {
@@ -202,20 +203,52 @@ fn calculate_tangents(
     tex_coords: &[TexCoord],
     indices: &Indices,
 ) -> Vec<Tangent> {
-    let mut tangents = vec![Tangent([0.0, 0.0, 0.0, 0.0]); positions.len()];
-    let num_faces = indices.len().unwrap_or_else(|| positions.len()) / 3;
-    mikktspace::generate_tangents(
-        &|| 3,
-        &|| num_faces,
-        &|face, vert| &positions[indices.map(face, vert)].0,
-        &|face, vert| &normals[indices.map(face, vert)].0,
-        &|face, vert| &tex_coords[indices.map(face, vert)].0,
-        &mut |face, vert, tangent| {
+    struct TangentsGeometry<'a> {
+        tangents: Vec<Tangent>,
+        num_faces: usize,
+        positions: &'a [Position],
+        normals: &'a [Normal],
+        tex_coords: &'a [TexCoord],
+        indices: &'a Indices,
+    }
+
+    impl<'a> Geometry for TangentsGeometry<'a> {
+        fn num_faces(&self) -> usize {
+            self.num_faces
+        }
+        fn num_vertices_of_face(&self, _face: usize) -> usize {
+            3
+        }
+        fn position(&self, face: usize, vert: usize) -> [f32; 3] {
+            self.positions[self.indices.map(face, vert)].0
+        }
+        fn normal(&self, face: usize, vert: usize) -> [f32; 3] {
+            self.normals[self.indices.map(face, vert)].0
+        }
+        fn tex_coord(&self, face: usize, vert: usize) -> [f32; 2] {
+            self.tex_coords[self.indices.map(face, vert)].0
+        }
+
+        fn set_tangent_encoded(&mut self, tangent: [f32; 4], face: usize, vert: usize) {
             let [x, y, z, w] = tangent;
-            tangents[indices.map(face, vert)] = Tangent([x, y, z, -w]);
-        },
-    );
-    tangents
+            self.tangents[self.indices.map(face, vert)] = Tangent([x, y, z, -w]);
+        }
+    }
+
+    let mut geometry = TangentsGeometry {
+        tangents: vec![Tangent([0.0, 0.0, 0.0, 0.0]); positions.len()],
+        num_faces: indices.len().unwrap_or_else(|| positions.len()) / 3,
+        positions,
+        normals,
+        tex_coords,
+        indices,
+    };
+
+    if !generate_tangents_default(&mut geometry) {
+        warn!("Could not generate tangents!");
+    }
+
+    geometry.tangents
 }
 
 #[cfg(test)]

--- a/amethyst_gltf/src/format/mesh.rs
+++ b/amethyst_gltf/src/format/mesh.rs
@@ -7,7 +7,7 @@ use amethyst_rendy::{
     skinning::JointCombined,
 };
 use log::{trace, warn};
-use mikktspace::{generate_tangents_default, Geometry};
+use mikktspace::{generate_tangents, Geometry};
 use std::{iter::repeat, ops::Range};
 
 fn compute_if<T, F: Fn() -> T>(predicate: bool, func: F) -> Option<T> {
@@ -244,7 +244,7 @@ fn calculate_tangents(
         indices,
     };
 
-    if !generate_tangents_default(&mut geometry) {
+    if !generate_tangents(&mut geometry) {
         warn!("Could not generate tangents!");
     }
 

--- a/amethyst_gltf/src/format/mesh.rs
+++ b/amethyst_gltf/src/format/mesh.rs
@@ -197,44 +197,44 @@ fn calculate_normals(positions: &[Position], indices: &Indices) -> Vec<Normal> {
         .collect::<Vec<_>>()
 }
 
+struct TangentsGeometry<'a> {
+    tangents: Vec<Tangent>,
+    num_faces: usize,
+    positions: &'a [Position],
+    normals: &'a [Normal],
+    tex_coords: &'a [TexCoord],
+    indices: &'a Indices,
+}
+
+impl<'a> Geometry for TangentsGeometry<'a> {
+    fn num_faces(&self) -> usize {
+        self.num_faces
+    }
+    fn num_vertices_of_face(&self, _face: usize) -> usize {
+        3
+    }
+    fn position(&self, face: usize, vert: usize) -> [f32; 3] {
+        self.positions[self.indices.map(face, vert)].0
+    }
+    fn normal(&self, face: usize, vert: usize) -> [f32; 3] {
+        self.normals[self.indices.map(face, vert)].0
+    }
+    fn tex_coord(&self, face: usize, vert: usize) -> [f32; 2] {
+        self.tex_coords[self.indices.map(face, vert)].0
+    }
+
+    fn set_tangent_encoded(&mut self, tangent: [f32; 4], face: usize, vert: usize) {
+        let [x, y, z, w] = tangent;
+        self.tangents[self.indices.map(face, vert)] = Tangent([x, y, z, -w]);
+    }
+}
+
 fn calculate_tangents(
     positions: &[Position],
     normals: &[Normal],
     tex_coords: &[TexCoord],
     indices: &Indices,
 ) -> Vec<Tangent> {
-    struct TangentsGeometry<'a> {
-        tangents: Vec<Tangent>,
-        num_faces: usize,
-        positions: &'a [Position],
-        normals: &'a [Normal],
-        tex_coords: &'a [TexCoord],
-        indices: &'a Indices,
-    }
-
-    impl<'a> Geometry for TangentsGeometry<'a> {
-        fn num_faces(&self) -> usize {
-            self.num_faces
-        }
-        fn num_vertices_of_face(&self, _face: usize) -> usize {
-            3
-        }
-        fn position(&self, face: usize, vert: usize) -> [f32; 3] {
-            self.positions[self.indices.map(face, vert)].0
-        }
-        fn normal(&self, face: usize, vert: usize) -> [f32; 3] {
-            self.normals[self.indices.map(face, vert)].0
-        }
-        fn tex_coord(&self, face: usize, vert: usize) -> [f32; 2] {
-            self.tex_coords[self.indices.map(face, vert)].0
-        }
-
-        fn set_tangent_encoded(&mut self, tangent: [f32; 4], face: usize, vert: usize) {
-            let [x, y, z, w] = tangent;
-            self.tangents[self.indices.map(face, vert)] = Tangent([x, y, z, -w]);
-        }
-    }
-
     let mut geometry = TangentsGeometry {
         tangents: vec![Tangent([0.0, 0.0, 0.0, 0.0]); positions.len()],
         num_faces: indices.len().unwrap_or_else(|| positions.len()) / 3,


### PR DESCRIPTION
Hello, this is my first PR, so apologies in case I've done something wrong.

## Description

I was trying to run the GLTF example on Windows and I got told off by Visual Studio while compiling `amethyst_gltf`. The error message was as follows:

```
error: linking with `link.exe` failed: exit code: 1120
  |
  = note: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.24.28314\\bin\\HostX64\\x86\\link.exe" "/NOLOGO" "/NXCOMPAT" ... line too long to paste here
  = note: libmikktspace-ed048d53099c6187.rlib(mikktspace-ed048d53099c6187.mikktspace.24tkbvwf-cgu.0.rcgu.o) : error LNK2019: unresolved external symbol _genTangSpaceDefault@4 referenced in function __ZN10mikktspace8Closures8generate17hfe0598a16c7e4f72E
          C:\Users\mvask\Projects\amethyst\target\debug\examples\gltf.exe : fatal error LNK1120: 1 unresolved externals
```

To be honest I had no idea how to fix it, but given that the problem seemed to be with the `mikktspace` library, I figured I could try and update to a newer version. Doing a little research, I found out that `mikktspace` started out as a wrapper around C code (which is what Amethyst is using), and has been later transformed to Rust.

After the update, I had to adapt the code a bit, since the API of `mikktspace` has changed. Having done that, I was able to compile and run the GLTF example without problems, with the same visual result.

One thing to note is that the library has not released this new, Rusty version yet and the repository looks kind of inactive (last commit was about 7 months ago), so I decided to pin the Amethyst dependency on the latest commit on master.

## Additions

None

## Removals

None

## Modifications

Adapt the code using the `mikktspace` library to a new API.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
