### PR TITLE
Feature/2251/web socket transport mechanism

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,7 +182,7 @@ failure = "0.1.7"
 thread_profiler = { version = "0.3.0", optional = true }
 lazy_static = "1.4.0"
 glsl-layout = "0.3.2"
-console_log = { version = "0.2", optional = true }
+console_log = { version = "0.2", optional = true, features = ["color"] }
 web_worker = { git = "https://github.com/amethyst/web_worker", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ wasm = [
   "console_log",
   "web_worker",
 ]
+web_socket = ["amethyst_network/web_socket"]
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,7 +182,7 @@ failure = "0.1.7"
 thread_profiler = { version = "0.3.0", optional = true }
 lazy_static = "1.4.0"
 glsl-layout = "0.3.2"
-console_log = { version = "0.1.2", optional = true }
+console_log = { version = "0.2", optional = true }
 web_worker = { git = "https://github.com/amethyst/web_worker", optional = true }
 
 [dev-dependencies]

--- a/amethyst_network/Cargo.toml
+++ b/amethyst_network/Cargo.toml
@@ -20,7 +20,9 @@ repository = "https://github.com/amethyst/amethyst"
 license = "MIT/Apache-2.0"
 
 [features]
+default = ["web_socket"]
 profiler = [ "thread_profiler/thread_profiler" ]
+web_socket = ["tungstenite"]
 
 [dependencies]
 amethyst_core = { path = "../amethyst_core", version = "0.10.0", default-features = false }
@@ -29,3 +31,4 @@ bytes = "0.5"
 laminar = "0.3"
 log = "0.4"
 thread_profiler = { version = "0.3" , optional = true }
+tungstenite = { version = "0.10.1", optional = true }

--- a/amethyst_network/Cargo.toml
+++ b/amethyst_network/Cargo.toml
@@ -22,7 +22,7 @@ license = "MIT/Apache-2.0"
 [features]
 default = ["web_socket"]
 profiler = [ "thread_profiler/thread_profiler" ]
-web_socket = ["tungstenite"]
+web_socket = ["tungstenite", "crossbeam-channel", "js-sys", "web-sys", "wasm-bindgen"]
 
 [dependencies]
 amethyst_core = { path = "../amethyst_core", version = "0.10.0", default-features = false }
@@ -34,3 +34,9 @@ thread_profiler = { version = "0.3" , optional = true }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 tungstenite = { version = "0.10.1", optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+crossbeam-channel = { version = "0.4.0", optional = true }
+js-sys = { version = "0.3.37", optional = true }
+wasm-bindgen = { version = "0.2.60", optional = true }
+web-sys = { version = "0.3.37", optional = true, features = ["CloseEvent", "ErrorEvent", "Event", "MessageEvent", "WebSocket"] }

--- a/amethyst_network/Cargo.toml
+++ b/amethyst_network/Cargo.toml
@@ -39,4 +39,4 @@ tungstenite = { version = "0.10.1", optional = true }
 crossbeam-channel = { version = "0.4.0", optional = true }
 js-sys = { version = "0.3.37", optional = true }
 wasm-bindgen = { version = "0.2.60", optional = true }
-web-sys = { version = "0.3.37", optional = true, features = ["Blob", "CloseEvent", "ErrorEvent", "Event", "FileReaderSync", "MessageEvent", "WebSocket"] }
+web-sys = { version = "0.3.37", optional = true, features = ["Blob", "CloseEvent", "ErrorEvent", "Event", "FileReader", "MessageEvent", "WebSocket"] }

--- a/amethyst_network/Cargo.toml
+++ b/amethyst_network/Cargo.toml
@@ -39,4 +39,4 @@ tungstenite = { version = "0.10.1", optional = true }
 crossbeam-channel = { version = "0.4.0", optional = true }
 js-sys = { version = "0.3.37", optional = true }
 wasm-bindgen = { version = "0.2.60", optional = true }
-web-sys = { version = "0.3.37", optional = true, features = ["Blob", "CloseEvent", "ErrorEvent", "Event", "MessageEvent", "WebSocket"] }
+web-sys = { version = "0.3.37", optional = true, features = ["Blob", "CloseEvent", "ErrorEvent", "Event", "FileReaderSync", "MessageEvent", "WebSocket"] }

--- a/amethyst_network/Cargo.toml
+++ b/amethyst_network/Cargo.toml
@@ -39,4 +39,4 @@ tungstenite = { version = "0.10.1", optional = true }
 crossbeam-channel = { version = "0.4.0", optional = true }
 js-sys = { version = "0.3.37", optional = true }
 wasm-bindgen = { version = "0.2.60", optional = true }
-web-sys = { version = "0.3.37", optional = true, features = ["CloseEvent", "ErrorEvent", "Event", "MessageEvent", "WebSocket"] }
+web-sys = { version = "0.3.37", optional = true, features = ["Blob", "CloseEvent", "ErrorEvent", "Event", "MessageEvent", "WebSocket"] }

--- a/amethyst_network/Cargo.toml
+++ b/amethyst_network/Cargo.toml
@@ -31,4 +31,6 @@ bytes = "0.5"
 laminar = "0.3"
 log = "0.4"
 thread_profiler = { version = "0.3" , optional = true }
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
 tungstenite = { version = "0.10.1", optional = true }

--- a/amethyst_network/js/web_socket_send.js
+++ b/amethyst_network/js/web_socket_send.js
@@ -1,0 +1,16 @@
+function web_socket_send(web_socket, src) {
+    // Turn the array view into owned memory.
+    var standalone = [...src];
+    // Make it a Uint8Array.
+    let bytes = new Uint8Array(standalone);
+
+    console.log("Bytes to send: "+ bytes);
+    web_socket.send(bytes);
+}
+
+if (typeof exports === 'object' && typeof module === 'object')
+    module.exports = bytes_owned;
+else if (typeof define === 'function' && define['amd'])
+    define([], function() { return bytes_owned; });
+else if (typeof exports === 'object')
+    exports["bytes_owned"] = bytes_owned;

--- a/amethyst_network/src/simulation.rs
+++ b/amethyst_network/src/simulation.rs
@@ -12,4 +12,6 @@ pub use events::NetworkSimulationEvent;
 pub use message::Message;
 pub use requirements::{DeliveryRequirement, UrgencyRequirement};
 pub use timing::{NetworkSimulationTime, NetworkSimulationTimeSystem};
+#[cfg(feature = "web_socket")]
+pub use transport::web_socket;
 pub use transport::{laminar, tcp, udp, TransportResource};

--- a/amethyst_network/src/simulation/transport.rs
+++ b/amethyst_network/src/simulation/transport.rs
@@ -5,6 +5,8 @@
 pub mod laminar;
 pub mod tcp;
 pub mod udp;
+#[cfg(feature = "web_socket")]
+pub mod web_socket;
 
 const NETWORK_SIM_TIME_SYSTEM_NAME: &str = "simulation_time";
 const NETWORK_SEND_SYSTEM_NAME: &str = "network_send";

--- a/amethyst_network/src/simulation/transport/web_socket.rs
+++ b/amethyst_network/src/simulation/transport/web_socket.rs
@@ -3,48 +3,34 @@
 #[cfg(target_arch = "x86_64")]
 mod native;
 #[cfg(target_arch = "x86_64")]
-use self::native::{
-    WebSocketConnectionListenerSystem, WebSocketNetworkRecvSystem, WebSocketStreamManagementSystem,
+#[cfg(target_arch = "x86_64")]
+pub use self::native::{
+    WebSocketConnectionListenerSystem, WebSocketNetworkRecvSystem, WebSocketNetworkResource,
+    WebSocketNetworkSendSystem, WebSocketStreamManagementSystem,
 };
 
-#[cfg(target_arch = "x86_64")]
-use std::net::TcpStream;
-use std::{
-    collections::HashMap,
-    io,
-    net::{SocketAddr, TcpListener},
-};
+use std::net::TcpListener;
 
 #[cfg(target_arch = "wasm32")]
 mod web_sys;
 #[cfg(target_arch = "wasm32")]
-use self::web_sys::{WebSocketNetworkRecvSystem, WebSocketStreamManagementSystemDesc};
+use self::web_sys::{
+    WebSocketNetworkRecvSystem, WebSocketNetworkResource, WebSocketNetworkSendSystem,
+    WebSocketStreamManagementSystemDesc,
+};
 
 #[cfg(target_arch = "wasm32")]
 use amethyst_core::SystemDesc;
 use amethyst_core::{
     bundle::SystemBundle,
-    ecs::{DispatcherBuilder, Read, System, World, Write},
-    shrev::EventChannel,
+    ecs::{DispatcherBuilder, World},
 };
 use amethyst_error::Error;
-use log::warn;
 
 use crate::simulation::{
-    events::NetworkSimulationEvent,
-    message::Message,
-    requirements::DeliveryRequirement,
-    timing::{NetworkSimulationTime, NetworkSimulationTimeSystem},
-    transport::{
-        TransportResource, NETWORK_RECV_SYSTEM_NAME, NETWORK_SEND_SYSTEM_NAME,
-        NETWORK_SIM_TIME_SYSTEM_NAME,
-    },
+    timing::NetworkSimulationTimeSystem,
+    transport::{NETWORK_RECV_SYSTEM_NAME, NETWORK_SEND_SYSTEM_NAME, NETWORK_SIM_TIME_SYSTEM_NAME},
 };
-
-#[cfg(target_arch = "x86_64")]
-type WebSocket = tungstenite::protocol::WebSocket<TcpStream>;
-#[cfg(target_arch = "wasm32")]
-type WebSocket = ::web_sys::WebSocket;
 
 #[cfg(target_arch = "x86_64")]
 const CONNECTION_LISTENER_SYSTEM_NAME: &str = "ws_connection_listener";
@@ -122,113 +108,10 @@ impl<'a, 'b> SystemBundle<'a, 'b> for WebSocketNetworkBundle {
             send_recv_deps,
         );
 
+        #[cfg(target_arch = "x86_64")]
         world.insert(WebSocketNetworkResource::new(self.listener));
+        #[cfg(target_arch = "wasm32")]
+        world.insert(WebSocketNetworkResource::new());
         Ok(())
     }
 }
-
-/// System to send messages to a particular open `WebSocket`.
-pub struct WebSocketNetworkSendSystem;
-
-impl<'s> System<'s> for WebSocketNetworkSendSystem {
-    type SystemData = (
-        Write<'s, TransportResource>,
-        Write<'s, WebSocketNetworkResource>,
-        Read<'s, NetworkSimulationTime>,
-        Write<'s, EventChannel<NetworkSimulationEvent>>,
-    );
-
-    fn run(&mut self, (mut transport, mut net, sim_time, mut channel): Self::SystemData) {
-        let messages = transport.drain_messages_to_send(|_| sim_time.should_send_message_now());
-        for message in messages {
-            match message.delivery {
-                DeliveryRequirement::ReliableOrdered(Some(_)) => {
-                    warn!("Streams are not supported by TCP and will be ignored.");
-                    write_message(message, &mut net, &mut channel);
-                }
-                DeliveryRequirement::ReliableOrdered(_) | DeliveryRequirement::Default => {
-                    write_message(message, &mut net, &mut channel);
-                }
-                delivery => panic!(
-                    "{:?} is unsupported. TCP only supports ReliableOrdered by design.",
-                    delivery
-                ),
-            }
-        }
-    }
-}
-
-fn write_message(
-    message: Message,
-    net: &mut WebSocketNetworkResource,
-    channel: &mut EventChannel<NetworkSimulationEvent>,
-) {
-    if let Some((_, web_socket)) = net.get_socket(message.destination) {
-        if let Err(e) =
-            web_socket.write_message(tungstenite::Message::Binary(message.payload.to_vec()))
-        {
-            let error = io::Error::new(io::ErrorKind::Other, e);
-            channel.single_write(NetworkSimulationEvent::SendError(error, message));
-        }
-    }
-}
-
-pub struct WebSocketNetworkResource {
-    listener: Option<TcpListener>,
-    streams: HashMap<SocketAddr, (bool, WebSocket)>,
-}
-
-impl WebSocketNetworkResource {
-    pub fn new(listener: Option<TcpListener>) -> Self {
-        Self {
-            listener,
-            streams: HashMap::new(),
-        }
-    }
-
-    /// Returns an immutable reference to the listener if there is one configured.
-    pub fn get(&self) -> Option<&TcpListener> {
-        self.listener.as_ref()
-    }
-
-    /// Returns a mutable reference to the listener if there is one configured.
-    pub fn get_mut(&mut self) -> Option<&mut TcpListener> {
-        self.listener.as_mut()
-    }
-
-    /// Sets the bound listener to the `WebSocketNetworkResource`.
-    pub fn set_listener(&mut self, listener: TcpListener) {
-        self.listener = Some(listener);
-    }
-
-    /// Drops the listener from the `WebSocketNetworkResource`.
-    pub fn drop_listener(&mut self) {
-        self.listener = None;
-    }
-
-    /// Returns a tuple of an active WebSocket and whether ot not that stream is active
-    pub fn get_socket(&mut self, addr: SocketAddr) -> Option<&mut (bool, WebSocket)> {
-        self.streams.get_mut(&addr)
-    }
-
-    /// Drops the stream with the given `SocketAddr`. This will be called when a peer seems to have
-    /// been disconnected
-    pub fn drop_socket(&mut self, addr: SocketAddr) -> Option<(bool, WebSocket)> {
-        self.streams.remove(&addr)
-    }
-}
-
-impl Default for WebSocketNetworkResource {
-    fn default() -> Self {
-        Self {
-            listener: None,
-            streams: HashMap::new(),
-        }
-    }
-}
-
-// TODO: Split implementation for `WebSocketNetworkResource`
-#[cfg(target_arch = "wasm32")]
-unsafe impl Send for WebSocketNetworkResource {}
-#[cfg(target_arch = "wasm32")]
-unsafe impl Sync for WebSocketNetworkResource {}

--- a/amethyst_network/src/simulation/transport/web_socket.rs
+++ b/amethyst_network/src/simulation/transport/web_socket.rs
@@ -14,7 +14,7 @@ use std::net::TcpListener;
 #[cfg(target_arch = "wasm32")]
 mod web_sys;
 #[cfg(target_arch = "wasm32")]
-use self::web_sys::{
+pub use self::web_sys::{
     WebSocketNetworkRecvSystem, WebSocketNetworkResource, WebSocketNetworkSendSystem,
     WebSocketStreamManagementSystemDesc,
 };
@@ -36,14 +36,25 @@ use crate::simulation::{
 const CONNECTION_LISTENER_SYSTEM_NAME: &str = "ws_connection_listener";
 const STREAM_MANAGEMENT_SYSTEM_NAME: &str = "ws_stream_management";
 
-/// Use this network bundle to add the TCP transport layer to your game.
+/// Use this network bundle to add the `WebSocket` transport layer to your game.
+#[cfg(target_arch = "x86_64")]
 pub struct WebSocketNetworkBundle {
     listener: Option<TcpListener>,
 }
 
+/// Use this network bundle to add the `WebSocket` transport layer to your game.
+#[cfg(target_arch = "wasm32")]
+pub struct WebSocketNetworkBundle;
+
 impl WebSocketNetworkBundle {
+    #[cfg(target_arch = "x86_64")]
     pub fn new(listener: Option<TcpListener>) -> Self {
         Self { listener }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn new() -> Self {
+        Self
     }
 }
 

--- a/amethyst_network/src/simulation/transport/web_socket.rs
+++ b/amethyst_network/src/simulation/transport/web_socket.rs
@@ -31,7 +31,7 @@ use crate::simulation::{
     },
 };
 
-type WebSocketTcp = tungstenite::protocol::WebSocket<TcpStream>;
+type WebSocket = tungstenite::protocol::WebSocket<TcpStream>;
 
 const CONNECTION_LISTENER_SYSTEM_NAME: &str = "ws_connection_listener";
 const STREAM_MANAGEMENT_SYSTEM_NAME: &str = "ws_stream_management";
@@ -388,7 +388,7 @@ impl<'s> System<'s> for WebSocketNetworkRecvSystem {
 
 pub struct WebSocketNetworkResource {
     listener: Option<TcpListener>,
-    streams: HashMap<SocketAddr, (bool, WebSocketTcp)>,
+    streams: HashMap<SocketAddr, (bool, WebSocket)>,
 }
 
 impl WebSocketNetworkResource {
@@ -420,13 +420,13 @@ impl WebSocketNetworkResource {
     }
 
     /// Returns a tuple of an active WebSocket and whether ot not that stream is active
-    pub fn get_socket(&mut self, addr: SocketAddr) -> Option<&mut (bool, WebSocketTcp)> {
+    pub fn get_socket(&mut self, addr: SocketAddr) -> Option<&mut (bool, WebSocket)> {
         self.streams.get_mut(&addr)
     }
 
     /// Drops the stream with the given `SocketAddr`. This will be called when a peer seems to have
     /// been disconnected
-    pub fn drop_socket(&mut self, addr: SocketAddr) -> Option<(bool, WebSocketTcp)> {
+    pub fn drop_socket(&mut self, addr: SocketAddr) -> Option<(bool, WebSocket)> {
         self.streams.remove(&addr)
     }
 }

--- a/amethyst_network/src/simulation/transport/web_socket.rs
+++ b/amethyst_network/src/simulation/transport/web_socket.rs
@@ -1,6 +1,7 @@
 //! Network systems implementation backed by the web socket protocol (over TCP).
 
 use tungstenite::{
+    client::AutoStream,
     error::Error as TgError,
     handshake::{client::Request, HandshakeError},
 };
@@ -16,7 +17,7 @@ use log::{error, warn};
 use std::{
     collections::HashMap,
     io,
-    net::{SocketAddr, TcpListener, TcpStream},
+    net::{SocketAddr, TcpListener},
     ops::DerefMut,
 };
 
@@ -31,7 +32,7 @@ use crate::simulation::{
     },
 };
 
-type WebSocketTcp = tungstenite::protocol::WebSocket<TcpStream>;
+type WebSocketAuto = tungstenite::protocol::WebSocket<AutoStream>;
 
 const CONNECTION_LISTENER_SYSTEM_NAME: &str = "ws_connection_listener";
 const STREAM_MANAGEMENT_SYSTEM_NAME: &str = "ws_stream_management";
@@ -108,7 +109,7 @@ impl<'s> System<'s> for WebSocketStreamManagementSystem {
         Write<'s, EventChannel<NetworkSimulationEvent>>,
     );
 
-    // We cannot use `web_socket_network_resource.streams.entry(message.destination)`
+    // We cannot use `web_socket_network_resource.sockets.entry(message.destination)`
     // `.or_insert_with(|| { .. })` because there is a `return;` statement for early exit, which is
     // not allowed within the closure.
     #[allow(clippy::map_entry)]
@@ -119,23 +120,9 @@ impl<'s> System<'s> for WebSocketStreamManagementSystem {
         // Make connections for each message in the channel if one hasn't yet been established
         transport.get_messages().iter().for_each(|message| {
             if !web_socket_network_resource
-                .streams
+                .sockets
                 .contains_key(&message.destination)
             {
-                let stream = match TcpStream::connect(message.destination) {
-                    Ok(stream) => stream,
-                    Err(e) => {
-                        network_simulation_ec.single_write(
-                            NetworkSimulationEvent::ConnectionError(e, Some(message.destination)),
-                        );
-                        return;
-                    }
-                };
-                stream
-                    .set_nonblocking(true)
-                    .expect("Setting non-blocking mode");
-                stream.set_nodelay(true).expect("Setting nodelay");
-
                 // We are simply establishing a connection for arbitrary data, so we use a blank
                 // `Request`.
                 //
@@ -147,31 +134,19 @@ impl<'s> System<'s> for WebSocketStreamManagementSystem {
                         .body(())
                         .expect("Failed to build empty request.")
                 };
-                match tungstenite::client::client(request, stream) {
+
+                // For now, we *do* block on connect, so we don't use the
+                // `tungstenite::client::client` method.
+                //
+                // Ideally we would use that, and if we hit `Err(HandshakeError::Interrupted(_))`,
+                // then we would try again later.
+                match tungstenite::client::connect(request) {
                     // We don't care about the handshake response
                     Ok((web_socket, _response)) => {
                         dbg!(format!("Connected to {}", &message.destination));
                         web_socket_network_resource
-                            .streams
+                            .sockets
                             .insert(message.destination, (true, web_socket));
-                    }
-                    Err(HandshakeError::Interrupted(_)) => {
-                        // TODO: retry connecting.
-                    }
-                    Err(HandshakeError::Failure(TgError::Io(io_error))) => {
-                        match io_error.kind() {
-                            io::ErrorKind::WouldBlock => {
-                                // TODO: retry connecting
-                            }
-                            _ => {
-                                network_simulation_ec.single_write(
-                                    NetworkSimulationEvent::ConnectionError(
-                                        io_error,
-                                        Some(message.destination),
-                                    ),
-                                );
-                            }
-                        }
                     }
                     Err(handshake_error) => {
                         let error = io::Error::new(io::ErrorKind::Other, handshake_error);
@@ -189,7 +164,7 @@ impl<'s> System<'s> for WebSocketStreamManagementSystem {
 
         // Remove inactive connections
         web_socket_network_resource
-            .streams
+            .sockets
             .retain(|addr, (active, _)| {
                 if !*active {
                     network_simulation_ec.single_write(NetworkSimulationEvent::Disconnect(*addr));
@@ -222,9 +197,9 @@ impl<'s> System<'s> for WebSocketConnectionListenerSystem {
                             .expect("Setting nonblocking mode");
                         stream.set_nodelay(true).expect("Setting nodelay");
 
-                        match tungstenite::server::accept(stream) {
+                        match tungstenite::server::accept(AutoStream::Plain(stream)) {
                             Ok(web_socket) => {
-                                resource.streams.insert(addr, (true, web_socket));
+                                resource.sockets.insert(addr, (true, web_socket));
                                 network_simulation_ec
                                     .single_write(NetworkSimulationEvent::Connect(addr));
                             }
@@ -311,20 +286,17 @@ impl<'s> System<'s> for WebSocketNetworkRecvSystem {
         (mut web_socket_network_resource, mut network_simulation_ec): Self::SystemData,
     ) {
         let web_socket_network_resource = web_socket_network_resource.deref_mut();
-        for (_, (active, web_socket_tcp)) in web_socket_network_resource.streams.iter_mut() {
-            // If we can't get a peer_addr, there is likely something pretty wrong with the
-            // connection so we'll mark it inactive.
-            let peer_addr = match web_socket_tcp.get_ref().peer_addr() {
-                Ok(addr) => addr,
-                Err(e) => {
-                    warn!("Encountered an error getting peer_addr: {:?}", e);
-                    *active = false;
-                    continue;
-                }
-            };
+        for (peer_addr, (active, web_socket)) in web_socket_network_resource.sockets.iter_mut() {
+            // If we can't read, the connection may have dropped so we'll mark it inactive.
+            let peer_addr = *peer_addr;
+            if !web_socket.can_read() {
+                warn!("Unable to read from `peer_addr`: `{}`", peer_addr);
+                *active = false;
+                continue;
+            }
 
             loop {
-                match web_socket_tcp.read_message() {
+                match web_socket.read_message() {
                     Ok(message) => {
                         // https://docs.rs/tungstenite/0.10.1/tungstenite/enum.Message.html
                         match message {
@@ -388,14 +360,14 @@ impl<'s> System<'s> for WebSocketNetworkRecvSystem {
 
 pub struct WebSocketNetworkResource {
     listener: Option<TcpListener>,
-    streams: HashMap<SocketAddr, (bool, WebSocketTcp)>,
+    sockets: HashMap<SocketAddr, (bool, WebSocketAuto)>,
 }
 
 impl WebSocketNetworkResource {
     pub fn new(listener: Option<TcpListener>) -> Self {
         Self {
             listener,
-            streams: HashMap::new(),
+            sockets: HashMap::new(),
         }
     }
 
@@ -420,14 +392,14 @@ impl WebSocketNetworkResource {
     }
 
     /// Returns a tuple of an active WebSocket and whether ot not that stream is active
-    pub fn get_socket(&mut self, addr: SocketAddr) -> Option<&mut (bool, WebSocketTcp)> {
-        self.streams.get_mut(&addr)
+    pub fn get_socket(&mut self, addr: SocketAddr) -> Option<&mut (bool, WebSocketAuto)> {
+        self.sockets.get_mut(&addr)
     }
 
     /// Drops the stream with the given `SocketAddr`. This will be called when a peer seems to have
     /// been disconnected
-    pub fn drop_socket(&mut self, addr: SocketAddr) -> Option<(bool, WebSocketTcp)> {
-        self.streams.remove(&addr)
+    pub fn drop_socket(&mut self, addr: SocketAddr) -> Option<(bool, WebSocketAuto)> {
+        self.sockets.remove(&addr)
     }
 }
 
@@ -435,7 +407,7 @@ impl Default for WebSocketNetworkResource {
     fn default() -> Self {
         Self {
             listener: None,
-            streams: HashMap::new(),
+            sockets: HashMap::new(),
         }
     }
 }

--- a/amethyst_network/src/simulation/transport/web_socket.rs
+++ b/amethyst_network/src/simulation/transport/web_socket.rs
@@ -1,0 +1,441 @@
+//! Network systems implementation backed by the web socket protocol (over TCP).
+
+use tungstenite::{
+    error::Error as TgError,
+    handshake::{client::Request, HandshakeError},
+};
+
+use amethyst_core::{
+    bundle::SystemBundle,
+    ecs::{DispatcherBuilder, Read, System, World, Write},
+    shrev::EventChannel,
+};
+use amethyst_error::Error;
+use bytes::Bytes;
+use log::{error, warn};
+use std::{
+    collections::HashMap,
+    io,
+    net::{SocketAddr, TcpListener, TcpStream},
+    ops::DerefMut,
+};
+
+use crate::simulation::{
+    events::NetworkSimulationEvent,
+    message::Message,
+    requirements::DeliveryRequirement,
+    timing::{NetworkSimulationTime, NetworkSimulationTimeSystem},
+    transport::{
+        TransportResource, NETWORK_RECV_SYSTEM_NAME, NETWORK_SEND_SYSTEM_NAME,
+        NETWORK_SIM_TIME_SYSTEM_NAME,
+    },
+};
+
+type WebSocketTcp = tungstenite::protocol::WebSocket<TcpStream>;
+
+const CONNECTION_LISTENER_SYSTEM_NAME: &str = "ws_connection_listener";
+const STREAM_MANAGEMENT_SYSTEM_NAME: &str = "ws_stream_management";
+
+/// Use this network bundle to add the TCP transport layer to your game.
+pub struct WebSocketNetworkBundle {
+    listener: Option<TcpListener>,
+}
+
+impl WebSocketNetworkBundle {
+    pub fn new(listener: Option<TcpListener>) -> Self {
+        Self { listener }
+    }
+}
+
+impl<'a, 'b> SystemBundle<'a, 'b> for WebSocketNetworkBundle {
+    fn build(
+        self,
+        world: &mut World,
+        builder: &mut DispatcherBuilder<'_, '_>,
+    ) -> Result<(), Error> {
+        // NetworkSimulationTime should run first
+        // followed by WebSocketConnectionListenerSystem and WebSocketStreamManagementSystem
+        // then WebSocketNetworkSendSystem and WebSocketNetworkRecvSystem
+
+        builder.add(
+            NetworkSimulationTimeSystem,
+            NETWORK_SIM_TIME_SYSTEM_NAME,
+            &[],
+        );
+
+        builder.add(
+            WebSocketConnectionListenerSystem,
+            CONNECTION_LISTENER_SYSTEM_NAME,
+            &[NETWORK_SIM_TIME_SYSTEM_NAME],
+        );
+
+        builder.add(
+            WebSocketStreamManagementSystem,
+            STREAM_MANAGEMENT_SYSTEM_NAME,
+            &[NETWORK_SIM_TIME_SYSTEM_NAME],
+        );
+
+        builder.add(
+            WebSocketNetworkSendSystem,
+            NETWORK_SEND_SYSTEM_NAME,
+            &[
+                STREAM_MANAGEMENT_SYSTEM_NAME,
+                CONNECTION_LISTENER_SYSTEM_NAME,
+            ],
+        );
+
+        builder.add(
+            WebSocketNetworkRecvSystem,
+            NETWORK_RECV_SYSTEM_NAME,
+            &[
+                STREAM_MANAGEMENT_SYSTEM_NAME,
+                CONNECTION_LISTENER_SYSTEM_NAME,
+            ],
+        );
+
+        world.insert(WebSocketNetworkResource::new(self.listener));
+        Ok(())
+    }
+}
+
+/// System to manage the current active WebSocket connections.
+pub struct WebSocketStreamManagementSystem;
+
+impl<'s> System<'s> for WebSocketStreamManagementSystem {
+    type SystemData = (
+        Write<'s, WebSocketNetworkResource>,
+        Read<'s, TransportResource>,
+        Write<'s, EventChannel<NetworkSimulationEvent>>,
+    );
+
+    // We cannot use `web_socket_network_resource.streams.entry(message.destination)`
+    // `.or_insert_with(|| { .. })` because there is a `return;` statement for early exit, which is
+    // not allowed within the closure.
+    #[allow(clippy::map_entry)]
+    fn run(
+        &mut self,
+        (mut web_socket_network_resource, transport, mut network_simulation_ec): Self::SystemData,
+    ) {
+        // Make connections for each message in the channel if one hasn't yet been established
+        transport.get_messages().iter().for_each(|message| {
+            if !web_socket_network_resource
+                .streams
+                .contains_key(&message.destination)
+            {
+                let stream = match TcpStream::connect(message.destination) {
+                    Ok(stream) => stream,
+                    Err(e) => {
+                        network_simulation_ec.single_write(
+                            NetworkSimulationEvent::ConnectionError(e, Some(message.destination)),
+                        );
+                        return;
+                    }
+                };
+                stream
+                    .set_nonblocking(true)
+                    .expect("Setting non-blocking mode");
+                stream.set_nodelay(true).expect("Setting nodelay");
+
+                // We are simply establishing a connection for arbitrary data, so we use a blank
+                // `Request`.
+                //
+                // See <https://docs.rs/tungstenite/0.10.1/tungstenite/client/fn.client.html>
+                let request = {
+                    let uri = format!("ws://{}/", message.destination);
+                    Request::builder()
+                        .uri(uri)
+                        .body(())
+                        .expect("Failed to build empty request.")
+                };
+                match tungstenite::client::client(request, stream) {
+                    // We don't care about the handshake response
+                    Ok((web_socket, _response)) => {
+                        dbg!(format!("Connected to {}", &message.destination));
+                        web_socket_network_resource
+                            .streams
+                            .insert(message.destination, (true, web_socket));
+                    }
+                    Err(HandshakeError::Interrupted(_)) => {
+                        // TODO: retry connecting.
+                    }
+                    Err(HandshakeError::Failure(TgError::Io(io_error))) => {
+                        match io_error.kind() {
+                            io::ErrorKind::WouldBlock => {
+                                // TODO: retry connecting
+                            }
+                            _ => {
+                                network_simulation_ec.single_write(
+                                    NetworkSimulationEvent::ConnectionError(
+                                        io_error,
+                                        Some(message.destination),
+                                    ),
+                                );
+                            }
+                        }
+                    }
+                    Err(handshake_error) => {
+                        let error = io::Error::new(io::ErrorKind::Other, handshake_error);
+                        network_simulation_ec.single_write(
+                            NetworkSimulationEvent::ConnectionError(
+                                error,
+                                Some(message.destination),
+                            ),
+                        );
+                        return;
+                    }
+                }
+            }
+        });
+
+        // Remove inactive connections
+        web_socket_network_resource
+            .streams
+            .retain(|addr, (active, _)| {
+                if !*active {
+                    network_simulation_ec.single_write(NetworkSimulationEvent::Disconnect(*addr));
+                }
+                *active
+            });
+    }
+}
+
+/// System to listen for incoming connections and cache them to the resource.
+pub struct WebSocketConnectionListenerSystem;
+
+impl<'s> System<'s> for WebSocketConnectionListenerSystem {
+    type SystemData = (
+        Write<'s, WebSocketNetworkResource>,
+        Write<'s, EventChannel<NetworkSimulationEvent>>,
+    );
+
+    fn run(
+        &mut self,
+        (mut web_socket_network_resource, mut network_simulation_ec): Self::SystemData,
+    ) {
+        let resource = web_socket_network_resource.deref_mut();
+        if let Some(ref listener) = resource.listener {
+            loop {
+                match listener.accept() {
+                    Ok((stream, addr)) => {
+                        stream
+                            .set_nonblocking(true)
+                            .expect("Setting nonblocking mode");
+                        stream.set_nodelay(true).expect("Setting nodelay");
+
+                        match tungstenite::server::accept(stream) {
+                            Ok(web_socket) => {
+                                resource.streams.insert(addr, (true, web_socket));
+                                network_simulation_ec
+                                    .single_write(NetworkSimulationEvent::Connect(addr));
+                            }
+                            Err(HandshakeError::Interrupted(_)) => {
+                                break;
+                            }
+                            Err(HandshakeError::Failure(e)) => {
+                                error!("Handshake failure during accept: {}", e);
+                                break;
+                            }
+                        }
+                    }
+                    Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                        break;
+                    }
+                    Err(e) => {
+                        network_simulation_ec
+                            .single_write(NetworkSimulationEvent::ConnectionError(e, None));
+                        break;
+                    }
+                };
+            }
+        }
+    }
+}
+
+/// System to send messages to a particular open `WebSocket`.
+pub struct WebSocketNetworkSendSystem;
+
+impl<'s> System<'s> for WebSocketNetworkSendSystem {
+    type SystemData = (
+        Write<'s, TransportResource>,
+        Write<'s, WebSocketNetworkResource>,
+        Read<'s, NetworkSimulationTime>,
+        Write<'s, EventChannel<NetworkSimulationEvent>>,
+    );
+
+    fn run(&mut self, (mut transport, mut net, sim_time, mut channel): Self::SystemData) {
+        let messages = transport.drain_messages_to_send(|_| sim_time.should_send_message_now());
+        for message in messages {
+            match message.delivery {
+                DeliveryRequirement::ReliableOrdered(Some(_)) => {
+                    warn!("Streams are not supported by TCP and will be ignored.");
+                    write_message(message, &mut net, &mut channel);
+                }
+                DeliveryRequirement::ReliableOrdered(_) | DeliveryRequirement::Default => {
+                    write_message(message, &mut net, &mut channel);
+                }
+                delivery => panic!(
+                    "{:?} is unsupported. TCP only supports ReliableOrdered by design.",
+                    delivery
+                ),
+            }
+        }
+    }
+}
+
+fn write_message(
+    message: Message,
+    net: &mut WebSocketNetworkResource,
+    channel: &mut EventChannel<NetworkSimulationEvent>,
+) {
+    if let Some((_, web_socket)) = net.get_socket(message.destination) {
+        if let Err(e) =
+            web_socket.write_message(tungstenite::Message::Binary(message.payload.to_vec()))
+        {
+            let error = io::Error::new(io::ErrorKind::Other, e);
+            channel.single_write(NetworkSimulationEvent::SendError(error, message));
+        }
+    }
+}
+
+/// System to receive messages from all open `WebSocket`s.
+pub struct WebSocketNetworkRecvSystem;
+
+impl<'s> System<'s> for WebSocketNetworkRecvSystem {
+    type SystemData = (
+        Write<'s, WebSocketNetworkResource>,
+        Write<'s, EventChannel<NetworkSimulationEvent>>,
+    );
+
+    fn run(
+        &mut self,
+        (mut web_socket_network_resource, mut network_simulation_ec): Self::SystemData,
+    ) {
+        let web_socket_network_resource = web_socket_network_resource.deref_mut();
+        for (_, (active, web_socket_tcp)) in web_socket_network_resource.streams.iter_mut() {
+            // If we can't get a peer_addr, there is likely something pretty wrong with the
+            // connection so we'll mark it inactive.
+            let peer_addr = match web_socket_tcp.get_ref().peer_addr() {
+                Ok(addr) => addr,
+                Err(e) => {
+                    warn!("Encountered an error getting peer_addr: {:?}", e);
+                    *active = false;
+                    continue;
+                }
+            };
+
+            loop {
+                match web_socket_tcp.read_message() {
+                    Ok(message) => {
+                        // https://docs.rs/tungstenite/0.10.1/tungstenite/enum.Message.html
+                        match message {
+                            tungstenite::Message::Text(message_string) => {
+                                let event = NetworkSimulationEvent::Message(
+                                    peer_addr,
+                                    Bytes::copy_from_slice(message_string.as_bytes()),
+                                );
+                                network_simulation_ec.single_write(event);
+                            }
+                            tungstenite::Message::Binary(bytes) => {
+                                let event = NetworkSimulationEvent::Message(
+                                    peer_addr,
+                                    Bytes::copy_from_slice(&bytes),
+                                );
+                                network_simulation_ec.single_write(event);
+                            }
+                            tungstenite::Message::Ping(_bytes) => {
+                                // TODO Send Message::Pong
+                            }
+                            tungstenite::Message::Pong(bytes) => {
+                                // We aren't sending `Ping`s, so shouldn't receive `Pong`s
+                                warn!(
+                                    "Received `tungstenite::Message::Pong` but reply has not been \
+                                    implemented. Bytes: {:?}",
+                                    bytes
+                                );
+                            }
+                            tungstenite::Message::Close(_close_frame) => {
+                                *active = false;
+                                break;
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        match e {
+                            TgError::ConnectionClosed | TgError::AlreadyClosed => {
+                                *active = false;
+                            }
+                            TgError::Io(io_error) => match io_error.kind() {
+                                io::ErrorKind::ConnectionReset => *active = false,
+                                io::ErrorKind::WouldBlock => {}
+                                _ => {
+                                    network_simulation_ec
+                                        .single_write(NetworkSimulationEvent::RecvError(io_error));
+                                }
+                            },
+                            _ => {
+                                let error = io::Error::new(io::ErrorKind::Other, e);
+                                network_simulation_ec
+                                    .single_write(NetworkSimulationEvent::RecvError(error));
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub struct WebSocketNetworkResource {
+    listener: Option<TcpListener>,
+    streams: HashMap<SocketAddr, (bool, WebSocketTcp)>,
+}
+
+impl WebSocketNetworkResource {
+    pub fn new(listener: Option<TcpListener>) -> Self {
+        Self {
+            listener,
+            streams: HashMap::new(),
+        }
+    }
+
+    /// Returns an immutable reference to the listener if there is one configured.
+    pub fn get(&self) -> Option<&TcpListener> {
+        self.listener.as_ref()
+    }
+
+    /// Returns a mutable reference to the listener if there is one configured.
+    pub fn get_mut(&mut self) -> Option<&mut TcpListener> {
+        self.listener.as_mut()
+    }
+
+    /// Sets the bound listener to the `WebSocketNetworkResource`.
+    pub fn set_listener(&mut self, listener: TcpListener) {
+        self.listener = Some(listener);
+    }
+
+    /// Drops the listener from the `WebSocketNetworkResource`.
+    pub fn drop_listener(&mut self) {
+        self.listener = None;
+    }
+
+    /// Returns a tuple of an active WebSocket and whether ot not that stream is active
+    pub fn get_socket(&mut self, addr: SocketAddr) -> Option<&mut (bool, WebSocketTcp)> {
+        self.streams.get_mut(&addr)
+    }
+
+    /// Drops the stream with the given `SocketAddr`. This will be called when a peer seems to have
+    /// been disconnected
+    pub fn drop_socket(&mut self, addr: SocketAddr) -> Option<(bool, WebSocketTcp)> {
+        self.streams.remove(&addr)
+    }
+}
+
+impl Default for WebSocketNetworkResource {
+    fn default() -> Self {
+        Self {
+            listener: None,
+            streams: HashMap::new(),
+        }
+    }
+}

--- a/amethyst_network/src/simulation/transport/web_socket.rs
+++ b/amethyst_network/src/simulation/transport/web_socket.rs
@@ -3,12 +3,12 @@
 #[cfg(target_arch = "x86_64")]
 mod native;
 #[cfg(target_arch = "x86_64")]
-#[cfg(target_arch = "x86_64")]
 pub use self::native::{
     WebSocketConnectionListenerSystem, WebSocketNetworkRecvSystem, WebSocketNetworkResource,
     WebSocketNetworkSendSystem, WebSocketStreamManagementSystem,
 };
 
+#[cfg(target_arch = "x86_64")]
 use std::net::TcpListener;
 
 #[cfg(target_arch = "wasm32")]

--- a/amethyst_network/src/simulation/transport/web_socket.rs
+++ b/amethyst_network/src/simulation/transport/web_socket.rs
@@ -1,8 +1,10 @@
 //! Network systems implementation backed by the web socket protocol (over TCP).
 
-use tungstenite::{
-    error::Error as TgError,
-    handshake::{client::Request, HandshakeError},
+#[cfg(target_arch = "x86_64")]
+mod native;
+#[cfg(target_arch = "x86_64")]
+use self::native::{
+    WebSocketConnectionListenerSystem, WebSocketNetworkRecvSystem, WebSocketStreamManagementSystem,
 };
 
 use amethyst_core::{
@@ -11,13 +13,11 @@ use amethyst_core::{
     shrev::EventChannel,
 };
 use amethyst_error::Error;
-use bytes::Bytes;
-use log::{error, warn};
+use log::warn;
 use std::{
     collections::HashMap,
     io,
     net::{SocketAddr, TcpListener, TcpStream},
-    ops::DerefMut,
 };
 
 use crate::simulation::{
@@ -98,159 +98,6 @@ impl<'a, 'b> SystemBundle<'a, 'b> for WebSocketNetworkBundle {
     }
 }
 
-/// System to manage the current active WebSocket connections.
-pub struct WebSocketStreamManagementSystem;
-
-impl<'s> System<'s> for WebSocketStreamManagementSystem {
-    type SystemData = (
-        Write<'s, WebSocketNetworkResource>,
-        Read<'s, TransportResource>,
-        Write<'s, EventChannel<NetworkSimulationEvent>>,
-    );
-
-    // We cannot use `web_socket_network_resource.streams.entry(message.destination)`
-    // `.or_insert_with(|| { .. })` because there is a `return;` statement for early exit, which is
-    // not allowed within the closure.
-    #[allow(clippy::map_entry)]
-    fn run(
-        &mut self,
-        (mut web_socket_network_resource, transport, mut network_simulation_ec): Self::SystemData,
-    ) {
-        // Make connections for each message in the channel if one hasn't yet been established
-        transport.get_messages().iter().for_each(|message| {
-            if !web_socket_network_resource
-                .streams
-                .contains_key(&message.destination)
-            {
-                let stream = match TcpStream::connect(message.destination) {
-                    Ok(stream) => stream,
-                    Err(e) => {
-                        network_simulation_ec.single_write(
-                            NetworkSimulationEvent::ConnectionError(e, Some(message.destination)),
-                        );
-                        return;
-                    }
-                };
-                stream
-                    .set_nonblocking(true)
-                    .expect("Setting non-blocking mode");
-                stream.set_nodelay(true).expect("Setting nodelay");
-
-                // We are simply establishing a connection for arbitrary data, so we use a blank
-                // `Request`.
-                //
-                // See <https://docs.rs/tungstenite/0.10.1/tungstenite/client/fn.client.html>
-                let request = {
-                    let uri = format!("ws://{}/", message.destination);
-                    Request::builder()
-                        .uri(uri)
-                        .body(())
-                        .expect("Failed to build empty request.")
-                };
-                let mut handshake_result = tungstenite::client::client(request, stream);
-                loop {
-                    match handshake_result {
-                        Err(HandshakeError::Interrupted(client_handshake)) => {
-                            // This is the expected result when connecting with a non-blocking TCP stream.
-                            // Next, we start the client_handshake and try to get its final result.
-                            handshake_result = client_handshake.handshake();
-                        }
-                        // We don't care about the handshake response
-                        Ok((web_socket, _response)) => {
-                            dbg!(format!("Connected to {}", &message.destination));
-                            web_socket_network_resource
-                                .streams
-                                .insert(message.destination, (true, web_socket));
-                            break;
-                        }
-                        Err(HandshakeError::Failure(TgError::Io(io_error))) => {
-                            network_simulation_ec.single_write(
-                                NetworkSimulationEvent::ConnectionError(
-                                    io_error,
-                                    Some(message.destination),
-                                ),
-                            );
-                            break;
-                        }
-                        Err(handshake_error) => {
-                            let error = io::Error::new(io::ErrorKind::Other, handshake_error);
-                            network_simulation_ec.single_write(
-                                NetworkSimulationEvent::ConnectionError(
-                                    error,
-                                    Some(message.destination),
-                                ),
-                            );
-                            break;
-                        }
-                    }
-                }
-            }
-        });
-
-        // Remove inactive connections
-        web_socket_network_resource
-            .streams
-            .retain(|addr, (active, _)| {
-                if !*active {
-                    network_simulation_ec.single_write(NetworkSimulationEvent::Disconnect(*addr));
-                }
-                *active
-            });
-    }
-}
-
-/// System to listen for incoming connections and cache them to the resource.
-pub struct WebSocketConnectionListenerSystem;
-
-impl<'s> System<'s> for WebSocketConnectionListenerSystem {
-    type SystemData = (
-        Write<'s, WebSocketNetworkResource>,
-        Write<'s, EventChannel<NetworkSimulationEvent>>,
-    );
-
-    fn run(
-        &mut self,
-        (mut web_socket_network_resource, mut network_simulation_ec): Self::SystemData,
-    ) {
-        let resource = web_socket_network_resource.deref_mut();
-        if let Some(ref listener) = resource.listener {
-            loop {
-                match listener.accept() {
-                    Ok((stream, addr)) => {
-                        stream
-                            .set_nonblocking(true)
-                            .expect("Setting nonblocking mode");
-                        stream.set_nodelay(true).expect("Setting nodelay");
-
-                        match tungstenite::server::accept(stream) {
-                            Ok(web_socket) => {
-                                resource.streams.insert(addr, (true, web_socket));
-                                network_simulation_ec
-                                    .single_write(NetworkSimulationEvent::Connect(addr));
-                            }
-                            Err(HandshakeError::Interrupted(_)) => {
-                                break;
-                            }
-                            Err(HandshakeError::Failure(e)) => {
-                                error!("Handshake failure during accept: {}", e);
-                                break;
-                            }
-                        }
-                    }
-                    Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                        break;
-                    }
-                    Err(e) => {
-                        network_simulation_ec
-                            .single_write(NetworkSimulationEvent::ConnectionError(e, None));
-                        break;
-                    }
-                };
-            }
-        }
-    }
-}
-
 /// System to send messages to a particular open `WebSocket`.
 pub struct WebSocketNetworkSendSystem;
 
@@ -293,95 +140,6 @@ fn write_message(
         {
             let error = io::Error::new(io::ErrorKind::Other, e);
             channel.single_write(NetworkSimulationEvent::SendError(error, message));
-        }
-    }
-}
-
-/// System to receive messages from all open `WebSocket`s.
-pub struct WebSocketNetworkRecvSystem;
-
-impl<'s> System<'s> for WebSocketNetworkRecvSystem {
-    type SystemData = (
-        Write<'s, WebSocketNetworkResource>,
-        Write<'s, EventChannel<NetworkSimulationEvent>>,
-    );
-
-    fn run(
-        &mut self,
-        (mut web_socket_network_resource, mut network_simulation_ec): Self::SystemData,
-    ) {
-        let web_socket_network_resource = web_socket_network_resource.deref_mut();
-        for (_, (active, web_socket_tcp)) in web_socket_network_resource.streams.iter_mut() {
-            // If we can't get a peer_addr, there is likely something pretty wrong with the
-            // connection so we'll mark it inactive.
-            let peer_addr = match web_socket_tcp.get_ref().peer_addr() {
-                Ok(addr) => addr,
-                Err(e) => {
-                    warn!("Encountered an error getting peer_addr: {:?}", e);
-                    *active = false;
-                    continue;
-                }
-            };
-
-            loop {
-                match web_socket_tcp.read_message() {
-                    Ok(message) => {
-                        // https://docs.rs/tungstenite/0.10.1/tungstenite/enum.Message.html
-                        match message {
-                            tungstenite::Message::Text(message_string) => {
-                                let event = NetworkSimulationEvent::Message(
-                                    peer_addr,
-                                    Bytes::copy_from_slice(message_string.as_bytes()),
-                                );
-                                network_simulation_ec.single_write(event);
-                            }
-                            tungstenite::Message::Binary(bytes) => {
-                                let event = NetworkSimulationEvent::Message(
-                                    peer_addr,
-                                    Bytes::copy_from_slice(&bytes),
-                                );
-                                network_simulation_ec.single_write(event);
-                            }
-                            tungstenite::Message::Ping(_bytes) => {
-                                // TODO Send Message::Pong
-                            }
-                            tungstenite::Message::Pong(bytes) => {
-                                // We aren't sending `Ping`s, so shouldn't receive `Pong`s
-                                warn!(
-                                    "Received `tungstenite::Message::Pong` but reply has not been \
-                                    implemented. Bytes: {:?}",
-                                    bytes
-                                );
-                            }
-                            tungstenite::Message::Close(_close_frame) => {
-                                *active = false;
-                                break;
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        match e {
-                            TgError::ConnectionClosed | TgError::AlreadyClosed => {
-                                *active = false;
-                            }
-                            TgError::Io(io_error) => match io_error.kind() {
-                                io::ErrorKind::ConnectionReset => *active = false,
-                                io::ErrorKind::WouldBlock => {}
-                                _ => {
-                                    network_simulation_ec
-                                        .single_write(NetworkSimulationEvent::RecvError(io_error));
-                                }
-                            },
-                            _ => {
-                                let error = io::Error::new(io::ErrorKind::Other, e);
-                                network_simulation_ec
-                                    .single_write(NetworkSimulationEvent::RecvError(error));
-                            }
-                        }
-                        break;
-                    }
-                }
-            }
         }
     }
 }

--- a/amethyst_network/src/simulation/transport/web_socket/native.rs
+++ b/amethyst_network/src/simulation/transport/web_socket/native.rs
@@ -1,0 +1,258 @@
+use std::{io, net::TcpStream, ops::DerefMut};
+
+use amethyst_core::{
+    ecs::{Read, System, Write},
+    shrev::EventChannel,
+};
+use bytes::Bytes;
+use log::{error, warn};
+use tungstenite::{
+    error::Error as TgError,
+    handshake::{client::Request, HandshakeError},
+};
+
+use crate::simulation::{events::NetworkSimulationEvent, transport::TransportResource};
+
+use super::WebSocketNetworkResource;
+
+/// System to listen for incoming connections and cache them to the resource.
+pub struct WebSocketConnectionListenerSystem;
+
+impl<'s> System<'s> for WebSocketConnectionListenerSystem {
+    type SystemData = (
+        Write<'s, WebSocketNetworkResource>,
+        Write<'s, EventChannel<NetworkSimulationEvent>>,
+    );
+
+    fn run(
+        &mut self,
+        (mut web_socket_network_resource, mut network_simulation_ec): Self::SystemData,
+    ) {
+        let resource = web_socket_network_resource.deref_mut();
+        if let Some(ref listener) = resource.listener {
+            loop {
+                match listener.accept() {
+                    Ok((stream, addr)) => {
+                        stream
+                            .set_nonblocking(true)
+                            .expect("Setting nonblocking mode");
+                        stream.set_nodelay(true).expect("Setting nodelay");
+
+                        match tungstenite::server::accept(stream) {
+                            Ok(web_socket) => {
+                                resource.streams.insert(addr, (true, web_socket));
+                                network_simulation_ec
+                                    .single_write(NetworkSimulationEvent::Connect(addr));
+                            }
+                            Err(HandshakeError::Interrupted(_)) => {
+                                break;
+                            }
+                            Err(HandshakeError::Failure(e)) => {
+                                error!("Handshake failure during accept: {}", e);
+                                break;
+                            }
+                        }
+                    }
+                    Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                        break;
+                    }
+                    Err(e) => {
+                        network_simulation_ec
+                            .single_write(NetworkSimulationEvent::ConnectionError(e, None));
+                        break;
+                    }
+                };
+            }
+        }
+    }
+}
+
+/// System to receive messages from all open `WebSocket`s.
+pub struct WebSocketNetworkRecvSystem;
+
+impl<'s> System<'s> for WebSocketNetworkRecvSystem {
+    type SystemData = (
+        Write<'s, WebSocketNetworkResource>,
+        Write<'s, EventChannel<NetworkSimulationEvent>>,
+    );
+
+    fn run(
+        &mut self,
+        (mut web_socket_network_resource, mut network_simulation_ec): Self::SystemData,
+    ) {
+        let web_socket_network_resource = web_socket_network_resource.deref_mut();
+        for (_, (active, web_socket_tcp)) in web_socket_network_resource.streams.iter_mut() {
+            // If we can't get a peer_addr, there is likely something pretty wrong with the
+            // connection so we'll mark it inactive.
+            let peer_addr = match web_socket_tcp.get_ref().peer_addr() {
+                Ok(addr) => addr,
+                Err(e) => {
+                    warn!("Encountered an error getting peer_addr: {:?}", e);
+                    *active = false;
+                    continue;
+                }
+            };
+
+            loop {
+                match web_socket_tcp.read_message() {
+                    Ok(message) => {
+                        // https://docs.rs/tungstenite/0.10.1/tungstenite/enum.Message.html
+                        match message {
+                            tungstenite::Message::Text(message_string) => {
+                                let event = NetworkSimulationEvent::Message(
+                                    peer_addr,
+                                    Bytes::copy_from_slice(message_string.as_bytes()),
+                                );
+                                network_simulation_ec.single_write(event);
+                            }
+                            tungstenite::Message::Binary(bytes) => {
+                                let event = NetworkSimulationEvent::Message(
+                                    peer_addr,
+                                    Bytes::copy_from_slice(&bytes),
+                                );
+                                network_simulation_ec.single_write(event);
+                            }
+                            tungstenite::Message::Ping(_bytes) => {
+                                // TODO Send Message::Pong
+                            }
+                            tungstenite::Message::Pong(bytes) => {
+                                // We aren't sending `Ping`s, so shouldn't receive `Pong`s
+                                warn!(
+                                    "Received `tungstenite::Message::Pong` but reply has not been \
+                                    implemented. Bytes: {:?}",
+                                    bytes
+                                );
+                            }
+                            tungstenite::Message::Close(_close_frame) => {
+                                *active = false;
+                                break;
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        match e {
+                            TgError::ConnectionClosed | TgError::AlreadyClosed => {
+                                *active = false;
+                            }
+                            TgError::Io(io_error) => match io_error.kind() {
+                                io::ErrorKind::ConnectionReset => *active = false,
+                                io::ErrorKind::WouldBlock => {}
+                                _ => {
+                                    network_simulation_ec
+                                        .single_write(NetworkSimulationEvent::RecvError(io_error));
+                                }
+                            },
+                            _ => {
+                                let error = io::Error::new(io::ErrorKind::Other, e);
+                                network_simulation_ec
+                                    .single_write(NetworkSimulationEvent::RecvError(error));
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// System to manage the current active WebSocket connections.
+pub struct WebSocketStreamManagementSystem;
+
+impl<'s> System<'s> for WebSocketStreamManagementSystem {
+    type SystemData = (
+        Write<'s, WebSocketNetworkResource>,
+        Read<'s, TransportResource>,
+        Write<'s, EventChannel<NetworkSimulationEvent>>,
+    );
+
+    // We cannot use `web_socket_network_resource.streams.entry(message.destination)`
+    // `.or_insert_with(|| { .. })` because there is a `return;` statement for early exit, which is
+    // not allowed within the closure.
+    #[allow(clippy::map_entry)]
+    fn run(
+        &mut self,
+        (mut web_socket_network_resource, transport, mut network_simulation_ec): Self::SystemData,
+    ) {
+        // Make connections for each message in the channel if one hasn't yet been established
+        transport.get_messages().iter().for_each(|message| {
+            if !web_socket_network_resource
+                .streams
+                .contains_key(&message.destination)
+            {
+                let stream = match TcpStream::connect(message.destination) {
+                    Ok(stream) => stream,
+                    Err(e) => {
+                        network_simulation_ec.single_write(
+                            NetworkSimulationEvent::ConnectionError(e, Some(message.destination)),
+                        );
+                        return;
+                    }
+                };
+                stream
+                    .set_nonblocking(true)
+                    .expect("Setting non-blocking mode");
+                stream.set_nodelay(true).expect("Setting nodelay");
+
+                // We are simply establishing a connection for arbitrary data, so we use a blank
+                // `Request`.
+                //
+                // See <https://docs.rs/tungstenite/0.10.1/tungstenite/client/fn.client.html>
+                let request = {
+                    let uri = format!("ws://{}/", message.destination);
+                    Request::builder()
+                        .uri(uri)
+                        .body(())
+                        .expect("Failed to build empty request.")
+                };
+                let mut handshake_result = tungstenite::client::client(request, stream);
+                loop {
+                    match handshake_result {
+                        Err(HandshakeError::Interrupted(client_handshake)) => {
+                            // This is the expected result when connecting with a non-blocking TCP stream.
+                            // Next, we start the client_handshake and try to get its final result.
+                            handshake_result = client_handshake.handshake();
+                        }
+                        // We don't care about the handshake response
+                        Ok((web_socket, _response)) => {
+                            dbg!(format!("Connected to {}", &message.destination));
+                            web_socket_network_resource
+                                .streams
+                                .insert(message.destination, (true, web_socket));
+                            break;
+                        }
+                        Err(HandshakeError::Failure(TgError::Io(io_error))) => {
+                            network_simulation_ec.single_write(
+                                NetworkSimulationEvent::ConnectionError(
+                                    io_error,
+                                    Some(message.destination),
+                                ),
+                            );
+                            break;
+                        }
+                        Err(handshake_error) => {
+                            let error = io::Error::new(io::ErrorKind::Other, handshake_error);
+                            network_simulation_ec.single_write(
+                                NetworkSimulationEvent::ConnectionError(
+                                    error,
+                                    Some(message.destination),
+                                ),
+                            );
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+
+        // Remove inactive connections
+        web_socket_network_resource
+            .streams
+            .retain(|addr, (active, _)| {
+                if !*active {
+                    network_simulation_ec.single_write(NetworkSimulationEvent::Disconnect(*addr));
+                }
+                *active
+            });
+    }
+}

--- a/amethyst_network/src/simulation/transport/web_socket/native.rs
+++ b/amethyst_network/src/simulation/transport/web_socket/native.rs
@@ -1,4 +1,9 @@
-use std::{io, net::TcpStream, ops::DerefMut};
+use std::{
+    collections::HashMap,
+    io,
+    net::{SocketAddr, TcpListener, TcpStream},
+    ops::DerefMut,
+};
 
 use amethyst_core::{
     ecs::{Read, System, Write},
@@ -11,9 +16,12 @@ use tungstenite::{
     handshake::{client::Request, HandshakeError},
 };
 
-use crate::simulation::{events::NetworkSimulationEvent, transport::TransportResource};
+use crate::simulation::{
+    events::NetworkSimulationEvent, message::Message, requirements::DeliveryRequirement,
+    timing::NetworkSimulationTime, transport::TransportResource,
+};
 
-use super::WebSocketNetworkResource;
+type WebSocket = tungstenite::protocol::WebSocket<TcpStream>;
 
 /// System to listen for incoming connections and cache them to the resource.
 pub struct WebSocketConnectionListenerSystem;
@@ -63,6 +71,52 @@ impl<'s> System<'s> for WebSocketConnectionListenerSystem {
                     }
                 };
             }
+        }
+    }
+}
+
+/// System to send messages to a particular open `WebSocket`.
+pub struct WebSocketNetworkSendSystem;
+
+impl<'s> System<'s> for WebSocketNetworkSendSystem {
+    type SystemData = (
+        Write<'s, TransportResource>,
+        Write<'s, WebSocketNetworkResource>,
+        Read<'s, NetworkSimulationTime>,
+        Write<'s, EventChannel<NetworkSimulationEvent>>,
+    );
+
+    fn run(&mut self, (mut transport, mut net, sim_time, mut channel): Self::SystemData) {
+        let messages = transport.drain_messages_to_send(|_| sim_time.should_send_message_now());
+        for message in messages {
+            match message.delivery {
+                DeliveryRequirement::ReliableOrdered(Some(_)) => {
+                    warn!("Streams are not supported by TCP and will be ignored.");
+                    write_message(message, &mut net, &mut channel);
+                }
+                DeliveryRequirement::ReliableOrdered(_) | DeliveryRequirement::Default => {
+                    write_message(message, &mut net, &mut channel);
+                }
+                delivery => panic!(
+                    "{:?} is unsupported. TCP only supports ReliableOrdered by design.",
+                    delivery
+                ),
+            }
+        }
+    }
+}
+
+fn write_message(
+    message: Message,
+    net: &mut WebSocketNetworkResource,
+    channel: &mut EventChannel<NetworkSimulationEvent>,
+) {
+    if let Some((_, web_socket)) = net.get_socket(message.destination) {
+        if let Err(e) =
+            web_socket.write_message(tungstenite::Message::Binary(message.payload.to_vec()))
+        {
+            let error = io::Error::new(io::ErrorKind::Other, e);
+            channel.single_write(NetworkSimulationEvent::SendError(error, message));
         }
     }
 }
@@ -254,5 +308,59 @@ impl<'s> System<'s> for WebSocketStreamManagementSystem {
                 }
                 *active
             });
+    }
+}
+
+pub struct WebSocketNetworkResource {
+    listener: Option<TcpListener>,
+    streams: HashMap<SocketAddr, (bool, WebSocket)>,
+}
+
+impl WebSocketNetworkResource {
+    pub fn new(listener: Option<TcpListener>) -> Self {
+        Self {
+            listener,
+            streams: HashMap::new(),
+        }
+    }
+
+    /// Returns an immutable reference to the listener if there is one configured.
+    pub fn get(&self) -> Option<&TcpListener> {
+        self.listener.as_ref()
+    }
+
+    /// Returns a mutable reference to the listener if there is one configured.
+    pub fn get_mut(&mut self) -> Option<&mut TcpListener> {
+        self.listener.as_mut()
+    }
+
+    /// Sets the bound listener to the `WebSocketNetworkResource`.
+    pub fn set_listener(&mut self, listener: TcpListener) {
+        self.listener = Some(listener);
+    }
+
+    /// Drops the listener from the `WebSocketNetworkResource`.
+    pub fn drop_listener(&mut self) {
+        self.listener = None;
+    }
+
+    /// Returns a tuple of an active WebSocket and whether ot not that stream is active
+    pub fn get_socket(&mut self, addr: SocketAddr) -> Option<&mut (bool, WebSocket)> {
+        self.streams.get_mut(&addr)
+    }
+
+    /// Drops the stream with the given `SocketAddr`. This will be called when a peer seems to have
+    /// been disconnected
+    pub fn drop_socket(&mut self, addr: SocketAddr) -> Option<(bool, WebSocket)> {
+        self.streams.remove(&addr)
+    }
+}
+
+impl Default for WebSocketNetworkResource {
+    fn default() -> Self {
+        Self {
+            listener: None,
+            streams: HashMap::new(),
+        }
     }
 }

--- a/amethyst_network/src/simulation/transport/web_socket/web_sys.rs
+++ b/amethyst_network/src/simulation/transport/web_socket/web_sys.rs
@@ -1,0 +1,249 @@
+use std::{
+    io,
+    net::SocketAddr,
+    ops::{Deref, DerefMut},
+};
+
+use amethyst_core::{
+    ecs::{Read, ReadExpect, System, SystemData, World, Write},
+    shrev::EventChannel,
+    SystemDesc,
+};
+use bytes::Bytes;
+use crossbeam_channel::{Receiver, Sender};
+use js_sys::Uint8Array;
+use log::error;
+use wasm_bindgen::{prelude::*, JsCast};
+use web_sys::{CloseEvent, ErrorEvent, Event, MessageEvent, WebSocket};
+
+use crate::simulation::{events::NetworkSimulationEvent, transport::TransportResource};
+
+use super::WebSocketNetworkResource;
+
+/// System to receive messages from all open `WebSocket`s.
+pub struct WebSocketNetworkRecvSystem;
+
+impl<'s> System<'s> for WebSocketNetworkRecvSystem {
+    type SystemData = (
+        Write<'s, WebSocketNetworkResource>,
+        Write<'s, EventChannel<NetworkSimulationEvent>>,
+        ReadExpect<'s, WebSocketWseBuffer>,
+    );
+
+    fn run(
+        &mut self,
+        (mut web_socket_network_resource, mut network_simulation_ec, web_socket_nse_buffer): Self::SystemData,
+    ) {
+        // Transfer all `NetworkSimulationEvent`s from the `WebSocketWseBuffer` into the
+        // `EventChannel<NetworkSimulationEvent>`.
+        web_socket_nse_buffer
+            .try_iter()
+            .for_each(|web_socket_event| {
+                let WebSocketEvent {
+                    socket_addr,
+                    event_type,
+                } = web_socket_event;
+
+                match event_type {
+                    WebSocketEventType::Close => {
+                        // Even though we could make the `onclose_callback` write
+                        // `NetworkSimulationEvent::Disconnect`, we edit the `active` status and allow
+                        // the `WebSocketStreamManagementSystem` to send the events, as that keeps the
+                        // web implementation consistent with the native implementation.
+                        if let Some((active, _web_socket)) = web_socket_network_resource
+                            .deref_mut()
+                            .streams
+                            .get_mut(&socket_addr)
+                        {
+                            *active = false;
+                        }
+                    }
+                    WebSocketEventType::NetworkSimulationEvent(nse) => {
+                        network_simulation_ec.single_write(nse);
+                    }
+                }
+            });
+    }
+}
+
+/// Builds a `WebSocketStreamManagementSystem`.
+#[derive(Default, Debug)]
+pub struct WebSocketStreamManagementSystemDesc;
+
+impl<'a, 'b> SystemDesc<'a, 'b, WebSocketStreamManagementSystem>
+    for WebSocketStreamManagementSystemDesc
+{
+    fn build(self, world: &mut World) -> WebSocketStreamManagementSystem {
+        <WebSocketStreamManagementSystem as System<'_>>::SystemData::setup(world);
+
+        let (tx, rx) = crossbeam_channel::unbounded();
+        let web_socket_nse_buffer = WebSocketWseBuffer { tx, rx };
+        world.insert(web_socket_nse_buffer);
+
+        WebSocketStreamManagementSystem
+    }
+}
+
+/// System to manage the current active WebSocket connections.
+pub struct WebSocketStreamManagementSystem;
+
+impl<'s> System<'s> for WebSocketStreamManagementSystem {
+    type SystemData = (
+        Write<'s, WebSocketNetworkResource>,
+        Read<'s, TransportResource>,
+        Write<'s, EventChannel<NetworkSimulationEvent>>,
+        ReadExpect<'s, WebSocketWseBuffer>,
+    );
+
+    // We cannot use `web_socket_network_resource.streams.entry(message.destination)`
+    // `.or_insert_with(|| { .. })` because there is a `return;` statement for early exit, which is
+    // not allowed within the closure.
+    #[allow(clippy::map_entry)]
+    fn run(
+        &mut self,
+        (
+            mut web_socket_network_resource,
+            transport,
+            mut network_simulation_ec,
+            web_socket_nse_buffer,
+        ): Self::SystemData,
+    ) {
+        // Make connections for each message in the channel if one hasn't yet been established
+        transport.get_messages().iter().for_each(|message| {
+            if !web_socket_network_resource
+                .streams
+                .contains_key(&message.destination)
+            {
+                // Create a WebSocket
+                match WebSocket::new("wss://echo.websocket.org") {
+                    Ok(ws) => {
+                        let wse_tx = web_socket_nse_buffer.tx.clone();
+                        NseCallbacks::setup(message.destination, &mut ws, wse_tx);
+
+                        web_socket_network_resource
+                            .streams
+                            .insert(message.destination, (true, ws));
+                    }
+                    Err(e) => {
+                        let event = Event::from(e);
+                        let error = io::Error::new(io::ErrorKind::Other, event.type_());
+                        network_simulation_ec.single_write(
+                            NetworkSimulationEvent::ConnectionError(
+                                error,
+                                Some(message.destination),
+                            ),
+                        );
+                    }
+                }
+            }
+        });
+
+        // Remove inactive connections
+        web_socket_network_resource
+            .streams
+            .retain(|addr, (active, _)| {
+                if !*active {
+                    network_simulation_ec.single_write(NetworkSimulationEvent::Disconnect(*addr));
+                }
+                *active
+            });
+    }
+}
+
+/// `NetworkSimulationEvent` callbacks for `WebSocket`s.
+struct NseCallbacks;
+
+impl NseCallbacks {
+    /// Sets up the web socket to send `NetworkSimulationEvent`s.
+    pub fn setup(socket_addr: SocketAddr, ws: &mut WebSocket, wse_tx: Sender<WebSocketEvent>) {
+        let tx = wse_tx.clone();
+        let onmessage_callback = Closure::wrap(Box::new(move |e: MessageEvent| {
+            // Convert javascript ArrayBuffer into Vec<u8>
+            let data = e.data();
+            let array = Uint8Array::new(&data);
+            let mut bytes = Vec::with_capacity(array.length() as usize);
+            array.copy_to(&mut bytes);
+
+            let nse = NetworkSimulationEvent::Message(peer_addr, Bytes::copy_from_slice(&bytes));
+            let wse = WebSocketEvent {
+                socket_addr,
+                event_type: WebSocketEventType::NetworkSimulationEvent(nse),
+            };
+            tx.send(wse);
+        }) as Box<dyn FnMut(MessageEvent)>);
+
+        // Set message event handler on `WebSocket`.
+        ws.set_onmessage(Some(onmessage_callback.as_ref().unchecked_ref()));
+        // Forget the callback to keep it alive.
+        onmessage_callback.forget();
+
+        let tx = wse_tx.clone();
+        let onclose_callback = Closure::wrap(Box::new(move |e: CloseEvent| {
+            // If we receive an `onclose`, we are disconnected from the server, which is likely an
+            // error.
+            error!("Disconnected from server: {}", e.reason());
+
+            let wse = WebSocketEvent {
+                socket_addr,
+                event_type: WebSocketEventType::Close,
+            };
+            tx.send(wse);
+        }) as Box<dyn FnMut(ErrorEvent)>);
+        ws.set_onclose(Some(onclose_callback.as_ref().unchecked_ref()));
+        onclose_callback.forget();
+
+        let onerror_callback = Closure::wrap(Box::new(move |e: ErrorEvent| {
+            error!(
+                "error: {}, file: {}, line: {}, col: {}\n{:?}",
+                e.message(),
+                e.filename(),
+                e.lineno(),
+                e.colno(),
+                e.error(),
+            );
+
+            // TODO: send event?
+        }) as Box<dyn FnMut(ErrorEvent)>);
+        ws.set_onerror(Some(onerror_callback.as_ref().unchecked_ref()));
+        onerror_callback.forget();
+    }
+}
+
+/// Buffer for `NetworkSimulationEvent`s received from a web socket event handler.
+///
+/// This is an intermediate storage as the event handlers cannot each hold a mutable reference to
+/// the `EventChannel<NetworkSimulationEvent>`.
+struct WebSocketEventBuffer<T> {
+    /// Sender for `T` events.
+    tx: Sender<T>,
+    /// Receiver for `T` events.
+    rx: Receiver<T>,
+}
+
+impl<T> Deref for WebSocketEventBuffer<T> {
+    type Target = Receiver<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.rx
+    }
+}
+
+impl<T> DerefMut for WebSocketEventBuffer<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.rx
+    }
+}
+
+#[derive(Debug)]
+struct WebSocketEvent {
+    socket_addr: SocketAddr,
+    event_type: WebSocketEventType,
+}
+
+#[derive(Debug)]
+enum WebSocketEventType {
+    Close,
+    NetworkSimulationEvent(NetworkSimulationEvent),
+}
+
+type WebSocketWseBuffer = WebSocketEventBuffer<WebSocketEvent>;

--- a/amethyst_test/Cargo.toml
+++ b/amethyst_test/Cargo.toml
@@ -48,6 +48,7 @@ shader-compiler = ["amethyst/shader-compiler"]
 test-support = ["amethyst/test-support"]
 experimental-spirv-reflection = ["amethyst/experimental-spirv-reflection"]
 wasm = ["amethyst/wasm"]
+web_socket = ["amethyst/web_socket"]
 
 # Used to tag tests that need an audio backend to run.
 test_audio = []

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 * Basic GL rendering. ([#2192], [#2198])
 * `AmethystApplication::with_bundle_event_fn` takes in a bundle that needs a reference to the `EventLoop`. ([#2240])
 * WASM logger is configurable though `LoggerConfig` when using [`console_log`]. ([#2249], [#2250])
+* `amethyst_network` supports `WebSocket`s behind the `"web_socket"` feature. ([#2251], [#2253])
 
 ### Changed
 
@@ -38,6 +39,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#2245]: https://github.com/amethyst/amethyst/pull/2245
 [#2249]: https://github.com/amethyst/amethyst/issues/2249
 [#2250]: https://github.com/amethyst/amethyst/pull/2250
+[#2251]: https://github.com/amethyst/amethyst/issues/2251
+[#2253]: https://github.com/amethyst/amethyst/pull/2253
 [`console_log`]: https://crates.io/crates/console_log
 
 ## [0.15.0] - 2020-03-24


### PR DESCRIPTION
## Description

Enables `WebSocket`s as a transport layer option.

Closes #2251.

## Additions

* `amethyst_network` supports `WebSocket`s behind the `"web_socket"` feature.

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --workspace --features "gl"`
