### PR TITLE
Fix renderable example

### DIFF
--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -200,12 +200,12 @@ fn main() -> Result<(), Error> {
 
     let game_data = GameDataBuilder::default()
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
-        .with(ExampleSystem::default(), "example_system", &[])
+        .with_bundle(InputBundle::<StringBindings>::new())?
+        .with(ExampleSystem::default(), "example_system", &["input_system"])
         .with_bundle(TransformBundle::new().with_dep(&["example_system"]))?
         .with_bundle(UiBundle::<StringBindings>::new())?
         .with_bundle(HotReloadBundle::default())?
         .with_bundle(FpsCounterBundle::default())?
-        .with_bundle(InputBundle::<StringBindings>::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -201,7 +201,11 @@ fn main() -> Result<(), Error> {
     let game_data = GameDataBuilder::default()
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
         .with_bundle(InputBundle::<StringBindings>::new())?
-        .with(ExampleSystem::default(), "example_system", &["input_system"])
+        .with(
+            ExampleSystem::default(),
+            "example_system",
+            &["input_system"],
+        )
         .with_bundle(TransformBundle::new().with_dep(&["example_system"]))?
         .with_bundle(UiBundle::<StringBindings>::new())?
         .with_bundle(HotReloadBundle::default())?


### PR DESCRIPTION
Currently running `cargo run --example renderable --features vulkan` leads to a macro error saying that "input_system" is not registered.

## Description

Presumably the way bundle loading changed between now and when this example was written?

## Modifications

- Changed bundle loading order in rendering example

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
