### PR TITLE
Feature/guard threading with parallel feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,17 @@ default = [
   "network",
   "renderer",
 
+  # Enable parallel execution by default.
+  # Currently not supported in WASM, so users have to disable default features if building for WASM.
+  "parallel",
+
   # mp3 not enabled by default as it requires `minimp3`, which cannot be compiled for WASM targets.
   "flac",
   "vorbis",
   "wav",
 ]
+
+parallel = ["amethyst_core/parallel"]
 
 # Renderer backend
 gl = ["amethyst_rendy/gl", "amethyst_ui/gl"]
@@ -147,7 +153,7 @@ amethyst_animation = { path = "amethyst_animation", version = "0.10.0", optional
 amethyst_assets = { path = "amethyst_assets", version = "0.11.0" }
 amethyst_audio = { path = "amethyst_audio", version = "0.10.0", default-features = false, optional = true }
 amethyst_config = { path = "amethyst_config", version = "0.14.0" }
-amethyst_core = { path = "amethyst_core", version = "0.10.0" }
+amethyst_core = { path = "amethyst_core", version = "0.10.0", default-features = false }
 amethyst_error = { path = "amethyst_error", version = "0.5.0" }
 amethyst_controls = { path = "amethyst_controls", version = "0.9.0" }
 amethyst_derive = { path = "amethyst_derive", version = "0.8.0" }
@@ -370,6 +376,3 @@ required-features = [ "tiles" ]
 
 [package.metadata.docs.rs]
 features = ["animation", "audio", "gltf", "tiles", "json", "locale", "network", "sdl_controller", "vulkan"]
-
-[patch.crates-io]
-shred = { git = "https://github.com/amethyst/shred.git", branch = "wasm" }

--- a/amethyst_animation/Cargo.toml
+++ b/amethyst_animation/Cargo.toml
@@ -18,7 +18,7 @@ travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.11.0" }
-amethyst_core = { path = "../amethyst_core", version = "0.10.0" }
+amethyst_core = { path = "../amethyst_core", version = "0.10.0", default-features = false }
 amethyst_error = { path = "../amethyst_error", version = "0.5.0" }
 amethyst_derive = { path = "../amethyst_derive", version = "0.8.0" }
 amethyst_rendy = { path = "../amethyst_rendy", version = "0.5.0" }

--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -20,7 +20,7 @@ repository = "https://github.com/amethyst/amethyst"
 travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
-amethyst_core = { path = "../amethyst_core", version = "0.10.0" }
+amethyst_core = { path = "../amethyst_core", version = "0.10.0", default-features = false }
 amethyst_derive = { path = "../amethyst_derive", version = "0.8.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.5.0" }
 crossbeam-queue = "0.1.2"

--- a/amethyst_audio/Cargo.toml
+++ b/amethyst_audio/Cargo.toml
@@ -20,7 +20,7 @@ travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.11.0" }
-amethyst_core = { path = "../amethyst_core", version = "0.10.0" }
+amethyst_core = { path = "../amethyst_core", version = "0.10.0", default-features = false }
 amethyst_error = { path = "../amethyst_error", version = "0.5.0" }
 cpal = { git = "https://github.com/amethyst/cpal", branch = "wasm" }
 derive-new = "0.5"

--- a/amethyst_controls/Cargo.toml
+++ b/amethyst_controls/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.11.0" }
-amethyst_core = { path = "../amethyst_core", version = "0.10.0" }
+amethyst_core = { path = "../amethyst_core", version = "0.10.0", default-features = false }
 amethyst_derive = { path = "../amethyst_derive", version = "0.8.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.5.0" }
 amethyst_input = { path = "../amethyst_input", version = "0.11.0" }

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -39,7 +39,8 @@ amethyst = { path = "..", version = "0.15.0" }
 ron = "0.5.1"
 
 [features]
-default = ["specs/parallel", "specs-hierarchy/parallel"]
+default = ["parallel"]
+parallel = ["specs/parallel", "specs-hierarchy/parallel"]
 profiler = ["thread_profiler/thread_profiler"]
 saveload = ["specs/serde"]
 storage-event-control = ["specs/storage-event-control"]

--- a/amethyst_derive/Cargo.toml
+++ b/amethyst_derive/Cargo.toml
@@ -23,7 +23,7 @@ proc_macro_roids = "0.7"
 proc-macro-crate = "0.1"
 
 [dev-dependencies]
-amethyst_core = { path = "../amethyst_core", version = "0.10.0" }
+amethyst_core = { path = "../amethyst_core", version = "0.10.0", default-features = false }
 amethyst_assets = { path = "../amethyst_assets", version = "0.11.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.5.0" }
 amethyst_test = { path = "../amethyst_test", version = "0.6.0" }

--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "amethyst/amethyst" }
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.11.0" }
 amethyst_animation = { path = "../amethyst_animation", version = "0.10.0" }
