### PR TITLE
Improvement/misc ui improvements

### DIFF
--- a/amethyst_ui/src/button/builder.rs
+++ b/amethyst_ui/src/button/builder.rs
@@ -259,7 +259,7 @@ impl<'a, G: PartialEq + Send + Sync + 'static, I: WidgetId> UiButtonBuilder<G, I
     }
 
     /// Build this with the `UiButtonBuilderResources`.
-    pub fn build(mut self, mut res: UiButtonBuilderResources<'a, G, I>) -> (I, UiButton) {
+    pub fn build(mut self, res: &mut UiButtonBuilderResources<'a, G, I>) -> (I, UiButton) {
         let image_entity = res.entities.create();
         let text_entity = res.entities.create();
         let widget = UiButton::new(text_entity, image_entity);
@@ -410,7 +410,7 @@ impl<'a, G: PartialEq + Send + Sync + 'static, I: WidgetId> UiButtonBuilder<G, I
 
     /// Create the UiButton based on provided configuration parameters.
     pub fn build_from_world(self, world: &World) -> (I, UiButton) {
-        self.build(UiButtonBuilderResources::<G, I>::fetch(&world))
+        self.build(&mut UiButtonBuilderResources::<G, I>::fetch(&world))
     }
 }
 

--- a/amethyst_ui/src/layout.rs
+++ b/amethyst_ui/src/layout.rs
@@ -53,7 +53,7 @@ impl Anchor {
     /// Returns the normalized offset using the `Anchor` setting.
     /// The normalized offset is a [-0.5,0.5] value
     /// indicating the relative offset multiplier from the parent's position (centered).
-    pub fn norm_offset(&self) -> (f32, f32) {
+    pub fn norm_offset(self) -> (f32, f32) {
         match self {
             Anchor::TopLeft => (-0.5, 0.5),
             Anchor::TopMiddle => (0.0, 0.5),
@@ -68,7 +68,7 @@ impl Anchor {
     }
 
     /// Vertical align. Used by the `UiGlyphsSystem`.
-    pub(crate) fn vertical_align(&self) -> VerticalAlign {
+    pub(crate) fn vertical_align(self) -> VerticalAlign {
         match self {
             Anchor::TopLeft => VerticalAlign::Top,
             Anchor::TopMiddle => VerticalAlign::Top,
@@ -83,7 +83,7 @@ impl Anchor {
     }
 
     /// Horizontal align. Used by the `UiGlyphsSystem`.
-    pub(crate) fn horizontal_align(&self) -> HorizontalAlign {
+    pub(crate) fn horizontal_align(self) -> HorizontalAlign {
         match self {
             Anchor::TopLeft => HorizontalAlign::Left,
             Anchor::TopMiddle => HorizontalAlign::Center,

--- a/amethyst_ui/src/layout.rs
+++ b/amethyst_ui/src/layout.rs
@@ -27,7 +27,7 @@ pub enum ScaleMode {
 
 /// Indicated where the anchor is, relative to the parent (or to the screen, if there is no parent).
 /// Follow a normal english Y,X naming.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
 pub enum Anchor {
     /// Anchors the entity at the top left of the parent.
     TopLeft,

--- a/amethyst_ui/src/prefab.rs
+++ b/amethyst_ui/src/prefab.rs
@@ -163,8 +163,8 @@ where
     ) -> Result<(), Error> {
         let mut transform = UiTransform::new(
             self.id.clone(),
-            self.anchor.clone(),
-            self.pivot.clone(),
+            self.anchor,
+            self.pivot,
             self.x,
             self.y,
             self.z,
@@ -301,12 +301,12 @@ impl<'a> PrefabData<'a> for UiTextData {
         let mut ui_text = UiText::new(font_handle, self.text.clone(), self.color, self.font_size);
         ui_text.password = self.password;
 
-        if let Some(ref align) = self.align {
-            ui_text.align = align.clone();
+        if let Some(align) = self.align {
+            ui_text.align = align;
         }
 
-        if let Some(ref line_mode) = self.line_mode {
-            ui_text.line_mode = line_mode.clone();
+        if let Some(line_mode) = self.line_mode {
+            ui_text.line_mode = line_mode;
         }
 
         texts.insert(entity, ui_text)?;

--- a/amethyst_ui/src/text.rs
+++ b/amethyst_ui/src/text.rs
@@ -19,7 +19,7 @@ use amethyst_window::ScreenDimensions;
 use super::*;
 
 /// How lines should behave when they are longer than the maximum line length.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize)]
 pub enum LineMode {
     /// Single line. It ignores line breaks.
     Single,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,9 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 ### Changed
 
 - Re-export `TargetedEvent` from amethyst_ui. ([#2114])
+- `amethyst::ui::Anchor` is now `Copy`. ([#2148])
+- `amethyst::ui::LineMode` is now `Copy`. ([#2148])
+- `UiButtonBuilder::build` takes in `&mut UiButtonBuilderResources`. ([#2148])
 
 ### Deprecated
 
@@ -43,6 +46,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#2138]: https://github.com/amethyst/amethyst/pull/2138
 [#2143]: https://github.com/amethyst/amethyst/pull/2143
 [#2146]: https://github.com/amethyst/amethyst/issues/2146
+[#2148]: https://github.com/amethyst/amethyst/pull/2148
 [#2149]: https://github.com/amethyst/amethyst/pull/2149
 
 ## [0.14.0] - 2020-01-30


### PR DESCRIPTION
## Description

- `amethyst::ui::Anchor` is now `Copy`.
- `amethyst::ui::LineMode` is now `Copy`.
- `UiButtonBuilder::build` takes in `&mut UiButtonBuilderResources`.

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
