### PR TITLE
Implement HTTP asset source for WASM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ test-support = [
 ]
 experimental-spirv-reflection = ["amethyst_rendy/experimental-spirv-reflection"]
 wasm = [
+  "amethyst_assets/wasm",
   "amethyst_rendy/wasm",
   "amethyst_window/wasm",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ experimental-spirv-reflection = ["amethyst_rendy/experimental-spirv-reflection"]
 wasm = [
   "amethyst_assets/wasm",
   "amethyst_rendy/wasm",
+  "amethyst_utils/wasm",
   "amethyst_window/wasm",
 ]
 

--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -39,6 +39,16 @@ objekt = "0.1.2"
 erased-serde = "0.3.9"
 inventory = "0.1.5"
 lazy_static = "1.4"
+wasm-bindgen = { version = "0.2.59", optional = true }
+js-sys = { version = "0.3.36", optional = true }
+
+[dependencies.web-sys]
+version = "0.3.36"
+optional = true
+features = [
+  'XmlHttpRequest',
+  'XmlHttpRequestResponseType',
+]
 
 [dev-dependencies]
 serde_json = "1"
@@ -46,3 +56,8 @@ serde_json = "1"
 [features]
 profiler = [ "thread_profiler/thread_profiler" ]
 json = [ "serde_json" ]
+wasm = [
+  "web-sys",
+  "wasm-bindgen",
+  "js-sys",
+]

--- a/amethyst_assets/src/lib.rs
+++ b/amethyst_assets/src/lib.rs
@@ -30,7 +30,7 @@ pub use crate::{
 #[cfg(not(feature = "wasm"))]
 pub use crate::source::Directory;
 #[cfg(feature = "wasm")]
-pub use crate::source::HTTP;
+pub use crate::source::HttpSource;
 
 pub use rayon::ThreadPool;
 

--- a/amethyst_assets/src/lib.rs
+++ b/amethyst_assets/src/lib.rs
@@ -23,9 +23,14 @@ pub use crate::{
     },
     progress::{Completion, Progress, ProgressCounter, Tracker},
     reload::{HotReloadBundle, HotReloadStrategy, HotReloadSystem, Reload, SingleFile},
-    source::{Directory, Source},
+    source::Source,
     storage::{AssetStorage, Handle, ProcessingState, Processor, WeakHandle},
 };
+
+#[cfg(not(feature = "wasm"))]
+pub use crate::source::Directory;
+#[cfg(feature = "wasm")]
+pub use crate::source::HTTP;
 
 pub use rayon::ThreadPool;
 

--- a/amethyst_assets/src/loader.rs
+++ b/amethyst_assets/src/loader.rs
@@ -31,7 +31,7 @@ impl Loader {
         #[cfg(not(feature = "wasm"))]
         return Self::with_default_source(crate::source::Directory::new(directory), pool);
         #[cfg(feature = "wasm")]
-        return Self::with_default_source(crate::source::HTTP::new(directory), pool);
+        return Self::with_default_source(crate::source::HttpSource::new(directory), pool);
     }
 
     /// Creates a new asset loader, using the provided source

--- a/amethyst_assets/src/loader.rs
+++ b/amethyst_assets/src/loader.rs
@@ -11,7 +11,7 @@ use thread_profiler::profile_scope;
 use crate::{
     error::Error,
     storage::{AssetStorage, Handle, Processed},
-    Asset, Directory, Format, FormatValue, Progress, Source,
+    Asset, Format, FormatValue, Progress, Source,
 };
 
 /// The asset loader, holding the sources and a reference to the `ThreadPool`.
@@ -28,7 +28,10 @@ impl Loader {
     where
         P: Into<PathBuf>,
     {
-        Self::with_default_source(Directory::new(directory), pool)
+        #[cfg(not(feature = "wasm"))]
+        return Self::with_default_source(crate::source::Directory::new(directory), pool);
+        #[cfg(feature = "wasm")]
+        return Self::with_default_source(crate::source::HTTP::new(directory), pool);
     }
 
     /// Creates a new asset loader, using the provided source

--- a/amethyst_assets/src/source/http.rs
+++ b/amethyst_assets/src/source/http.rs
@@ -1,0 +1,92 @@
+use js_sys::Uint8Array;
+use std::path::{Path, PathBuf};
+use web_sys::{XmlHttpRequest, XmlHttpRequestResponseType};
+
+#[cfg(feature = "profiler")]
+use thread_profiler::profile_scope;
+
+use amethyst_error::{format_err, Error, ResultExt};
+
+use crate::{error, source::Source};
+
+/// HTTP source.
+///
+/// Loads assets inside web worker using XmlHttpRequest.
+/// Used as a default source for WASM target.
+#[derive(Debug)]
+pub struct HTTP {
+    loc: PathBuf,
+}
+
+impl HTTP {
+    /// Creates a new http source.
+    pub fn new<P>(loc: P) -> Self
+    where
+        P: Into<PathBuf>,
+    {
+        HTTP { loc: loc.into() }
+    }
+
+    fn path(&self, s_path: &str) -> PathBuf {
+        let mut path = self.loc.clone();
+        path.extend(Path::new(s_path).iter());
+
+        path
+    }
+}
+
+impl Source for HTTP {
+    fn modified(&self, _path: &str) -> Result<u64, Error> {
+        #[cfg(feature = "profiler")]
+        profile_scope!("http_modified_asset");
+
+        // Unimplemented. Maybe possible to tie into webpack hot module reloading?
+        Ok(0)
+    }
+
+    fn load(&self, path: &str) -> Result<Vec<u8>, Error> {
+        #[cfg(feature = "profiler")]
+        profile_scope!("http_load_asset");
+
+        let path = self.path(path);
+        let path_str = path
+            .to_str()
+            .ok_or_else(|| format_err!("Path contains non-unicode characters: {:?}", path))
+            .with_context(|_| error::Error::Source)?;
+
+        let xhr = XmlHttpRequest::new()
+            .map_err(|_| format_err!("Failed to construct XmlHttpRequest"))
+            .with_context(|_| error::Error::Source)?;
+
+        // Synchronous GET request. Should only be run in web worker.
+        xhr.open_with_async("GET", path_str, false).unwrap();
+        xhr.set_response_type(XmlHttpRequestResponseType::Arraybuffer);
+
+        // We block here and wait for http fetch to complete
+        xhr.send()
+            .map_err(|_| format_err!("XmlHttpRequest send failed"))
+            .with_context(|_| error::Error::Source)?;
+
+        // Status returns a result but according to javascript spec it should never return error.
+        // Returns 0 if request was not completed.
+        let status = xhr.status().unwrap();
+        if status != 200 {
+            let msg = xhr.status_text().unwrap_or_else(|_| "".to_string());
+            return Err(format_err!(
+                "XmlHttpRequest failed with code {}. Error: {}",
+                status,
+                msg
+            ))
+            .with_context(|_| error::Error::Source);
+        }
+
+        let resp = xhr.response().unwrap();
+
+        // Convert javascript ArrayBuffer into Vec<u8>
+        let arr = Uint8Array::new(&resp);
+        let mut v = vec![0; arr.length() as usize];
+        arr.copy_to(&mut v);
+
+        Ok(v)
+    }
+}

--- a/amethyst_assets/src/source/mod.rs
+++ b/amethyst_assets/src/source/mod.rs
@@ -3,7 +3,7 @@ use amethyst_error::Error;
 #[cfg(not(feature = "wasm"))]
 pub use self::dir::Directory;
 #[cfg(feature = "wasm")]
-pub use self::http::HTTP;
+pub use self::http::HttpSource;
 
 #[cfg(feature = "profiler")]
 use thread_profiler::profile_scope;

--- a/amethyst_assets/src/source/mod.rs
+++ b/amethyst_assets/src/source/mod.rs
@@ -1,11 +1,17 @@
 use amethyst_error::Error;
 
+#[cfg(not(feature = "wasm"))]
 pub use self::dir::Directory;
+#[cfg(feature = "wasm")]
+pub use self::http::HTTP;
 
 #[cfg(feature = "profiler")]
 use thread_profiler::profile_scope;
 
+#[cfg(not(feature = "wasm"))]
 mod dir;
+#[cfg(feature = "wasm")]
+mod http;
 
 /// A trait for asset sources, which provides
 /// methods for loading bytes.

--- a/amethyst_utils/Cargo.toml
+++ b/amethyst_utils/Cargo.toml
@@ -32,3 +32,4 @@ thread_profiler = { version = "0.3", optional = true }
 
 [features]
 profiler = [ "thread_profiler/thread_profiler" ]
+wasm = [ ]


### PR DESCRIPTION
## Description

Solves #2182. Tested on browser with a hacky implementation of #2177 (not included).

Should we add unit tests? Would have to fire up an HTTP server to test.

## Additions

- Added HTTP source

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [ ] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
