### PR TITLE
Fixed custom game data example

### DIFF
--- a/examples/custom_game_data/main.rs
+++ b/examples/custom_game_data/main.rs
@@ -207,9 +207,9 @@ fn main() -> Result<(), Error> {
         .with_base(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
         .with_running(ExampleSystem::default(), "example_system", &[])
         .with_base_bundle(TransformBundle::new())
-        .with_base_bundle(UiBundle::<StringBindings>::new())
         .with_base_bundle(FpsCounterBundle::default())
         .with_base_bundle(InputBundle::<StringBindings>::new())
+        .with_base_bundle(UiBundle::<StringBindings>::new())
         .with_base_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(


### PR DESCRIPTION
## Description

Since the Ui Bundle relies upon the Input Bundle and the custom game data example instantiated them in the wrong order the code was broken. I changed the order.

## Modifications

main.rs file in custom game data example.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
