### PR TITLE
Maintenance/correct amethyst test features

### DIFF
--- a/amethyst_test/Cargo.toml
+++ b/amethyst_test/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/amethyst/amethyst"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-amethyst = { path = "..", version = "0.14.0" }
+amethyst = { path = "..", version = "0.14.0", default-features = false }
 derivative = "1.0"
 derive-new = "0.5"
 derive_deref = "1.1.0"
@@ -24,10 +24,27 @@ log = "0.4"
 serde = "1.0"
 
 [features]
-default = []
-empty = ["amethyst/empty"]
-metal = ["amethyst/metal"]
+default = ["animation", "audio", "locale", "network", "renderer"]
+
 vulkan = ["amethyst/vulkan"]
+metal = ["amethyst/metal"]
+empty = ["amethyst/empty"]
+tiles = ["amethyst/tiles"]
+animation = ["amethyst/animation"]
+audio = ["amethyst/audio"]
+gltf = ["amethyst/gltf"]
+locale = ["amethyst/locale"]
+network = ["amethyst/network"]
+renderer = ["amethyst/renderer"]
+profiler = ["amethyst/profiler"]
+sdl_controller = ["amethyst/sdl_controller"]
+json = ["amethyst/json"]
+saveload = ["amethyst/saveload"]
+server = ["amethyst/server"]
+no-slow-safety-checks = ["amethyst/no-slow-safety-checks"]
+shader-compiler = ["amethyst/shader-compiler"]
+test-support = ["amethyst/test-support"]
+experimental-spirv-reflection = ["amethyst/experimental-spirv-reflection"]
 
 # Used to tag tests that need an audio backend to run.
-audio = []
+test_audio = []

--- a/amethyst_test/src/amethyst_application.rs
+++ b/amethyst_test/src/amethyst_application.rs
@@ -955,7 +955,7 @@ mod test {
     /// ```
     ///
     /// For more details, see <https://github.com/amethyst/amethyst/issues/1595>.
-    #[cfg(feature = "audio")]
+    #[cfg(feature = "test_audio")]
     mod audio_test {
         use amethyst::{
             assets::AssetStorage,

--- a/amethyst_test/src/fixture/mod.rs
+++ b/amethyst_test/src/fixture/mod.rs
@@ -3,10 +3,13 @@
 //! Technically all effect and assertion functions can be moved here if it is useful for external
 //! crates.
 
+#[cfg(feature = "animation")]
 pub use self::{
     material_animation_fixture::MaterialAnimationFixture,
     sprite_render_animation_fixture::SpriteRenderAnimationFixture,
 };
 
+#[cfg(feature = "animation")]
 mod material_animation_fixture;
+#[cfg(feature = "animation")]
 mod sprite_render_animation_fixture;

--- a/amethyst_test/src/lib.rs
+++ b/amethyst_test/src/lib.rs
@@ -318,7 +318,6 @@
 pub use crate::{
     amethyst_application::{AmethystApplication, HIDPI, SCREEN_HEIGHT, SCREEN_WIDTH},
     effect_return::EffectReturn,
-    fixture::{MaterialAnimationFixture, SpriteRenderAnimationFixture},
     game_update::GameUpdate,
     in_memory_source::{InMemorySource, IN_MEMORY_SOURCE_ID},
     state::{
@@ -332,6 +331,9 @@ pub(crate) use crate::{
     system_injection_bundle::SystemInjectionBundle,
     thread_local_injection_bundle::ThreadLocalInjectionBundle,
 };
+
+#[cfg(feature = "animation")]
+pub use crate::fixture::{MaterialAnimationFixture, SpriteRenderAnimationFixture};
 
 mod amethyst_application;
 mod effect_return;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - Caret for editable text box is drawn in correct position. ([#2146], [#2149])
 - Caret for editable text box is positioned correctly on first click. ([#2151])
 - Editable text is correctly blurred / unfocused when clicking outside its bounds. ([#2091], [#2151])
+- `amethyst_test` crate features now map 1-1 to `amethyst` features. ([#2153])
 
 ### Security
 
@@ -53,6 +54,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#2148]: https://github.com/amethyst/amethyst/pull/2148
 [#2149]: https://github.com/amethyst/amethyst/pull/2149
 [#2151]: https://github.com/amethyst/amethyst/pull/2151
+[#2153]: https://github.com/amethyst/amethyst/pull/2153
 
 ## [0.14.0] - 2020-01-30
 


### PR DESCRIPTION
## Description

`amethyst_test` crate features now map 1-1 to `amethyst` features.

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- **n/a** Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
