### PR TITLE
The dependency ordering for laminar and udp are backward

### DIFF
--- a/amethyst_network/src/simulation/transport/laminar.rs
+++ b/amethyst_network/src/simulation/transport/laminar.rs
@@ -39,7 +39,18 @@ impl<'a, 'b> SystemBundle<'a, 'b> for LaminarNetworkBundle {
         world: &mut World,
         builder: &mut DispatcherBuilder<'_, '_>,
     ) -> Result<(), Error> {
-        builder.add(LaminarNetworkSendSystem, NETWORK_SEND_SYSTEM_NAME, &[]);
+        builder.add(
+            NetworkSimulationTimeSystem,
+            NETWORK_SIM_TIME_SYSTEM_NAME,
+            &[],
+        );
+
+        builder.add(
+            LaminarNetworkSendSystem,
+            NETWORK_SEND_SYSTEM_NAME,
+            &[NETWORK_SIM_TIME_SYSTEM_NAME],
+        );
+
         builder.add(
             LaminarNetworkPollSystem,
             NETWORK_POLL_SYSTEM_NAME,
@@ -50,11 +61,7 @@ impl<'a, 'b> SystemBundle<'a, 'b> for LaminarNetworkBundle {
             NETWORK_RECV_SYSTEM_NAME,
             &[NETWORK_POLL_SYSTEM_NAME],
         );
-        builder.add(
-            NetworkSimulationTimeSystem,
-            NETWORK_SIM_TIME_SYSTEM_NAME,
-            &[NETWORK_RECV_SYSTEM_NAME],
-        );
+
         world.insert(LaminarSocketResource::new(self.socket));
         Ok(())
     }

--- a/amethyst_network/src/simulation/transport/udp.rs
+++ b/amethyst_network/src/simulation/transport/udp.rs
@@ -39,17 +39,22 @@ impl<'a, 'b> SystemBundle<'a, 'b> for UdpNetworkBundle {
         world: &mut World,
         builder: &mut DispatcherBuilder<'_, '_>,
     ) -> Result<(), Error> {
-        builder.add(UdpNetworkSendSystem, NETWORK_SEND_SYSTEM_NAME, &[]);
-        builder.add(
-            UdpNetworkRecvSystem::with_buffer_capacity(self.recv_buffer_size_bytes),
-            NETWORK_RECV_SYSTEM_NAME,
-            &[],
-        );
         builder.add(
             NetworkSimulationTimeSystem,
             NETWORK_SIM_TIME_SYSTEM_NAME,
-            &[NETWORK_SEND_SYSTEM_NAME, NETWORK_RECV_SYSTEM_NAME],
+            &[],
         );
+        builder.add(
+            UdpNetworkRecvSystem::with_buffer_capacity(self.recv_buffer_size_bytes),
+            NETWORK_RECV_SYSTEM_NAME,
+            &[NETWORK_SIM_TIME_SYSTEM_NAME],
+        );
+        builder.add(
+            UdpNetworkSendSystem,
+            NETWORK_SEND_SYSTEM_NAME,
+            &[NETWORK_SIM_TIME_SYSTEM_NAME],
+        );
+
         world.insert(UdpSocketResource::new(self.socket));
         Ok(())
     }


### PR DESCRIPTION
It looks as though I got the order of these wrong, though I swear the behavior I noticed was the opposite at the time I wrote it. Very specifically in this commit: https://github.com/amethyst/amethyst/commit/f3874f280e464d9c0ef93482fc69558c7d66a73c#diff-4174748f4e78ca2a28b7480eb243f814

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