-amethyst_core = { path = "../amethyst_core", version = "0.10.0" }
+amethyst_core = { path = "../amethyst_core", version = "0.10.0", default-features = false }
 amethyst_error = { path = "../amethyst_error", version = "0.5.0" }
 amethyst_rendy = { path = "../amethyst_rendy", version = "0.5.0" }
 err-derive = "0.2.3"

--- a/amethyst_input/Cargo.toml
+++ b/amethyst_input/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT/Apache-2.0"
 travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
-amethyst_core = { path = "../amethyst_core", version = "0.10.0" }
+amethyst_core = { path = "../amethyst_core", version = "0.10.0", default-features = false }
 amethyst_error = { path = "../amethyst_error", version = "0.5.0" }
 amethyst_config = { path = "../amethyst_config/", version = "0.14.0" }
 amethyst_window = { path = "../amethyst_window", version = "0.5.0" }

--- a/amethyst_locale/Cargo.toml
+++ b/amethyst_locale/Cargo.toml
@@ -21,7 +21,7 @@ travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.11.0" }
-amethyst_core = { path = "../amethyst_core", version = "0.10.0" }
+amethyst_core = { path = "../amethyst_core", version = "0.10.0", default-features = false }
 amethyst_error = { path = "../amethyst_error", version = "0.5.0" }
 serde = { version = "1.0", features = ["derive"] }
 fluent = "0.11"

--- a/amethyst_network/Cargo.toml
+++ b/amethyst_network/Cargo.toml
@@ -23,7 +23,7 @@ license = "MIT/Apache-2.0"
 profiler = [ "thread_profiler/thread_profiler" ]
 
 [dependencies]
-amethyst_core = { path = "../amethyst_core", version = "0.10.0" }
+amethyst_core = { path = "../amethyst_core", version = "0.10.0", default-features = false }
 amethyst_error = { path = "../amethyst_error", version = "0.5.0" }
 bytes = "0.5"
 laminar = "0.3"

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -13,7 +13,7 @@ features = ["shader-compiler", "test-support", "winit", "vulkan"]
 
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.11.0" }
-amethyst_core = { path = "../amethyst_core", version = "0.10.0" }
+amethyst_core = { path = "../amethyst_core", version = "0.10.0", default-features = false }
 amethyst_derive = { path = "../amethyst_derive", version = "0.8.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.5.0" }
 amethyst_window = { path = "../amethyst_window", version = "0.5.0", optional = true }

--- a/amethyst_test/Cargo.toml
+++ b/amethyst_test/Cargo.toml
@@ -26,6 +26,7 @@ serde = "1.0"
 [features]
 default = ["animation", "audio", "locale", "network", "renderer"]
 
+parallel = ["amethyst/parallel"]
 vulkan = ["amethyst/vulkan"]
 metal = ["amethyst/metal"]
 empty = ["amethyst/empty"]

--- a/amethyst_tiles/Cargo.toml
+++ b/amethyst_tiles/Cargo.toml
@@ -18,7 +18,7 @@ travis-ci = { repository = "amethyst/amethyst" }
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.11.0" }
 amethyst_rendy = { path = "../amethyst_rendy", version = "0.5.0" }
