### PR TITLE
Fixing world_to_screen camera transformation #2057

### DIFF
--- a/amethyst_rendy/src/camera.rs
+++ b/amethyst_rendy/src/camera.rs
@@ -562,8 +562,9 @@ impl Projection {
         screen_diagonal: Vector2<f32>,
         camera_transform: &Transform,
     ) -> Point2<f32> {
+        let transformation_matrix = camera_transform.global_matrix().try_inverse().unwrap();
         let screen_pos =
-            (camera_transform.global_matrix() * self.as_matrix()).transform_point(&world_position);
+            (self.as_matrix() * transformation_matrix).transform_point(&world_position);
 
         Point2::new(
             (screen_pos.x + 1.0) * screen_diagonal.x / 2.0,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - TileMap to_tile doesn't panic in debug mode. It instead return Result<Point<u32>,TileOutOfBounds>. ([#2020],[#2070])
 - Added new Error options for `NetworkSimulationEvent`.
 - Changed amethyst config directory from `$HOME/.amethyst` to `$HOME/.config/amethyst` ([#2079])
+- Changed `world_to_screen` camera transformation to match inverse of the one in `screen_ray` ([#2057])
 
 ### Deprecated
 
@@ -84,6 +85,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#2070]: https://github.com/amethyst/amethyst/pull/2070
 [#2079]: https://github.com/amethyst/amethyst/pull/2079
 [#2080]: https://github.com/amethyst/amethyst/pull/2080
+[#2057]: https://github.com/amethyst/amethyst/issues/2057
 
 
 ## [0.13.3] - 2019-10-4


### PR DESCRIPTION
## Description

Changed `world_to_screen` camera transformation to match inverse of the one in `screen_ray`

## PR Checklist

By placing an x in the boxes I certify that I have:

- [X] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [X] Ran `cargo +stable fmt --all`
- [X] Ran `cargo clippy --all --features "empty"`
- [X] Ran `cargo test --all --features "empty"`
