### PR TITLE
fixup: switch legion-ecs builtin shaders to use `from_bytes`

### DIFF
--- a/amethyst_rendy/src/legion/pass/mod.rs
+++ b/amethyst_rendy/src/legion/pass/mod.rs
@@ -13,93 +13,93 @@ pub use self::{base_3d::*, debug_lines::*, flat::*, flat2d::*, pbr::*, shaded::*
 use rendy::{hal::pso::ShaderStageFlags, shader::SpirvShader};
 
 lazy_static::lazy_static! {
-    static ref POS_TEX_VERTEX: SpirvShader = SpirvShader::new(
+    static ref POS_TEX_VERTEX: SpirvShader = SpirvShader::from_bytes(
         include_bytes!("../../../compiled/vertex/pos_tex.vert.spv"),
         ShaderStageFlags::VERTEX,
         "main",
-    );
+    ).unwrap();
 
-    static ref POS_TEX_SKIN_VERTEX: SpirvShader = SpirvShader::new(
+    static ref POS_TEX_SKIN_VERTEX: SpirvShader = SpirvShader::from_bytes(
         include_bytes!("../../../compiled/vertex/pos_tex_skin.vert.spv"),
         ShaderStageFlags::VERTEX,
         "main",
-    );
+    ).unwrap();
 
-    static ref POS_NORM_TEX_VERTEX: SpirvShader = SpirvShader::new(
+    static ref POS_NORM_TEX_VERTEX: SpirvShader = SpirvShader::from_bytes(
         include_bytes!("../../../compiled/vertex/pos_norm_tex.vert.spv"),
         ShaderStageFlags::VERTEX,
         "main",
-    );
+    ).unwrap();
 
-    static ref POS_NORM_TEX_SKIN_VERTEX: SpirvShader = SpirvShader::new(
+    static ref POS_NORM_TEX_SKIN_VERTEX: SpirvShader = SpirvShader::from_bytes(
         include_bytes!("../../../compiled/vertex/pos_norm_tex_skin.vert.spv"),
         ShaderStageFlags::VERTEX,
         "main",
-    );
+    ).unwrap();
 
-    static ref POS_NORM_TANG_TEX_VERTEX: SpirvShader = SpirvShader::new(
+    static ref POS_NORM_TANG_TEX_VERTEX: SpirvShader = SpirvShader::from_bytes(
         include_bytes!("../../../compiled/vertex/pos_norm_tang_tex.vert.spv"),
         ShaderStageFlags::VERTEX,
         "main",
-    );
+    ).unwrap();
 
-    static ref POS_NORM_TANG_TEX_SKIN_VERTEX: SpirvShader = SpirvShader::new(
+    static ref POS_NORM_TANG_TEX_SKIN_VERTEX: SpirvShader = SpirvShader::from_bytes(
         include_bytes!("../../../compiled/vertex/pos_norm_tang_tex_skin.vert.spv"),
         ShaderStageFlags::VERTEX,
         "main",
-    );
+    ).unwrap();
 
-    static ref FLAT_FRAGMENT: SpirvShader = SpirvShader::new(
+    static ref FLAT_FRAGMENT: SpirvShader = SpirvShader::from_bytes(
         include_bytes!("../../../compiled/fragment/flat.frag.spv"),
         ShaderStageFlags::FRAGMENT,
         "main",
-    );
+    ).unwrap();
 
-    static ref SHADED_FRAGMENT: SpirvShader = SpirvShader::new(
+    static ref SHADED_FRAGMENT: SpirvShader = SpirvShader::from_bytes(
         include_bytes!("../../../compiled/fragment/shaded.frag.spv"),
         ShaderStageFlags::FRAGMENT,
         "main",
-    );
+    ).unwrap();
 
-    static ref PBR_FRAGMENT: SpirvShader = SpirvShader::new(
+    static ref PBR_FRAGMENT: SpirvShader = SpirvShader::from_bytes(
         include_bytes!("../../../compiled/fragment/pbr.frag.spv"),
         ShaderStageFlags::FRAGMENT,
         "main",
-    );
+    ).unwrap();
 
-    static ref SPRITE_VERTEX: SpirvShader = SpirvShader::new(
+    static ref SPRITE_VERTEX: SpirvShader = SpirvShader::from_bytes(
         include_bytes!("../../../compiled/vertex/sprite.vert.spv"),
         ShaderStageFlags::VERTEX,
         "main",
-    );
+    ).unwrap();
 
-    static ref SPRITE_FRAGMENT: SpirvShader = SpirvShader::new(
+    static ref SPRITE_FRAGMENT: SpirvShader = SpirvShader::from_bytes(
         include_bytes!("../../../compiled/fragment/sprite.frag.spv"),
         ShaderStageFlags::FRAGMENT,
         "main",
-    );
+    ).unwrap();
 
-    static ref SKYBOX_VERTEX: SpirvShader = SpirvShader::new(
+    static ref SKYBOX_VERTEX: SpirvShader = SpirvShader::from_bytes(
         include_bytes!("../../../compiled/vertex/skybox.vert.spv"),
         ShaderStageFlags::VERTEX,
         "main",
-    );
+    ).unwrap();
 
-    static ref SKYBOX_FRAGMENT: SpirvShader = SpirvShader::new(
+    static ref SKYBOX_FRAGMENT: SpirvShader = SpirvShader::from_bytes(
         include_bytes!("../../../compiled/fragment/skybox.frag.spv"),
         ShaderStageFlags::FRAGMENT,
         "main",
-    );
+    ).unwrap();
 
-    static ref DEBUG_LINES_VERTEX: SpirvShader = SpirvShader::new(
+    static ref DEBUG_LINES_VERTEX: SpirvShader = SpirvShader::from_bytes(
         include_bytes!("../../../compiled/vertex/debug_lines.vert.spv"),
         ShaderStageFlags::VERTEX,
         "main",
-    );
+    ).unwrap();
 
-    static ref DEBUG_LINES_FRAGMENT: SpirvShader = SpirvShader::new(
+    static ref DEBUG_LINES_FRAGMENT: SpirvShader = SpirvShader::from_bytes(
         include_bytes!("../../../compiled/fragment/debug_lines.frag.spv"),
         ShaderStageFlags::FRAGMENT,
         "main",
-    );
+    ).unwrap();
 }


### PR DESCRIPTION
@jaynus had started doing this in 9f2117935a9ceadaae8ff68f51f015ab4288e752.

Per discussion in discord, it looks like `SprivShader::new()` formerly accepted a `Vec<u8>`, but was updated to accept `Vec<u32>` instead, to match up with Vulkan's requirements. With the above commit, we're no longer invoking `to_vec()` on the included `[u8; N]`, but it still wasn't enough to make `SpirvShader::new()` happy.

I suspect this code predated upstream Amethyst switching to the `from_bytes` API, and I've simply fixed it up to eliminate a decent chunk of [E03098](https://doc.rust-lang.org/error-index.html#E0308).