### PR TITLE
Bugfix/2146/redraw ui caret

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 ### Fixed
 
 - Editable text fields now correctly highlight strings containing spaces. ([#2108], [#2143])
+- Caret for editable text box is drawn in correct position. ([#2146], [#2149])
 
 ### Security
 
@@ -41,6 +42,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#2136]: https://github.com/amethyst/amethyst/pull/2136
 [#2138]: https://github.com/amethyst/amethyst/pull/2138
 [#2143]: https://github.com/amethyst/amethyst/pull/2143
+[#2146]: https://github.com/amethyst/amethyst/issues/2146
+[#2149]: https://github.com/amethyst/amethyst/pull/2149
 
 ## [0.14.0] - 2020-01-30
 


### PR DESCRIPTION
## Description

Caret for editable text box is drawn in correct position.

Fixes #2146.

![caret_move](https://user-images.githubusercontent.com/2993230/75134886-8d67bc80-5744-11ea-9274-52721a10ead8.gif)

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
