### PR TITLE
WIP: Fix #2170 Overly aggressive 3D model culling

### DIFF
--- a/examples/fly_camera/main.rs
+++ b/examples/fly_camera/main.rs
@@ -32,7 +32,7 @@ impl SimpleState for ExampleState {
             .create_entity()
             .named("Fly Camera Scene")
             .with(prefab_handle)
-            .with(BoundingSphere::origin(1.0))
+            .with(BoundingSphere::origin(1.732))
             .build();
     }
 

--- a/examples/fly_camera/main.rs
+++ b/examples/fly_camera/main.rs
@@ -11,6 +11,7 @@ use amethyst::{
         plugins::{RenderShaded3D, RenderToWindow},
         rendy::mesh::{Normal, Position, TexCoord},
         types::DefaultBackend,
+        visibility::BoundingSphere,
         RenderingBundle,
     },
     utils::{application_root_dir, scene::BasicScenePrefab},
@@ -31,6 +32,7 @@ impl SimpleState for ExampleState {
             .create_entity()
             .named("Fly Camera Scene")
             .with(prefab_handle)
+            .with(BoundingSphere::origin(1.0))
             .build();
     }
 


### PR DESCRIPTION
## Description

**Need help, see comments**
This PR fixes the fly_camera example which culls its cube too early.

## Additions

To fix it, a `BoundingSphere` is added to the cube.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
