### PR TITLE
Bumped dependency versions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,20 +65,6 @@ profiler = [
     "amethyst_utils/profiler",
     "amethyst_tiles/profiler",
 ]
-nightly = [
-    "amethyst_animation/nightly",
-    "amethyst_assets/nightly",
-    "amethyst_audio/nightly",
-    "amethyst_config/nightly",
-    "amethyst_core/nightly",
-    "amethyst_controls/nightly",
-    "amethyst_network/nightly",
-    "amethyst_rendy/nightly",
-    "amethyst_input/nightly",
-    "amethyst_ui/nightly",
-    "amethyst_utils/nightly",
-    "amethyst_tiles/nightly",
-]
 sdl_controller = [
     "amethyst_input/sdl_controller",
 ]
@@ -140,31 +126,31 @@ amethyst_ui = { path = "amethyst_ui", version = "0.9.0" }
 amethyst_utils = { path = "amethyst_utils", version = "0.9.0" }
 amethyst_window = { path = "amethyst_window", version = "0.4.0" }
 amethyst_tiles = { path = "amethyst_tiles", version = "0.2.0", optional = true }
-crossbeam-channel = "0.3.9"
-derivative = "1.0"
-fern = { version = "0.5", features = ["colored"] }
-log = { version = "0.4.6", features = ["serde"] }
-rayon = "1.1.0"
-rustc_version_runtime = "0.1"
+crossbeam-channel = "0.4.0"
+derivative = "1.0.3"
+fern = { version = "0.5.9", features = ["colored"] }
+log = { version = "0.4.8", features = ["serde"] }
+rayon = "1.3.0"
+rustc_version_runtime = "0.1.5"
 sentry = { version = "0.17.0", optional = true }
 winit = { version = "0.19", features = ["serde", "icon_loading"] }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.104", features = ["derive"] }
 palette = { version = "0.4", features = ["serde"] }
-failure = "0.1"
-thread_profiler = { version = "0.3", optional = true }
-lazy_static = "1.3"
-glsl-layout = "0.3"
+failure = "0.1.6"
+thread_profiler = { version = "0.3.0", optional = true }
+lazy_static = "1.4.0"
+glsl-layout = "0.3.2"
 
 [dev-dependencies]
-derive-new = "0.5"
+derive-new = "0.5.8"
 env_logger = "0.7.1"
-genmesh = "0.6"
-ron = "0.5"
-specs-derive = "0.4"
+genmesh = "0.6.2"
+ron = "0.5.1"
+specs-derive = "0.4.1"
 
 [build-dependencies]
 dirs = "2.0.2"
-vergen = "3.0"
+vergen = "3.0.4"
 
 [[example]]
 name = "hello_world"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ pipeline {
                         sh 'cargo update'
                         // Perform actual check
                         echo 'Running Cargo check...'
-                        sh 'cargo check --all --all-targets --features "nightly vulkan sdl_controller json saveload tiles"'
+                        sh 'cargo check --all --all-targets --features "vulkan sdl_controller json saveload tiles"'
                     }
                 }
             }

--- a/amethyst_animation/Cargo.toml
+++ b/amethyst_animation/Cargo.toml
@@ -36,4 +36,3 @@ thread_profiler = { version = "0.3", optional = true }
 
 [features]
 profiler = [ "thread_profiler/thread_profiler" ]
-nightly = [ "amethyst_core/nightly" ]

--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -28,22 +28,21 @@ derivative = "1.0"
 derive-new = "0.5"
 fnv = "1"
 log = "0.4.6"
-parking_lot = "0.9"
-rayon = "1.1.0"
+parking_lot = "0.10"
+rayon = "1.3.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", optional = true }
 ron = "0.5"
 thread_profiler = { version = "0.3", optional = true }
-err-derive = "0.1"
+err-derive = "0.2"
 objekt = "0.1.2"
 erased-serde = "0.3.9"
-inventory = "0.1.3"
-lazy_static = "1.3"
+inventory = "0.1.5"
+lazy_static = "1.4"
 
 [dev-dependencies]
 serde_json = "1"
 
 [features]
 profiler = [ "thread_profiler/thread_profiler" ]
-nightly = [ "amethyst_core/nightly" ]
 json = [ "serde_json" ]

--- a/amethyst_assets/src/prefab/system.rs
+++ b/amethyst_assets/src/prefab/system.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, marker::PhantomData, ops::Deref};
+use std::{collections::HashMap, marker::PhantomData};
 
 use derivative::Derivative;
 use log::error;
@@ -102,7 +102,7 @@ where
             mut tags,
             mut prefab_system_data,
         ) = data;
-        let strategy = strategy.as_ref().map(Deref::deref);
+        let strategy = strategy.as_deref();
         prefab_storage.process(
             |mut d| {
                 d.tag = Some(self.next_tag);

--- a/amethyst_assets/src/storage.rs
+++ b/amethyst_assets/src/storage.rs
@@ -541,13 +541,11 @@ where
         #[cfg(feature = "profiler")]
         profile_scope!("processor_system");
 
-        use std::ops::Deref;
-
         storage.process(
             ProcessableAsset::process,
             time.frame_number(),
             &**pool,
-            strategy.as_ref().map(Deref::deref),
+            strategy.as_deref(),
         );
     }
 }

--- a/amethyst_audio/Cargo.toml
+++ b/amethyst_audio/Cargo.toml
@@ -27,7 +27,7 @@ derive-new = "0.5"
 log = "0.4.6"
 rodio = "0.9"
 serde = { version = "1.0", features = ["derive"] }
-smallvec = { version = "1.0", features = ["serde"] }
+smallvec = { version = "1.2", features = ["serde"] }
 thread_profiler = { version = "0.3", optional = true }
 
 [dev-dependencies]
