### PR TITLE
Update Fluent to 0.11

### DIFF
--- a/amethyst_locale/Cargo.toml
+++ b/amethyst_locale/Cargo.toml
@@ -24,7 +24,7 @@ amethyst_assets = { path = "../amethyst_assets", version = "0.10.0" }
 amethyst_core = { path = "../amethyst_core", version = "0.9.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.4.0" }
 serde = { version = "1.0", features = ["derive"] }
-fluent = "0.10.2"
+fluent = "0.11"
 unic-langid = { version = "0.8", features = ["macros"] }
 
 thread_profiler = { version = "0.3", optional = true }

--- a/amethyst_locale/src/lib.rs
+++ b/amethyst_locale/src/lib.rs
@@ -13,7 +13,8 @@
 use amethyst_assets::{Asset, Format, Handle};
 use amethyst_core::ecs::prelude::VecStorage;
 use amethyst_error::Error;
-pub use fluent::*;
+pub use fluent::concurrent::FluentBundle;
+pub use fluent::FluentResource;
 use serde::{Deserialize, Serialize};
 use unic_langid::langid;
 


### PR DESCRIPTION
We reworked how concurrent vs. single-thread FluentBundle works and I'd like to make sure that concurrent uses like amethyst work well.