### PR TITLE
Maintenance/event channel docs

### DIFF
--- a/book/src/concepts/event-channel.md
+++ b/book/src/concepts/event-channel.md
@@ -1,36 +1,32 @@
 # Event Channel
 
-This chapter will be easier than the previous ones. 
-
-While it is not essential to understand it to use amethyst, it can make your life much much easier in a lot of situations where using only data would make your code too complex.
-
 ## What is an event channel?
 
-An `EventChannel` acts like a queue for any type that is `Send + Sync + 'static`.
+An `EventChannel` is a broadcast queue of events. Events may be any type that implements `Send + Sync + 'static`.
 
-It is a single producer/multiple receiver queue. This means that it works best when used with only a single "thing" (usually a system) producing events.
-In most cases, the `EventChannel` should be stored in a global resource for ease of access. More on this later.
+Typically, `EventChannel`s are inserted as resources in the `World`.
 
-## Creating an event channel
+## Examples
 
-Super simple!
+### Creating an event channel
 
 ```rust,edition2018,no_run,noplaypen
 # extern crate amethyst;
 # use amethyst::shrev::EventChannel;
-    // In the following examples, we are going to use `MyEvent` values as events.
-    #[derive(Debug)]
-    pub enum MyEvent {
-        A,
-        B,
-    }
-    
-    let mut channel = EventChannel::<MyEvent>::new();
+// In the following examples, `MyEvent` is the event type of the channel.
+#[derive(Debug)]
+pub enum MyEvent {
+    A,
+    B,
+}
+
+let mut channel = EventChannel::<MyEvent>::new();
 ```
 
-## Writing events to the event channel
+### Writing events to the event channel
 
-Single: 
+Single:
+
 ```rust,edition2018,no_run,noplaypen
 # extern crate amethyst;
 # #[derive(Debug)]
@@ -44,7 +40,8 @@ Single:
 # }
 ```
 
-Multiple: 
+Multiple:
+
 ```rust,edition2018,no_run,noplaypen
 # extern crate amethyst;
 # #[derive(Debug)]
@@ -58,26 +55,11 @@ Multiple:
 # }
 ```
 
-## Reading events
+### Reading events
 
-This is the part where it becomes tricky.
-To be able to track where each of the receiver's reading is at, the `EventChannel` needs to be aware of their presence.
-This is done by registering a `ReaderId`.
+`EventChannel`s guarantee sending events in order to each reader.
 
-```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
-# #[derive(Debug)]
-# pub enum MyEvent {
-#   A,
-#   B,
-# }
-# fn main() {
-#   let mut channel = amethyst::shrev::EventChannel::<MyEvent>::new();
-    let mut reader = channel.register_reader();
-# }
-```
-
-Then, when you want to read the events:
+To subscribe to events, register a reader against the `EventChannel` to receive a `ReaderId`:
 
 ```rust,edition2018,no_run,noplaypen
 # extern crate amethyst;
@@ -88,26 +70,44 @@ Then, when you want to read the events:
 # }
 # fn main() {
 #   let mut channel = amethyst::shrev::EventChannel::<MyEvent>::new();
-#   let mut reader = channel.register_reader();
-    for event in channel.read(&mut reader) {
-        // The type of the event is inferred from the generic type
-        // we assigned to the `EventChannel<MyEvent>` earlier when creating it.
-        println!("Received event value of: {:?}", event);
-    }
+let mut reader_id = channel.register_reader();
 # }
 ```
+
+When reading events, pass the `ReaderId` in:
+
+```rust,edition2018,no_run,noplaypen
+# extern crate amethyst;
+# #[derive(Debug)]
+# pub enum MyEvent {
+#   A,
+#   B,
+# }
+# fn main() {
+#   let mut channel = amethyst::shrev::EventChannel::<MyEvent>::new();
+#   let mut reader_id = channel.register_reader();
+for event in channel.read(&mut reader_id) {
+    // The type of the event is inferred from the generic type
+    // we assigned to the `EventChannel<MyEvent>` earlier when creating it.
+    println!("Received event value of: {:?}", event);
+}
+# }
+```
+
 Note that you only need to have a read access to the channel when reading events.
 It is the `ReaderId` that needs to be mutable to keep track of where your last read was.
 
-**IMPORTANT: The event channel automatically grows as events are added to it and only decreases in size once all readers have read through the older events.
-This mean that if you create a `ReaderId` but don't read from it on each frame, the event channel will start to consume more and more memory.**
+> **IMPORTANT:** The event channel automatically grows as events are added to it and only decreases in size once all readers have read through the older events.
+>
+> This mean that if you create a `ReaderId` but don't read from it on each frame, the event channel will start to consume more and more memory.
 
 ## Patterns
 
 When using the event channel, we usually re-use the same pattern over and over again to maximize parallelism.
 It goes as follow:
 
