### PR TITLE
FIX issue #2095. Account for the scaling percent of all ancestors of a given entity with a UiTransform.

### DIFF
--- a/amethyst_ui/src/drag.rs
+++ b/amethyst_ui/src/drag.rs
@@ -128,9 +128,8 @@ where
 
             let change = mouse_pos - *prev;
 
-            let (scale_x, scale_y) = get_scale_for_entity(
-                *entity, &hierarchy, &ui_transforms, &screen_dimensions
-            );
+            let (scale_x, scale_y) =
+                get_scale_for_entity(*entity, &hierarchy, &ui_transforms, &screen_dimensions);
 
             let ui_transform = ui_transforms.get_mut(*entity).unwrap();
             ui_transform.local_x += scale_x * change[0];
@@ -173,9 +172,9 @@ fn get_scale_for_entity<S: GenericReadStorage<Component = UiTransform>>(
 ) -> (f32, f32) {
     match ui_transforms.get(entity).unwrap().scale_mode {
         ScaleMode::Pixel => (1.0, 1.0),
-        ScaleMode::Percent => get_scale_for_percent_mode_entity(
-            entity, hierarchy, ui_transforms, screen_dimensions
-        ),
+        ScaleMode::Percent => {
+            get_scale_for_percent_mode_entity(entity, hierarchy, ui_transforms, screen_dimensions)
+        }
     }
 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -58,6 +58,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - Run `System::setup` for pausable systems' delegate. ([#2029])
 - Fixed an incorrect dimensions being used in Tile Encoders, causing bad lookups in assymetric maps in any Z-level besides 0 ([#2017])
 - Fix encoders dimensional cases and optimize storage space ([#2059])
+- Fix dragging UI widgets that have ScaleMode::Percent ([#2111])
 
 ### Security
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -91,6 +91,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#2080]: https://github.com/amethyst/amethyst/pull/2080
 [#2057]: https://github.com/amethyst/amethyst/issues/2057
 [#2099]: https://github.com/amethyst/amethyst/issues/2099
+[#2111]: https://github.com/amethyst/amethyst/pull/2111
 
 
 ## [0.13.3] - 2019-10-4


### PR DESCRIPTION
## Description

FIX issue #2095. When dragging UI entities, account for the scaling percent of all ancestors with UiTransforms.

## Modifications

- Modified the DragWidgetSystem

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`

Note: I ran clippy, but it failed in the amethyst_tiles crate. I don't know if I can ignore dependencies.

I also want to write unit tests but I'm having a hard time getting the system dependencies set up at the moment. Maybe someone could help me with that.