### PR TITLE
Fix asset handle reuse in rendy subs

### DIFF
--- a/amethyst_assets/src/storage.rs
+++ b/amethyst_assets/src/storage.rs
@@ -614,9 +614,10 @@ pub(crate) enum Processed<A: Asset> {
 /// A weak handle, which is useful if you don't directly need the asset
 /// like in caches. This way, the asset can still get dropped (if you want that).
 #[derive(Derivative)]
-#[derivative(Clone(bound = ""))]
+#[derivative(Clone(bound = ""), Debug(bound = ""))]
 pub struct WeakHandle<A> {
     id: Weak<u32>,
+    #[derivative(Debug = "ignore")]
     marker: PhantomData<A>,
 }
 
@@ -633,6 +634,6 @@ impl<A> WeakHandle<A> {
     /// Returns `true` if the original handle is dead.
     #[inline]
     pub fn is_dead(&self) -> bool {
-        self.upgrade().is_none()
+        self.id.upgrade().is_none()
     }
 }

--- a/amethyst_rendy/src/submodules/material.rs
+++ b/amethyst_rendy/src/submodules/material.rs
@@ -14,7 +14,7 @@ use crate::{
     types::{Backend, Texture},
     util,
 };
-use amethyst_assets::{AssetStorage, Handle};
+use amethyst_assets::{AssetStorage, Handle, WeakHandle};
 use amethyst_core::ecs::{Read, SystemData, World};
 use glsl_layout::*;
 
@@ -129,6 +129,7 @@ enum MaterialState<B: Backend> {
         set: Escape<DescriptorSet<B>>,
         slot: usize,
         generation: u32,
+        handle: WeakHandle<Material>,
     },
 }
 
@@ -268,6 +269,7 @@ impl<B: Backend, T: for<'a> StaticTextureSet<'a>> MaterialSub<B, T> {
             set,
             slot,
             generation: self.generation,
+            handle: handle.downgrade(),
         })
     }
 
@@ -283,9 +285,20 @@ impl<B: Backend, T: for<'a> StaticTextureSet<'a>> MaterialSub<B, T> {
 
         let id = self.lookup.forward(handle.id());
         match self.materials.get_mut(id) {
-            Some(MaterialState::Loaded { generation, .. }) => {
-                *generation = self.generation;
-                return Some((MaterialId(id as u32), false));
+            Some(MaterialState::Loaded {
+                slot,
+                generation,
+                handle,
+                ..
+            }) => {
+                // If handle is dead, new material was loaded (handle id reused)
+                if handle.is_dead() {
+                    self.allocator.release(*slot);
+                } else {
+                    // Material loaded and ready
+                    *generation = self.generation;
+                    return Some((MaterialId(id as u32), false));
+                }
             }
             Some(MaterialState::Unloaded { generation }) if *generation == self.generation => {
                 return None

--- a/amethyst_rendy/src/submodules/texture.rs
+++ b/amethyst_rendy/src/submodules/texture.rs
@@ -9,7 +9,7 @@ use crate::{
     types::{Backend, Texture},
     util,
 };
-use amethyst_assets::{AssetStorage, Handle};
+use amethyst_assets::{AssetStorage, Handle, WeakHandle};
 use amethyst_core::ecs::{Read, SystemData, World};
 
 #[cfg(feature = "profiler")]
@@ -24,7 +24,7 @@ enum TextureState<B: Backend> {
         set: Escape<DescriptorSet<B>>,
         generation: u32,
         version: u32,
-        handle: Handle<Texture>,
+        handle: WeakHandle<Texture>,
         layout: hal::image::Layout,
     },
 }
@@ -75,19 +75,27 @@ impl<B: Backend> TextureSub<B> {
                     handle,
                     layout,
                 } if *generation == self.generation => {
-                    if let Some((new_tex, new_version)) = tex_storage.get_with_version(handle) {
-                        if version != new_version {
-                            if let Some(desc) = texture_desc(new_tex, *layout) {
-                                unsafe {
-                                    let set = set.raw();
-                                    factory.write_descriptor_sets(vec![desc_write(set, 0, desc)]);
+                    if let Some(handle) = handle.upgrade() {
+                        if let Some((new_tex, new_version)) = tex_storage.get_with_version(&handle)
+                        {
+                            if version != new_version {
+                                if let Some(desc) = texture_desc(new_tex, *layout) {
+                                    unsafe {
+                                        let set = set.raw();
+                                        factory
+                                            .write_descriptor_sets(vec![desc_write(set, 0, desc)]);
+                                    }
+                                    *version = *new_version;
+                                } else {
+                                    *state = TextureState::Unloaded {
+                                        generation: self.generation,
+                                    };
                                 }
-                                *version = *new_version;
-                            } else {
-                                *state = TextureState::Unloaded {
-                                    generation: self.generation,
-                                };
                             }
+                        } else {
+                            *state = TextureState::Unloaded {
+                                generation: self.generation,
+                            };
                         }
                     } else {
                         *state = TextureState::Unloaded {
@@ -95,7 +103,6 @@ impl<B: Backend> TextureSub<B> {
                         };
                     }
                 }
-                // Todo: cleanup long unused textures
                 _ => {}
             }
         }
@@ -127,7 +134,7 @@ impl<B: Backend> TextureSub<B> {
             set,
             generation: self.generation,
             version: *version,
-            handle: handle.clone(),
+            handle: handle.downgrade(),
             layout,
         })
     }
@@ -145,7 +152,8 @@ impl<B: Backend> TextureSub<B> {
 
         let id = self.lookup.forward(handle.id());
         match self.textures.get(id) {
-            Some(TextureState::Loaded { .. }) => {
+            // If handle is dead, new texture was loaded (handle id is reused)
+            Some(TextureState::Loaded { handle, .. }) if !handle.is_dead() => {
                 return Some((TextureId(id as u32), false));
             }
             Some(TextureState::Unloaded { generation }) if *generation == self.generation => {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [kc]: http://keepachangelog.com/
 [sv]: http://semver.org/
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed asset handle reuse bug in renderer. ([#2258])
+
+[#2258]: https://github.com/amethyst/amethyst/pull/2258
+
 
 ## [0.15.0] - 2020-03-24
 


### PR DESCRIPTION
## Description

Asset handle id is used as a unique identifier in renderer, however, handle ids can be reused and this causes renderer to use old assets. For example if `Material` is unloaded and new one is loaded with the same handle id, `MaterialSub` will not update sampler descriptors and old textures will be used.

To solve this, `WeakHandle` is used instead, which allows unloading of assets (`Handle` was previously used in `TextureSub` which prevented unloads) and checking if original asset is still present with `is_dead()`.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