@@ -35,4 +35,3 @@ amethyst_utils = { path = "../amethyst_utils", version = "0.9.0"}
 
 [features]
 profiler = [ "thread_profiler/thread_profiler" ]
-nightly = [ "amethyst_core/nightly" ]

--- a/amethyst_config/Cargo.toml
+++ b/amethyst_config/Cargo.toml
@@ -27,4 +27,3 @@ serde_derive = "1"
 
 [features]
 profiler = [ "thread_profiler/thread_profiler" ]
-nightly = []

--- a/amethyst_controls/Cargo.toml
+++ b/amethyst_controls/Cargo.toml
@@ -29,4 +29,3 @@ thread_profiler = { version = "0.3", optional = true }
 
 [features]
 profiler = [ "thread_profiler/thread_profiler" ]
-nightly = [ "amethyst_core/nightly" ]

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -16,20 +16,20 @@ travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
 nalgebra = { version = "0.19.0", features = ["serde-serialize", "mint"] }
-alga = { version = "0.9.0", default-features = false }
-alga_derive = "0.9.0"
-approx = "0.3"
+alga = { version = "0.9.2", default-features = false }
+alga_derive = "0.9.1"
+approx = "0.3.2"
 amethyst_error = { path = "../amethyst_error", version = "0.4.0" }
-fnv = "1"
-log = "0.4.6"
-num-traits = "0.2.0"
-rayon = "1.1.0"
+fnv = "1.0.6"
+log = "0.4.8"
+num-traits = "0.2.11"
+rayon = "1.3.0"
 serde = { version = "1", features = ["derive"] }
-specs = { version = "0.15.1", default-features = false, features = ["shred-derive", "specs-derive"] }
-specs-hierarchy = { version = "0.5.1", default-features = false }
-getset = "0.0.8"
-derive-new = "0.5.6"
-derivative = "1.0"
+specs = { version = "0.16.0", default-features = false, features = ["shred-derive", "specs-derive"] }
+specs-hierarchy = { version = "0.6", default-features = false }
+getset = "0.0.9"
+derive-new = "0.5.8"
+derivative = "1.0.3"
 
 thread_profiler = { version = "0.3", optional = true }
 
@@ -40,5 +40,4 @@ ron = "0.5.1"
 [features]
 default = ["specs/parallel", "specs-hierarchy/parallel"]
 profiler = ["thread_profiler/thread_profiler"]
-nightly = ["specs/nightly"]
 saveload = ["specs/serde"]

--- a/amethyst_core/src/event.rs
+++ b/amethyst_core/src/event.rs
@@ -70,7 +70,7 @@ mod tests {
 
     impl From<TestEvent> for AggregateEvent {
         fn from(event: TestEvent) -> Self {
-            AggregateEvent::Test(event.clone())
+            AggregateEvent::Test(event)
         }
     }
 

--- a/amethyst_core/src/transform/systems.rs
+++ b/amethyst_core/src/transform/systems.rs
@@ -371,7 +371,7 @@ mod tests {
         // Release the indeterminate forms!
         local.set_translation_xyz(0.0 / 0.0, 0.0 / 0.0, 0.0 / 0.0);
 
-        world.create_entity().with(local.clone()).build();
+        world.create_entity().with(local).build();
 
         hs.run_now(&world);
         system.run_now(&world);
@@ -386,7 +386,7 @@ mod tests {
         let mut local = Transform::default();
         // Release the indeterminate forms!
         local.set_translation_xyz(1.0 / 0.0, 1.0 / 0.0, 1.0 / 0.0);
-        world.create_entity().with(local.clone()).build();
+        world.create_entity().with(local).build();
 
         hs.run_now(&world);
         system.run_now(&world);

--- a/amethyst_derive/Cargo.toml
+++ b/amethyst_derive/Cargo.toml
@@ -19,7 +19,7 @@ heck = "0.3.1"
 syn = { version = "1.0", features = ["full", "visit"] }
 quote = "1.0"
 proc-macro2 = "1.0"
-proc_macro_roids = "0.6"
+proc_macro_roids = "0.7"
 proc-macro-crate = "0.1"
 
 [dev-dependencies]

--- a/amethyst_derive/src/lib.rs
+++ b/amethyst_derive/src/lib.rs
@@ -4,13 +4,13 @@
 #![recursion_limit = "256"]
 #![warn(
     missing_debug_implementations,
+    missing_docs,
     rust_2018_idioms,
     rust_2018_compatibility,
     clippy::all
 )]
-// #![warn(missing_docs)]
-// missing_docs is disabled for this crate because of a bug in current rust stable:
-// https://github.com/rust-lang/rust/issues/42008
+// Needed because `nightly` warns on `extern crate proc_macro;`, but `stable` still requires it.
+#![allow(unused_extern_crates)]
 
 extern crate proc_macro;
 

--- a/amethyst_derive/tests/test.rs
+++ b/amethyst_derive/tests/test.rs
@@ -140,13 +140,12 @@ mod tests {
                 let entities = world.read_resource::<EntitiesRes>();
                 let storage = world.read_storage::<External>();
 
-                assert_eq!(
-                    (&entities, &storage)
-                        .join()
-                        .map(|(_, ex)| assert_eq!(ex.inner, 100))
-                        .count(),
-                    1
-                );
+                let entities_components = (&entities, &storage).join().collect::<Vec<_>>();
+
+                assert_eq!(entities_components.len(), 1);
+                entities_components
+                    .into_iter()
+                    .for_each(|(_, ex)| assert_eq!(ex.inner, 100));
             }
         );
     }
