### PR TITLE
Reset y val on score in pong tutorial

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-05.md
+++ b/book/src/pong-tutorial/pong-tutorial-05.md
@@ -49,7 +49,7 @@ use amethyst::{
     ecs::prelude::{Join, System, SystemData, World, WriteStorage},
 };
 
-use crate::pong::{Ball, ARENA_WIDTH};
+use crate::pong::{Ball, ARENA_WIDTH, ARENA_HEIGHT};
 
 #[derive(SystemDesc)]
 pub struct WinnerSystem;
@@ -394,6 +394,7 @@ accordingly:
 #     }
 #
 #     pub const ARENA_WIDTH: f32 = 100.0;
+#     pub const ARENA_HEIGHT: f32 = 100.0;
 # }
 #
 use amethyst::{

--- a/book/src/pong-tutorial/pong-tutorial-05.md
+++ b/book/src/pong-tutorial/pong-tutorial-05.md
@@ -78,6 +78,7 @@ impl<'s> System<'s> for WinnerSystem {
             if did_hit {
                 ball.velocity[0] = -ball.velocity[0]; // Reverse Direction
                 transform.set_translation_x(ARENA_WIDTH / 2.0); // Reset Position
+                transform.set_translation_y(ARENA_HEIGHT / 2.0); // Reset Position
             }
         }
     }

--- a/book/src/pong-tutorial/pong-tutorial-05.md
+++ b/book/src/pong-tutorial/pong-tutorial-05.md
@@ -405,7 +405,7 @@ use amethyst::{
     ui::UiText,
 };
 
-use crate::pong::{Ball, ScoreBoard, ScoreText, ARENA_WIDTH};
+use crate::pong::{Ball, ScoreBoard, ScoreText, ARENA_WIDTH, ARENA_HEIGHT};
 
 #[derive(SystemDesc)]
 pub struct WinnerSystem;
@@ -456,6 +456,8 @@ impl<'s> System<'s> for WinnerSystem {
             if did_hit {
 #                 ball.velocity[0] = -ball.velocity[0]; // Reverse Direction
 #                 transform.set_translation_x(ARENA_WIDTH / 2.0); // Reset Position
+#                 transform.set_translation_y(ARENA_HEIGHT / 2.0); // Reset Position
+
                 // --snip--
 
                 // Print the scoreboard.

--- a/book/src/pong-tutorial/pong-tutorial-05.md
+++ b/book/src/pong-tutorial/pong-tutorial-05.md
@@ -39,6 +39,7 @@ Then, we'll create `systems/winner.rs`:
 #     }
 #
 #     pub const ARENA_WIDTH: f32 = 100.0;
+#     pub const ARENA_HEIGHT: f32 = 100.0;
 # }
 #
 use amethyst::{

--- a/book/src/pong-tutorial/pong-tutorial-06.md
+++ b/book/src/pong-tutorial/pong-tutorial-06.md
@@ -245,6 +245,8 @@ impl<'s> System<'s> for WinnerSystem {
             if did_hit {
                 ball.velocity[0] = -ball.velocity[0]; // Reverse Direction
                 transform.set_translation_x(ARENA_WIDTH / 2.0); // Reset Position
+                transform.set_translation_y(ARENA_HEIGHT / 2.0); // Reset Position
+
                 play_score_sound(&*sounds, &storage, audio_output.as_ref().map(|o| o.deref()));
 
                 // Print the scoreboard.

--- a/examples/pong/systems/winner.rs
+++ b/examples/pong/systems/winner.rs
@@ -40,7 +40,7 @@ impl<'s> System<'s> for WinnerSystem {
         ): Self::SystemData,
     ) {
         for (ball, transform) in (&mut balls, &mut transforms).join() {
-            use crate::ARENA_WIDTH;
+            use crate::{ARENA_WIDTH, ARENA_HEIGHT};
 
             let ball_x = transform.translation().x;
 
@@ -68,6 +68,7 @@ impl<'s> System<'s> for WinnerSystem {
                 // Reset the ball.
                 ball.velocity[0] = -ball.velocity[0];
                 transform.set_translation_x(ARENA_WIDTH / 2.0);
+                transform.set_translation_y(ARENA_HEIGHT / 2.0);
 
                 // Print the score board.
                 println!(

--- a/examples/pong/systems/winner.rs
+++ b/examples/pong/systems/winner.rs
@@ -40,7 +40,7 @@ impl<'s> System<'s> for WinnerSystem {
         ): Self::SystemData,
     ) {
         for (ball, transform) in (&mut balls, &mut transforms).join() {
-            use crate::{ARENA_WIDTH, ARENA_HEIGHT};
+            use crate::{ARENA_HEIGHT, ARENA_WIDTH};
 
             let ball_x = transform.translation().x;
 


### PR DESCRIPTION


## Description

Not technically a bug, but when running through the tutorial, I found it very jarring that ball y doesn't reset on score. I updated the pong tutorial code to reset y val to the center on score.

## Additions

## Removals

## Modifications

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
