### PR TITLE
WASM: use multi-platform time library (fixes #2183)

### DIFF
--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -21,6 +21,7 @@ alga_derive = "0.9.1"
 approx = "0.3.2"
 amethyst_error = { path = "../amethyst_error", version = "0.4.0" }
 fnv = "1.0.6"
+instant = "0.1"
 log = "0.4.8"
 num-traits = "0.2.11"
 rayon = "1.3.0"

--- a/amethyst_core/src/timing.rs
+++ b/amethyst_core/src/timing.rs
@@ -1,6 +1,7 @@
 //! Utilities for working with time.
 
-use std::time::{Duration, Instant};
+use instant::Instant;
+use std::time::Duration;
 
 /// Frame timing values.
 #[derive(Clone, Copy, Debug, PartialEq)]


### PR DESCRIPTION
## Description

Fixes `unimplemented` crash due to `std::time::Instant` on wasm. Used the [insant](https://github.com/sebcrozet/instant) library which is a drop in replacement and is already used as dependency in `winit`.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
