### PR TITLE
Feature/2249/configurable web logger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ wasm = [
   "amethyst_rendy/wasm",
   "amethyst_utils/wasm",
   "amethyst_window/wasm",
+  "console_log",
   "web_worker",
 ]
 
@@ -180,6 +181,7 @@ failure = "0.1.7"
 thread_profiler = { version = "0.3.0", optional = true }
 lazy_static = "1.4.0"
 glsl-layout = "0.3.2"
+console_log = { version = "0.1.2", optional = true }
 web_worker = { git = "https://github.com/amethyst/web_worker", optional = true }
 
 [dev-dependencies]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 * Basic GL rendering. ([#2192], [#2198])
 * `AmethystApplication::with_bundle_event_fn` takes in a bundle that needs a reference to the `EventLoop`. ([#2240])
+* WASM logger is configurable though `LoggerConfig` when using [`console_log`]. ([#2249], [#2250])
 
 ### Changed
 
@@ -35,6 +36,9 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#2240]: https://github.com/amethyst/amethyst/pull/2240
 [#2241]: https://github.com/amethyst/amethyst/issues/2241
 [#2245]: https://github.com/amethyst/amethyst/pull/2245
+[#2249]: https://github.com/amethyst/amethyst/issues/2249
+[#2250]: https://github.com/amethyst/amethyst/pull/2250
+[`console_log`]: https://crates.io/crates/console_log
 
 ## [0.15.0] - 2020-03-24
 


### PR DESCRIPTION
## Description

Closes #2249.

## Additions

- WASM logger is configurable though `LoggerConfig` when using [`console_log`].

[`console_log`]: https://crates.io/crates/console_log

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- **n/a** Ran `cargo test --workspace --features "gl"`
