### PR TITLE
Bump Fluent to 0.10

### DIFF
--- a/amethyst_locale/Cargo.toml
+++ b/amethyst_locale/Cargo.toml
@@ -24,8 +24,8 @@ amethyst_assets = { path = "../amethyst_assets", version = "0.10.0" }
 amethyst_core = { path = "../amethyst_core", version = "0.9.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.4.0" }
 serde = { version = "1.0", features = ["derive"] }
-fluent = "0.9"
-unic-langid = { version = "0.7", features = ["macros"] }
+fluent = "0.10.2"
+unic-langid = { version = "0.8", features = ["macros"] }
 
 thread_profiler = { version = "0.3", optional = true }
 


### PR DESCRIPTION
Fluent is now in 0.10 and adds a bunch of nice features like plugs for number and date formatting.

Fortunately, bumping seems easy :)