### PR TITLE
Changed Texture Asset name constant to "Texture"

### DIFF
--- a/amethyst_rendy/src/types.rs
+++ b/amethyst_rendy/src/types.rs
@@ -125,7 +125,7 @@ impl Asset for Mesh {
 }
 
 impl Asset for Texture {
-    const NAME: &'static str = "Mesh";
+    const NAME: &'static str = "Texture";
     type Data = TextureData;
     type HandleStorage = DenseVecStorage<Handle<Self>>;
 }


### PR DESCRIPTION
## Description

I saw the that the name constant of both `Texture` and `Mesh` as `Asset` was `"Mesh"`, and that simply seems like a copy-paste error. Changed the one for `Texture` to `"Texture"`.

This is actually my first PR ever, so if I've done something wrong or not according to guidelines, don't refrain from giving constructive c
riticism.
## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
