### PR TITLE
Bugfix/2108/ui text spaces highlight

### DIFF
--- a/amethyst_ui/src/glyphs.rs
+++ b/amethyst_ui/src/glyphs.rs
@@ -184,6 +184,7 @@ impl<'a, B: Backend> System<'a> for UiGlyphsSystem<B> {
         {
             ui_text.cached_glyphs.clear();
 
+            let font_asset = font_storage.get(&ui_text.font).map(|font| font.0.clone());
             let font_lookup = fonts_map_ref
                 .entry(ui_text.font.id())
                 .or_insert(FontState::NotFound);
@@ -193,7 +194,7 @@ impl<'a, B: Backend> System<'a> for UiGlyphsSystem<B> {
                 }
             }
 
-            if let Some(font_id) = font_lookup.id() {
+            if let (Some(font_id), Some(font_asset)) = (font_lookup.id(), font_asset) {
                 let tint_color = tint.map_or([1., 1., 1., 1.], |t| {
                     let (r, g, b, a) = t.0.into_components();
                     [r, g, b, a]
@@ -310,19 +311,67 @@ impl<'a, B: Backend> System<'a> for UiGlyphsSystem<B> {
                     text,
                 };
 
-                ui_text.cached_glyphs.extend(
-                    glyph_brush_ref
-                        .glyphs_custom_layout(&section, &layout)
-                        .map(|g| {
-                            let pos = g.position();
-                            let advance_width = g.unpositioned().h_metrics().advance_width;
-                            CachedGlyph {
-                                x: pos.x,
-                                y: -pos.y,
-                                advance_width,
+                // `GlyphBrush::glyphs_custom_layout` does not return glyphs for invisible
+                // characters.
+                //
+                // <https://docs.rs/glyph_brush/0.6.2/glyph_brush/trait.GlyphCruncher.html
+                //  #tymethod.glyphs_custom_layout>
+                //
+                // For support, see:
+                //
+                // <https://github.com/alexheretic/glyph-brush/issues/80>
+                let mut nonempty_cached_glyphs = glyph_brush_ref
+                    .glyphs_custom_layout(&section, &layout)
+                    .map(|g| {
+                        let pos = g.position();
+                        let advance_width = g.unpositioned().h_metrics().advance_width;
+                        CachedGlyph {
+                            x: pos.x,
+                            y: -pos.y,
+                            advance_width,
+                        }
+                    });
+
+                let mut last_cached_glyph: Option<CachedGlyph> = None;
+                let all_glyphs = ui_text.text.graphemes(true).filter_map(|s| {
+                    let c = if s.len() == 1 {
+                        if let Some(c) = s.chars().next() {
+                            if c.is_whitespace() {
+                                Some(c)
+                            } else {
+                                None
                             }
-                        }),
-                );
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    };
+                    if let Some(c) = c {
+                        let (x, y) = if let Some(last_cached_glyph) = last_cached_glyph {
+                            let x = last_cached_glyph.x + last_cached_glyph.advance_width;
+                            let y = last_cached_glyph.y;
+                            (x, y)
+                        } else {
+                            (0.0, 0.0)
+                        };
+
+                        let advance_width =
+                            font_asset.glyph(c).scaled(scale).h_metrics().advance_width;
+
+                        let cached_glyph = CachedGlyph {
+                            x,
+                            y,
+                            advance_width,
+                        };
+                        last_cached_glyph = Some(cached_glyph);
+                        last_cached_glyph
+                    } else {
+                        last_cached_glyph = nonempty_cached_glyphs.next();
+                        last_cached_glyph
+                    }
+                });
+                ui_text.cached_glyphs.extend(all_glyphs);
 
                 glyph_brush_ref.queue_custom_layout(section, &layout);
             }

--- a/amethyst_ui/src/glyphs.rs
+++ b/amethyst_ui/src/glyphs.rs
@@ -333,21 +333,8 @@ impl<'a, B: Backend> System<'a> for UiGlyphsSystem<B> {
                     });
 
                 let mut last_cached_glyph: Option<CachedGlyph> = None;
-                let all_glyphs = ui_text.text.graphemes(true).filter_map(|s| {
-                    let c = if s.len() == 1 {
-                        if let Some(c) = s.chars().next() {
-                            if c.is_whitespace() {
-                                Some(c)
-                            } else {
-                                None
-                            }
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    };
-                    if let Some(c) = c {
+                let all_glyphs = ui_text.text.chars().filter_map(|c| {
+                    if c.is_whitespace() {
                         let (x, y) = if let Some(last_cached_glyph) = last_cached_glyph {
                             let x = last_cached_glyph.x + last_cached_glyph.advance_width;
                             let y = last_cached_glyph.y;

--- a/amethyst_ui/src/text.rs
+++ b/amethyst_ui/src/text.rs
@@ -246,6 +246,7 @@ impl<'a> System<'a> for TextEditingMouseSystem {
                                     mouse_y,
                                     &text.cached_glyphs,
                                 );
+                                text_editing.cursor_blink_timer = 0.0;
 
                                 // The end of the text, while not a glyph, is still something
                                 // you'll likely want to click your cursor to, so if the cursor is

--- a/amethyst_ui/src/text.rs
+++ b/amethyst_ui/src/text.rs
@@ -46,12 +46,12 @@ pub struct UiText {
     pub line_mode: LineMode,
     /// How to align the text within its `UiTransform`.
     pub align: Anchor,
-    /// Cached glyph positions, used to process mouse highlighting
+    /// Cached glyph positions including invisible characters, used to process mouse highlighting.
     #[serde(skip)]
     pub(crate) cached_glyphs: Vec<CachedGlyph>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub(crate) struct CachedGlyph {
     pub(crate) x: f32,
     pub(crate) y: f32,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,17 +26,21 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ### Removed
 
-* `"nightly"` feature is removed, missing resource panic message includes type name on stable. ([#2136])
+- `"nightly"` feature is removed, missing resource panic message includes type name on stable. ([#2136])
 
 ### Fixed
 
+- Editable text fields now correctly highlight strings containing spaces. ([#2108], [#2143])
+
 ### Security
 
+[#2108]: https://github.com/amethyst/amethyst/issues/2108
 [#2114]: https://github.com/amethyst/amethyst/pull/2114
 [#2115]: https://github.com/amethyst/amethyst/pull/2115
 [#2128]: https://github.com/amethyst/amethyst/pull/2128
 [#2136]: https://github.com/amethyst/amethyst/pull/2136
 [#2138]: https://github.com/amethyst/amethyst/pull/2138
+[#2143]: https://github.com/amethyst/amethyst/pull/2143
 
 ## [0.14.0] - 2020-01-30
 


### PR DESCRIPTION
## Description

Fixes #2108.

![ui_highlight](https://user-images.githubusercontent.com/2993230/74990152-5b85fa00-54a7-11ea-8a5a-71881175f960.gif)

## Fixes

- Editable text fields now correctly highlight strings containing spaces.

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
