### PR TITLE
Export the get_parent_pixel_size function

### DIFF
--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -50,7 +50,7 @@ pub use self::{
     },
     text::{LineMode, TextEditing, TextEditingMouseSystem, TextEditingMouseSystemDesc, UiText},
     text_editing::{TextEditingInputSystem, TextEditingInputSystemDesc},
-    transform::{UiFinder, UiTransform},
+    transform::{get_parent_pixel_size, UiFinder, UiTransform},
     widgets::{Widget, WidgetId, Widgets},
 };
 

--- a/amethyst_ui/src/transform.rs
+++ b/amethyst_ui/src/transform.rs
@@ -1,11 +1,16 @@
 use std::marker::PhantomData;
 
-use amethyst_core::ecs::{
-    prelude::{
-        Component, DenseVecStorage, Entities, Entity, FlaggedStorage, Join, ReadStorage, World,
+use amethyst_core::{
+    ecs::{
+        prelude::{
+            Component, DenseVecStorage, Entities, Entity, FlaggedStorage, Join, ReadStorage, World,
+        },
+        shred::{ResourceId, SystemData},
+        storage::GenericReadStorage,
     },
-    shred::{ResourceId, SystemData},
+    ParentHierarchy,
 };
+use amethyst_window::ScreenDimensions;
 
 use serde::{Deserialize, Serialize};
 
@@ -162,10 +167,40 @@ impl UiTransform {
     pub fn global_z(&self) -> f32 {
         self.global_z
     }
+
+    /// Returns the width of this UiTransform (in pixels) as computed by the `UiTransformSystem`.
+    pub fn pixel_width(&self) -> f32 {
+        self.pixel_width
+    }
+
+    /// Returns the height of this UiTransform (in pixels) as computed by the `UiTransformSystem`.
+    pub fn pixel_height(&self) -> f32 {
+        self.pixel_height
+    }
 }
 
 impl Component for UiTransform {
     type Storage = FlaggedStorage<Self, DenseVecStorage<Self>>;
+}
+
+/// Get the (width, height) in pixels of the parent of this `UiTransform`.
+pub fn get_parent_pixel_size<S: GenericReadStorage<Component = UiTransform>>(
+    entity: Entity,
+    hierarchy: &ParentHierarchy,
+    ui_transforms: &S,
+    screen_dimensions: &ScreenDimensions,
+) -> (f32, f32) {
+    let mut parent_width = screen_dimensions.width();
+    let mut parent_height = screen_dimensions.height();
+
+    if let Some(parent) = hierarchy.parent(entity) {
+        if let Some(ui_transform) = ui_transforms.get(parent) {
+            parent_width = ui_transform.pixel_width();
+            parent_height = ui_transform.pixel_height();
+        }
+    }
+
+    (parent_width, parent_height)
 }
 
 #[cfg(test)]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 - Support settings module log levels from a RON file ([#2115])
 - Export the `get_parent_pixel_size` functions from the ui module ([[#2128])
+- Export the `pixel_width` and `pixel_height` methods on the `UiTransform` ([[#2128])
 
 ### Changed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 ### Added
 
 - Support settings module log levels from a RON file ([#2115])
+- Export the `get_parent_pixel_size` functions from the ui module ([[#2128])
 
 ### Changed
 
@@ -29,6 +30,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 [#2114]: https://github.com/amethyst/amethyst/pull/2114
 [#2115]: https://github.com/amethyst/amethyst/pull/2115
+[#2128]: https://github.com/amethyst/amethyst/pull/2128
 
 ## [0.14.0] - 2020-01-30
 


### PR DESCRIPTION
## Description

The function can be used to get the pixel (width, height) of an entity's parent's `UiTransform`. The function is a simplified version of what already existed in the `ui::drag` module.

## Additions

- export a new function from `amethyst_ui` module

## Modifications

- change the `get_scale_for_entity` to only check the parent's pixel size rather than checking the "scaled" size on all ancestors

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
