### PR TITLE
Corrected feature dependencies between member crates.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,9 @@ experimental-spirv-reflection = ["amethyst_rendy/experimental-spirv-reflection"]
 wasm = [
   "amethyst_assets/wasm",
   "amethyst_audio/wasm",
+  "amethyst_input/wasm",
   "amethyst_rendy/wasm",
+  "amethyst_ui/wasm",
   "amethyst_utils/wasm",
   "amethyst_window/wasm",
   "console_log",

--- a/amethyst_input/Cargo.toml
+++ b/amethyst_input/Cargo.toml
@@ -35,3 +35,4 @@ approx = "0.3"
 [features]
 profiler = [ "thread_profiler/thread_profiler" ]
 sdl_controller = ["sdl2"]
+wasm = ["amethyst_window/wasm", "winit/web-sys"]

--- a/amethyst_rendy/src/bundle.rs
+++ b/amethyst_rendy/src/bundle.rs
@@ -53,7 +53,7 @@ pub struct RenderingBundle<B: Backend> {
 impl<B: Backend> RenderingBundle<B> {
     /// Create empty `RenderingBundle`. You must register a plugin using
     /// [`with_plugin`] in order to actually display anything.
-    #[cfg(not(feature = "wasm"))]
+    #[cfg(all(not(feature = "wasm"), feature = "window"))]
     pub fn new(display_config: DisplayConfig, event_loop: &EventLoop<()>) -> Self {
         log::debug!("Intializing Rendy");
         let config: rendy::factory::Config = Default::default();
@@ -72,7 +72,7 @@ impl<B: Backend> RenderingBundle<B> {
 
     /// Create empty `RenderingBundle`. You must register a plugin using
     /// [`with_plugin`] in order to actually display anything.
-    #[cfg(feature = "wasm")]
+    #[cfg(all(feature = "wasm", feature = "window"))]
     pub fn new(
         display_config: DisplayConfig,
         event_loop: &EventLoop<()>,

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -53,3 +53,12 @@ empty = ["amethyst_rendy/empty"]
 
 profiler = [ "thread_profiler/thread_profiler" ]
 system_font = ["font-kit"]
+
+wasm = [
+  "amethyst_audio/wasm",
+  "amethyst_core/wasm",
+  "amethyst_window/wasm",
+  "amethyst_rendy/wasm",
+  "amethyst_rendy/window",
+  "winit/web-sys",
+]

--- a/amethyst_utils/Cargo.toml
+++ b/amethyst_utils/Cargo.toml
@@ -31,9 +31,10 @@ specs-hierarchy = { version = "0.6", default-features = false }
 thread_profiler = { version = "0.3", optional = true }
 
 [features]
+gl = ["amethyst_rendy/gl"]
 vulkan = ["amethyst_rendy/vulkan"]
 metal = ["amethyst_rendy/metal"]
 empty = ["amethyst_rendy/empty"]
 
-profiler = [ "thread_profiler/thread_profiler" ]
-wasm = [ ]
+profiler = ["thread_profiler/thread_profiler"]
+wasm = ["amethyst_window/wasm", "amethyst_rendy/wasm", "amethyst_rendy/window"]


### PR DESCRIPTION
## Description

This allows Rust API docs to build when running `cargo doc` in each crate with the relevant features.

Closes #2260.

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- **n/a** Ran `cargo +stable fmt --all`
- **n/a** Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