@@ -162,13 +161,12 @@ mod tests {
                 let entities = world.read_resource::<EntitiesRes>();
                 let storage = world.read_storage::<Stuff<usize>>();
 
-                assert_eq!(
-                    (&entities, &storage)
-                        .join()
-                        .map(|(_, ex)| assert_eq!(ex.inner, 1))
-                        .count(),
-                    1
-                );
+                let entities_components = (&entities, &storage).join().collect::<Vec<_>>();
+
+                assert_eq!(entities_components.len(), 1);
+                entities_components
+                    .into_iter()
+                    .for_each(|(_, ex)| assert_eq!(ex.inner, 1));
             }
         );
     }
@@ -184,13 +182,12 @@ mod tests {
                 let entities = world.read_resource::<EntitiesRes>();
                 let storage = world.read_storage::<External>();
 
-                assert_eq!(
-                    (&entities, &storage)
-                        .join()
-                        .map(|(_, ex)| assert_eq!(ex.inner, 2))
-                        .count(),
-                    1
-                );
+                let entities_components = (&entities, &storage).join().collect::<Vec<_>>();
+
+                assert_eq!(entities_components.len(), 1);
+                entities_components
+                    .into_iter()
+                    .for_each(|(_, ex)| assert_eq!(ex.inner, 2));
             }
         );
     }
@@ -210,16 +207,15 @@ mod tests {
                 let stuff_storage = world.read_storage::<Stuff<String>>();
                 let external_storage = world.read_storage::<External>();
 
-                assert_eq!(
-                    (&entities, &stuff_storage, &external_storage)
-                        .join()
-                        .map(|(_, st, ex)| {
-                            assert_eq!(st.inner, "three");
-                            assert_eq!(ex.inner, 4);
-                        })
-                        .count(),
-                    1
-                );
+                let entities_components = (&entities, &stuff_storage, &external_storage)
+                    .join()
+                    .collect::<Vec<_>>();
+
+                assert_eq!(entities_components.len(), 1);
+                entities_components.into_iter().for_each(|(_, st, ex)| {
+                    assert_eq!(st.inner, "three");
+                    assert_eq!(ex.inner, 4);
+                });
             }
         );
     }

--- a/amethyst_error/Cargo.toml
+++ b/amethyst_error/Cargo.toml
@@ -19,4 +19,4 @@ repository = "https://github.com/amethyst/amethyst"
 travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
-backtrace = "0.3.13"
+backtrace = "0.3.44"

--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -20,10 +20,10 @@ amethyst_animation = { path = "../amethyst_animation/", version = "0.9.0" }
 amethyst_core = { path = "../amethyst_core/", version = "0.9.0" }
 amethyst_error = { path = "../amethyst_error/", version = "0.4.0" }
 amethyst_rendy = { path = "../amethyst_rendy", version = "0.4.0" }
-err-derive = "0.1"
+err-derive = "0.2"
 base64 = "0.11"
 fnv = "1"
-gltf = "0.14"
+gltf = "0.15"
 hibitset = { version = "0.6.2", features = ["parallel"] }
 itertools = "0.8"
 log = "0.4.6"
@@ -36,4 +36,3 @@ derivative = "1.0"
 
 [features]
 profiler = [ "thread_profiler/thread_profiler" ]
-nightly = [ "amethyst_core/nightly" ]

--- a/amethyst_gltf/src/format/animation.rs
+++ b/amethyst_gltf/src/format/animation.rs
@@ -120,6 +120,5 @@ where
         Linear => InterpolationFunction::Linear,
         Step => InterpolationFunction::Step,
         CubicSpline => InterpolationFunction::CubicSpline,
-        CatmullRomSpline => InterpolationFunction::CatmullRomSpline,
     }
 }

--- a/amethyst_gltf/src/format/importer.rs
+++ b/amethyst_gltf/src/format/importer.rs
@@ -156,13 +156,13 @@ pub fn get_image_data(
                 } else {
                     let mimetype = uri
                         .split(',')
-                        .nth(0)
+                        .next()
                         .expect("Unreachable: `split` will always return at least one element")
                         .split(':')
                         .nth(1)
                         .expect("URI does not contain ':'")
                         .split(';')
-                        .nth(0)
+                        .next()
                         .expect("Unreachable: `split` will always return at least one element");
                     Ok((data, ImageFormat::from_mime_type(mimetype)))
                 }

--- a/amethyst_input/Cargo.toml
+++ b/amethyst_input/Cargo.toml
@@ -24,18 +24,14 @@ derive-new = "0.5"
 fnv = "1"
 serde = { version = "1", features = ["derive"] }
 winit = { version = "0.19", features = ["serde"] }
-sdl2 = { version = "0.32.2", optional = true }
+sdl2 = { version = "0.33", optional = true }
+smallvec = { version = "1.2", features = ["serde"] }
 
 thread_profiler = { version = "0.3", optional = true }
-
-[dependencies.smallvec]
-version = "0.6"
-features = ["serde"]
 
 [dev-dependencies]
 approx = "0.3"
 
 [features]
 profiler = [ "thread_profiler/thread_profiler" ]
-nightly = [ "amethyst_core/nightly" ]
 sdl_controller = ["sdl2"]

--- a/amethyst_locale/Cargo.toml
+++ b/amethyst_locale/Cargo.toml
@@ -24,8 +24,8 @@ amethyst_assets = { path = "../amethyst_assets", version = "0.10.0" }
 amethyst_core = { path = "../amethyst_core", version = "0.9.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.4.0" }
 serde = { version = "1.0", features = ["derive"] }
-fluent = "0.8"
-unic-langid = { version = "0.6", features = ["macros"] }
+fluent = "0.9"
+unic-langid = { version = "0.7", features = ["macros"] }
 
 thread_profiler = { version = "0.3", optional = true }
 

--- a/amethyst_network/Cargo.toml
+++ b/amethyst_network/Cargo.toml
@@ -21,12 +21,11 @@ license = "MIT/Apache-2.0"
 
 [features]
 profiler = [ "thread_profiler/thread_profiler" ]
