### PR TITLE
docs: Update amethyst_rendy/sprite/struct.SpriteSheetFormat example

### DIFF
--- a/amethyst_rendy/src/sprite/mod.rs
+++ b/amethyst_rendy/src/sprite/mod.rs
@@ -415,7 +415,7 @@ impl SpriteGrid {
 /// Example:
 /// ```text,ignore
 /// #![enable(implicit_some)]
-/// (
+/// List((
 ///     // Width of the texture
 ///     texture_width: 48,
 ///     // Height of the texture
@@ -431,7 +431,8 @@ impl SpriteGrid {
 ///             width: 16,
 ///             // Height of the sprite
 ///             height: 16,
-///             // Number of pixels to shift the sprite to the left and down relative to the entity holding it when rendering
+///             // Number of pixels to shift the sprite to the left and down relative to the
+///             // entity holding it when rendering
 ///             offsets: (0.0, 0.0), // This is optional and defaults to (0.0, 0.0)
 ///         ),
 ///         (
@@ -441,7 +442,7 @@ impl SpriteGrid {
 ///             height: 16,
 ///         ),
 ///     ],
-/// )
+/// ))
 /// ```
 ///
 /// Such a spritesheet description can be loaded using a `Loader` by passing it the handle of the corresponding loaded texture.


### PR DESCRIPTION
## Description

It's a docs fixup. Makes the example for SpriteSheetFormat look pretty, and makes it correct for 0.14.0.

Closes #2130

## Additions

- N/A

## Removals

- N/A

## Modifications

- ~~Use rust syntax highlighting for RON SpriteSheet asset code block (no_run instead of ignore)~~ Not true anymore :(
- Update the RON asset to use the Sprites enum.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
