### PR TITLE
[Minor] bump failure version to fix compile failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ sentry = { version = "0.17.0", optional = true }
 winit = { version = "0.19", features = ["serde", "icon_loading"] }
 serde = { version = "1.0.104", features = ["derive"] }
 palette = { version = "0.4", features = ["serde"] }
-failure = "0.1.6"
+failure = "0.1.7"
 thread_profiler = { version = "0.3.0", optional = true }
 lazy_static = "1.4.0"
 glsl-layout = "0.3.2"

--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -34,7 +34,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", optional = true }
 ron = "0.5"
 thread_profiler = { version = "0.3", optional = true }
-err-derive = "0.2"
+err-derive = "0.2.3"
 objekt = "0.1.2"
 erased-serde = "0.3.9"
 inventory = "0.1.5"

--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -20,7 +20,7 @@ amethyst_animation = { path = "../amethyst_animation/", version = "0.9.0" }
 amethyst_core = { path = "../amethyst_core/", version = "0.9.0" }
 amethyst_error = { path = "../amethyst_error/", version = "0.4.0" }
 amethyst_rendy = { path = "../amethyst_rendy", version = "0.4.0" }
-err-derive = "0.2"
+err-derive = "0.2.3"
 base64 = "0.11"
 fnv = "1"
 gltf = "0.15"

--- a/amethyst_tiles/Cargo.toml
+++ b/amethyst_tiles/Cargo.toml
@@ -33,7 +33,7 @@ lazy_static = "1.4"
 rayon = "1.3.0"
 bitintr = "0.3"
 glsl-layout = "0.3"
-err-derive = "0.2"
+err-derive = "0.2.3"
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
## Description

Bumps version of `failure` to fix compile failures that currently occur. Please see https://users.rust-lang.org/t/failure-derive-compilation-error/39062, it seems version `0.1.6` broke, and should be fixed with version `0.1.7`. 


