### PR TITLE
Fix all the broken examples with UiBundle failing being loaded without InputBundle

### DIFF
--- a/examples/custom_ui/main.rs
+++ b/examples/custom_ui/main.rs
@@ -4,7 +4,7 @@ use amethyst::{
     assets::{PrefabLoader, PrefabLoaderSystemDesc, RonFormat},
     core::transform::TransformBundle,
     ecs::prelude::WorldExt,
-    input::StringBindings,
+    input::{InputBundle, StringBindings},
     prelude::*,
     renderer::{
         plugins::RenderToWindow,
@@ -100,6 +100,7 @@ fn main() -> amethyst::Result<()> {
     let game_data = GameDataBuilder::default()
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
         .with_bundle(TransformBundle::new())?
+        .with_bundle(InputBundle::<StringBindings>::new())?
         .with_bundle(UiBundle::<StringBindings, CustomUi>::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -202,10 +202,10 @@ fn main() -> Result<(), Error> {
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
         .with(ExampleSystem::default(), "example_system", &[])
         .with_bundle(TransformBundle::new().with_dep(&["example_system"]))?
+        .with_bundle(InputBundle::<StringBindings>::new())?
         .with_bundle(UiBundle::<StringBindings>::new())?
         .with_bundle(HotReloadBundle::default())?
         .with_bundle(FpsCounterBundle::default())?
-        .with_bundle(InputBundle::<StringBindings>::new())?
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(

--- a/examples/renderable_custom/main.rs
+++ b/examples/renderable_custom/main.rs
@@ -206,10 +206,10 @@ fn main() -> Result<(), Error> {
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])
         .with(ExampleSystem::default(), "example_system", &[])
         .with_bundle(TransformBundle::new().with_dep(&["example_system"]))?
+        .with_bundle(InputBundle::<StringBindings>::new())?
         .with_bundle(UiBundle::<StringBindings>::new())?
         .with_bundle(HotReloadBundle::default())?
         .with_bundle(FpsCounterBundle::default())?
-        .with_bundle(InputBundle::<StringBindings>::new())?
         // The below Systems, are used to handle some rendering resources.
         // Most likely these must be always called as last thing.
         .with_system_desc(


### PR DESCRIPTION
## Description

Fixes all the examples that were left broken after #2168 and #2155

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [ ] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
