### PR TITLE
docs: clarify the behaviour of FrameLimitStrategy::Sleep

### DIFF
--- a/amethyst_core/src/frame_limiter.rs
+++ b/amethyst_core/src/frame_limiter.rs
@@ -46,10 +46,9 @@
 //! * `Yield` will call [`thread::yield_now`] repeatedly until the frame duration has
 //!   passed. This will result in the most accurate frame timings, but effectively guarantees
 //!   that one CPU core will be fully utilized during the frame's idle time.
-//! * `Sleep` will call [`thread::sleep`] with a duration of 0 milliseconds until the
-//!   frame duration has passed. This will result in lower CPU usage while the game is idle, but
-//!   risks fluctuations in frame timing if the operating system doesn't wake the game until
-//!   after the frame should have started.
+//! * `Sleep` will sleep for the approximate remainder of the frame duration. This will result in
+//!   lower CPU usage while the game is idle, but risks fluctuations in frame timing if the
+//!   operating system doesn't wake the game until after the frame should have started.
 //! * `SleepAndYield` will sleep until there's only a small amount of time left in the frame,
 //!   and then will yield until the next frame starts. This approach attempts to get the
 //!   consistent frame timings of yielding, while reducing CPU usage compared to the yield-only


### PR DESCRIPTION
To say that Sleep performs `std::sleep(0)` is misleading, when in fact the sleep duration is calculated based on the elapsed time since the previous frame, per the target frame rate.

Goes along with #2083

## Description

Updated a bit of documentation

## Additions

`(⊙_⊙)？`

## Removals

`¯\(°_o)/¯`

## Modifications

`o((⊙﹏⊙))o.`

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated. **(N/A)**
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment. **(N/A)**
- [x] Added unit tests for new code added in this PR. **(N/A)**
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
