### PR TITLE
re-export UiImageLoadPrefab so users can put it in their custom prefabs

### DIFF
--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -35,8 +35,8 @@ pub use self::{
     layout::{Anchor, ScaleMode, Stretch, UiTransformSystem, UiTransformSystemDesc},
     pass::{DrawUi, DrawUiDesc, RenderUi},
     prefab::{
-        NoCustomUi, ToNativeWidget, UiButtonData, UiCreator, UiFormat, UiImagePrefab,
-        UiImageLoadPrefab, UiLoader, UiLoaderSystem, UiLoaderSystemDesc, UiPrefab, UiTextData,
+        NoCustomUi, ToNativeWidget, UiButtonData, UiCreator, UiFormat, UiImageLoadPrefab,
+        UiImagePrefab, UiLoader, UiLoaderSystem, UiLoaderSystemDesc, UiPrefab, UiTextData,
         UiTransformData, UiWidget,
     },
     resize::{ResizeSystem, ResizeSystemDesc, UiResize},

--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -35,8 +35,9 @@ pub use self::{
     layout::{Anchor, ScaleMode, Stretch, UiTransformSystem, UiTransformSystemDesc},
     pass::{DrawUi, DrawUiDesc, RenderUi},
     prefab::{
-        NoCustomUi, ToNativeWidget, UiButtonData, UiCreator, UiFormat, UiImagePrefab, UiLoader,
-        UiLoaderSystem, UiLoaderSystemDesc, UiPrefab, UiTextData, UiTransformData, UiWidget,
+        NoCustomUi, ToNativeWidget, UiButtonData, UiCreator, UiFormat, UiImagePrefab,
+        UiImageLoadPrefab, UiLoader, UiLoaderSystem, UiLoaderSystemDesc, UiPrefab, UiTextData,
+        UiTransformData, UiWidget,
     },
     resize::{ResizeSystem, ResizeSystemDesc, UiResize},
     selection::{

--- a/amethyst_ui/src/prefab.rs
+++ b/amethyst_ui/src/prefab.rs
@@ -353,25 +353,40 @@ pub enum UiImageLoadPrefab {
     Texture(TexturePrefab),
     /// A partial textured image
     PartialTexture {
+        /// Texture prefab.
         tex: TexturePrefab,
+        /// Left.
         left: f32,
+        /// Right.
         right: f32,
+        /// Bottom.
         bottom: f32,
+        /// Top.
         top: f32,
     },
     /// Solid color image
     SolidColor(f32, f32, f32, f32),
     /// 9-Slice image
     NineSlice {
+        /// X start.
         x_start: u32,
+        /// Y start.
         y_start: u32,
+        /// Width.
         width: u32,
+        /// Height.
         height: u32,
+        /// Left distance.
         left_dist: u32,
+        /// Right distance.
         right_dist: u32,
+        /// Top distance.
         top_dist: u32,
+        /// Bottom distance.
         bottom_dist: u32,
+        /// Texture prefab.
         tex: TexturePrefab,
+        /// Texture dimensions.
         texture_dimensions: (u32, u32),
     },
 }

--- a/amethyst_ui/src/prefab.rs
+++ b/amethyst_ui/src/prefab.rs
@@ -343,7 +343,7 @@ impl<'a> PrefabData<'a> for UiTextData {
 /// Loadable `UiImage` data. Adds UiImage component to the entity.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
-pub struct UiImagePrefab(UiImageLoadPrefab);
+pub struct UiImagePrefab(pub UiImageLoadPrefab);
 
 /// Loadable `UiImage` data. Returns image component from `add_to_entity` instead of adding it.
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
## Description

Make UiImageLoadPrefab public.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
