### PR TITLE
Clear selecteds if selectables do not contain an event target

### DIFF
--- a/amethyst_ui/src/bundle.rs
+++ b/amethyst_ui/src/bundle.rs
@@ -53,6 +53,11 @@ where
             &["transform_system"],
         );
         builder.add(
+            UiMouseSystem::<T>::new(),
+            "ui_mouse_system",
+            &["input_system", "ui_transform"],
+        );
+        builder.add(
             Processor::<FontAsset>::new(),
             "font_processor",
             &["ui_loader"],
@@ -65,7 +70,7 @@ where
         builder.add(
             SelectionMouseSystemDesc::<G, T>::default().build(world),
             "ui_mouse_selection",
-            &[],
+            &["ui_mouse_system"],
         );
         builder.add(
             SelectionKeyboardSystemDesc::<G>::default().build(world),
@@ -88,11 +93,6 @@ where
             ResizeSystemDesc::default().build(world),
             "ui_resize_system",
             &[],
-        );
-        builder.add(
-            UiMouseSystem::<T>::new(),
-            "ui_mouse_system",
-            &["ui_transform"],
         );
         builder.add(
             UiButtonSystemDesc::default().build(world),

--- a/amethyst_ui/src/text.rs
+++ b/amethyst_ui/src/text.rs
@@ -194,74 +194,82 @@ impl<'a> System<'a> for TextEditingMouseSystem {
             }
         }
 
+        let mut just_pressed = false;
+        let mut moved_while_pressed = false;
+
         // Process only if an editable text is selected.
         for event in events.read(&mut self.reader) {
-            for (ref mut text, ref mut text_editing, _) in
-                (&mut texts, &mut text_editings, &selecteds).join()
-            {
-                // Process events for the whole UI.
-                match *event {
-                    Event::WindowEvent {
-                        event: WindowEvent::CursorMoved { position, .. },
-                        ..
-                    } => {
-                        let hidpi = screen_dimensions.hidpi_factor() as f32;
-                        self.mouse_position = (
-                            position.x as f32 * hidpi,
-                            (screen_dimensions.height() - position.y as f32) * hidpi,
-                        );
-                        if self.left_mouse_button_pressed {
-                            let (mouse_x, mouse_y) = self.mouse_position;
-                            text_editing.highlight_vector =
-                                closest_glyph_index_to_mouse(mouse_x, mouse_y, &text.cached_glyphs)
-                                    - text_editing.cursor_position;
-                            // The end of the text, while not a glyph, is still something
-                            // you'll likely want to click your cursor to, so if the cursor is
-                            // near the end of the text, check if we should put it at the end
-                            // of the text.
-                            if should_advance_to_end(mouse_x, text_editing, text) {
-                                text_editing.highlight_vector += 1;
-                            }
-                        }
+            // Process events for the whole UI.
+            match *event {
+                Event::WindowEvent {
+                    event: WindowEvent::CursorMoved { position, .. },
+                    ..
+                } => {
+                    let hidpi = screen_dimensions.hidpi_factor() as f32;
+                    self.mouse_position = (
+                        position.x as f32 * hidpi,
+                        (screen_dimensions.height() - position.y as f32) * hidpi,
+                    );
+                    if self.left_mouse_button_pressed {
+                        moved_while_pressed = true;
                     }
-                    Event::WindowEvent {
-                        event:
-                            WindowEvent::MouseInput {
-                                button: MouseButton::Left,
-                                state,
-                                ..
-                            },
-                        ..
-                    } => {
-                        match state {
-                            ElementState::Pressed => {
-                                self.left_mouse_button_pressed = true;
-
-                                // If we focused an editable text field be sure to position the cursor
-                                // in it.
-                                let (mouse_x, mouse_y) = self.mouse_position;
-                                text_editing.highlight_vector = 0;
-                                text_editing.cursor_position = closest_glyph_index_to_mouse(
-                                    mouse_x,
-                                    mouse_y,
-                                    &text.cached_glyphs,
-                                );
-                                text_editing.cursor_blink_timer = 0.0;
-
-                                // The end of the text, while not a glyph, is still something
-                                // you'll likely want to click your cursor to, so if the cursor is
-                                // near the end of the text, check if we should put it at the end
-                                // of the text.
-                                if should_advance_to_end(mouse_x, text_editing, text) {
-                                    text_editing.cursor_position += 1;
-                                }
-                            }
-                            ElementState::Released => {
-                                self.left_mouse_button_pressed = false;
-                            }
-                        }
+                }
+                Event::WindowEvent {
+                    event:
+                        WindowEvent::MouseInput {
+                            button: MouseButton::Left,
+                            state,
+                            ..
+                        },
+                    ..
+                } => match state {
+                    ElementState::Pressed => {
+                        println!("hey");
+                        just_pressed = true;
+                        self.left_mouse_button_pressed = true;
                     }
-                    _ => {}
+                    ElementState::Released => {
+                        self.left_mouse_button_pressed = false;
+                    }
+                },
+                _ => {}
+            }
+        }
+
+        for (ref mut text, ref mut text_editing, selected) in
+            (&mut texts, &mut text_editings, selecteds.maybe()).join()
+        {
+            if selected.is_none() {
+                // If an editable text field is no longer selected, we should reset
+                // the highlight vector.
+                text_editing.highlight_vector = 0;
+            } else if just_pressed {
+                // If we focused an editable text field be sure to position the cursor
+                // in it.
+                let (mouse_x, mouse_y) = self.mouse_position;
+                text_editing.highlight_vector = 0;
+                text_editing.cursor_position =
+                    closest_glyph_index_to_mouse(mouse_x, mouse_y, &text.cached_glyphs);
+                text_editing.cursor_blink_timer = 0.0;
+
+                // The end of the text, while not a glyph, is still something
+                // you'll likely want to click your cursor to, so if the cursor is
+                // near the end of the text, check if we should put it at the end
+                // of the text.
+                if should_advance_to_end(mouse_x, text_editing, text) {
+                    text_editing.cursor_position += 1;
+                }
+            } else if moved_while_pressed {
+                let (mouse_x, mouse_y) = self.mouse_position;
+                text_editing.highlight_vector =
+                    closest_glyph_index_to_mouse(mouse_x, mouse_y, &text.cached_glyphs)
+                        - text_editing.cursor_position;
+                // The end of the text, while not a glyph, is still something
+                // you'll likely want to click your cursor to, so if the cursor is
+                // near the end of the text, check if we should put it at the end
+                // of the text.
+                if should_advance_to_end(mouse_x, text_editing, text) {
+                    text_editing.highlight_vector += 1;
                 }
             }
         }

--- a/amethyst_ui/src/text.rs
+++ b/amethyst_ui/src/text.rs
@@ -224,7 +224,6 @@ impl<'a> System<'a> for TextEditingMouseSystem {
                     ..
                 } => match state {
                     ElementState::Pressed => {
-                        println!("hey");
                         just_pressed = true;
                         self.left_mouse_button_pressed = true;
                     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,10 +20,11 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ### Changed
 
-- Re-export `TargetedEvent` from amethyst_ui. ([#2114])
+- Re-export `TargetedEvent` from `amethyst_ui`. ([#2114])
 - `amethyst::ui::Anchor` is now `Copy`. ([#2148])
 - `amethyst::ui::LineMode` is now `Copy`. ([#2148])
 - `UiButtonBuilder::build` takes in `&mut UiButtonBuilderResources`. ([#2148])
+- ***Breaking:*** `UiBundle` depends on `InputBundle` being registered with the dispatcher first. ([#2151])
 
 ### Deprecated
 
@@ -35,9 +36,12 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 - Editable text fields now correctly highlight strings containing spaces. ([#2108], [#2143])
 - Caret for editable text box is drawn in correct position. ([#2146], [#2149])
+- Caret for editable text box is positioned correctly on first click. ([#2151])
+- Editable text is correctly blurred / unfocused when clicking outside its bounds. ([#2091], [#2151])
 
 ### Security
 
+[#2091]: https://github.com/amethyst/amethyst/issues/2091
 [#2108]: https://github.com/amethyst/amethyst/issues/2108
 [#2114]: https://github.com/amethyst/amethyst/pull/2114
 [#2115]: https://github.com/amethyst/amethyst/pull/2115
@@ -48,6 +52,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#2146]: https://github.com/amethyst/amethyst/issues/2146
 [#2148]: https://github.com/amethyst/amethyst/pull/2148
 [#2149]: https://github.com/amethyst/amethyst/pull/2149
+[#2151]: https://github.com/amethyst/amethyst/pull/2151
 
 ## [0.14.0] - 2020-01-30
 

--- a/examples/ui/main.rs
+++ b/examples/ui/main.rs
@@ -131,11 +131,11 @@ fn main() -> amethyst::Result<()> {
     let game_data = GameDataBuilder::default()
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
         .with_bundle(TransformBundle::new())?
+        .with_bundle(InputBundle::<StringBindings>::new())?
         .with_bundle(UiBundle::<StringBindings>::new())?
         .with(Processor::<Source>::new(), "source_processor", &[])
         .with_system_desc(UiEventHandlerSystemDesc::default(), "ui_event_handler", &[])
         .with_bundle(FpsCounterBundle::default())?
-        .with_bundle(InputBundle::<StringBindings>::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(


### PR DESCRIPTION
## Description

An attempt to fix #2091

I'm not sure what this comment is about:
https://github.com/amethyst/amethyst/blob/72f7d8f913b4a4d8f05733f2d0c27315d6a09530/amethyst_ui/src/selection.rs#L257
So maybe my change breaks something..

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
