### PR TITLE
Build docs with gitlab ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ before_script:
 prepare:
   stage: .pre
   only:
-    - build-docs-with-gitlab-ci
+    - master
   script:
     - cargo --version
     - rustc --version
@@ -39,7 +39,7 @@ prepare:
 docs:
   stage: build-docs
   only:
-    - build-docs-with-gitlab-ci
+    - master
   cache:
     key: docs-cache
     paths:
@@ -72,7 +72,7 @@ book:
   image: hrektts/mdbook:latest
   stage: build-docs
   only:
-    - build-docs-with-gitlab-ci
+    - master
   cache:
     key: book-cache
     paths:
@@ -104,7 +104,7 @@ deploy-docs:
   image: alpine:latest
   stage: deploy-docs
   only:
-    - build-docs-with-gitlab-ci
+    - master
   dependencies:
     - docs
     - book
@@ -170,7 +170,7 @@ invalidate-aws:
   image: frolvlad/alpine-glibc:latest
   stage: invalidate-aws
   only:
-    - build-docs-with-gitlab-ci
+    - master
   dependencies:
     - docs
     - book

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,7 +79,13 @@ book:
       - book-paths-updated
   script:
     # Install dependencies
-    - apt-get update && apt-get install git -y
+    - apt-get update && apt-get install git curl -y
+
+    # We need git lfs to clone all examples
+    # See https://github.com/git-lfs/git-lfs/wiki/Installation
+    - curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
+    - apt-get install git-lfs
+    - git lfs install
 
     # Build stable, master and wasm book
     - bash gitlab-ci-helper.sh build-book master book-public-master "/master/*"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ prepare:
 
     - if [[ -z "$TAG_STABLE" ]]; then echo "TAG_STABLE must be set!"; exit 1; fi;
     - if [[ -z "$TAG_LAST_STABLE" ]]; then echo "TAG_LAST_STABLE must be set!"; exit 1; fi;
-    - if [[ -z "$TAG_WASM" ]]; then echo "TAG_WASM must be set!"; exit 1; fi;
+    - if [[ -z "$BRANCH_WASM" ]]; then echo "BRANCH_WASM must be set!"; exit 1; fi;
 
     - if [[ -z "$DOCS_SERVER" ]]; then echo "DOCS_SERVER must be set!"; exit 1; fi;
     - if [[ -z "$DOCS_APP" ]]; then echo "DOCS_APP must be set!"; exit 1; fi;
@@ -94,6 +94,14 @@ deploy-docs:
   dependencies:
     - build-docs
   script:
+    - echo "Adding docs deploy SSH key..."
+
+    # See https://docs.gitlab.com/ee/ci/ssh_keys/
+    - eval $(ssh-agent -s)
+    - echo "$DOCS_SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add -
+    - mkdir -p ~/.ssh
+    - chmod 700 ~/.ssh
+
     - echo "Deploying docs..."
     - tar c build-docs | ssh dokku@${DOCS_SERVER} tar:in ${DOCS_APP}
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,9 @@ stages:
 
 default:
   before_script:
+    # See https://github.com/git-lfs/git-lfs/wiki/Installation
+    - curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
+    - apt-get install git-lfs
     - git lfs install
 
 prepare:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,6 @@ prepare:
     - rustc --version
 
     - if [[ -z "$TAG_STABLE" ]]; then echo "TAG_STABLE must be set!"; exit 1; fi;
-    - if [[ -z "$TAG_LAST_STABLE" ]]; then echo "TAG_LAST_STABLE must be set!"; exit 1; fi;
     - if [[ -z "$BRANCH_WASM" ]]; then echo "BRANCH_WASM must be set!"; exit 1; fi;
 
     - if [[ -z "$DOCS_SERVER" ]]; then echo "DOCS_SERVER must be set!"; exit 1; fi;
