### PR TITLE
Change Callback type to FnOnce

### DIFF
--- a/src/callback_queue.rs
+++ b/src/callback_queue.rs
@@ -4,7 +4,7 @@ use crossbeam_channel::{Receiver, Sender};
 /// The type of a callback.
 /// This is meant to be created from within asynchonous functions (`Future` for example).
 /// See `CallbackQueue` for more details.
-pub type Callback = Box<dyn Fn(&mut World) + Send>;
+pub type Callback = Box<dyn FnOnce(&mut World) + Send>;
 
 /// A simple `Callback` queue.
 /// Using the `Sender` you can get using the `send_handle` method, you


### PR DESCRIPTION
## Description

Change `Callback` type from `Fn` to `FnOnce`

As the callback will only be called once, it is better to use `FnOnce` and thus it is more generic, allowing more use case.
This should not change existing code, as every `Fn` implement `FnOnce`

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] ~~Updated the content of the book if this PR would make the book outdated.~~
- [ ] ~~Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.~~
- [ ] ~~Added unit tests for new code added in this PR.~~
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [X] Ran `cargo +stable fmt --all`
- [X] Ran `cargo clippy --all --features "empty"`
- [X] Ran `cargo test --all --features "empty"`
