### PR TITLE
Fixes tiles example MapMovementSystem

### DIFF
--- a/examples/tiles/main.rs
+++ b/examples/tiles/main.rs
@@ -225,7 +225,7 @@ impl<'s> System<'s> for MapMovementSystem {
     type SystemData = (
         Read<'s, Time>,
         WriteStorage<'s, Transform>,
-        ReadStorage<'s, TileMap<ExampleTile>>,
+        ReadStorage<'s, TileMap<ExampleTile, MortonEncoder>>,
         Read<'s, InputHandler<StringBindings>>,
     );
 


### PR DESCRIPTION
## Description

The `MapMovementSystem` system in the tiles example is currently broken, it's looking for the wrong component (wrong type arguments).


## Modifications

- Just adds the proper type argument to the `ReadStorage<TileMap...` in the system.

## PR Checklist

By placing an x in the boxes I certify that I have:

- n/a Updated the content of the book if this PR would make the book outdated.
- n/a Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- n/a Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
