### PR TITLE
Support targeting multiple entities with UiEvents generated by the MouseUiSystem

### DIFF
--- a/amethyst_ui/src/event.rs
+++ b/amethyst_ui/src/event.rs
@@ -203,13 +203,7 @@ where
             .expect("Unexpected NaN")
     });
 
-    let mut first_opaque = None;
-    for (i, (_e, t)) in entity_transforms.iter().enumerate() {
-        if t.opaque {
-            first_opaque = Some(i);
-            break;
-        }
-    }
+    let first_opaque = entity_transforms.iter().position(|(_e, t)| t.opaque);
     if let Some(i) = first_opaque {
         entity_transforms.truncate(i + 1);
     }

--- a/amethyst_ui/src/event.rs
+++ b/amethyst_ui/src/event.rs
@@ -13,7 +13,7 @@ use amethyst_core::{
 use amethyst_input::{BindingTypes, InputHandler};
 use amethyst_window::ScreenDimensions;
 use serde::{Deserialize, Serialize};
-use std::marker::PhantomData;
+use std::{collections::HashSet, marker::PhantomData};
 use winit::MouseButton;
 
 /// An event that pertains to a specific `Entity`, for example a `UiEvent` for clicking on a widget
@@ -99,8 +99,8 @@ impl Component for Interactable {
 #[derive(Default, Debug)]
 pub struct UiMouseSystem<T: BindingTypes> {
     was_down: bool,
-    click_started_on: Option<Entity>,
-    last_target: Option<Entity>,
+    click_started_on: HashSet<Entity>,
+    last_targets: HashSet<Entity>,
     _marker: PhantomData<T>,
 }
 
@@ -109,8 +109,8 @@ impl<T: BindingTypes> UiMouseSystem<T> {
     pub fn new() -> Self {
         UiMouseSystem {
             was_down: false,
-            click_started_on: None,
-            last_target: None,
+            click_started_on: HashSet::new(),
+            last_targets: HashSet::new(),
             _marker: PhantomData,
         }
     }
@@ -142,7 +142,7 @@ impl<'a, T: BindingTypes> System<'a> for UiMouseSystem<T> {
             let x = pos_x as f32;
             let y = screen_dimensions.height() - pos_y as f32;
 
-            let target = targeted(
+            let targets = targeted(
                 (x, y),
                 (
                     &*entities,
@@ -153,36 +153,31 @@ impl<'a, T: BindingTypes> System<'a> for UiMouseSystem<T> {
                 )
                     .join(),
             );
-            if target != self.last_target {
-                if let Some(last_target) = self.last_target {
-                    events.single_write(UiEvent::new(UiEventType::HoverStop, last_target));
+            for target in targets.difference(&self.last_targets) {
+                events.single_write(UiEvent::new(UiEventType::HoverStart, *target));
+            }
+            for last_target in self.last_targets.difference(&targets) {
+                events.single_write(UiEvent::new(UiEventType::HoverStop, *last_target));
+            }
+
+            if click_started {
+                self.click_started_on = targets.clone();
+                for target in targets.iter() {
+                    events.single_write(UiEvent::new(UiEventType::ClickStart, *target));
                 }
-                if let Some(target) = target {
-                    events.single_write(UiEvent::new(UiEventType::HoverStart, target));
+            } else if click_stopped {
+                for click_start_target in self.click_started_on.intersection(&targets) {
+                    events.single_write(UiEvent::new(UiEventType::Click, *click_start_target));
                 }
             }
 
-            if let Some(e) = target {
-                if click_started {
-                    events.single_write(UiEvent::new(UiEventType::ClickStart, e));
-                    self.click_started_on = Some(e);
-                } else if click_stopped {
-                    if let Some(e2) = self.click_started_on {
-                        if e2 == e {
-                            events.single_write(UiEvent::new(UiEventType::Click, e2));
-                        }
-                    }
-                }
-            }
-
-            self.last_target = target;
+            self.last_targets = targets;
         }
 
         // Could be used for drag and drop
         if click_stopped {
-            if let Some(e) = self.click_started_on {
-                events.single_write(UiEvent::new(UiEventType::ClickStop, e));
-                self.click_started_on = None;
+            for click_start_target in self.click_started_on.drain() {
+                events.single_write(UiEvent::new(UiEventType::ClickStop, click_start_target));
             }
         }
 
@@ -190,26 +185,40 @@ impl<'a, T: BindingTypes> System<'a> for UiMouseSystem<T> {
     }
 }
 
-/// Checks if an interactable entity is at the position `pos` and doesn't have anything on top blocking the check.
-/// If you have a non-interactable entity over an interactable entity, it will consider the interactable one blocked, depending
-/// on if `pos` is over the non-interactable one or not.
-pub fn targeted<'a, I>(pos: (f32, f32), transforms: I) -> Option<Entity>
+/// Finds all interactable entities at the position `pos` which don't have any opaque entities on
+/// top blocking them.
+pub fn targeted<'a, I>(pos: (f32, f32), transforms: I) -> HashSet<Entity>
 where
     I: Iterator<Item = (Entity, &'a UiTransform, Option<&'a Interactable>, (), ())> + 'a,
 {
-    transforms
-        .filter(|(_e, t, _m, _, _)| t.opaque && t.position_inside(pos.0, pos.1))
-        .max_by(|(_e1, t1, _m1, _, _), (_e2, t2, _m2, _, _)| {
-            t1.global_z
-                .partial_cmp(&t2.global_z)
-                .expect("Unexpected NaN")
+    let mut entity_transforms: Vec<(Entity, &UiTransform)> = transforms
+        .filter(|(_e, t, _m, _, _)| {
+            (t.opaque || t.transparent_target) && t.position_inside(pos.0, pos.1)
         })
-        .and_then(|(e, _, m, _, _)| m.map(|_m| e))
+        .map(|(e, t, _m, _, _)| (e, t))
+        .collect();
+    entity_transforms.sort_by(|(_, t1), (_, t2)| {
+        t2.global_z
+            .partial_cmp(&t1.global_z)
+            .expect("Unexpected NaN")
+    });
+
+    let mut first_opaque = None;
+    for (i, (_e, t)) in entity_transforms.iter().enumerate() {
+        if t.opaque {
+            first_opaque = Some(i);
+            break;
+        }
+    }
+    if let Some(i) = first_opaque {
+        entity_transforms.truncate(i + 1);
+    }
+
+    entity_transforms.into_iter().map(|(e, _t)| e).collect()
 }
 
-/// Checks if an interactable entity is at the position `pos`, doesn't have anything on top blocking the check, and is below specified height.
-/// If you have a non-interactable entity over an interactable entity, it will consider the interactable one blocked, depending
-/// on if `pos` is over the non-interactable one or not.
+/// Checks if an interactable entity is at the position `pos`, doesn't have anything on top blocking
+/// the check, and is below specified height.
 pub fn targeted_below<'a, I>(pos: (f32, f32), height: f32, transforms: I) -> Option<Entity>
 where
     I: Iterator<Item = (Entity, &'a UiTransform, Option<&'a Interactable>, (), ())> + 'a,

--- a/amethyst_ui/src/prefab.rs
+++ b/amethyst_ui/src/prefab.rs
@@ -52,6 +52,10 @@ pub struct UiTransformData<G> {
     /// the next element (for example, the text on a button).
     #[derivative(Default(value = "true"))]
     pub opaque: bool,
+    /// Allows transparent (`opaque = false`) transforms to still be targeted by the events that
+    /// pass through them.
+    #[derivative(Default(value = "false"))]
+    pub transparent_target: bool,
     /// Renders this UI element by evaluating transform as a percentage of the parent size,
     /// rather than rendering it with pixel units.
     pub percent: bool,
@@ -173,6 +177,7 @@ where
         if !self.opaque {
             transform = transform.into_transparent();
         }
+        transform.transparent_target = self.transparent_target;
         if self.percent {
             transform = transform.into_percent();
         }

--- a/amethyst_ui/src/transform.rs
+++ b/amethyst_ui/src/transform.rs
@@ -80,6 +80,9 @@ pub struct UiTransform {
     /// If set to false, the element will behaves as if it was transparent and will let events go to
     /// the next element (for example, the text on a button).
     pub opaque: bool,
+    /// Allows transparent (opaque = false) transforms to still be targeted by the events that pass
+    /// through them.
+    pub transparent_target: bool,
     /// A private field to keep this from being initialized without new.
     pd: PhantomData<()>,
 }
@@ -114,6 +117,7 @@ impl UiTransform {
             pixel_height: height,
             scale_mode: ScaleMode::Pixel,
             opaque: true,
+            transparent_target: false,
             pd: PhantomData,
         }
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - Support settings module log levels from a RON file ([#2115])
 - Export the `get_parent_pixel_size` functions from the ui module ([[#2128])
 - Export the `pixel_width` and `pixel_height` methods on the `UiTransform` ([[#2128])
+- Support UiEvents targeting multiple overlapping entities ([#2138])
 
 ### Changed
 
@@ -35,6 +36,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#2115]: https://github.com/amethyst/amethyst/pull/2115
 [#2128]: https://github.com/amethyst/amethyst/pull/2128
 [#2136]: https://github.com/amethyst/amethyst/pull/2136
+[#2138]: https://github.com/amethyst/amethyst/pull/2138
 
 ## [0.14.0] - 2020-01-30
 


### PR DESCRIPTION
## Description

Support targeting multiple entities with UiEvents generated by the MouseUiSystem

## Additions

- Add the `transparent_target: bool` field to `UiTransform` and `UiTransformData`.

## Modifications

- Use the field in `ui::events::targeted` to support the desired behavior.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