-amethyst_core = { path = "../amethyst_core", version = "0.10.0" }
+amethyst_core = { path = "../amethyst_core", version = "0.10.0", default-features = false }
 amethyst_error = { path = "../amethyst_error", version = "0.5.0" }
 amethyst_window = { path = "../amethyst_window", version = "0.5.0" }
 log = { version = "0.4.6", features = ["serde"] }

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT/Apache-2.0"
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.11.0" }
 amethyst_audio = { path = "../amethyst_audio", version = "0.10.0", default-features = false }
-amethyst_core = { path = "../amethyst_core", version = "0.10.0" }
+amethyst_core = { path = "../amethyst_core", version = "0.10.0", default-features = false }
 amethyst_derive = { path = "../amethyst_derive", version = "0.8.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.5.0" }
 amethyst_input = { path = "../amethyst_input", version = "0.11.0" }

--- a/amethyst_utils/Cargo.toml
+++ b/amethyst_utils/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "amethyst/amethyst" }
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.11.0" }
 amethyst_controls = { path = "../amethyst_controls", version = "0.9.0" }
-amethyst_core = { path = "../amethyst_core", version = "0.10.0" }
+amethyst_core = { path = "../amethyst_core", version = "0.10.0", default-features = false }
 amethyst_error = { path = "../amethyst_error", version = "0.5.0" }
 amethyst_derive = { path = "../amethyst_derive", version = "0.8.0" }
 amethyst_rendy = { path = "../amethyst_rendy", version = "0.5.0" }
@@ -26,7 +26,7 @@ derive-new = "0.5.8"
 log = "0.4.6"
 serde = { version = "1.0", features = ["derive"] }
 specs-derive = "0.4.1"
-specs-hierarchy = "0.6.0"
+specs-hierarchy = { version = "0.6", default-features = false }
 
 thread_profiler = { version = "0.3", optional = true }
 

--- a/amethyst_window/Cargo.toml
+++ b/amethyst_window/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT/Apache-2.0"
 travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
-amethyst_core = { path = "../amethyst_core", version = "0.10.0" }
+amethyst_core = { path = "../amethyst_core", version = "0.10.0", default-features = false }
 amethyst_config = { path = "../amethyst_config", version = "0.14.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.5.0" }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * ***Breaking:*** MP3 loading is now behind the `"mp3"` feature, disabled by default.
 * ***Breaking:*** System fonts support is now behind the `"system_font"` feature, disabled by default.
 * Support audio playback in WASM target. ([#2195], [#2219])
+* Threading is toggle-able with `"parallel"` feature (enabled by default). ([#2238])
 
 ### Fixed
 
@@ -28,6 +29,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#2195]: https://github.com/amethyst/amethyst/issues/2195
 [#2198]: https://github.com/amethyst/amethyst/pull/2198
 [#2219]: https://github.com/amethyst/amethyst/pull/2219
+[#2238]: https://github.com/amethyst/amethyst/pull/2238
 
 ## [0.15.0] - 2020-03-24
 

--- a/src/game_data.rs
+++ b/src/game_data.rs
@@ -462,7 +462,7 @@ impl<'a, 'b> GameDataBuilder<'a, 'b> {
 
 impl<'a, 'b> DataInit<GameData<'a, 'b>> for GameDataBuilder<'a, 'b> {
     fn build(self, mut world: &mut World) -> GameData<'a, 'b> {
-        #[cfg(not(no_threading))]
+        #[cfg(feature = "parallel")]
         let pool = (*world.read_resource::<ArcThreadPool>()).clone();
 
         let mut dispatcher_builder = self.disp_builder;
@@ -474,9 +474,9 @@ impl<'a, 'b> DataInit<GameData<'a, 'b>> for GameDataBuilder<'a, 'b> {
             })
             .unwrap_or_else(|e| panic!("Failed to set up dispatcher: {}", e));
 
-        #[cfg(not(no_threading))]
+        #[cfg(feature = "parallel")]
         let mut dispatcher = dispatcher_builder.with_pool(pool).build();
-        #[cfg(no_threading)]
+        #[cfg(not(feature = "parallel"))]
         let mut dispatcher = dispatcher_builder.build();
         dispatcher.setup(&mut world);
         GameData::new(dispatcher)


### PR DESCRIPTION
## Description

Threading is toggle-able with `"parallel"` feature (enabled by default). This removes the `shred` patch.

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --no-default-features --features "gl"`
