### PR TITLE
Don't remove HiddenPropagate components set by users manually

### DIFF
--- a/amethyst_core/src/hidden.rs
+++ b/amethyst_core/src/hidden.rs
@@ -14,9 +14,32 @@ impl Component for Hidden {
 
 /// Like [Hidden](struct.Hidden.html), but can propagate through children when the [HideHierarchySystem](struct.HideHierarchySystem.html)
 /// is enabled in the [RenderBundle](struct.RenderBundle.html).
-#[derive(Clone, Debug, Default)]
-pub struct HiddenPropagate;
+#[derive(Clone, Debug)]
+pub struct HiddenPropagate {
+    pub(crate) was_propagated: bool,
+}
 
 impl Component for HiddenPropagate {
-    type Storage = FlaggedStorage<Self, NullStorage<Self>>;
+    type Storage = FlaggedStorage<Self>;
+}
+
+impl HiddenPropagate {
+    /// Creates an instance of HiddenPropagate.
+    pub fn new() -> Self {
+        Self {
+            was_propagated: false,
+        }
+    }
+
+    /// Is meant to be used only by HideHierarchySystem.
+    pub(crate) fn new_propagated() -> Self {
+        Self {
+            was_propagated: true,
+        }
+    }
+
+    /// Returns true if this component was propagated by [HideHierarchySystem](struct.HideHierarchySystem.html) automatically.
+    pub fn was_propagated(&self) -> bool {
+        self.was_propagated
+    }
 }

--- a/amethyst_core/src/hide_system.rs
+++ b/amethyst_core/src/hide_system.rs
@@ -114,13 +114,24 @@ impl<'a> System<'a> for HideHierarchySystem {
                 if parent_dirty {
                     if hidden.contains(parent_entity) {
                         for child in hierarchy.all_children_iter(parent_entity) {
-                            if let Err(e) = hidden.insert(child, HiddenPropagate::default()) {
-                                error!("Failed to automatically add `HiddenPropagate`: {:?}", e);
-                            };
+                            if !hidden.contains(child) {
+                                if let Err(e) =
+                                    hidden.insert(child, HiddenPropagate::new_propagated())
+                                {
+                                    error!(
+                                        "Failed to automatically add `HiddenPropagate`: {:?}",
+                                        e
+                                    );
+                                };
+                            }
                         }
                     } else {
                         for child in hierarchy.all_children_iter(parent_entity) {
-                            hidden.remove(child);
+                            if let Some(hidden_propagate) = hidden.get(child) {
+                                if hidden_propagate.was_propagated {
+                                    hidden.remove(child);
+                                }
+                            }
                         }
                     }
                 } else if self_dirty {
@@ -129,13 +140,24 @@ impl<'a> System<'a> for HideHierarchySystem {
                     // stand-alone if.
                     if hidden.contains(*entity) {
                         for child in hierarchy.all_children_iter(*entity) {
-                            if let Err(e) = hidden.insert(child, HiddenPropagate::default()) {
-                                error!("Failed to automatically add `HiddenPropagate`: {:?}", e);
-                            };
+                            if !hidden.contains(child) {
+                                if let Err(e) =
+                                    hidden.insert(child, HiddenPropagate::new_propagated())
+                                {
+                                    error!(
+                                        "Failed to automatically add `HiddenPropagate`: {:?}",
+                                        e
+                                    );
+                                };
+                            }
                         }
                     } else {
                         for child in hierarchy.all_children_iter(*entity) {
-                            hidden.remove(child);
+                            if let Some(hidden_propagate) = hidden.get(child) {
+                                if hidden_propagate.was_propagated {
+                                    hidden.remove(child);
+                                }
+                            }
                         }
                     }
                 }

--- a/amethyst_ui/src/prefab.rs
+++ b/amethyst_ui/src/prefab.rs
@@ -187,7 +187,7 @@ where
         }
 
         if self.hidden {
-            system_data.2.insert(entity, HiddenPropagate)?;
+            system_data.2.insert(entity, HiddenPropagate::new())?;
         }
 
         if let Some(u) = self.selectable {


### PR DESCRIPTION
## Description

### Motivation
Let's imagine the following scenario:
A user has a modal window with two child elements: `TextBody`, `ConfirmationButton`. In some cases a user would like to show a modal window without a confirmation button (for instance, it's a loading process that should just block the UI for some time). If a user removes `HiddenPropagate` from the window, this change will be propagated to all the children, and right now there's no way to mark the `ConfirmationButton` entity that its `HiddenPropagate` shouldn't be removed automatically.

This PR adds a flag to `HiddenPropagate` that can prevent `HideHierarchySystem` from removing the component automatically, which should solve the problem.

## Additions
`HiddenPropagate` now contains a `was_propagated` flag indicating whether this entity was created by `HideHierarchySystem` or not. Its storage has been changed to `DenseVecStorage`.

## Removals
`HiddenPropagate` now doesn't have `Default` trait implementation. That's not a big deal, I can easily bring it back, but I thought that might make other `amethyst_core` developer's choice more conscious, if they want to use it.

## Modifications
`HiddenPropagate` doesn't get removed automatically if it was inserted manually by a user.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
  ^ (the latest clippy has got a lot of warnings for the code I didn't introduce)
- [x] Ran `cargo test --all --features "empty"`