-nightly = [ "amethyst_core/nightly" ]
 
 [dependencies]
 amethyst_core = { path = "../amethyst_core", version = "0.9.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.4.0" }
-bytes = "0.4"
+bytes = "0.5"
 laminar = "0.3"
 log = "0.4"
 thread_profiler = { version = "0.3" , optional = true }

--- a/amethyst_network/Cargo.toml
+++ b/amethyst_network/Cargo.toml
@@ -25,7 +25,7 @@ profiler = [ "thread_profiler/thread_profiler" ]
 [dependencies]
 amethyst_core = { path = "../amethyst_core", version = "0.9.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.4.0" }
-bytes = "0.4"
+bytes = "0.5"
 laminar = "0.3"
 log = "0.4"
 thread_profiler = { version = "0.3" , optional = true }

--- a/amethyst_network/Cargo.toml
+++ b/amethyst_network/Cargo.toml
@@ -25,7 +25,7 @@ profiler = [ "thread_profiler/thread_profiler" ]
 [dependencies]
 amethyst_core = { path = "../amethyst_core", version = "0.9.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.4.0" }
-bytes = "0.5"
+bytes = "0.4"
 laminar = "0.3"
 log = "0.4"
 thread_profiler = { version = "0.3" , optional = true }

--- a/amethyst_network/src/simulation/message.rs
+++ b/amethyst_network/src/simulation/message.rs
@@ -26,7 +26,7 @@ impl Message {
     ) -> Self {
         Self {
             destination,
-            payload: Bytes::from(payload),
+            payload: Bytes::copy_from_slice(payload),
             delivery,
             urgency,
         }

--- a/amethyst_network/src/simulation/message.rs
+++ b/amethyst_network/src/simulation/message.rs
@@ -26,7 +26,7 @@ impl Message {
     ) -> Self {
         Self {
             destination,
-            payload: Bytes::copy_from_slice(payload),
+            payload: Bytes::from(payload),
             delivery,
             urgency,
         }

--- a/amethyst_network/src/simulation/transport/laminar.rs
+++ b/amethyst_network/src/simulation/transport/laminar.rs
@@ -155,7 +155,7 @@ impl<'s> System<'s> for LaminarNetworkRecvSystem {
                 let event = match event {
                     SocketEvent::Packet(packet) => NetworkSimulationEvent::Message(
                         packet.addr(),
-                        Bytes::copy_from_slice(packet.payload()),
+                        Bytes::from(packet.payload()),
                     ),
                     SocketEvent::Connect(addr) => NetworkSimulationEvent::Connect(addr),
                     SocketEvent::Timeout(addr) => NetworkSimulationEvent::Disconnect(addr),

--- a/amethyst_network/src/simulation/transport/laminar.rs
+++ b/amethyst_network/src/simulation/transport/laminar.rs
@@ -155,7 +155,7 @@ impl<'s> System<'s> for LaminarNetworkRecvSystem {
                 let event = match event {
                     SocketEvent::Packet(packet) => NetworkSimulationEvent::Message(
                         packet.addr(),
-                        Bytes::from(packet.payload()),
+                        Bytes::copy_from_slice(packet.payload()),
                     ),
                     SocketEvent::Connect(addr) => NetworkSimulationEvent::Connect(addr),
                     SocketEvent::Timeout(addr) => NetworkSimulationEvent::Disconnect(addr),

--- a/amethyst_network/src/simulation/transport/tcp.rs
+++ b/amethyst_network/src/simulation/transport/tcp.rs
@@ -248,7 +248,7 @@ impl<'s> System<'s> for TcpNetworkRecvSystem {
                         if recv_len > 0 {
                             let event = NetworkSimulationEvent::Message(
                                 peer_addr,
-                                Bytes::copy_from_slice(&resource.recv_buffer[..recv_len]),
+                                Bytes::from(&resource.recv_buffer[..recv_len]),
                             );
                             event_channel.single_write(event);
                         } else {

--- a/amethyst_network/src/simulation/transport/tcp.rs
+++ b/amethyst_network/src/simulation/transport/tcp.rs
@@ -248,7 +248,7 @@ impl<'s> System<'s> for TcpNetworkRecvSystem {
                         if recv_len > 0 {
                             let event = NetworkSimulationEvent::Message(
                                 peer_addr,
-                                Bytes::from(&resource.recv_buffer[..recv_len]),
+                                Bytes::copy_from_slice(&resource.recv_buffer[..recv_len]),
                             );
                             event_channel.single_write(event);
                         } else {

--- a/amethyst_network/src/simulation/transport/udp.rs
+++ b/amethyst_network/src/simulation/transport/udp.rs
@@ -116,7 +116,7 @@ impl<'s> System<'s> for UdpNetworkRecvSystem {
                     Ok((recv_len, address)) => {
                         let event = NetworkSimulationEvent::Message(
                             address,
-                            Bytes::from(&self.recv_buffer[..recv_len]),
+                            Bytes::copy_from_slice(&self.recv_buffer[..recv_len]),
                         );
                         // TODO: Handle other types of events.
                         event_channel.single_write(event);

--- a/amethyst_network/src/simulation/transport/udp.rs
+++ b/amethyst_network/src/simulation/transport/udp.rs
@@ -116,7 +116,7 @@ impl<'s> System<'s> for UdpNetworkRecvSystem {
                     Ok((recv_len, address)) => {
                         let event = NetworkSimulationEvent::Message(
                             address,
-                            Bytes::copy_from_slice(&self.recv_buffer[..recv_len]),
+                            Bytes::from(&self.recv_buffer[..recv_len]),
                         );
                         // TODO: Handle other types of events.
                         event_channel.single_write(event);

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -22,7 +22,7 @@ derive-new = "0.5.6"
 failure = "0.1"
 genmesh = "0.6"
 glsl-layout = "0.3"
-lazy_static = "1.3"
+lazy_static = "1.4"
 log = "0.4"
 palette = { version = "0.4", features = ["serde"] }
 rendy = { version = "0.4.1", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1"] }
@@ -30,14 +30,14 @@ ron = "0.5"
 serde = { version = "1", features = ["serde_derive"] }
 fnv = "1"
 derivative = "1.0"
-smallvec = "0.6.9"
-static_assertions = "1.0"
+smallvec = "1.2.0"
+static_assertions = "1.1"
 
 thread_profiler = { version = "0.3", optional = true }
 approx = "0.3.2"
 
 [dev-dependencies]
-rayon = "1.1.0"
+rayon = "1.3.0"
 more-asserts = "0.2.1"
 criterion = "0.3.0"
 winit = "0.19"
@@ -49,7 +49,6 @@ vulkan = ["rendy/vulkan"]
 vulkan-x11 = ["rendy/vulkan-x11"]
 empty = ["rendy/empty"]
 profiler = [ "thread_profiler/thread_profiler", "rendy/profiler" ]
-nightly = [ "amethyst_core/nightly" ]
 no-slow-safety-checks = ["rendy/no-slow-safety-checks"]
 shader-compiler =  ["rendy/shader-compiler"]
 test-support =  []

--- a/amethyst_rendy/src/plugins.rs
+++ b/amethyst_rendy/src/plugins.rs
@@ -86,10 +86,9 @@ mod window {
         #[allow(clippy::map_clone)]
         fn should_rebuild(&mut self, world: &World) -> bool {
             let new_dimensions = world.try_fetch::<ScreenDimensions>();
-            use std::ops::Deref;
-            if self.dimensions.as_ref() != new_dimensions.as_ref().map(|d| d.deref()) {
+            if self.dimensions.as_ref() != new_dimensions.as_deref() {
                 self.dirty = true;
-                self.dimensions = new_dimensions.map(|d| d.deref().clone());
+                self.dimensions = new_dimensions.map(|d| (*d).clone());
                 return false;
             }
             self.dirty

--- a/amethyst_rendy/src/sprite/mod.rs
+++ b/amethyst_rendy/src/sprite/mod.rs
@@ -624,7 +624,7 @@ List((
                 offsets: [0., 0.],
                 tex_coords: TextureCoordinates {
                     left: 0.,
-                    right: 0.33333334,
+                    right: 0.333_333_34,
                     bottom: 1.0,
                     top: 0.0,
                 },
@@ -634,7 +634,7 @@ List((
                 height: 16.,
                 offsets: [0., 0.],
                 tex_coords: TextureCoordinates {
-                    left: 0.33333334,
+                    left: 0.333_333_34,
                     right: 1.0,
                     bottom: 1.0,
                     top: 0.0,

--- a/amethyst_rendy/src/sprite/prefab.rs
+++ b/amethyst_rendy/src/sprite/prefab.rs
@@ -355,7 +355,7 @@ mod tests {
                     },
                 ],
             })],
-            texture: TexturePrefab::Handle(texture.clone()),
+            texture: TexturePrefab::Handle(texture),
             name: None,
         };
         prefab

--- a/amethyst_rendy/src/system.rs
+++ b/amethyst_rendy/src/system.rs
@@ -203,7 +203,6 @@ impl<'a, B: Backend> System<'a> for MeshProcessorSystem<B> {
         #[cfg(feature = "profiler")]
         profile_scope!("mesh_processor");
 
-        use std::ops::Deref;
         mesh_storage.process(
             |b| {
                 #[cfg(feature = "profiler")]
@@ -216,7 +215,7 @@ impl<'a, B: Backend> System<'a> for MeshProcessorSystem<B> {
             },
             time.frame_number(),
             &**pool,
-            strategy.as_ref().map(Deref::deref),
+            strategy.as_deref(),
         );
     }
 }
@@ -242,7 +241,6 @@ impl<'a, B: Backend> System<'a> for TextureProcessorSystem<B> {
         #[cfg(feature = "profiler")]
         profile_scope!("texture_processor");
 
-        use std::ops::Deref;
         texture_storage.process(
             |b| {
                 #[cfg(feature = "profiler")]
@@ -264,7 +262,7 @@ impl<'a, B: Backend> System<'a> for TextureProcessorSystem<B> {
             },
             time.frame_number(),
             &**pool,
-            strategy.as_ref().map(Deref::deref),
+            strategy.as_deref(),
         );
     }
 }

--- a/amethyst_test/Cargo.toml
+++ b/amethyst_test/Cargo.toml
@@ -17,7 +17,7 @@ amethyst = { path = "..", version = "0.14.0" }
 derivative = "1.0"
 derive-new = "0.5"
 derive_deref = "1.1.0"
-lazy_static = "1.3"
+lazy_static = "1.4"
 log = "0.4"
 
 [dev-dependencies]
@@ -25,7 +25,6 @@ serde = "1.0"
 
 [features]
 default = []
-nightly = ["amethyst/nightly"]
 empty = ["amethyst/empty"]
 metal = ["amethyst/metal"]
 vulkan = ["amethyst/vulkan"]

--- a/amethyst_test/src/amethyst_application.rs
+++ b/amethyst_test/src/amethyst_application.rs
@@ -267,6 +267,8 @@ where
         // If we get something else, we just inform the user to check the test output.
         if let Some(inner) = error.downcast_ref::<&str>() {
             Error::from_string((*inner).to_string())
+        } else if let Some(inner) = error.downcast_ref::<String>() {
+            Error::from_string(inner.clone())
         } else {
             Error::from_string(
                 "Unable to detect additional information from test failure.\n\
@@ -630,7 +632,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic] // This cannot be expect explicit because of nightly feature.
+    #[should_panic(expected = "Tried to fetch resource of type `ApplicationResource`")]
     fn assertion_when_resource_is_not_added_should_panic() {
         let assertion_fn = |world: &mut World| {
             // Panics if `ApplicationResource` was not added.
@@ -675,7 +677,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic] // This cannot be expect explicit because of nightly feature.
+    #[should_panic(expected = "Tried to fetch resource of type `LoadResource`")]
     fn assertion_switch_with_loading_state_without_add_resource_should_panic() {
         let state_fns = || {
             let assertion_fn = |world: &mut World| {
@@ -692,7 +694,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic] // This cannot be expect explicit because of nightly feature.
+    #[should_panic(expected = "Tried to fetch resource of type `LoadResource`")]
     fn assertion_push_with_loading_state_without_add_resource_should_panic() {
         // Alternative to embedding the `FunctionState` is to switch to a `PopState` but still
         // provide the assertion function

--- a/amethyst_tiles/Cargo.toml
+++ b/amethyst_tiles/Cargo.toml
@@ -27,13 +27,13 @@ thread_profiler = { version = "0.3", optional = true }
 fnv = "1"
 derivative = "1.0"
 hibitset = { version = "0.6.2", features = ["parallel"] }
-smallvec = "0.6"
+smallvec = "1.2.0"
 failure = "0.1"
-lazy_static = "1.3"
-rayon = "1.0.2"
+lazy_static = "1.4"
+rayon = "1.3.0"
 bitintr = "0.3"
 glsl-layout = "0.3"
-err-derive = "0.1"
+err-derive = "0.2"
 
 [dev-dependencies]
 criterion = "0.3"
@@ -42,4 +42,3 @@ approx = "0.3"
 
 [features]
 profiler = [ "thread_profiler/thread_profiler" ]
-nightly = [ "amethyst_core/nightly" ]

--- a/amethyst_tiles/src/map.rs
+++ b/amethyst_tiles/src/map.rs
@@ -50,6 +50,10 @@ pub trait Map {
     /// This performs an inverse matrix transformation of the world coordinate, scaling and translating using this
     /// maps `origin` and `tile_dimensions` respectively. If the tile map entity has a transform component, then
     /// it also translates the point using the it's transform.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `TileOutOfBoundsError` if the coordinate is not within the bounds of the tiles
     fn to_tile(
         &self,
         coord: &Vector3<f32>,

--- a/amethyst_tiles/src/map.rs
+++ b/amethyst_tiles/src/map.rs
@@ -402,8 +402,8 @@ mod tests {
         let mut inner = TileMap::<TestTile, E>::new(dimensions, Vector3::new(10, 10, 1), None);
         let map = UnsafeWrapper::new(&mut inner);
 
-        (0..dimensions.x).into_iter().for_each(|x| {
-            (0..dimensions.y).into_iter().for_each(|y| {
+        (0..dimensions.x).for_each(|x| {
+            (0..dimensions.y).for_each(|y| {
                 for z in 0..dimensions.z {
                     let point = Point3::new(x, y, z);
 
@@ -412,8 +412,8 @@ mod tests {
             });
         });
 
-        (0..dimensions.x).into_iter().for_each(|x| {
-            (0..dimensions.y).into_iter().for_each(|y| {
+        (0..dimensions.x).for_each(|x| {
+            (0..dimensions.y).for_each(|y| {
                 for z in 0..dimensions.z {
                     let point = Point3::new(x, y, z);
                     assert_eq!(map.get().get(&Point3::new(x, y, z)).unwrap().point, point);

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -28,19 +28,18 @@ fnv = "1"
 glsl-layout = "0.3"
 ron = "0.5"
 serde = { version = "1.0", features = ["derive"] }
-smallvec = "0.6"
+smallvec = "1.2"
 unicode-normalization = "0.1"
-unicode-segmentation = "1.2"
+unicode-segmentation = "1.6"
 winit = { version = "0.19", features = ["serde"] }
 log = "0.4.6"
-font-kit = "0.4"
+font-kit = "0.5"
 paste = "0.1"
 rand = "0.7"
-lazy_static = "1.3"
+lazy_static = "1.4"
 failure = "0.1"
 glyph_brush = "0.6.0"
 thread_profiler = { version = "0.3", optional = true }
 
 [features]
 profiler = [ "thread_profiler/thread_profiler" ]
-nightly = [ "amethyst_core/nightly" ]

--- a/amethyst_ui/src/glyphs.rs
+++ b/amethyst_ui/src/glyphs.rs
@@ -371,7 +371,7 @@ impl<'a, B: Backend> System<'a> for UiGlyphsSystem<B> {
                 move |glyph| {
                     // The glyph's Z parameter smuggles entity id, so glyphs can be associated
                     // for rendering as part of specific components.
-                    let entity_id: u32 = unsafe { std::mem::transmute(glyph.z) };
+                    let entity_id: u32 = glyph.z.to_bits();
 
                     let mut uv = glyph.tex_coords;
                     let bounds_max_x = glyph.bounds.max.x as f32;

--- a/amethyst_utils/Cargo.toml
+++ b/amethyst_utils/Cargo.toml
@@ -25,11 +25,10 @@ amethyst_window = { path = "../amethyst_window", version = "0.4.0" }
 derive-new = "0.5.8"
 log = "0.4.6"
 serde = { version = "1.0", features = ["derive"] }
-specs-derive = "0.4.0"
-specs-hierarchy = "0.5.1"
+specs-derive = "0.4.1"
+specs-hierarchy = "0.6.0"
 
 thread_profiler = { version = "0.3", optional = true }
 
 [features]
 profiler = [ "thread_profiler/thread_profiler" ]
-nightly = [ "amethyst_core/nightly" ]

--- a/amethyst_window/Cargo.toml
+++ b/amethyst_window/Cargo.toml
@@ -24,5 +24,4 @@ winit = { version = "0.19", features = ["serde", "icon_loading"] }
 
 [features]
 profiler = [ "thread_profiler/thread_profiler" ]
-nightly = []
 test-support =  []

--- a/book/src/appendices/c_feature_gates.md
+++ b/book/src/appendices/c_feature_gates.md
@@ -67,6 +67,10 @@ You can open this file using the chromium browser (or google chrome) and navigat
 
 ## Nightly
 
+> **Note:** Only applicable to Amethyst 0.14 and earlier.
+>
+> Version after 0.14 no longer have the `"nightly"` feature, as the type names are available on stable Rust.
+
 Enabling the `nightly` feature adds a bit of debug information when running into runtime issues. To
 use it, you need to use the nightly rust compiler toolchain.
 
@@ -85,6 +89,6 @@ When using Amethyst as a dependency of your project, you can use the following t
 ```ignore
 [dependencies.amethyst]
 version = "*"
-default-features = false 
+default-features = false
 features = ["audio", "animation"] # you can add more or replace those
 ```

--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -317,38 +317,18 @@ fn on_start(&mut self, data: StateData<'_, GameData<'_, '_>>) {
 Let's run our blank screen game!
 
 ```text,ignore
-thread 'main' panicked at 'Tried to fetch a resource, but the resource does not exist.
-Try adding the resource by inserting it manually or using the `setup` method.
+Tried to fetch resource of type `MaskedStorage<Paddle>`[^1] from the `World`, but the resource does not exist.
+
+You may ensure the resource exists through one of the following methods:
+
+* Inserting it when the world is created: `world.insert(..)`.
+* If the resource implements `Default`, include it in a system's `SystemData`, and ensure the system is registered in the dispatcher.
+* If the resource does not implement `Default`, insert in the world during `System::setup`.
+
+[^1]: Full type name: `amethyst::ecs::storage::MaskedStorage<pong::Paddle>`
 ```
 
-Uh oh, what's wrong? Sadly the message is pretty difficult to decipher.
-
-If you are using a `nightly` compiler and enable the `nightly` feature of
-Amethyst, you will receive a more informative error message:
-
-```text,ignore
-thread 'main' panicked at 'Tried to fetch a resource of type "amethyst::ecs::storage::MaskedStorage<pong::Paddle>", but the resource does not exist.
-Try adding the resource by inserting it manually or using the `setup` method.'
-```
-
-To turn on the `nightly` feature, enable the `nightly` flag for the Amethyst crate in your Cargo.toml file.  
-Use *one* of the below methods for declaring dependencies (using both will result in an error):
-#### In Dependencies:
-
-```toml
-[dependencies]
-amethyst = { version = "X.XX", features = ["nightly"] }
-```
-
-#### In Separate Table:
-
-```toml
-[dependencies.amethyst]
-version = "X.XX"
-features = ["nightly"]
-```
-
-Run the project using the nightly channel if you don't have it as your default: `cargo +nightly run`.
+Uh oh, what's wrong?
 
 For a `Component` to be used, there must be a `Storage<ComponentType>` resource
 set up in the `World`. The error message above means we have registered the

--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -563,7 +563,7 @@ signature to:
 # extern crate amethyst;
 # use amethyst::ecs::World;
 # use amethyst::{assets::Handle, renderer::sprite::SpriteSheet};
-fn initialise_paddles(world: &mut World, sprite_sheet: Handle<SpriteSheet>)
+fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>)
 # { }
 ```
 
@@ -575,10 +575,10 @@ the right one is flipped horizontally.
 # extern crate amethyst;
 # use amethyst::ecs::World;
 # use amethyst::{assets::Handle, renderer::{SpriteRender, SpriteSheet}};
-# fn initialise_paddles(world: &mut World, sprite_sheet: Handle<SpriteSheet>) {
+# fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>) {
 // Assign the sprites for the paddles
 let sprite_render = SpriteRender {
-    sprite_sheet: sprite_sheet.clone(),
+    sprite_sheet: sprite_sheet_handle,
     sprite_number: 0, // paddle is the first sprite in the sprite_sheet
 };
 # }
@@ -596,9 +596,9 @@ Next we simply add the components to the paddle entities:
 # use amethyst::assets::Handle;
 # use amethyst::renderer::sprite::{SpriteSheet, SpriteRender};
 # use amethyst::prelude::*;
-# fn initialise_paddles(world: &mut World, sprite_sheet: Handle<SpriteSheet>) {
+# fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>) {
 # let sprite_render = SpriteRender {
-#   sprite_sheet: sprite_sheet.clone(),
+#   sprite_sheet: sprite_sheet_handle,
 #   sprite_number: 0, // paddle is the first sprite in the sprite_sheet
 # };
 // Create a left plank entity.
@@ -611,7 +611,7 @@ world
 // Create right plank entity.
 world
     .create_entity()
-    .with(sprite_render.clone())
+    .with(sprite_render)
     // ... other components
     .build();
 # }

--- a/book/src/pong-tutorial/pong-tutorial-05.md
+++ b/book/src/pong-tutorial/pong-tutorial-05.md
@@ -221,7 +221,7 @@ Finally, add the `UiBundle` after the `InputBundle`:
 # let game_data = GameDataBuilder::default()
 .with_bundle(UiBundle::<StringBindings>::new())?
 # ;
-# 
+#
 # Ok(())
 # }
 ```
@@ -280,7 +280,7 @@ use amethyst::{
 };
 
 # pub struct Pong;
-# 
+#
 impl SimpleState for Pong {
     fn on_start(&mut self, data: StateData<'_, GameData<'_, '_>>) {
 #       let world = data.world;
@@ -316,17 +316,14 @@ fn initialise_scoreboard(world: &mut World) {
             "0".to_string(),
             [1., 1., 1., 1.],
             50.,
-        )).build();
+        ))
+        .build();
 
     let p2_score = world
         .create_entity()
         .with(p2_transform)
-        .with(UiText::new(
-            font.clone(),
-            "0".to_string(),
-            [1., 1., 1., 1.],
-            50.,
-        )).build();
+        .with(UiText::new(font, "0".to_string(), [1., 1., 1., 1.], 50.))
+        .build();
 
 # pub struct ScoreText {pub p1_score: Entity,pub p2_score: Entity,}
     world.insert(ScoreText { p1_score, p2_score });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ### Removed
 
+* `"nightly"` feature is removed, missing resource panic message includes type name on stable. ([#2136])
+
 ### Fixed
 
 ### Security
@@ -32,6 +34,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#2114]: https://github.com/amethyst/amethyst/pull/2114
 [#2115]: https://github.com/amethyst/amethyst/pull/2115
 [#2128]: https://github.com/amethyst/amethyst/pull/2128
+[#2136]: https://github.com/amethyst/amethyst/pull/2136
 
 ## [0.14.0] - 2020-01-30
 

--- a/examples/pong/pong.rs
+++ b/examples/pong/pong.rs
@@ -105,7 +105,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
 
     // Assign the sprites for the paddles
     let sprite_render = SpriteRender {
-        sprite_sheet: sprite_sheet_handle.clone(),
+        sprite_sheet: sprite_sheet_handle,
         sprite_number: 0, // paddle is the first sprite in the sprite_sheet
     };
 
@@ -125,7 +125,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
     // Create right plank entity.
     world
         .create_entity()
-        .with(sprite_render.clone())
+        .with(sprite_render)
         .with(Paddle {
             velocity: PADDLE_VELOCITY,
             side: Side::Right,

--- a/examples/pong_tutorial_02/pong.rs
+++ b/examples/pong_tutorial_02/pong.rs
@@ -102,7 +102,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
 
     // Assign the sprites for the paddles
     let sprite_render = SpriteRender {
-        sprite_sheet: sprite_sheet_handle.clone(),
+        sprite_sheet: sprite_sheet_handle,
         sprite_number: 0, // paddle is the first sprite in the sprite_sheet
     };
 
@@ -117,7 +117,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
     // Create right plank entity.
     world
         .create_entity()
-        .with(sprite_render.clone())
+        .with(sprite_render)
         .with(Paddle::new(Side::Right))
         .with(right_transform)
         .build();

--- a/examples/pong_tutorial_03/pong.rs
+++ b/examples/pong_tutorial_03/pong.rs
@@ -103,7 +103,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
 
     // Assign the sprites for the paddles
     let sprite_render = SpriteRender {
-        sprite_sheet: sprite_sheet_handle.clone(),
+        sprite_sheet: sprite_sheet_handle,
         sprite_number: 0, // paddle is the first sprite in the sprite_sheet
     };
 
@@ -118,7 +118,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
     // Create right plank entity.
     world
         .create_entity()
-        .with(sprite_render.clone())
+        .with(sprite_render)
         .with(Paddle::new(Side::Right))
         .with(right_transform)
         .build();

--- a/examples/pong_tutorial_04/pong.rs
+++ b/examples/pong_tutorial_04/pong.rs
@@ -143,7 +143,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
 
     // Assign the sprites for the paddles
     let sprite_render = SpriteRender {
-        sprite_sheet: sprite_sheet_handle.clone(),
+        sprite_sheet: sprite_sheet_handle,
         sprite_number: 0, // paddle is the first sprite in the sprite_sheet
     };
 
@@ -158,7 +158,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
     // Create right plank entity.
     world
         .create_entity()
-        .with(sprite_render.clone())
+        .with(sprite_render)
         .with(Paddle::new(Side::Right))
         .with(right_transform)
         .build();

--- a/examples/pong_tutorial_05/pong.rs
+++ b/examples/pong_tutorial_05/pong.rs
@@ -158,7 +158,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
 
     // Assign the sprites for the paddles
     let sprite_render = SpriteRender {
-        sprite_sheet: sprite_sheet_handle.clone(),
+        sprite_sheet: sprite_sheet_handle,
         sprite_number: 0, // paddle is the first sprite in the sprite_sheet
     };
 
@@ -173,7 +173,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
     // Create right plank entity.
     world
         .create_entity()
-        .with(sprite_render.clone())
+        .with(sprite_render)
         .with(Paddle::new(Side::Right))
         .with(right_transform)
         .build();
@@ -246,12 +246,7 @@ fn initialise_scoreboard(world: &mut World) {
     let p2_score = world
         .create_entity()
         .with(p2_transform)
-        .with(UiText::new(
-            font.clone(),
-            "0".to_string(),
-            [1., 1., 1., 1.],
-            50.,
-        ))
+        .with(UiText::new(font, "0".to_string(), [1., 1., 1., 1.], 50.))
         .build();
 
     world.insert(ScoreText { p1_score, p2_score });

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -30,7 +30,7 @@ test_bins_by_crate="$(
   )"
 
 # Set `LD_LIBRARY_PATH` so that tests can link against it
-target_arch=$(rustup target list | grep -F default | cut -d ' ' -f 1)
+target_arch=$(rustup toolchain list | grep -F default | cut -d ' ' -f 1 | rev | cut -d '-' -f 1-4 | rev)
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:$(rustc --print sysroot)/lib/rustlib/${target_arch}/lib/"
 
 crate_coverage_dirs=()


### PR DESCRIPTION
## Description

Updated dependency versions, excluding:

* rendy
* palette: need to update this in `rendy`
* image: need to update this in `rendy`
* rodio: see #2044
* cpal: see #2044
* objekt: crate renamed to `dyn-clone`, but asset implementation is going to be replaced with `atelier-assets`.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