@@ -58,13 +57,6 @@ book:
     - mv book/book/* book-public/stable/
     - rm -rf book/book
 
-    - echo "Building last stable book ($TAG_LAST_STABLE)..."
-    - git checkout $TAG_LAST_STABLE
-    - mkdir book-public/last-stable
-    - ./cargo/bin/mdbook build book
-    - mv book/book/* book-public/last-stable/
-    - rm -rf book/book
-
     - touch book-public/.static
     - echo "/ amethyst" >> book-public/CHECKS
 
@@ -93,12 +85,6 @@ docs:
     - mkdir docs-public/stable
     - cargo doc --all --features="animation gltf vulkan"
     - cp -r target/doc/* docs-public/stable/
-
-    - echo "Building last stable docs ($TAG_LAST_STABLE)..."
-    - git checkout $TAG_LAST_STABLE
-    - mkdir docs-public/last-stable
-    - cargo doc --all --features="animation gltf vulkan"
-    - cp -r target/doc/* docs-public/last-stable/
 
     - touch docs-public/.static
     - echo "/ amethyst" >> docs-public/CHECKS

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,101 @@
+image: rust/latest
+
+variables:
+  CARGO_HOME: $CI_PROJECT_DIR/cargo
+  APT_CACHE_DIR: $CI_PROJECT_DIR/apt
+
+stages:
+  - build-docs
+  - deploy-docs
+
+prepare:
+  stage: .pre
+  only:
+    - master
+  script:
+    - cargo --version
+    - rustc --version
+
+    - if [[ -z "$TAG_STABLE" ]]; then echo "TAG_STABLE must be set!"; exit 1; fi;
+    - if [[ -z "$TAG_LAST_STABLE" ]]; then echo "TAG_LAST_STABLE must be set!"; exit 1; fi;
+    - if [[ -z "$TAG_WASM" ]]; then echo "TAG_WASM must be set!"; exit 1; fi;
+
+    - if [[ -z "$DOCS_SERVER" ]]; then echo "DOCS_SERVER must be set!"; exit 1; fi;
+    - if [[ -z "$DOCS_APP" ]]; then echo "DOCS_APP must be set!"; exit 1; fi;
+    - if [[ -z "$BOOK_APP" ]]; then echo "BOOK_APP must be set!"; exit 1; fi;
+
+book:
+  stage: build-docs
+  only:
+    - master
+  artifacts:
+    untracked: true
+  script:
+    - cargo install mdbook --no-default-features --features output --vers "^0.3.7"
+    - mdbook --version
+    - mkdir book-public
+
+    - echo "Building master book..."
+    - mkdir book-public/master
+    - mdbook build book
+    - mv book/book/* book-public/master/
+    - rm -rf book/book
+
+    - echo "Building stable book ($TAG_STABLE)..."
+    - git checkout $TAG_STABLE
+    - mkdir book-public/stable
+    - mdbook build book
+    - mv book/book/* book-public/stable/
+    - rm -rf book/book
+
+    - echo "Building last stable book ($TAG_LAST_STABLE)..."
+    - git checkout $TAG_LAST_STABLE
+    - mkdir book-public/last-stable
+    - mdbook build book
+    - mv book/book/* book-public/last-stable/
+    - rm -rf book/book
+
+    - touch book-public/.static
+    - echo "/ amethyst" >> book-public/CHECKS
+
+docs:
+  stage: build-docs
+  only:
+    - build-docs-with-gitlab-ci
+  artifacts:
+    untracked: true
+  script:
+    - mkdir docs-public
+
+    - echo "Building master docs..."
+    - mkdir docs-public/master
+    - cargo doc --all --features="animation gltf vulkan"
+    - cp -r target/doc/* docs-public/master/
+
+    - echo "Building stable docs ($TAG_STABLE)..."
+    - git checkout $TAG_STABLE
+    - mkdir docs-public/stable
+    - cargo doc --all --features="animation gltf vulkan"
+    - cp -r target/doc/* docs-public/stable/
+
+    - echo "Building last stable docs ($TAG_LAST_STABLE)..."
+    - git checkout $TAG_LAST_STABLE
+    - mkdir docs-public/last-stable
+    - cargo doc --all --features="animation gltf vulkan"
+    - cp -r target/doc/* docs-public/last-stable/
+
+    - touch docs-public/.static
+    - echo "/ amethyst" >> docs-public/CHECKS
+
+deploy-docs:
+  stage: deploy-docs
+  only:
+    - build-docs-with-gitlab-ci
+  dependencies:
+    - build-docs
+  script:
+    - echo "Deploying docs..."
+    - tar c build-docs | ssh dokku@${DOCS_SERVER} tar:in ${DOCS_APP}
+
+    - echo "Deploying book..."
+    - tar c build-book | ssh dokku@${DOCS_SERVER} tar:in ${BOOK_APP}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,30 +35,33 @@ book:
   stage: build-docs
   only:
     - build-docs-with-gitlab-ci
+  cache:
+    paths:
+      - cargo/
   artifacts:
     untracked: true
   script:
     - cargo install mdbook --no-default-features --features output --vers "^0.3.7"
-    - mdbook --version
+    - ./cargo/bin/mdbook --version
     - mkdir book-public
 
     - echo "Building master book..."
     - mkdir book-public/master
-    - mdbook build book
+    - ./cargo/bin/mdbook build book
     - mv book/book/* book-public/master/
     - rm -rf book/book
 
     - echo "Building stable book ($TAG_STABLE)..."
     - git checkout $TAG_STABLE
     - mkdir book-public/stable
-    - mdbook build book
+    - ./cargo/bin/mdbook build book
     - mv book/book/* book-public/stable/
     - rm -rf book/book
 
     - echo "Building last stable book ($TAG_LAST_STABLE)..."
     - git checkout $TAG_LAST_STABLE
     - mkdir book-public/last-stable
-    - mdbook build book
+    - ./cargo/bin/mdbook build book
     - mv book/book/* book-public/last-stable/
     - rm -rf book/book
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,19 +1,9 @@
 image: rust:latest
 
-variables:
-  CARGO_HOME: $CI_PROJECT_DIR/cargo
-  APT_CACHE_DIR: $CI_PROJECT_DIR/apt
-
 stages:
   - build-docs
   - deploy-docs
-
-default:
-  before_script:
-    # See https://github.com/git-lfs/git-lfs/wiki/Installation
-    - curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
-    - apt-get install git-lfs
-    - git lfs install
+  - invalidate-aws
 
 prepare:
   stage: .pre
@@ -23,6 +13,7 @@ prepare:
     - cargo --version
     - rustc --version
 
+    # Check if required deploy vars are set
     - if [[ -z "$TAG_STABLE" ]]; then echo "TAG_STABLE must be set!"; exit 1; fi;
     - if [[ -z "$BRANCH_WASM" ]]; then echo "BRANCH_WASM must be set!"; exit 1; fi;
 
@@ -30,63 +21,73 @@ prepare:
     - if [[ -z "$DOCS_APP" ]]; then echo "DOCS_APP must be set!"; exit 1; fi;
     - if [[ -z "$BOOK_APP" ]]; then echo "BOOK_APP must be set!"; exit 1; fi;
 
-book:
-  stage: build-docs
-  only:
-    - build-docs-with-gitlab-ci
-  cache:
-    paths:
-      - cargo/
-  artifacts:
-    untracked: true
-  script:
-    - cargo install mdbook --no-default-features --features output --vers "^0.3.7"
-    - ./cargo/bin/mdbook --version
-    - mkdir book-public
+# For the docs and book build, we output the built sites as artifacts and cache them.
+# A file containing the revision hash is output into the directory, so we can check
+# if we need to rebuild and redeploy. If we detect an existing cached version, we check
+# the revision and rebuild appropriately.
 
-    - echo "Building master book..."
-    - mkdir book-public/master
-    - ./cargo/bin/mdbook build book
-    - mv book/book/* book-public/master/
-    - rm -rf book/book
-
-    - echo "Building stable book ($TAG_STABLE)..."
-    - git checkout $TAG_STABLE
-    - mkdir book-public/stable
-    - ./cargo/bin/mdbook build book
-    - mv book/book/* book-public/stable/
-    - rm -rf book/book
-
-    - touch book-public/.static
-    - echo "/ amethyst" >> book-public/CHECKS
+# Additionally, we output the paths that were rebuilt into docs-paths-updated and
+# book-paths-updated, so that we can later trigger invalidations in cloudfront for
+# the relevant paths.
 
 docs:
   stage: build-docs
   only:
     - build-docs-with-gitlab-ci
+  cache:
+    key: docs-cache
+    paths:
+      - docs-public-master/
+      - docs-public-stable/
+      - docs-public-wasm/
   artifacts:
-    untracked: true
+    paths:
+      - docs-public-master/
+      - docs-public-stable/
+      - docs-public-wasm/
+      - docs-paths-updated
   script:
-    - echo "Installing dependencies..."
-    - apt-get update && apt-get install -y libasound2-dev libcurl4-openssl-dev libdw-dev libelf-dev libexpat1-dev libfreetype6-dev libiberty-dev libsdl2-dev libssl-dev libx11-xcb-dev libxcb1-dev && apt-get clean
+    # Install dependencies
 
-    - mkdir docs-public
+    # We need git lfs to clone all examples
+    # See https://github.com/git-lfs/git-lfs/wiki/Installation
+    - curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
+    - apt-get install git-lfs
+    - git lfs install
 
-    - echo "Building master docs..."
-    - mkdir docs-public/master
-    - cargo doc --all --features="animation gltf vulkan"
-    - cp -r target/doc/* docs-public/master/
+    # Build stable, master and wasm docs
+    - bash gitlab-ci-helper.sh build-docs master docs-public-master "/master/*"
+    - bash gitlab-ci-helper.sh build-docs $TAG_STABLE docs-public-stable "/stable/*"
+    - bash gitlab-ci-helper.sh build-docs-wasm $BRANCH_WASM docs-public-wasm "/wasm/*"
 
-    - echo "Building stable docs ($TAG_STABLE)..."
-    - git checkout $TAG_STABLE
-    - mkdir docs-public/stable
-    - cargo doc --all --features="animation gltf vulkan"
-    - cp -r target/doc/* docs-public/stable/
+book:
+  image: hrektts/mdbook:latest
+  stage: build-docs
+  only:
+    - build-docs-with-gitlab-ci
+  cache:
+    key: book-cache
+    paths:
+      - book-public-master/
+      - book-public-stable/
+      - book-public-wasm/
+  artifacts:
+    paths:
+      - book-public-master/
+      - book-public-stable/
+      - book-public-wasm/
+      - book-paths-updated
+  script:
+    # Install dependencies
+    - apt-get update && apt-get install git -y
 
-    - touch docs-public/.static
-    - echo "/ amethyst" >> docs-public/CHECKS
+    # Build stable, master and wasm book
+    - bash gitlab-ci-helper.sh build-book master book-public-master "/master/*"
+    - bash gitlab-ci-helper.sh build-book $TAG_STABLE book-public-stable "/stable/*"
+    - bash gitlab-ci-helper.sh build-book $BRANCH_WASM book-public-wasm "/wasm/*"
 
 deploy-docs:
+  image: alpine:latest
   stage: deploy-docs
   only:
     - build-docs-with-gitlab-ci
@@ -94,16 +95,79 @@ deploy-docs:
     - docs
     - book
   script:
+    # Install dependencies
+    - apk update && apk add --no-cache bash git openssh ca-certificates
     - echo "Adding docs deploy SSH key..."
 
+    # Add the key for dokku deployment and set permissions
     # See https://docs.gitlab.com/ee/ci/ssh_keys/
     - eval $(ssh-agent -s)
     - echo "$DOCS_SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add -
     - mkdir -p ~/.ssh
     - chmod 700 ~/.ssh
 
+    # These are the folders we'll package and deploy as tarballs
+    - mkdir docs-public && mkdir book-public
+
+    # Move our static files, mark the directory as the root directory
+    # by creating .static and copy our custom nginx config
+    - mv docs-public-stable docs-public/stable
+    - mv docs-public-master docs-public/master
+    - mv docs-public-wasm docs-public/wasm
+    - touch docs-public/.static
+    - cp docs-nginx.conf.sigil docs-public/app-nginx.conf.sigil
+
+    # Check if the index file contains the package name to validate the deployment
+    - echo "/stable/amethyst/ amethyst" >> docs-public/CHECKS
+    - echo "/master/amethyst/ amethyst" >> docs-public/CHECKS
+    - echo "/wasm/amethyst/ amethyst" >> docs-public/CHECKS
+
+    # Check if the revision file contains the revisions we just deployed
+    - echo "/master/.rev $(cat docs-public/master/.rev)" >> docs-public/CHECKS
+    - echo "/stable/.rev $(cat docs-public/stable/.rev)" >> docs-public/CHECKS
+    - echo "/wasm/.rev $(cat docs-public/wasm/.rev)" >> docs-public/CHECKS
+
+    # Move our static files, mark the directory as the root directory
+    # by creating .static and copy our custom nginx config
+    - mv book-public-stable book-public/stable
+    - mv book-public-master book-public/master
+    - mv book-public-wasm book-public/wasm
+    - touch book-public/.static
+    - cp docs-nginx.conf.sigil book-public/app-nginx.conf.sigil
+
+    # Check if the index file contains the package name to validate the deployment
+    - echo "/stable/ Amethyst" >> book-public/CHECKS
+    - echo "/master/ Amethyst" >> book-public/CHECKS
+    - echo "/wasm/ Amethyst" >> book-public/CHECKS
+
+    # Check if the revision file contains the revisions we just deployed
+    - echo "/master/.rev $(cat book-public/master/.rev)" >> book-public/CHECKS
+    - echo "/stable/.rev $(cat book-public/stable/.rev)" >> book-public/CHECKS
+    - echo "/wasm/.rev $(cat book-public/wasm/.rev)" >> book-public/CHECKS
+
+    # Deploy!
     - echo "Deploying docs..."
     - tar c docs-public | ssh -o StrictHostKeyChecking=no dokku@${DOCS_SERVER} tar:in ${DOCS_APP}
 
     - echo "Deploying book..."
     - tar c book-public | ssh -o StrictHostKeyChecking=no dokku@${DOCS_SERVER} tar:in ${BOOK_APP}
+
+invalidate-aws:
+  image: frolvlad/alpine-glibc:latest
+  stage: invalidate-aws
+  only:
+    - build-docs-with-gitlab-ci
+  dependencies:
+    - docs
+    - book
+    - deploy-docs
+  script:
+    # Install dependencies
+    - apk update && apk add --no-cache bash curl ca-certificates unzip
+    - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+    - unzip -qq awscliv2.zip
+    - ./aws/install
+    - /usr/local/bin/aws --version
+
+    # Create invalidations for changed paths
+    - bash gitlab-ci-helper.sh invalidate-aws

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,7 +92,8 @@ deploy-docs:
   only:
     - build-docs-with-gitlab-ci
   dependencies:
-    - build-docs
+    - docs
+    - book
   script:
     - echo "Adding docs deploy SSH key..."
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,7 +103,7 @@ deploy-docs:
     - chmod 700 ~/.ssh
 
     - echo "Deploying docs..."
-    - tar c docs-public | ssh dokku@${DOCS_SERVER} tar:in ${DOCS_APP}
+    - tar c docs-public | ssh -o StrictHostKeyChecking=no dokku@${DOCS_SERVER} tar:in ${DOCS_APP}
 
     - echo "Deploying book..."
-    - tar c book-public | ssh dokku@${DOCS_SERVER} tar:in ${BOOK_APP}
+    - tar c book-public | ssh -o StrictHostKeyChecking=no dokku@${DOCS_SERVER} tar:in ${BOOK_APP}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,9 +66,6 @@ docs:
     - build-docs-with-gitlab-ci
   artifacts:
     untracked: true
-  cache:
-    paths:
-      - target/
   script:
     - echo "Installing dependencies..."
     - apt-get update && apt-get install -y libasound2-dev libcurl4-openssl-dev libdw-dev libelf-dev libexpat1-dev libfreetype6-dev libiberty-dev libsdl2-dev libssl-dev libx11-xcb-dev libxcb1-dev && apt-get clean

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: rust/latest
+image: rust:latest
 
 variables:
   CARGO_HOME: $CI_PROJECT_DIR/cargo

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,6 +65,9 @@ docs:
   artifacts:
     untracked: true
   script:
+    - echo "Installing dependencies..."
+    - apt-get update && apt-get install -y libasound2-dev libcurl4-openssl-dev libdw-dev libelf-dev libexpat1-dev libfreetype6-dev libiberty-dev libsdl2-dev libssl-dev libx11-xcb-dev libxcb1-dev && apt-get clean
+
     - mkdir docs-public
 
     - echo "Building master docs..."

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -139,7 +139,7 @@ deploy-docs:
     # Check if the revision file contains the revisions we just deployed
     - echo "/master/.rev $(cat docs-public/master/.rev)" >> docs-public/CHECKS
     - echo "/stable/.rev $(cat docs-public/stable/.rev)" >> docs-public/CHECKS
-    - echo "/wasm/.rev $(cat docs-public/wasm/.rev)" >> docs-public/CHECKS
+    # - echo "/wasm/.rev $(cat docs-public/wasm/.rev)" >> docs-public/CHECKS
 
     # Move our static files, mark the directory as the root directory
     # by creating .static and copy our custom nginx config
@@ -157,7 +157,7 @@ deploy-docs:
     # Check if the revision file contains the revisions we just deployed
     - echo "/master/.rev $(cat book-public/master/.rev)" >> book-public/CHECKS
     - echo "/stable/.rev $(cat book-public/stable/.rev)" >> book-public/CHECKS
-    - echo "/wasm/.rev $(cat book-public/wasm/.rev)" >> book-public/CHECKS
+    # - echo "/wasm/.rev $(cat book-public/wasm/.rev)" >> book-public/CHECKS
 
     # Deploy!
     - echo "Deploying docs..."

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,12 @@ stages:
   - deploy-docs
   - invalidate-aws
 
+before_script:
+  # We need to make a copy of the script, in case we
+  # checkout a branch somewhere that doesn't contain it
+  - cp gitlab-ci-helper.sh .gitlab-ci-helper.sh
+  - chmod +x .gitlab-ci-helper.sh
+
 prepare:
   stage: .pre
   only:
@@ -55,10 +61,12 @@ docs:
     - apt-get install git-lfs
     - git lfs install
 
+    - apt-get update && apt-get install -y libasound2-dev libcurl4-openssl-dev libdw-dev libelf-dev libexpat1-dev libfreetype6-dev libiberty-dev libsdl2-dev libssl-dev libx11-xcb-dev libxcb1-dev && apt-get clean
+
     # Build stable, master and wasm docs
-    - bash gitlab-ci-helper.sh build-docs master docs-public-master "/master/*"
-    - bash gitlab-ci-helper.sh build-docs $TAG_STABLE docs-public-stable "/stable/*"
-    - bash gitlab-ci-helper.sh build-docs-wasm $BRANCH_WASM docs-public-wasm "/wasm/*"
+    - ./.gitlab-ci-helper.sh build-docs master docs-public-master "/master/*"
+    - ./.gitlab-ci-helper.sh build-docs $TAG_STABLE docs-public-stable "/stable/*"
+    - ./.gitlab-ci-helper.sh build-docs-wasm $BRANCH_WASM docs-public-wasm "/wasm/*"
 
 book:
   image: hrektts/mdbook:latest
@@ -88,9 +96,9 @@ book:
     - git lfs install
 
     # Build stable, master and wasm book
-    - bash gitlab-ci-helper.sh build-book master book-public-master "/master/*"
-    - bash gitlab-ci-helper.sh build-book $TAG_STABLE book-public-stable "/stable/*"
-    - bash gitlab-ci-helper.sh build-book $BRANCH_WASM book-public-wasm "/wasm/*"
+    - ./.gitlab-ci-helper.sh build-book master book-public-master "/master/*"
+    - ./.gitlab-ci-helper.sh build-book $TAG_STABLE book-public-stable "/stable/*"
+    - ./.gitlab-ci-helper.sh build-book $BRANCH_WASM book-public-wasm "/wasm/*"
 
 deploy-docs:
   image: alpine:latest
@@ -176,4 +184,4 @@ invalidate-aws:
     - /usr/local/bin/aws --version
 
     # Create invalidations for changed paths
-    - bash gitlab-ci-helper.sh invalidate-aws
+    - ./.gitlab-ci-helper.sh invalidate-aws

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,7 +103,7 @@ deploy-docs:
     - chmod 700 ~/.ssh
 
     - echo "Deploying docs..."
-    - tar c build-docs | ssh dokku@${DOCS_SERVER} tar:in ${DOCS_APP}
+    - tar c docs-public | ssh dokku@${DOCS_SERVER} tar:in ${DOCS_APP}
 
     - echo "Deploying book..."
-    - tar c build-book | ssh dokku@${DOCS_SERVER} tar:in ${BOOK_APP}
+    - tar c book-public | ssh dokku@${DOCS_SERVER} tar:in ${BOOK_APP}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -134,7 +134,7 @@ deploy-docs:
     # Check if the index file contains the package name to validate the deployment
     - echo "/stable/amethyst/ amethyst" >> docs-public/CHECKS
     - echo "/master/amethyst/ amethyst" >> docs-public/CHECKS
-    - echo "/wasm/amethyst/ amethyst" >> docs-public/CHECKS
+    # - echo "/wasm/amethyst/ amethyst" >> docs-public/CHECKS
 
     # Check if the revision file contains the revisions we just deployed
     - echo "/master/.rev $(cat docs-public/master/.rev)" >> docs-public/CHECKS
@@ -152,7 +152,7 @@ deploy-docs:
     # Check if the index file contains the package name to validate the deployment
     - echo "/stable/ Amethyst" >> book-public/CHECKS
     - echo "/master/ Amethyst" >> book-public/CHECKS
-    - echo "/wasm/ Amethyst" >> book-public/CHECKS
+    # - echo "/wasm/ Amethyst" >> book-public/CHECKS
 
     # Check if the revision file contains the revisions we just deployed
     - echo "/master/.rev $(cat book-public/master/.rev)" >> book-public/CHECKS

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,10 +8,14 @@ stages:
   - build-docs
   - deploy-docs
 
+default:
+  before_script:
+    - git lfs install
+
 prepare:
   stage: .pre
   only:
-    - master
+    - build-docs-with-gitlab-ci
   script:
     - cargo --version
     - rustc --version
@@ -27,7 +31,7 @@ prepare:
 book:
   stage: build-docs
   only:
-    - master
+    - build-docs-with-gitlab-ci
   artifacts:
     untracked: true
   script:
@@ -64,6 +68,9 @@ docs:
     - build-docs-with-gitlab-ci
   artifacts:
     untracked: true
+  cache:
+    paths:
+      - target/
   script:
     - echo "Installing dependencies..."
     - apt-get update && apt-get install -y libasound2-dev libcurl4-openssl-dev libdw-dev libelf-dev libexpat1-dev libfreetype6-dev libiberty-dev libsdl2-dev libssl-dev libx11-xcb-dev libxcb1-dev && apt-get clean

--- a/docs-nginx.conf.sigil
+++ b/docs-nginx.conf.sigil
@@ -1,0 +1,43 @@
+worker_processes 1;
+error_log stderr;
+pid nginx.pid;
+daemon off;
+
+events {
+  worker_connections 768;
+}
+
+http {
+  types_hash_max_size 2048;
+  include mime.types;
+  server {
+    listen {{ $.PORT }};
+    server_name  _;
+    root /app/www;
+    index index.html;
+    port_in_redirect off;
+
+    location = / {
+      return 301 /master;
+    }
+
+    location = /master/.rev {
+      types {}
+      default_type text/plain;
+    }
+
+    location = /stable/.rev {
+      types {}
+      default_type text/plain;
+    }
+    
+    location = /wasm/.rev {
+      types {}
+      default_type text/plain;
+    }
+
+    location / {
+      try_files $uri $uri/ /index.html;
+    }
+  }
+}

--- a/docs-nginx.conf.sigil
+++ b/docs-nginx.conf.sigil
@@ -18,7 +18,7 @@ http {
     port_in_redirect off;
 
     location = / {
-      return 301 /master;
+      return 301 /master/;
     }
 
     location = /master/.rev {

--- a/gitlab-ci-helper.sh
+++ b/gitlab-ci-helper.sh
@@ -16,7 +16,7 @@ function build_book {
   HEAD_REV=$(git rev-parse HEAD)
 
   # Check if the existing ref matches
-  if test "$(cat ${DIR}/.rev || '')" = "$HEAD_REV"; then
+  if [[ "$(cat ${DIR}/.rev)" = "$HEAD_REV" ]]; then
     echo "Cached book build for $REF found in $DIR!"
     exit 0
   fi
@@ -48,7 +48,7 @@ function build_docs_wasm {
   HEAD_REV=$(git rev-parse HEAD)
 
   # Check if the existing ref matches
-  if [[ "$(cat ${DIR}/.rev || '')" = "$HEAD_REV" ]]; then
+  if [[ "$(cat ${DIR}/.rev)" = "$HEAD_REV" ]]; then
     echo "Cached docs build for $REF found in $DIR!"
     exit 0
   fi

--- a/gitlab-ci-helper.sh
+++ b/gitlab-ci-helper.sh
@@ -16,7 +16,7 @@ function build_book {
   HEAD_REV=$(git rev-parse HEAD)
 
   # Check if the existing ref matches
-  if [[ "$(cat ${DIR}/.rev)" = "$HEAD_REV" ]]; then
+  if [[ "$(cat ${DIR}/.rev 2>/dev/null || echo '')" = "$HEAD_REV" ]]; then
     echo "Cached book build for $REF found in $DIR!"
     exit 0
   fi

--- a/gitlab-ci-helper.sh
+++ b/gitlab-ci-helper.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+set -euxo pipefail
+
+function build_book {
+  if [[ -z "$1" ]] || [[ -z "$2" ]] || [[ -z "$3" ]]; then
+    echo "Usage: build-book REF DIR INVALIDATION_PATH"
+    exit 1
+  fi
+
+  REF=$1
+  DIR=$2
+  INVALIDATION_PATH=$3
+
+  # Checkout the ref we were given
+  git checkout -q $REF
+  HEAD_REV=$(git rev-parse HEAD)
+
+  # Check if the existing ref matches
+  if test "$(cat ${DIR}/.rev)" = "$HEAD_REV"; then
+    echo "Cached book build for $REF found in $DIR!"
+    exit 0
+  fi
+
+  rm -rf $DIR
+  mkdir -p $DIR
+  echo "Building book for $REF..."
+  mdbook build book -d "../$DIR"
+
+  # Write the newly built rev to the rev file
+  echo "$HEAD_REV" >> $DIR/.rev
+
+  # Write the invalidation path since we just rebuilt
+  echo "$INVALIDATION_PATH" >> ./book-paths-updated
+}
+
+function build_docs_wasm {
+  if [[ -z "$1" ]] || [[ -z "$2" ]] || [[ -z "$3" ]]; then
+    echo "Usage: build-book REF DIR INVALIDATION_PATH"
+    exit 1
+  fi
+
+  REF=$1
+  DIR=$2
+  INVALIDATION_PATH=$3
+
+  # Checkout the ref we were given
+  git checkout -q $REF
+  HEAD_REV=$(git rev-parse HEAD)
+
+  # Check if the existing ref matches
+  if [[ "$(cat ${DIR}/.rev)" = "$HEAD_REV" ]]; then
+    echo "Cached docs build for $REF found in $DIR!"
+    exit 0
+  fi
+
+  rm -rf $DIR
+  mkdir -p $DIR
+  echo "Building wasm docs for $REF..."
+
+  # TODO: build wasm branch here
+  # cargo doc --all --features="animation gltf vulkan"
+
+  # taken from run.sh for future reference:
+  # # (cd amethyst_animation && cargo doc --no-deps)
+  # (cd amethyst_assets && cargo doc --target wasm32-unknown-unknown --features="wasm" --no-deps)
+  # (cd amethyst_audio && cargo doc --target wasm32-unknown-unknown --no-default-features --features="wasm vorbis wav" --no-deps)
+  # (cd amethyst_config && cargo doc --target wasm32-unknown-unknown --no-deps)
+  # (cd amethyst_controls && cargo doc --target wasm32-unknown-unknown --features="wasm" --no-deps)
+  # (cd amethyst_core && cargo doc --target wasm32-unknown-unknown --no-default-features --features="wasm" --no-deps)
+  # (cd amethyst_derive && cargo doc --target wasm32-unknown-unknown --no-deps)
+  # (cd amethyst_error && cargo doc --target wasm32-unknown-unknown --no-deps)
+  # # (cd amethyst_gltf && cargo doc --no-deps)
+  # # (cd amethyst_input && cargo doc --target wasm32-unknown-unknown --features="wasm" --no-deps)
+  # # (cd amethyst_locale && cargo doc --no-deps)
+  # (cd amethyst_network && cargo doc --target wasm32-unknown-unknown --features="web_socket" --no-deps)
+  # (cd amethyst_rendy && cargo doc --target wasm32-unknown-unknown --features="wasm gl" --no-deps)
+  # # (cd amethyst_test && cargo doc --features="wasm gl web_socket" --no-deps)
+  # # (cd amethyst_tiles && cargo doc --features="wasm gl web_socket" --no-deps)
+  # # (cd amethyst_ui && cargo doc --target wasm32-unknown-unknown --no-default-features --features="gl wasm" --no-deps)
+  # # (cd amethyst_utils && cargo doc --target wasm32-unknown-unknown --no-default-features --features="wasm" --no-deps)
+  # (cd amethyst_window && cargo doc --target wasm32-unknown-unknown --no-default-features --features="wasm" --no-deps)
+  # cargo doc --target wasm32-unknown-unknown --no-default-features --features="audio network renderer wasm vorbis wav gl web_socket" --no-deps
+  # cd ..
+
+  mv target/doc/* $DIR/
+
+  # Write the newly built rev to the rev file
+  echo "$HEAD_REV" >> $DIR/.rev
+
+  # Write the invalidation path since we just rebuilt
+  echo "$INVALIDATION_PATH" >> ./docs-paths-updated
+}
+
+function build_docs {
+  if [[ -z "$1" ]] || [[ -z "$2" ]] || [[ -z "$3" ]]; then
+    echo "Usage: build-book REF DIR INVALIDATION_PATH"
+    exit 1
+  fi
+
+  REF=$1
+  DIR=$2
+  INVALIDATION_PATH=$3
+
+  # Checkout the ref we were given
+  git checkout -q $REF
+  HEAD_REV=$(git rev-parse HEAD)
+
+  # Check if the existing ref matches
+  if [[ "$(cat ${DIR}/.rev)" = "$HEAD_REV" ]]; then
+    echo "Cached docs build for $REF found in $DIR!"
+    exit 0
+  fi
+
+  rm -rf $DIR
+  mkdir -p $DIR
+  echo "Building docs for $REF..."
+  cargo doc --all --features="animation gltf vulkan"
+  mv target/doc/* $DIR/
+
+  # Write the newly built rev to the rev file
+  echo "$HEAD_REV" >> $DIR/.rev
+
+  # Write the invalidation path since we just rebuilt
+  echo "$INVALIDATION_PATH" >> ./docs-paths-updated
+}
+
+function invalidate_aws {
+  # Check if there are any updated docs paths
+  if [[ -f "docs-paths-updated" ]]; then
+    echo "Invalidating docs paths..."
+    if [[ -z "$AWS_DOCS_DISTRIBUTION_ID" ]]; then
+      echo "AWS_DOCS_DISTRIBUTION_ID must be set"
+      exit 1
+    fi
+
+    # Loop through updated docs paths and create an invalidation for each
+    while read p; do
+      echo "Creating invalidation for docs path $p"
+      /usr/local/bin/aws cloudfront create-invalidation \
+        --distribution-id "$AWS_DOCS_DISTRIBUTION_ID" \
+        --paths "$p"
+    done < docs-paths-updated
+  fi
+
+  # Check if there are any updated book paths
+  if [[ -f "book-paths-updated" ]]; then
+    echo "Invalidating book paths..."
+    if [[ -z "$AWS_BOOK_DISTRIBUTION_ID" ]]; then
+      echo "AWS_BOOK_DISTRIBUTION_ID must be set"
+      exit 1
+    fi
+
+    # Loop through updated book paths and create an invalidation for each
+    while read p; do
+      echo "Creating invalidation for book path $p"
+      /usr/local/bin/aws cloudfront create-invalidation \
+        --distribution-id "$AWS_BOOK_DISTRIBUTION_ID" \
+        --paths "$p"
+    done < book-paths-updated
+  fi
+}
+
+SUBCOMMAND=$1
+case $SUBCOMMAND in
+  "build-docs")
+    build_docs $2 $3 $4
+    ;;
+  "build-docs-wasm")
+    build_docs_wasm $2 $3 $4
+  "build-book")
+    build_book $2 $3 $4
+    ;;
+  "invalidate-aws")
+    invalidate_aws
+    ;;
+  *)
+    shift
+    echo "Usage: gitlab-ci-helper (build-book|build-docs|build-docs-wasm|invalidate-aws) [ARGS...]"
+esac

--- a/gitlab-ci-helper.sh
+++ b/gitlab-ci-helper.sh
@@ -16,7 +16,7 @@ function build_book {
   HEAD_REV=$(git rev-parse HEAD)
 
   # Check if the existing ref matches
-  if test "$(cat ${DIR}/.rev)" = "$HEAD_REV"; then
+  if test "$(cat ${DIR}/.rev || '')" = "$HEAD_REV"; then
     echo "Cached book build for $REF found in $DIR!"
     exit 0
   fi
@@ -48,7 +48,7 @@ function build_docs_wasm {
   HEAD_REV=$(git rev-parse HEAD)
 
   # Check if the existing ref matches
-  if [[ "$(cat ${DIR}/.rev)" = "$HEAD_REV" ]]; then
+  if [[ "$(cat ${DIR}/.rev || '')" = "$HEAD_REV" ]]; then
     echo "Cached docs build for $REF found in $DIR!"
     exit 0
   fi

--- a/gitlab-ci-helper.sh
+++ b/gitlab-ci-helper.sh
@@ -2,7 +2,7 @@
 set -euxo pipefail
 
 function build_book {
-  if [[ -z "$1" ]] || [[ -z "$2" ]] || [[ -z "$3" ]]; then
+  if [[ -z "$1" || -z "$2" || -z "$3" ]]; then
     echo "Usage: build-book REF DIR INVALIDATION_PATH"
     exit 1
   fi
@@ -16,7 +16,7 @@ function build_book {
   HEAD_REV=$(git rev-parse HEAD)
 
   # Check if the existing ref matches
-  if [[ "$(cat ${DIR}/.rev 2>/dev/null || echo '')" = "$HEAD_REV" ]]; then
+  if [[ -f "$DIR" && -f "${DIR}/.rev" && "$(cat ${DIR}/.rev)" = "$HEAD_REV" ]]; then
     echo "Cached book build for $REF found in $DIR!"
     exit 0
   fi
@@ -34,7 +34,7 @@ function build_book {
 }
 
 function build_docs_wasm {
-  if [[ -z "$1" ]] || [[ -z "$2" ]] || [[ -z "$3" ]]; then
+  if [[ -z "$1" || -z "$2" || -z "$3" ]]; then
     echo "Usage: build-book REF DIR INVALIDATION_PATH"
     exit 1
   fi
@@ -48,8 +48,7 @@ function build_docs_wasm {
   HEAD_REV=$(git rev-parse HEAD)
 
   # Check if the existing ref matches
-
-  if [[ "$(cat ${DIR}/.rev 2>/dev/null || echo '')" = "$HEAD_REV" ]]; then
+  if [[ -f "$DIR" && -f "${DIR}/.rev" && "$(cat ${DIR}/.rev)" = "$HEAD_REV" ]]; then
     echo "Cached docs build for $REF found in $DIR!"
     exit 0
   fi
@@ -93,7 +92,7 @@ function build_docs_wasm {
 }
 
 function build_docs {
-  if [[ -z "$1" ]] || [[ -z "$2" ]] || [[ -z "$3" ]]; then
+  if [[ -z "$1" || -z "$2" || -z "$3" ]]; then
     echo "Usage: build-book REF DIR INVALIDATION_PATH"
     exit 1
   fi
@@ -107,7 +106,7 @@ function build_docs {
   HEAD_REV=$(git rev-parse HEAD)
 
   # Check if the existing ref matches
-  if [[ "$(cat ${DIR}/.rev 2>/dev/null || echo '')" = "$HEAD_REV" ]]; then
+  if [[ -f "$DIR" && -f "${DIR}/.rev" && "$(cat ${DIR}/.rev)" = "$HEAD_REV" ]]; then
     echo "Cached docs build for $REF found in $DIR!"
     exit 0
   fi

--- a/gitlab-ci-helper.sh
+++ b/gitlab-ci-helper.sh
@@ -48,7 +48,8 @@ function build_docs_wasm {
   HEAD_REV=$(git rev-parse HEAD)
 
   # Check if the existing ref matches
-  if [[ "$(cat ${DIR}/.rev)" = "$HEAD_REV" ]]; then
+
+  if [[ "$(cat ${DIR}/.rev 2>/dev/null || echo '')" = "$HEAD_REV" ]]; then
     echo "Cached docs build for $REF found in $DIR!"
     exit 0
   fi
@@ -106,7 +107,7 @@ function build_docs {
   HEAD_REV=$(git rev-parse HEAD)
 
   # Check if the existing ref matches
-  if [[ "$(cat ${DIR}/.rev)" = "$HEAD_REV" ]]; then
+  if [[ "$(cat ${DIR}/.rev 2>/dev/null || echo '')" = "$HEAD_REV" ]]; then
     echo "Cached docs build for $REF found in $DIR!"
     exit 0
   fi

--- a/gitlab-ci-helper.sh
+++ b/gitlab-ci-helper.sh
@@ -167,6 +167,7 @@ case $SUBCOMMAND in
     ;;
   "build-docs-wasm")
     build_docs_wasm $2 $3 $4
+    ;;
   "build-book")
     build_book $2 $3 $4
     ;;

--- a/gitlab-ci-helper.sh
+++ b/gitlab-ci-helper.sh
@@ -82,13 +82,13 @@ function build_docs_wasm {
   # cargo doc --target wasm32-unknown-unknown --no-default-features --features="audio network renderer wasm vorbis wav gl web_socket" --no-deps
   # cd ..
 
-  mv target/doc/* $DIR/
+  # mv target/doc/* $DIR/
 
   # Write the newly built rev to the rev file
-  echo "$HEAD_REV" >> $DIR/.rev
+  # echo "$HEAD_REV" >> $DIR/.rev
 
   # Write the invalidation path since we just rebuilt
-  echo "$INVALIDATION_PATH" >> ./docs-paths-updated
+  # echo "$INVALIDATION_PATH" >> ./docs-paths-updated
 }
 
 function build_docs {


### PR DESCRIPTION
## Description

This PR will move over the build process for the docs and the book to GitLab CI. This way, we'll have more insight into when and why the build process fails, and the entire process can be more transparent and straightforward.

No changes to any engine code are made in this PR.