### PR TITLE
Simplify mouse axis, only one radius value would ever be used for a given config

### DIFF
--- a/amethyst_input/src/axis.rs
+++ b/amethyst_input/src/axis.rs
@@ -32,10 +32,8 @@ pub enum Axis {
         axis: MouseAxis,
         /// Should the API be allowed to return values outside [-1..1]?
         over_extendable: bool,
-        /// Zone to which the movement is relative on the X axis
-        radius_x: f32,
-        /// Zone to which the movement is relative on the Y axis
-        radius_y: f32,
+        /// Zone to which the movement is relative
+        radius: f32,
     },
     /// Represents the wheel on a PC mouse.
     MouseWheel {

--- a/amethyst_input/src/input_handler.rs
+++ b/amethyst_input/src/input_handler.rs
@@ -557,8 +557,7 @@ where
             Axis::Mouse {
                 axis,
                 over_extendable,
-                radius_x,
-                radius_y,
+                radius,
             } => {
                 let current_pos = self.mouse_position.unwrap_or((0., 0.));
                 let last_pos = self.mouse_last_position.unwrap_or(current_pos);
@@ -568,10 +567,7 @@ where
                     MouseAxis::Y => last_pos.1 - current_pos.1,
                 };
 
-                let rel_delta = match axis {
-                    MouseAxis::X => delta / radius_x,
-                    MouseAxis::Y => delta / radius_y,
-                };
+                let rel_delta = delta / radius;
 
                 if over_extendable {
                     rel_delta

--- a/amethyst_input/src/input_handler.rs
+++ b/amethyst_input/src/input_handler.rs
@@ -405,7 +405,7 @@ where
     pub fn send_frame_begin(&mut self) {
         self.mouse_wheel_vertical = 0.0;
         self.mouse_wheel_horizontal = 0.0;
-        self.mouse_last_position = self.mouse_position.clone();
+        self.mouse_last_position = self.mouse_position;
     }
 
     /// Returns an iterator over all keys that are down.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - Added new Error options for `NetworkSimulationEvent`.
 - Changed amethyst config directory from `$HOME/.amethyst` to `$HOME/.config/amethyst` ([#2079])
 - Changed `world_to_screen` camera transformation to match inverse of the one in `screen_ray` ([#2057])
+- `amethyst_input::Axis::Mouse` now only has a single radius value. One of the two values was guaranteed to be unused. ([#2099])
 
 ### Deprecated
 
@@ -86,6 +87,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#2079]: https://github.com/amethyst/amethyst/pull/2079
 [#2080]: https://github.com/amethyst/amethyst/pull/2080
 [#2057]: https://github.com/amethyst/amethyst/issues/2057
+[#2099]: https://github.com/amethyst/amethyst/issues/2099
 
 
 ## [0.13.3] - 2019-10-4


### PR DESCRIPTION
## Description

For a mouse input axis one of the two radial values is guaranteed to go unused, so this simplifies the structure.

## Additions

- amethyst_input::Axis::Mouse::radius

## Removals

- amethyst_input::Axis::Mouse::radius_x
- amethyst_input::Axis::Mouse::radius_y

## Modifications

- N/A

## PR Checklist

By placing an x in the boxes I certify that I have:

- N/A Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- N/A Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