-Create the event channel and add it to to the world during `State` creation:
+Create the event channel and add it to the world during `State` creation:
+
 ```rust,edition2018,no_run,noplaypen
 # extern crate amethyst;
 # use amethyst::{ecs::{World, WorldExt}, shrev::EventChannel};
@@ -118,14 +118,14 @@ Create the event channel and add it to to the world during `State` creation:
 # }
 # fn main() {
 #   let mut world = World::new();
-world.insert(
-    EventChannel::<MyEvent>::new(),
-);
+world.insert(EventChannel::<MyEvent>::new());
 # }
 ```
+
 _Note: You can also derive `Default`, this way you don't have to manually create your resource and add it. Resources implementing `Default` are automatically added to `Resources` when a `System` uses them (`Read` or `Write` in `SystemData`)._
 
 In the **producer** `System`, get a mutable reference to your resource:
+
 ```rust,edition2018,no_run,noplaypen
 # extern crate amethyst;
 # use amethyst::ecs::Write;
@@ -143,6 +143,7 @@ type SystemData = Write<'a, EventChannel<MyEvent>>;
 ```
 
 In the **receiver** `System`s, you need to store the `ReaderId` somewhere.
+
 ```rust,edition2018,no_run,noplaypen
 # extern crate amethyst;
 # use amethyst::shrev::ReaderId;
@@ -156,7 +157,9 @@ struct ReceiverSystem {
     reader: Option<ReaderId<MyEvent>>,
 }
 ```
+
 and you also need to get read access:
+
 ```rust,edition2018,no_run,noplaypen
 # extern crate amethyst;
 # use amethyst::ecs::Read;
@@ -174,6 +177,7 @@ and you also need to get read access:
 ```
 
 Then, in the `System`'s `new` method:
+
 ```rust,edition2018,no_run,noplaypen
 # extern crate amethyst;
 # use amethyst::shrev::{EventChannel, ReaderId};
@@ -183,13 +187,13 @@ Then, in the `System`'s `new` method:
 #   A,
 #   B,
 # }
-# struct MySystem { reader: ReaderId<MyEvent>, }
+# struct MySystem { reader_id: ReaderId<MyEvent>, }
 #
 impl MySystem {
     pub fn new(world: &mut World) -> Self {
         <Self as System<'_>>::SystemData::setup(world);
-        let reader = world.fetch_mut::<EventChannel<MyEvent>>().register_reader();
-        Self { reader }
+        let reader_id = world.fetch_mut::<EventChannel<MyEvent>>().register_reader();
+        Self { reader_id }
     }
 }
 #
@@ -200,6 +204,7 @@ impl MySystem {
 ```
 
 Finally, you can read events from your `System`.
+
 ```rust,edition2018,no_run,noplaypen
 # extern crate amethyst;
 # use amethyst::ecs::Read;
@@ -210,12 +215,12 @@ Finally, you can read events from your `System`.
 #   B,
 # }
 # struct MySystem {
-#   reader: amethyst::shrev::ReaderId<MyEvent>,
+#   reader_id: amethyst::shrev::ReaderId<MyEvent>,
 # }
 impl<'a> amethyst::ecs::System<'a> for MySystem {
     type SystemData = Read<'a, EventChannel<MyEvent>>;
     fn run(&mut self, my_event_channel: Self::SystemData) {
-        for event in my_event_channel.read(&mut self.reader) {
+        for event in my_event_channel.read(&mut self.reader_id) {
             println!("Received an event: {:?}", event);
         }
     }

--- a/examples/states_ui/main.rs
+++ b/examples/states_ui/main.rs
@@ -41,6 +41,9 @@ pub fn main() -> amethyst::Result<()> {
         // a lot of other bundles/systems depend on this (without it being explicitly clear), so it
         // makes sense to add it early on
         .with_bundle(TransformBundle::new())?
+        // This system is in 'events.rs'. Basically, it registers UI events that
+        // happen. Without it, the buttons will not react.
+        .with_bundle(InputBundle::<StringBindings>::new())?
         // this bundle allows us to 'find' the Buttons and other UI elements later on
         .with_bundle(UiBundle::<StringBindings>::new())?
         // this allows us to reload '*.ron' files during execution
@@ -57,9 +60,6 @@ pub fn main() -> amethyst::Result<()> {
             "ui_event_handler",
             &[],
         )
-        // This system is in 'events.rs'. Basically, it registers UI events that
-        // happen. Without it, the buttons will not react.
-        .with_bundle(InputBundle::<StringBindings>::new())?
         // Necessary for the FPS counter in the upper left corner to work.
         // (simply uncommenting will fail at runtime, since the resource is expected to exist, you
         // need to uncomment line 107-114 in game.rs for it to still work)


### PR DESCRIPTION
## Description

Small improvements to event channel docs, and fixed `states_ui` example.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- **n/a** Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
