### PR TITLE
Re-export the TargetedEvent trait

### DIFF
--- a/amethyst_ui/src/event.rs
+++ b/amethyst_ui/src/event.rs
@@ -16,7 +16,10 @@ use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 use winit::MouseButton;
 
+/// An event that pertains to a specific `Entity`, for example a `UiEvent` for clicking on a widget
+/// entity.
 pub trait TargetedEvent {
+    /// The `Entity` targeted by the event.
     fn get_target(&self) -> Entity;
 }
 

--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -18,7 +18,9 @@ pub use self::{
         UiButtonBuilderResources, UiButtonSystem, UiButtonSystemDesc,
     },
     drag::{DragWidgetSystemDesc, Draggable},
-    event::{targeted, targeted_below, Interactable, UiEvent, UiEventType, UiMouseSystem},
+    event::{
+        targeted, targeted_below, Interactable, TargetedEvent, UiEvent, UiEventType, UiMouseSystem,
+    },
     event_retrigger::{
         EventReceiver, EventRetrigger, EventRetriggerSystem, EventRetriggerSystemDesc,
     },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ### Changed
 
+- Re-export `TargetedEvent` from amethyst_ui. ([#2114])
+
 ### Deprecated
 
 ### Removed
@@ -22,6 +24,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 ### Fixed
 
 ### Security
+
+[#2114]: https://github.com/amethyst/amethyst/pull/2114
 
 ## [0.14.0] - 2020-01-30
 


### PR DESCRIPTION
## Description

Re-export the TargetedEvent trait. I found this useful as a trait bound in my project. Might as well standardize it.

## Additions

- A couple doc comments explaining the trait.

## Modifications

- One new trait export from amethyst_ui

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
