### PR TITLE
Add input context support

### DIFF
--- a/amethyst_controls/src/bundles.rs
+++ b/amethyst_controls/src/bundles.rs
@@ -7,7 +7,7 @@ use amethyst_core::{
     SystemDesc,
 };
 use amethyst_error::Error;
-use amethyst_input::BindingTypes;
+use amethyst_input::{BindingTypes, Context};
 
 use super::*;
 
@@ -33,16 +33,17 @@ use super::*;
 /// * `MouseFocusUpdateSystem`
 /// * `CursorHideSystem`
 #[derive(Debug)]
-pub struct FlyControlBundle<T: BindingTypes> {
+pub struct FlyControlBundle<C: Context, T: BindingTypes> {
     sensitivity_x: f32,
     sensitivity_y: f32,
     speed: f32,
     right_input_axis: Option<T::Axis>,
     up_input_axis: Option<T::Axis>,
     forward_input_axis: Option<T::Axis>,
+    phantom: PhantomData<C>,
 }
 
-impl<T: BindingTypes> FlyControlBundle<T> {
+impl<C: Context, T: BindingTypes> FlyControlBundle<C, T> {
     /// Builds a new fly control bundle using the provided axes as controls.
     pub fn new(
         right_input_axis: Option<T::Axis>,
@@ -56,6 +57,7 @@ impl<T: BindingTypes> FlyControlBundle<T> {
             right_input_axis,
             up_input_axis,
             forward_input_axis,
+            phantom: PhantomData,
         }
     }
 
@@ -73,14 +75,14 @@ impl<T: BindingTypes> FlyControlBundle<T> {
     }
 }
 
-impl<'a, 'b, T: BindingTypes> SystemBundle<'a, 'b> for FlyControlBundle<T> {
+impl<'a, 'b, C: Context, T: BindingTypes> SystemBundle<'a, 'b> for FlyControlBundle<C, T> {
     fn build(
         self,
         world: &mut World,
         builder: &mut DispatcherBuilder<'a, 'b>,
     ) -> Result<(), Error> {
         builder.add(
-            FlyMovementSystemDesc::<T>::new(
+            FlyMovementSystemDesc::<C, T>::new(
                 self.speed,
                 self.right_input_axis,
                 self.up_input_axis,

--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -12,7 +12,9 @@ use amethyst_core::{
     transform::Transform,
 };
 use amethyst_derive::SystemDesc;
-use amethyst_input::{get_input_axis_simple, BindingTypes, InputHandler};
+use amethyst_input::{get_input_axis_simple, BindingTypes, Context, InputHandler};
+
+use std::marker::PhantomData;
 
 use crate::{
     components::{ArcBallControlTag, FlyControlTag},
@@ -26,8 +28,9 @@ use crate::{
 /// * `T`: This are the keys the `InputHandler` is using for axes and actions. Often, this is a `StringBindings`.
 #[derive(Debug, SystemDesc)]
 #[system_desc(name(FlyMovementSystemDesc))]
-pub struct FlyMovementSystem<T>
+pub struct FlyMovementSystem<C, T>
 where
+    C: Context,
     T: BindingTypes,
 {
     /// The movement speed of the movement in units per second.
@@ -38,9 +41,10 @@ where
     up_input_axis: Option<T::Axis>,
     /// The name of the input axis to locally move in the z coordinates.
     forward_input_axis: Option<T::Axis>,
+    phantom: PhantomData<C>,
 }
 
-impl<T: BindingTypes> FlyMovementSystem<T> {
+impl<C: Context, T: BindingTypes> FlyMovementSystem<C, T> {
     /// Builds a new `FlyMovementSystem` using the provided speeds and axis controls.
     pub fn new(
         speed: f32,
@@ -53,15 +57,16 @@ impl<T: BindingTypes> FlyMovementSystem<T> {
             right_input_axis,
             up_input_axis,
             forward_input_axis,
+            phantom: PhantomData,
         }
     }
 }
 
-impl<'a, T: BindingTypes> System<'a> for FlyMovementSystem<T> {
+impl<'a, C: Context, T: BindingTypes> System<'a> for FlyMovementSystem<C, T> {
     type SystemData = (
         Read<'a, Time>,
         WriteStorage<'a, Transform>,
-        Read<'a, InputHandler<T>>,
+        Read<'a, InputHandler<C, T>>,
         ReadStorage<'a, FlyControlTag>,
     );
 

--- a/amethyst_input/src/bindings.rs
+++ b/amethyst_input/src/bindings.rs
@@ -89,22 +89,24 @@ impl BindingTypes for StringBindings {
 ///
 /// Example Ron config file:
 /// ```ron
-/// (
-///     axes: {
-///         "updown": Emulated(
-///             pos: Key(Up),
-///             neg: Key(Down)
-///         ),
-///         "leftright": Emulated(
-///             pos: Key(Right),
-///             neg: Key(Left)
-///         )
-///     },
-///     actions: {
-///         "fire": [ [Mouse(Left)], [Key(X)] ], // Multiple bindings for one action
-///         "reload": [ [Key(LControl), Key(R)] ] // Combinations of multiple bindings possible
-///     }
-/// )
+/// {
+///     (): (
+///         axes: {
+///             "updown": Emulated(
+///                 pos: Key(Up),
+///                 neg: Key(Down)
+///             ),
+///             "leftright": Emulated(
+///                 pos: Key(Right),
+///                 neg: Key(Left)
+///             )
+///         },
+///         actions: {
+///             "fire": [ [Mouse(Left)], [Key(X)] ], // Multiple bindings for one action
+///             "reload": [ [Key(LControl), Key(R)] ] // Combinations of multiple bindings possible
+///         }
+///     )
+/// }
 /// ```
 #[derive(Derivative, Serialize, Deserialize)]
 #[derivative(Debug(bound = ""), Default(bound = ""), Clone(bound = ""))]

--- a/amethyst_input/src/lib.rs
+++ b/amethyst_input/src/lib.rs
@@ -29,7 +29,8 @@ pub use self::{
 };
 pub use winit::{ElementState, VirtualKeyCode};
 
-use std::iter::Iterator;
+use serde::{Deserialize, Serialize};
+use std::{hash::Hash, iter::Iterator};
 
 mod axis;
 mod bindings;
@@ -70,4 +71,30 @@ impl Iterator for KeyThenCode {
             _ => None,
         }
     }
+}
+
+/// Combination trait for the `InputHandler` context. Contexts decide which set of input bindings is in use. If you have no interest in using
+/// this feature, you can use the unit type, `()` anywhere that a `Context` is needed. To use this feature, an enum type is recommended, such as
+///
+/// ```
+/// use std::hash::Hash;
+/// use serde::{Deserialize, Serialize};
+///
+/// #[derive(Debug, Clone, Hash, PartialEq, Eq, Deserialize, Serialize)]
+/// pub enum MyInputContext {
+///     Walking,
+///     Flying,
+/// }
+/// ```
+///
+/// You can then use the context with the `InputHandler` APIs to define and switch contexts as need arises. The `Context` trait is automatically
+/// implemented for anything which implements all of the traits `Context` requires.
+pub trait Context:
+    Default + Clone + Send + Sync + Hash + Eq + for<'a> Deserialize<'a> + Serialize + 'static
+{
+}
+
+impl<T> Context for T where
+    T: Default + Clone + Send + Sync + Hash + Eq + for<'a> Deserialize<'a> + Serialize + 'static
+{
 }

--- a/amethyst_input/src/util.rs
+++ b/amethyst_input/src/util.rs
@@ -1,4 +1,4 @@
-use crate::{input_handler::InputHandler, BindingTypes};
+use crate::{input_handler::InputHandler, BindingTypes, Context};
 use winit::{ElementState, Event, KeyboardInput, MouseButton, VirtualKeyCode, WindowEvent};
 
 /// If this event was for manipulating a keyboard key then this will return the `VirtualKeyCode`
@@ -54,9 +54,9 @@ pub fn is_close_requested(event: &Event) -> bool {
 
 /// Gets the input axis value from the `InputHandler`.
 /// If the name is None, it will return the default value of the axis (0.0).
-pub fn get_input_axis_simple<T: BindingTypes>(
+pub fn get_input_axis_simple<C: Context, T: BindingTypes>(
     name: &Option<T::Axis>,
-    input: &InputHandler<T>,
+    input: &InputHandler<C, T>,
 ) -> f32 {
     name.as_ref()
         .and_then(|ref n| input.axis_value(n))

--- a/amethyst_test/src/amethyst_application.rs
+++ b/amethyst_test/src/amethyst_application.rs
@@ -5,7 +5,7 @@ use amethyst::{
     core::{transform::TransformBundle, EventReader, RunNowDesc, SystemBundle, SystemDesc},
     ecs::prelude::*,
     error::Error,
-    input::{BindingTypes, InputBundle},
+    input::{BindingTypes, Context, InputBundle},
     prelude::*,
     shred::Resource,
     ui::UiBundle,
@@ -112,11 +112,11 @@ impl AmethystApplication<GameData<'static, 'static>, StateEvent, StateEventReade
     ///
     /// This also adds a `ScreenDimensions` resource to the `World` so that UI calculations can be
     /// done.
-    pub fn ui_base<B: BindingTypes>(
+    pub fn ui_base<C: Context, B: BindingTypes>(
     ) -> AmethystApplication<GameData<'static, 'static>, StateEvent, StateEventReader> {
         AmethystApplication::blank()
             .with_bundle(TransformBundle::new())
-            .with_ui_bundles::<B>()
+            .with_ui_bundles::<C, B>()
             .with_resource(ScreenDimensions::new(SCREEN_WIDTH, SCREEN_HEIGHT, HIDPI))
     }
 
@@ -376,9 +376,9 @@ where
     /// # Type Parameters
     ///
     /// * `B`: Type representing the input binding types.
-    pub fn with_ui_bundles<B: BindingTypes>(self) -> Self {
-        self.with_bundle(InputBundle::<B>::new())
-            .with_bundle(UiBundle::<B>::new())
+    pub fn with_ui_bundles<C: Context, B: BindingTypes>(self) -> Self {
+        self.with_bundle(InputBundle::<C, B>::new())
+            .with_bundle(UiBundle::<C, B>::new())
     }
 
     /// Adds a resource to the `World`.
@@ -787,7 +787,7 @@ mod test {
             world.read_resource::<ScreenDimensions>();
         };
 
-        AmethystApplication::ui_base::<amethyst::input::StringBindings>()
+        AmethystApplication::ui_base::<(), amethyst::input::StringBindings>()
             .with_assertion(assertion_fn)
             .run()
     }

--- a/amethyst_ui/src/bundle.rs
+++ b/amethyst_ui/src/bundle.rs
@@ -14,7 +14,7 @@ use amethyst_core::{
     SystemDesc,
 };
 use amethyst_error::Error;
-use amethyst_input::BindingTypes;
+use amethyst_input::{BindingTypes, Context};
 use derive_new::new;
 use std::marker::PhantomData;
 
@@ -25,13 +25,14 @@ use std::marker::PhantomData;
 ///
 /// Will fail with error 'No resource with the given id' if the InputBundle is not added.
 #[derive(new, Debug)]
-pub struct UiBundle<T: BindingTypes, C = NoCustomUi, W = u32, G = ()> {
+pub struct UiBundle<CT: Context, T: BindingTypes, C = NoCustomUi, W = u32, G = ()> {
     #[new(default)]
-    _marker: PhantomData<(T, C, W, G)>,
+    _marker: PhantomData<(CT, T, C, W, G)>,
 }
 
-impl<'a, 'b, T, C, W, G> SystemBundle<'a, 'b> for UiBundle<T, C, W, G>
+impl<'a, 'b, CT, T, C, W, G> SystemBundle<'a, 'b> for UiBundle<CT, T, C, W, G>
 where
+    CT: Context,
     T: BindingTypes,
     C: ToNativeWidget,
     W: WidgetId,
@@ -53,7 +54,7 @@ where
             &["transform_system"],
         );
         builder.add(
-            UiMouseSystem::<T>::new(),
+            UiMouseSystem::<CT, T>::new(),
             "ui_mouse_system",
             &["input_system", "ui_transform"],
         );
@@ -68,7 +69,7 @@ where
             &[],
         );
         builder.add(
-            SelectionMouseSystemDesc::<G, T>::default().build(world),
+            SelectionMouseSystemDesc::<G, CT, T>::default().build(world),
             "ui_mouse_selection",
             &["ui_mouse_system"],
         );
@@ -100,7 +101,7 @@ where
             &["ui_mouse_system"],
         );
         builder.add(
-            DragWidgetSystemDesc::<T>::default().build(world),
+            DragWidgetSystemDesc::<CT, T>::default().build(world),
             "ui_drag_system",
             &["ui_mouse_system"],
         );

--- a/amethyst_ui/src/drag.rs
+++ b/amethyst_ui/src/drag.rs
@@ -14,7 +14,7 @@ use amethyst_core::{
     Hidden, HiddenPropagate, ParentHierarchy,
 };
 use amethyst_derive::SystemDesc;
-use amethyst_input::{BindingTypes, InputHandler};
+use amethyst_input::{BindingTypes, Context, InputHandler};
 use amethyst_window::ScreenDimensions;
 
 use crate::{
@@ -34,7 +34,7 @@ impl Component for Draggable {
 
 #[derive(Debug, SystemDesc)]
 #[system_desc(name(DragWidgetSystemDesc))]
-pub struct DragWidgetSystem<T: BindingTypes> {
+pub struct DragWidgetSystem<C: Context, T: BindingTypes> {
     #[system_desc(event_channel_reader)]
     ui_reader_id: ReaderId<UiEvent>,
 
@@ -45,11 +45,12 @@ pub struct DragWidgetSystem<T: BindingTypes> {
     #[system_desc(skip)]
     record: HashMap<Entity, (Vector2<f32>, Vector2<f32>)>,
 
-    phantom: PhantomData<T>,
+    phantom: PhantomData<(C, T)>,
 }
 
-impl<T> DragWidgetSystem<T>
+impl<C, T> DragWidgetSystem<C, T>
 where
+    C: Context,
     T: BindingTypes,
 {
     pub fn new(ui_reader_id: ReaderId<UiEvent>) -> Self {
@@ -61,13 +62,14 @@ where
     }
 }
 
-impl<'s, T> System<'s> for DragWidgetSystem<T>
+impl<'s, C, T> System<'s> for DragWidgetSystem<C, T>
 where
+    C: Context,
     T: BindingTypes,
 {
     type SystemData = (
         Entities<'s>,
-        Read<'s, InputHandler<T>>,
+        Read<'s, InputHandler<C, T>>,
         ReadExpect<'s, ScreenDimensions>,
         ReadExpect<'s, ParentHierarchy>,
         ReadStorage<'s, Hidden>,

--- a/amethyst_ui/src/event.rs
+++ b/amethyst_ui/src/event.rs
@@ -10,7 +10,7 @@ use amethyst_core::{
     shrev::EventChannel,
     Hidden, HiddenPropagate,
 };
-use amethyst_input::{BindingTypes, InputHandler};
+use amethyst_input::{BindingTypes, Context, InputHandler};
 use amethyst_window::ScreenDimensions;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, marker::PhantomData};
@@ -97,14 +97,14 @@ impl Component for Interactable {
 /// The system that generates events for `Interactable` enabled entities.
 /// The generic types A and B represent the A and B generic parameter of the InputHandler<A,B>.
 #[derive(Default, Debug)]
-pub struct UiMouseSystem<T: BindingTypes> {
+pub struct UiMouseSystem<C: Context, T: BindingTypes> {
     was_down: bool,
     click_started_on: HashSet<Entity>,
     last_targets: HashSet<Entity>,
-    _marker: PhantomData<T>,
+    _marker: PhantomData<(C, T)>,
 }
 
-impl<T: BindingTypes> UiMouseSystem<T> {
+impl<C: Context, T: BindingTypes> UiMouseSystem<C, T> {
     /// Creates a new UiMouseSystem.
     pub fn new() -> Self {
         UiMouseSystem {
@@ -116,14 +116,14 @@ impl<T: BindingTypes> UiMouseSystem<T> {
     }
 }
 
-impl<'a, T: BindingTypes> System<'a> for UiMouseSystem<T> {
+impl<'a, C: Context, T: BindingTypes> System<'a> for UiMouseSystem<C, T> {
     type SystemData = (
         Entities<'a>,
         ReadStorage<'a, Hidden>,
         ReadStorage<'a, HiddenPropagate>,
         ReadStorage<'a, UiTransform>,
         ReadStorage<'a, Interactable>,
-        Read<'a, InputHandler<T>>,
+        Read<'a, InputHandler<C, T>>,
         ReadExpect<'a, ScreenDimensions>,
         Write<'a, EventChannel<UiEvent>>,
     );

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -66,4 +66,5 @@
     * [`cgmath` to `nalgebra`](./appendices/b_migration_notes/cgmath_to_nalgebra.md)
     * [Rendy Migration](./appendices/b_migration_notes/rendy_migration.md)
     * [Specs Migration](./appendices/b_migration_notes/specs_migration.md)
+    * [Input Context Migration](./appendices/b_migration_notes/input_context_migration.md)
 * [Appendix C: Feature Gates](./appendices/c_feature_gates.md)

--- a/book/src/appendices/b_migration_notes/input_context_migration.md
+++ b/book/src/appendices/b_migration_notes/input_context_migration.md
@@ -1,0 +1,49 @@
+# Input Context Migration Guide
+
+Amethyst recently added a new feature called Input Contexts which breaks backwards compatibility with earlier input files.
+
+If you just want to get on with your day and don't care about this new feature, here's the transformations you need to apply.
+
+```ignore
+InputHandler<T> -> InputHandler<(), T>
+InputBundle<T> -> InputBundle<(), T>
+InputSystem<T> -> InputSystem<(), T>
+InputSystemDesc<T> -> InputSystemDesc<(), T>
+SdlEventsSystem<T> -> SdlEventsSystem<(), T>
+SdlEventsSystemDesc<T> -> SdlEventsSystemDesc<(), T>
+FlyControlBundle<T> -> FlyControlBundle<(), T>
+FlyMovementSystem<T> -> FlyMovementSystem<(), T>
+UiBundle<T> -> UiBundle<(), T>
+UiMouseSystem<T> -> UiMouseSystem<(), T>
+SelectionMouseSystem<T> -> SelectionMouseSystem<(), T>
+SelectionMouseSystemDesc<T> -> SelectionMouseSystemDesc<(), T>
+DragWidgetSystem<T> -> DragWidgetSystem<(), T>
+```
+
+```ron,ignore
+(
+    axes: {
+        // contents irrelevant
+    },
+    actions: {
+        // contents irrelevant
+    }
+)
+```
+
+Now becomes
+
+```ron,ignore
+{
+    (): (
+        axes: {
+            // contents irrelevant
+        },
+        actions: {
+            // contents irrelevant
+        }
+    )
+}
+```
+
+If on the other hand you do want to learn about this new feature, please read our new documentation on [Input Contexts](../../input/handling_input.html#input-contexts).

--- a/book/src/concepts/system.md
+++ b/book/src/concepts/system.md
@@ -446,7 +446,7 @@ struct MyGameplaySystem;
 
 impl<'s> System<'s> for MyGameplaySystem {
     type SystemData = (
-        Read<'s, InputHandler<StringBindings>>,
+        Read<'s, InputHandler<(), StringBindings>>,
         Write<'s, Game>,
     );
 

--- a/book/src/input/how_to_define_custom_control_bindings.md
+++ b/book/src/input/how_to_define_custom_control_bindings.md
@@ -82,18 +82,21 @@ We can now use this custom type in our `InputBundle` and create a RON config fil
 The config file might look something like this:
 
 ```ron,ignore
-(
-    axes: {
-        Vertical(0): Emulated(pos: Key(W), neg: Key(S)),
-        Horizontal(0): Emulated(pos: Key(D), neg: Key(A)),
-        Vertical(1): Emulated(pos: Key(Up), neg: Key(Down)),
-        Horizontal(1): Emulated(pos: Key(Right), neg: Key(Left)),
-    },
-    actions: {
-        Shoot(0): [[Key(Space)]],
-        Shoot(1): [[Key(Return)]],
-    },
-)
+{
+    (): (
+        axes: {
+            Vertical(0): Emulated(pos: Key(W), neg: Key(S)),
+            Horizontal(0): Emulated(pos: Key(D), neg: Key(A)),
+            Vertical(1): Emulated(pos: Key(Up), neg: Key(Down)),
+            Horizontal(1): Emulated(pos: Key(Right), neg: Key(Left)),
+        },
+        actions: {
+            Shoot(0): [[Key(Space)]],
+            Shoot(1): [[Key(Return)]],
+        },
+    )
+}
+
 ```
 
 Here the number after the binding type could be the ID of the player, but you can supply any other data as long as it derives the right traits.
@@ -110,7 +113,7 @@ use amethyst::input::InputBundle;
 # let input_config = "input.ron";
 #
 let input_bundle = 
-    InputBundle::<MovementBindingTypes>::new()
+    InputBundle::<(), MovementBindingTypes>::new()
         .with_bindings_from_file(input_config)?;
 #
 # Ok(())
@@ -125,7 +128,7 @@ And add the `InputBundle` to the game data just like before.
 # use amethyst::input::{InputBundle, StringBindings};
 #
 # fn main() -> amethyst::Result<()> {
-# let input_bundle = InputBundle::<StringBindings>::default();
+# let input_bundle = InputBundle::<(), StringBindings>::default();
 #
 let mut world = World::new();
 let game_data = GameDataBuilder::default()
@@ -172,7 +175,7 @@ impl<'s> System<'s> for MovementSystem {
     type SystemData = (
         WriteStorage<'s, Transform>,
         ReadStorage<'s, Player>,
-        Read<'s, InputHandler<MovementBindingTypes>>,
+        Read<'s, InputHandler<(), MovementBindingTypes>>,
     );
 
     fn run(&mut self, (mut transform, player, input): Self::SystemData) {

--- a/book/src/pong-tutorial/pong-tutorial-04.md
+++ b/book/src/pong-tutorial/pong-tutorial-04.md
@@ -351,7 +351,7 @@ as well as adding our new systems to the game data:
 # fn run(&mut self, _: Self::SystemData) { }
 # }
 # }
-# let input_bundle = amethyst::input::InputBundle::<StringBindings>::new();
+# let input_bundle = amethyst::input::InputBundle::<(), StringBindings>::new();
 let game_data = GameDataBuilder::default()
 #    .with_bundle(TransformBundle::new())?
 #    .with_bundle(input_bundle)?

--- a/book/src/pong-tutorial/pong-tutorial-05.md
+++ b/book/src/pong-tutorial/pong-tutorial-05.md
@@ -141,7 +141,7 @@ keep playing after someone scores and log who got the point.
 #
 # let path = "./config/display.ron";
 # let config = DisplayConfig::load(&path)?;
-# let input_bundle = amethyst::input::InputBundle::<StringBindings>::new();
+# let input_bundle = amethyst::input::InputBundle::<(), StringBindings>::new();
 #
 let game_data = GameDataBuilder::default()
 #    .with_bundle(TransformBundle::new())?
@@ -216,7 +216,7 @@ Finally, add the `UiBundle` after the `InputBundle`:
 # let display_config_path = "";
 # struct Pong;
 # let game_data = GameDataBuilder::default()
-.with_bundle(UiBundle::<StringBindings>::new())?
+.with_bundle(UiBundle::<(), StringBindings>::new())?
 # ;
 #
 # Ok(())
@@ -228,9 +228,9 @@ We're adding a `RenderUi` to our `RenderBundle`, and we're also adding the
 rendering UI visuals to our game in addition to the existing background and
 sprites.
 
-> **Note:** We're using a `UiBundle` with type `StringBindings` here because the
-`UiBundle` needs to know what types our `InputHandler` is using to map `actions`
-and `axes`. So just know that your `UiBundle` type should match your
+> **Note:** We're using a `UiBundle` with types `()` and `StringBindings` here because the
+`UiBundle` needs to know what types our `InputHandler` is using.
+So just know that your `UiBundle` type should match your
 `InputHandler` type. You can read more about those here: [UiBundle][ui-bundle],
 [InputHandler][input-handler].
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,25 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [kc]: http://keepachangelog.com/
 [sv]: http://semver.org/
 
+## Unreleased
+
+### Added
+
+
+### Changed
+
+- `InputHandler` has been refactored to support multiple input contexts.
+You'll need to adjust your input bindings files to use the new format. ([#2237])
+
+### Removed
+
+
+### Fixed
+
+
+
+[#2237]: https://github.com/amethyst/amethyst/pull/2237
+
 
 ## [0.15.0] - 2020-03-24
 

--- a/examples/arc_ball_camera/config/input.ron
+++ b/examples/arc_ball_camera/config/input.ron
@@ -3,23 +3,25 @@
     Bindings<StringBindings>
 */
 
-(
-    axes: {
-        "move_x": Emulated(
-            pos: Key(D),
-            neg: Key(A),
-        ),
-        "move_y": Emulated(
-            pos: Key(E),
-            neg: Key(Q),
-        ),
-        "move_z": Emulated(
-            pos: Key(S),
-            neg: Key(W),
-        ),
-    },
-    actions: {
+{
+    (): (
+        axes: {
+            "move_x": Emulated(
+                pos: Key(D),
+                neg: Key(A),
+            ),
+            "move_y": Emulated(
+                pos: Key(E),
+                neg: Key(Q),
+            ),
+            "move_z": Emulated(
+                pos: Key(S),
+                neg: Key(W),
+            ),
+        },
+        actions: {
 
-    },
-)
+        },
+    )
+}
 

--- a/examples/arc_ball_camera/main.rs
+++ b/examples/arc_ball_camera/main.rs
@@ -108,7 +108,7 @@ fn main() -> Result<(), Error> {
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
         .with_bundle(TransformBundle::new().with_dep(&[]))?
         .with_bundle(
-            InputBundle::<StringBindings>::new().with_bindings_from_file(&key_bindings_path)?,
+            InputBundle::<(), StringBindings>::new().with_bindings_from_file(&key_bindings_path)?,
         )?
         .with_bundle(ArcBallControlBundle::<StringBindings>::new())?
         .with_system_desc(

--- a/examples/asset_loading/main.rs
+++ b/examples/asset_loading/main.rs
@@ -123,7 +123,7 @@ fn main() -> Result<(), Error> {
     let display_config_path = app_root.join("examples/asset_loading/config/display.ron");
 
     let game_data = GameDataBuilder::default()
-        .with_bundle(InputBundle::<StringBindings>::new())?
+        .with_bundle(InputBundle::<(), StringBindings>::new())?
         .with_bundle(TransformBundle::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()

--- a/examples/auto_fov/main.rs
+++ b/examples/auto_fov/main.rs
@@ -52,8 +52,8 @@ fn main() -> Result<(), Error> {
         .with(AutoFovSystem::new(), "auto_fov", &["prefab"])
         .with(ShowFovSystem::new(), "show_fov", &["auto_fov"])
         .with_bundle(TransformBundle::new())?
-        .with_bundle(InputBundle::<StringBindings>::new())?
-        .with_bundle(UiBundle::<StringBindings>::new())?
+        .with_bundle(InputBundle::<(), StringBindings>::new())?
+        .with_bundle(UiBundle::<(), StringBindings>::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(

--- a/examples/custom_game_data/main.rs
+++ b/examples/custom_game_data/main.rs
@@ -207,9 +207,9 @@ fn main() -> Result<(), Error> {
         .with_base(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
         .with_running(ExampleSystem::default(), "example_system", &[])
         .with_base_bundle(TransformBundle::new())
-        .with_base_bundle(UiBundle::<StringBindings>::new())
+        .with_base_bundle(UiBundle::<(), StringBindings>::new())
         .with_base_bundle(FpsCounterBundle::default())
-        .with_base_bundle(InputBundle::<StringBindings>::new())
+        .with_base_bundle(InputBundle::<(), StringBindings>::new())
         .with_base_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(

--- a/examples/custom_render_pass/main.rs
+++ b/examples/custom_render_pass/main.rs
@@ -93,7 +93,7 @@ fn main() -> amethyst::Result<()> {
     let assets_dir = app_root.join("examples/assets/");
 
     let game_data = GameDataBuilder::default()
-        .with_bundle(InputBundle::<StringBindings>::new())?
+        .with_bundle(InputBundle::<(), StringBindings>::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(

--- a/examples/custom_ui/main.rs
+++ b/examples/custom_ui/main.rs
@@ -100,7 +100,7 @@ fn main() -> amethyst::Result<()> {
     let game_data = GameDataBuilder::default()
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
         .with_bundle(TransformBundle::new())?
-        .with_bundle(UiBundle::<StringBindings, CustomUi>::new())?
+        .with_bundle(UiBundle::<(), StringBindings, CustomUi>::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(

--- a/examples/custom_ui/main.rs
+++ b/examples/custom_ui/main.rs
@@ -100,7 +100,7 @@ fn main() -> amethyst::Result<()> {
     let game_data = GameDataBuilder::default()
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
         .with_bundle(TransformBundle::new())?
-        .with_bundle(InputBundle::<StringBindings>::new())?
+        .with_bundle(InputBundle::<(), StringBindings>::new())?
         .with_bundle(UiBundle::<(), StringBindings, CustomUi>::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()

--- a/examples/debug_lines/config/input.ron
+++ b/examples/debug_lines/config/input.ron
@@ -3,23 +3,25 @@
     Bindings<StringBindings>
 */
 
-(
-    axes: {
-        "move_x": Emulated(
-            pos: Key(D),
-            neg: Key(A),
-        ),
-        "move_y": Emulated(
-            pos: Key(E),
-            neg: Key(Q),
-        ),
-        "move_z": Emulated(
-            pos: Key(S),
-            neg: Key(W),
-        ),
-    },
-    actions: {
+{
+    (): (
+        axes: {
+            "move_x": Emulated(
+                pos: Key(D),
+                neg: Key(A),
+            ),
+            "move_y": Emulated(
+                pos: Key(E),
+                neg: Key(Q),
+            ),
+            "move_z": Emulated(
+                pos: Key(S),
+                neg: Key(W),
+            ),
+        },
+        actions: {
 
-    },
-)
+        },
+    )
+}
 

--- a/examples/debug_lines/main.rs
+++ b/examples/debug_lines/main.rs
@@ -173,7 +173,7 @@ fn main() -> amethyst::Result<()> {
     let key_bindings_path = app_root.join("examples/debug_lines/config/input.ron");
     let assets_dir = app_root.join("examples/assets/");
 
-    let fly_control_bundle = FlyControlBundle::<StringBindings>::new(
+    let fly_control_bundle = FlyControlBundle::<(), StringBindings>::new(
         Some(String::from("move_x")),
         Some(String::from("move_y")),
         Some(String::from("move_z")),
@@ -182,7 +182,7 @@ fn main() -> amethyst::Result<()> {
 
     let game_data = GameDataBuilder::default()
         .with_bundle(
-            InputBundle::<StringBindings>::new().with_bindings_from_file(&key_bindings_path)?,
+            InputBundle::<(), StringBindings>::new().with_bindings_from_file(&key_bindings_path)?,
         )?
         .with(ExampleLinesSystem, "example_lines_system", &[])
         .with_bundle(fly_control_bundle)?

--- a/examples/fly_camera/main.rs
+++ b/examples/fly_camera/main.rs
@@ -67,7 +67,7 @@ fn main() -> Result<(), Error> {
     let game_data = GameDataBuilder::default()
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
         .with_bundle(
-            FlyControlBundle::<StringBindings>::new(
+            FlyControlBundle::<(), StringBindings>::new(
                 Some(String::from("move_x")),
                 Some(String::from("move_y")),
                 Some(String::from("move_z")),
@@ -76,7 +76,7 @@ fn main() -> Result<(), Error> {
         )?
         .with_bundle(TransformBundle::new().with_dep(&["fly_movement"]))?
         .with_bundle(
-            InputBundle::<StringBindings>::new().with_bindings_from_file(&key_bindings_path)?,
+            InputBundle::<(), StringBindings>::new().with_bindings_from_file(&key_bindings_path)?,
         )?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()

--- a/examples/mouse_raycast/main.rs
+++ b/examples/mouse_raycast/main.rs
@@ -44,7 +44,7 @@ impl<'s> System<'s> for MouseRaycastSystem {
         Read<'s, AssetStorage<SpriteSheet>>,
         ReadExpect<'s, ScreenDimensions>,
         Read<'s, ActiveCamera>,
-        Read<'s, InputHandler<StringBindings>>,
+        Read<'s, InputHandler<(), StringBindings>>,
         UiFinder<'s>,
     );
 
@@ -264,8 +264,8 @@ fn main() -> amethyst::Result<()> {
 
     let game_data = GameDataBuilder::default()
         .with_bundle(TransformBundle::new())?
-        .with_bundle(InputBundle::<StringBindings>::new())?
-        .with_bundle(UiBundle::<StringBindings>::new())?
+        .with_bundle(InputBundle::<(), StringBindings>::new())?
+        .with_bundle(UiBundle::<(), StringBindings>::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(

--- a/examples/pong/config/input.ron
+++ b/examples/pong/config/input.ron
@@ -3,19 +3,21 @@
     Bindings<StringBindings>
 */
 
-(
-    axes: {
-        "left_paddle": Emulated(
-            pos: Key(W),
-            neg: Key(S),
-        ),
-        "right_paddle": Emulated(
-            pos: Key(Up),
-            neg: Key(Down),
-        ),
-    },
-    actions: {
+{
+    (): (
+        axes: {
+            "left_paddle": Emulated(
+                pos: Key(W),
+                neg: Key(S),
+            ),
+            "right_paddle": Emulated(
+                pos: Key(Up),
+                neg: Key(Down),
+            ),
+        },
+        actions: {
 
-    },
-)
+        },
+    )
+}
 

--- a/examples/pong/config/input_controller.ron
+++ b/examples/pong/config/input_controller.ron
@@ -3,23 +3,25 @@
     Bindings<StringBindings>
 */
 
-(
-    axes: {
-        "left_paddle": Controller(
-            controller_id: 0,
-            axis: LeftY,
-            invert: false,
-            dead_zone: 0.2,
-        ),
-        "right_paddle": Controller(
-            controller_id: 0,
-            axis: RightY,
-            invert: false,
-            dead_zone: 0.2,
-        ),
-    },
-    actions: {
+{
+    (): (
+        axes: {
+            "left_paddle": Controller(
+                controller_id: 0,
+                axis: LeftY,
+                invert: false,
+                dead_zone: 0.2,
+            ),
+            "right_paddle": Controller(
+                controller_id: 0,
+                axis: RightY,
+                invert: false,
+                dead_zone: 0.2,
+            ),
+        },
+        actions: {
 
-    },
-)
+        },
+    )
+}
 

--- a/examples/pong/main.rs
+++ b/examples/pong/main.rs
@@ -63,7 +63,7 @@ fn main() -> amethyst::Result<()> {
         // Add the transform bundle which handles tracking entity positions
         .with_bundle(TransformBundle::new())?
         .with_bundle(
-            InputBundle::<StringBindings>::new().with_bindings_from_file(key_bindings_path)?,
+            InputBundle::<(), StringBindings>::new().with_bindings_from_file(key_bindings_path)?,
         )?
         .with_bundle(PongBundle)?
         .with_bundle(AudioBundle::default())?
@@ -72,7 +72,7 @@ fn main() -> amethyst::Result<()> {
             "dj_system",
             &[],
         )
-        .with_bundle(UiBundle::<StringBindings>::new())?
+        .with_bundle(UiBundle::<(), StringBindings>::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 // The RenderToWindow plugin provides all the scaffolding for opening a window and

--- a/examples/pong/systems/paddle.rs
+++ b/examples/pong/systems/paddle.rs
@@ -16,7 +16,7 @@ impl<'s> System<'s> for PaddleSystem {
         ReadStorage<'s, Paddle>,
         WriteStorage<'s, Transform>,
         Read<'s, Time>,
-        Read<'s, InputHandler<StringBindings>>,
+        Read<'s, InputHandler<(), StringBindings>>,
     );
 
     fn run(&mut self, (paddles, mut transforms, time, input): Self::SystemData) {

--- a/examples/pong_tutorial_03/config/bindings.ron
+++ b/examples/pong_tutorial_03/config/bindings.ron
@@ -3,10 +3,13 @@
     Bindings<StringBindings>
 */
 
-(
-  axes: {
-    "left_paddle": Emulated(pos: Key(W), neg: Key(S)),
-    "right_paddle": Emulated(pos: Key(Up), neg: Key(Down)),
-  },
-  actions: {},
-)
+{
+  (): (
+    axes: {
+      "left_paddle": Emulated(pos: Key(W), neg: Key(S)),
+      "right_paddle": Emulated(pos: Key(Up), neg: Key(Down)),
+    },
+    actions: {},
+  )
+}
+

--- a/examples/pong_tutorial_03/main.rs
+++ b/examples/pong_tutorial_03/main.rs
@@ -30,7 +30,7 @@ fn main() -> amethyst::Result<()> {
         // Add the transform bundle which handles tracking entity positions
         .with_bundle(TransformBundle::new())?
         .with_bundle(
-            InputBundle::<StringBindings>::new().with_bindings_from_file(
+            InputBundle::<(), StringBindings>::new().with_bindings_from_file(
                 app_root.join("examples/pong_tutorial_03/config/bindings.ron"),
             )?,
         )?

--- a/examples/pong_tutorial_03/systems/paddle.rs
+++ b/examples/pong_tutorial_03/systems/paddle.rs
@@ -13,7 +13,7 @@ impl<'s> System<'s> for PaddleSystem {
     type SystemData = (
         WriteStorage<'s, Transform>,
         ReadStorage<'s, Paddle>,
-        Read<'s, InputHandler<StringBindings>>,
+        Read<'s, InputHandler<(), StringBindings>>,
     );
 
     fn run(&mut self, (mut transforms, paddles, input): Self::SystemData) {

--- a/examples/pong_tutorial_04/config/bindings.ron
+++ b/examples/pong_tutorial_04/config/bindings.ron
@@ -3,10 +3,12 @@
     Bindings<StringBindings>
 */
 
-(
-  axes: {
-    "left_paddle": Emulated(pos: Key(W), neg: Key(S)),
-    "right_paddle": Emulated(pos: Key(Up), neg: Key(Down)),
-  },
-  actions: {},
-)
+{
+  (): (
+    axes: {
+      "left_paddle": Emulated(pos: Key(W), neg: Key(S)),
+      "right_paddle": Emulated(pos: Key(Up), neg: Key(Down)),
+    },
+    actions: {},
+  )
+}

--- a/examples/pong_tutorial_04/main.rs
+++ b/examples/pong_tutorial_04/main.rs
@@ -30,7 +30,7 @@ fn main() -> amethyst::Result<()> {
         // Add the transform bundle which handles tracking entity positions
         .with_bundle(TransformBundle::new())?
         .with_bundle(
-            InputBundle::<StringBindings>::new().with_bindings_from_file(
+            InputBundle::<(), StringBindings>::new().with_bindings_from_file(
                 app_root.join("examples/pong_tutorial_04/config/bindings.ron"),
             )?,
         )?

--- a/examples/pong_tutorial_04/systems/paddle.rs
+++ b/examples/pong_tutorial_04/systems/paddle.rs
@@ -13,7 +13,7 @@ impl<'s> System<'s> for PaddleSystem {
     type SystemData = (
         WriteStorage<'s, Transform>,
         ReadStorage<'s, Paddle>,
-        Read<'s, InputHandler<StringBindings>>,
+        Read<'s, InputHandler<(), StringBindings>>,
     );
 
     fn run(&mut self, (mut transforms, paddles, input): Self::SystemData) {

--- a/examples/pong_tutorial_05/config/bindings.ron
+++ b/examples/pong_tutorial_05/config/bindings.ron
@@ -3,10 +3,12 @@
     Bindings<StringBindings>
 */
 
-(
-  axes: {
-    "left_paddle": Emulated(pos: Key(W), neg: Key(S)),
-    "right_paddle": Emulated(pos: Key(Up), neg: Key(Down)),
-  },
-  actions: {},
-)
+{
+  (): (
+    axes: {
+      "left_paddle": Emulated(pos: Key(W), neg: Key(S)),
+      "right_paddle": Emulated(pos: Key(Up), neg: Key(Down)),
+    },
+    actions: {},
+  )
+}

--- a/examples/pong_tutorial_05/main.rs
+++ b/examples/pong_tutorial_05/main.rs
@@ -31,11 +31,11 @@ fn main() -> amethyst::Result<()> {
         // Add the transform bundle which handles tracking entity positions
         .with_bundle(TransformBundle::new())?
         .with_bundle(
-            InputBundle::<StringBindings>::new().with_bindings_from_file(
+            InputBundle::<(), StringBindings>::new().with_bindings_from_file(
                 app_root.join("examples/pong_tutorial_05/config/bindings.ron"),
             )?,
         )?
-        .with_bundle(UiBundle::<StringBindings>::new())?
+        .with_bundle(UiBundle::<(), StringBindings>::new())?
         // We have now added our own systems, defined in the systems module
         .with(systems::PaddleSystem, "paddle_system", &["input_system"])
         .with(systems::MoveBallsSystem, "ball_system", &[])

--- a/examples/pong_tutorial_05/systems/paddle.rs
+++ b/examples/pong_tutorial_05/systems/paddle.rs
@@ -13,7 +13,7 @@ impl<'s> System<'s> for PaddleSystem {
     type SystemData = (
         WriteStorage<'s, Transform>,
         ReadStorage<'s, Paddle>,
-        Read<'s, InputHandler<StringBindings>>,
+        Read<'s, InputHandler<(), StringBindings>>,
     );
 
     fn run(&mut self, (mut transforms, paddles, input): Self::SystemData) {

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -202,10 +202,10 @@ fn main() -> Result<(), Error> {
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
         .with(ExampleSystem::default(), "example_system", &[])
         .with_bundle(TransformBundle::new().with_dep(&["example_system"]))?
-        .with_bundle(UiBundle::<StringBindings>::new())?
+        .with_bundle(UiBundle::<(), StringBindings>::new())?
         .with_bundle(HotReloadBundle::default())?
         .with_bundle(FpsCounterBundle::default())?
-        .with_bundle(InputBundle::<StringBindings>::new())?
+        .with_bundle(InputBundle::<(), StringBindings>::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(

--- a/examples/renderable_custom/main.rs
+++ b/examples/renderable_custom/main.rs
@@ -206,10 +206,10 @@ fn main() -> Result<(), Error> {
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
         .with(ExampleSystem::default(), "example_system", &[])
         .with_bundle(TransformBundle::new().with_dep(&["example_system"]))?
-        .with_bundle(UiBundle::<StringBindings>::new())?
+        .with_bundle(UiBundle::<(), StringBindings>::new())?
         .with_bundle(HotReloadBundle::default())?
         .with_bundle(FpsCounterBundle::default())?
-        .with_bundle(InputBundle::<StringBindings>::new())?
+        .with_bundle(InputBundle::<(), StringBindings>::new())?
         // The below Systems, are used to handle some rendering resources.
         // Most likely these must be always called as last thing.
         .with_system_desc(

--- a/examples/sprite_camera_follow/main.rs
+++ b/examples/sprite_camera_follow/main.rs
@@ -33,7 +33,7 @@ impl<'s> System<'s> for MovementSystem {
     type SystemData = (
         ReadStorage<'s, Player>,
         WriteStorage<'s, Transform>,
-        Read<'s, InputHandler<StringBindings>>,
+        Read<'s, InputHandler<(), StringBindings>>,
     );
 
     fn run(&mut self, (players, mut transforms, input): Self::SystemData) {
@@ -211,7 +211,7 @@ fn main() -> amethyst::Result<()> {
     let game_data = GameDataBuilder::default()
         .with_bundle(TransformBundle::new())?
         .with_bundle(
-            InputBundle::<StringBindings>::new().with_bindings_from_file(
+            InputBundle::<(), StringBindings>::new().with_bindings_from_file(
                 app_root.join("examples/sprite_camera_follow/config/input.ron"),
             )?,
         )?

--- a/examples/states_ui/main.rs
+++ b/examples/states_ui/main.rs
@@ -43,9 +43,9 @@ pub fn main() -> amethyst::Result<()> {
         .with_bundle(TransformBundle::new())?
         // This system is in 'events.rs'. Basically, it registers UI events that
         // happen. Without it, the buttons will not react.
-        .with_bundle(InputBundle::<StringBindings>::new())?
+        .with_bundle(InputBundle::<(), StringBindings>::new())?
         // this bundle allows us to 'find' the Buttons and other UI elements later on
-        .with_bundle(UiBundle::<StringBindings>::new())?
+        .with_bundle(UiBundle::<(), StringBindings>::new())?
         // this allows us to reload '*.ron' files during execution
         .with_bundle(HotReloadBundle::default())?
         // without this Bundle, our Program will silently (!) fail when trying to start the 'Game'.

--- a/examples/tiles/main.rs
+++ b/examples/tiles/main.rs
@@ -45,7 +45,7 @@ impl<'s> System<'s> for DrawSelectionSystem {
         ReadStorage<'s, Camera>,
         ReadStorage<'s, Transform>,
         WriteStorage<'s, DebugLinesComponent>,
-        Read<'s, InputHandler<StringBindings>>,
+        Read<'s, InputHandler<(), StringBindings>>,
     );
 
     fn run(
@@ -123,7 +123,7 @@ impl<'s> System<'s> for CameraSwitchSystem {
         ReadStorage<'s, Camera>,
         ReadStorage<'s, Transform>,
         ReadStorage<'s, Parent>,
-        Read<'s, InputHandler<StringBindings>>,
+        Read<'s, InputHandler<(), StringBindings>>,
     );
 
     fn run(
@@ -178,7 +178,7 @@ impl<'s> System<'s> for CameraMovementSystem {
         Entities<'s>,
         ReadStorage<'s, Camera>,
         WriteStorage<'s, Transform>,
-        Read<'s, InputHandler<StringBindings>>,
+        Read<'s, InputHandler<(), StringBindings>>,
     );
 
     fn run(&mut self, (active_camera, entities, cameras, mut transforms, input): Self::SystemData) {
@@ -226,7 +226,7 @@ impl<'s> System<'s> for MapMovementSystem {
         Read<'s, Time>,
         WriteStorage<'s, Transform>,
         ReadStorage<'s, TileMap<ExampleTile>>,
-        Read<'s, InputHandler<StringBindings>>,
+        Read<'s, InputHandler<(), StringBindings>>,
     );
 
     fn run(&mut self, (time, mut transforms, tilemaps, input): Self::SystemData) {
@@ -419,7 +419,7 @@ fn main() -> amethyst::Result<()> {
     let game_data = GameDataBuilder::default()
         .with_bundle(TransformBundle::new())?
         .with_bundle(
-            InputBundle::<StringBindings>::new()
+            InputBundle::<(), StringBindings>::new()
                 .with_bindings_from_file("examples/tiles/resources/input.ron")?,
         )?
         .with(

--- a/examples/ui/main.rs
+++ b/examples/ui/main.rs
@@ -131,8 +131,8 @@ fn main() -> amethyst::Result<()> {
     let game_data = GameDataBuilder::default()
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
         .with_bundle(TransformBundle::new())?
-        .with_bundle(InputBundle::<StringBindings>::new())?
-        .with_bundle(UiBundle::<StringBindings>::new())?
+        .with_bundle(InputBundle::<(), StringBindings>::new())?
+        .with_bundle(UiBundle::<(), StringBindings>::new())?
         .with(Processor::<Source>::new(), "source_processor", &[])
         .with_system_desc(UiEventHandlerSystemDesc::default(), "ui_event_handler", &[])
         .with_bundle(FpsCounterBundle::default())?


### PR DESCRIPTION
## Description

Production videogames have several different contexts they need to support for input, whether it be due to game features such as vehicles, inventory menus, or alternate protagonists. Up until now Amethyst's answer to this has been to allow the developer to reassign and alter the `bindings` variable as needed on the `InputHandler`. This approach has a few downsides.

1. Can't store all input bindings in a single file
2. It's not immediately clear to users how they should change the `bindings` variable after load, or that they even can.
3. It requires the user to juggle around various `Bindings` structures, with no provided location as to where they should live.

So, this PR introduces `Context`s. The InputHandler now stores multiple `Bindings` configurations, and decides which one to use based on the `Context` variable set on it. A `Context` can be anything, as it is defined in all places by a generic. If users wish to opt out of this feature, they can use the `()` Context value.

## Additions

- amethyst_input::Context
- amethyst_input::InputHandler::new_with_context
- amethyst_input::InputHandler::active_bindings
- amethyst_input::InputHandler::active_bindings_mut
- amethyst_input::InputHandler::set_context
- amethyst_input::InputHandler::context
- amethyst_input::InputHandler::set_bindings_for_context
- amethyst_input::InputHandler::bindings_for_context
- amethyst_input::InputHandler::bindings_for_context_mut
- amethyst_input::InputHandler::remove_bindings_for_context

## Removals

- amethyst_input::InputHandler::bindings is no longer public.

## Modifications

- amethyst_input::InputHandler now accepts a `Context` generic parameter
- amethyst_input::InputBundle now accepts a `Context` generic parameter
- amethyst_input::InputSystem now accepts a `Context` generic parameter
- amethyst_input::InputSystemDesc now accepts a `Context` generic parameter
- amethyst_input::SdlEventsSystem now accepts a `Context` generic parameter
- amethyst_input::SdlEventsSystemDesc now accepts a `Context` generic parameter
- amethyst_controls::FlyControlBundle now accepts a `Context` generic parameter
- amethyst_controls::FlyMovementSystem now accepts a `Context` generic parameter
- amethyst_test::AmethystApplication::ui_base now accepts a `Context` generic parameter
- amethyst_test::AmethystApplication::with_ui_bundle now accepts a `Context` generic parameter
- amethyst_ui::UiBundle now accepts a `Context` generic parameter
- amethyst_ui::UiMouseSystem now accepts a `Context` generic parameter
- amethyst_ui::SelectionMouseSystem now accepts a `Context` generic parameter
- amethyst_ui::SelectionMouseSystemDesc now accepts a `Context` generic parameter
- amethyst_ui::DragWidgetSystem now accepts a `Context` generic parameter

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
