### PR TITLE
Remove unnecessary `let world` from pong-tutorial

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-01.md
+++ b/book/src/pong-tutorial/pong-tutorial-01.md
@@ -180,7 +180,6 @@ let game_data = GameDataBuilder::default();
 
 # let app_root = application_root_dir()?;
 let assets_dir = app_root.join("assets");
-let mut world = World::new();
 let mut game = Application::new(assets_dir, Pong, game_data)?;
 game.run();
 #     Ok(())

--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -407,7 +407,6 @@ fn main() -> amethyst::Result<()> {
 #       app_root.join("examples/pong_tutorial_02/config/display.ron");
 #
     // ...
-    let mut world = World::new();
     let game_data = GameDataBuilder::default()
         // ...
 

--- a/book/src/pong-tutorial/pong-tutorial-03.md
+++ b/book/src/pong-tutorial/pong-tutorial-03.md
@@ -71,7 +71,6 @@ let input_bundle = InputBundle::<StringBindings>::new()
 # let assets_dir = "assets";
 # struct Pong;
 # impl SimpleState for Pong { }
-let mut world = World::new();
 let game_data = GameDataBuilder::default()
     .with_bundle(TransformBundle::new())?
     .with_bundle(input_bundle)?
@@ -231,7 +230,6 @@ fn main() -> amethyst::Result<()> {
 # }
 # }
 # let input_bundle = amethyst::input::InputBundle::<StringBindings>::new();
-let mut world = World::new();
 let game_data = GameDataBuilder::default()
     // ...
     .with_bundle(TransformBundle::new())?

--- a/book/src/pong-tutorial/pong-tutorial-04.md
+++ b/book/src/pong-tutorial/pong-tutorial-04.md
@@ -352,7 +352,6 @@ as well as adding our new systems to the game data:
 # }
 # }
 # let input_bundle = amethyst::input::InputBundle::<StringBindings>::new();
-let mut world = World::new();
 let game_data = GameDataBuilder::default()
 #    .with_bundle(TransformBundle::new())?
 #    .with_bundle(input_bundle)?

--- a/book/src/pong-tutorial/pong-tutorial-05.md
+++ b/book/src/pong-tutorial/pong-tutorial-05.md
@@ -143,7 +143,6 @@ keep playing after someone scores and log who got the point.
 # let config = DisplayConfig::load(&path)?;
 # let input_bundle = amethyst::input::InputBundle::<StringBindings>::new();
 #
-# let mut world = World::new();
 let game_data = GameDataBuilder::default()
 #    .with_bundle(TransformBundle::new())?
 #    .with_bundle(input_bundle)?
@@ -195,7 +194,6 @@ Then, add a `RenderUi` plugin to your `RenderBundle` like so:
 #     ui::RenderUi,
 # };
 # fn main() -> Result<(), amethyst::Error>{
-# let mut world = World::new();
 # let game_data = GameDataBuilder::default()
     .with_bundle(RenderingBundle::<DefaultBackend>::new()
         // ...
@@ -217,7 +215,6 @@ Finally, add the `UiBundle` after the `InputBundle`:
 # fn main() -> Result<(), amethyst::Error>{
 # let display_config_path = "";
 # struct Pong;
-# let mut world = World::new();
 # let game_data = GameDataBuilder::default()
 .with_bundle(UiBundle::<StringBindings>::new())?
 # ;


### PR DESCRIPTION
## Description

Remove unnecessary `let world` statements from pong tutorial.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
