### PR TITLE
Add support for setting module log levels via the LoggerConfig

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ### Added
 
+- Support settings module log levels from a RON file ([#2115])
+
 ### Changed
 
 ### Deprecated
@@ -22,6 +24,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 ### Fixed
 
 ### Security
+
+[#2115]: https://github.com/amethyst/amethyst/pull/2115
 
 ## [0.14.0] - 2020-01-30
 


### PR DESCRIPTION
## Description

Make it so you set your module log levels without recompiling, as so:

```
amethyst::Logger::from_config(LoggerConfig::load(&logger_config_path)?).start();
```

## Additions

- Add a field to the `LoggerConfig` that represents the log levels for some set of modules.
- Add `#[serde(default)]` to the `LoggerConfig` so it's easier to configure the logger from a RON file.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
