### PR TITLE
docs: Update pong-tutorial to suggest installing v0.14.0

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-01.md
+++ b/book/src/pong-tutorial/pong-tutorial-01.md
@@ -19,7 +19,7 @@ authors = []
 edition = "2018"
 
 [dependencies.amethyst]
-version = "0.13"
+version = "0.14"
 features = ["vulkan"]
 ```
 
@@ -27,7 +27,7 @@ Alternatively, if you are developing on macOS, you might want to use the `metal`
 
 ```toml
 [dependencies.amethyst]
-version = "0.13"
+version = "0.14"
 features = ["metal"]
 ```
 


### PR DESCRIPTION
## Description

https://book.amethyst.rs/stable/pong-tutorial/pong-tutorial-01.html currently points
to the v0.14.0 release, but the tutorial was not updated to reflect this, and led to
several issues being filed. :[

Closes #2137

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all` (n/a)
- [x] Ran `cargo clippy --all --features "empty"` (n/a)
- [x] Ran `cargo test --all --features "empty"` (n/a)
