### PR TITLE
Corrected an issue where fixed updates were tied to time_scale

### DIFF
--- a/amethyst_core/src/timing.rs
+++ b/amethyst_core/src/timing.rs
@@ -383,12 +383,14 @@ mod tests {
 
     // Test that fixed_update methods accumulate and return correctly
     // Test confirms that with a fixed update of 120fps, we run fixed update twice with the timer
+    // Runs at 10 times game speed, which shouldn't affect fixed updates
     #[test]
     fn fixed_update_120fps() {
         use super::Time;
 
         let mut time = Time::default();
         time.set_fixed_seconds(1.0 / 120.0);
+        time.set_time_scale(10.0);
 
         let step = 1.0 / 60.0;
         let mut fixed_count = 0;

--- a/amethyst_core/src/timing.rs
+++ b/amethyst_core/src/timing.rs
@@ -103,7 +103,6 @@ impl Time {
         self.interpolation_alpha
     }
 
-    /// Gets the total number of frames that have been played in this session.
     /// Sets both `delta_seconds` and `delta_time` based on the seconds given.
     ///
     /// This should only be called by the engine.  Bad things might happen if you call this in
@@ -169,7 +168,7 @@ impl Time {
     /// This should only be called by the engine.  Bad things might happen if you call this in
     /// your game.
     pub fn start_fixed_update(&mut self) {
-        self.fixed_time_accumulator += self.delta_seconds;
+        self.fixed_time_accumulator += self.delta_real_seconds;
     }
 
     /// Checks to see if we should perform another fixed update iteration, and if so, returns true

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [kc]: http://keepachangelog.com/
 [sv]: http://semver.org/
 
+## [Unreleased]
+
+### Fixed
+
+- Corrected an issue where fixed updates were tied to time scale. ([#2254])
+
+[#2254]: https://github.com/amethyst/amethyst/issues/2254
 
 ## [0.15.0] - 2020-03-24
 
@@ -41,9 +48,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - Caret for editable text box is positioned correctly on first click. ([#2151])
 - Editable text is correctly blurred / unfocused when clicking outside its bounds. ([#2091], [#2151])
 - `amethyst_test` crate features now map 1-1 to `amethyst` features. ([#2153])
-- Corrected an issue where fixed updates were tied to time scale. ([#2254])
 
-[#2254]: https://github.com/amethyst/amethyst/issues/2254
 [#2091]: https://github.com/amethyst/amethyst/issues/2091
 [#2108]: https://github.com/amethyst/amethyst/issues/2108
 [#2114]: https://github.com/amethyst/amethyst/pull/2114

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,7 +41,9 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - Caret for editable text box is positioned correctly on first click. ([#2151])
 - Editable text is correctly blurred / unfocused when clicking outside its bounds. ([#2091], [#2151])
 - `amethyst_test` crate features now map 1-1 to `amethyst` features. ([#2153])
+- Corrected an issue where fixed updates were tied to time scale. ([#2254])
 
+[#2254]: https://github.com/amethyst/amethyst/issues/2254
 [#2091]: https://github.com/amethyst/amethyst/issues/2091
 [#2108]: https://github.com/amethyst/amethyst/issues/2108
 [#2114]: https://github.com/amethyst/amethyst/pull/2114


### PR DESCRIPTION
Closes #2254

## Description

I can't figure out how to write a #[test] for this, as it either needs to run for multiple real seconds, or it would use set_delta_seconds() like the other tests, which breaks the time scale anyway. 

Everything seems to work? I'm still a little confused about how it worked before, but I'm not seeing millions of fixed_update calls per second in my project and all the unit tests pass.

## Modifications

- Changed time.start_fixed_update to use delta_real_seconds rather than delta_seconds.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
