### PR TITLE
fix mouse_raycast example bundle dependency problem

### DIFF
--- a/examples/mouse_raycast/main.rs
+++ b/examples/mouse_raycast/main.rs
@@ -264,8 +264,8 @@ fn main() -> amethyst::Result<()> {
 
     let game_data = GameDataBuilder::default()
         .with_bundle(TransformBundle::new())?
-        .with_bundle(UiBundle::<StringBindings>::new())?
         .with_bundle(InputBundle::<StringBindings>::new())?
+        .with_bundle(UiBundle::<StringBindings>::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(


### PR DESCRIPTION
## Description

Current "mouse_raycast" example is not able to run correctly, causing "system not registered" panic. Fix this by letting `InputBundle` go before `UiBundle`.

## Additions

- Detail API additions here if any
- Do not list changes or removals

## Removals

- List API removals here if any

## Modifications

- List changes to existing structures and functions here if any

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
