### PR TITLE
Make Shape::upload take reference to ShapeUpload

### DIFF
--- a/amethyst_rendy/src/shape.rs
+++ b/amethyst_rendy/src/shape.rs
@@ -170,7 +170,7 @@ impl Shape {
     pub fn upload<V, P>(
         &self,
         scale: Option<(f32, f32, f32)>,
-        upload: ShapeUpload<'_>,
+        upload: &ShapeUpload<'_>,
         progress: P,
     ) -> Handle<Mesh>
     where

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- `amethyst_rendy::shape::Shape::upload` takes `&ShapeUpload`. ([#2264])
+
 ### Fixed
 
 - Corrected an issue where fixed updates were tied to time scale. ([#2254])

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 [#2254]: https://github.com/amethyst/amethyst/issues/2254
 [#2258]: https://github.com/amethyst/amethyst/pull/2258
+[#2264]: https://github.com/amethyst/amethyst/pull/2264
 
 
 ## [0.15.0] - 2020-03-24


### PR DESCRIPTION
## Description

Closes #2263 

## Additions

- Detail API additions here if any
- Do not list changes or removals

## Modifications

- `amethyst_rendy::shape::Shape::upload` will take `&ShapeUpload` instead of `ShapeUpload`

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] ~~Added unit tests for new code added in this PR.~~
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
