### PR TITLE
Move footnotes into links at appropriate places in text

### DIFF
--- a/book/src/prefabs/how_to_define_prefabs_simple.md
+++ b/book/src/prefabs/how_to_define_prefabs_simple.md
@@ -1,6 +1,6 @@
 # How to Define Prefabs: Simple
 
-This guide explains how to enable a [`Component`] to be used in a [`Prefab`]. This can be applied where the [`Component`] type itself is completely serializable &ndash; the data is self-contained:
+This guide explains how to enable a [[`Component`](https://docs.amethyst.rs/stable/specs/trait.Component.html)] to be used in a [[`Prefab`](https://docs.amethyst.rs/stable/amethyst_assets/struct.Prefab.html)]. This can be applied where the [[`Component`](https://docs.amethyst.rs/stable/specs/trait.Component.html)] type itself is completely serializable &ndash; the data is self-contained:
 
 ```rust,no_run,noplaypen
 # extern crate amethyst;
@@ -72,11 +72,11 @@ If you are attempting to adapt a more complex type, please choose the appropriat
     pub struct Position(pub f32, pub f32, pub f32);
     ```
 
-    The [`PrefabData`][api_pf_derive] derive implements the [`PrefabData`] trait for the type. The `#[prefab(Component)]` attribute informs the [`PrefabData`] derive that this type is a [`Component`], as opposed to being composed of fields which implement [`PrefabData`].
+    The [[`PrefabData`](https://docs.amethyst.rs/stable/amethyst_assets/trait.PrefabData.html#impl-PrefabData)][api_pf_derive](https://docs.amethyst.rs/stable/amethyst_derive/derive.PrefabData.html) derive implements the [`PrefabData`] trait for the type. The `#[prefab(Component)]` attribute informs the [`PrefabData`] derive that this type is a [[`Component`](https://docs.amethyst.rs/stable/specs/trait.Component.html)], as opposed to being composed of fields which implement [`PrefabData`].
 
-    The [`#[serde(default)]`] attribute allows fields to not be specified in the prefab, and the fields' default value will be used. If this attribute is not present, then all fields must be specified in the prefab.
+    The [[`#[serde(default)]`](https://serde.rs/container-attrs.html#default)] attribute allows fields to not be specified in the prefab, and the fields' default value will be used. If this attribute is not present, then all fields must be specified in the prefab.
 
-    Finally, the [`#[serde(deny_unknown_fields)]`] ensures that deserialization produces an error if it encounters an unknown field. This will help expose mistakes in the prefab file, such as when there is a typo.
+    Finally, the [[`#[serde(deny_unknown_fields)]`](https://serde.rs/container-attrs.html#deny_unknown_fields)] ensures that deserialization produces an error if it encounters an unknown field. This will help expose mistakes in the prefab file, such as when there is a typo.
 
 4. Now the type can be used in a prefab:
 
@@ -91,17 +91,8 @@ If you are attempting to adapt a more complex type, please choose the appropriat
     )
     ```
 
-To see this in a complete example, run the [`prefab_basic` example][repo_prefab_basic] from the Amethyst repository:
+To see this in a complete example, run the [`prefab_basic` example](https://github.com/amethyst/amethyst/tree/master/examples/prefab_basic) from the Amethyst repository:
 
 ```bash
 cargo run --example prefab_basic
 ```
-
-[`#[serde(default)]`]: https://serde.rs/container-attrs.html#default
-[`#[serde(deny_unknown_fields)]`]: https://serde.rs/container-attrs.html#deny_unknown_fields
-[`Component`]: https://docs.amethyst.rs/stable/specs/trait.Component.html
-[`Prefab`]: https://docs.amethyst.rs/stable/amethyst_assets/struct.Prefab.html
-[`PrefabData`]: https://docs.amethyst.rs/stable/amethyst_assets/trait.PrefabData.html#impl-PrefabData%3C%27a%3E
-[api_pf_derive]: https://docs.amethyst.rs/stable/amethyst_derive/derive.PrefabData.html
-[bk_prefab_prelude]: how_to_define_prefabs_prelude.html
-[repo_prefab_basic]: https://github.com/amethyst/amethyst/tree/master/examples/prefab_basic

--- a/book/src/prefabs/how_to_define_prefabs_simple.md
+++ b/book/src/prefabs/how_to_define_prefabs_simple.md
@@ -1,6 +1,6 @@
 # How to Define Prefabs: Simple
 
-This guide explains how to enable a [[`Component`](https://docs.amethyst.rs/stable/specs/trait.Component.html)] to be used in a [[`Prefab`](https://docs.amethyst.rs/stable/amethyst_assets/struct.Prefab.html)]. This can be applied where the [[`Component`](https://docs.amethyst.rs/stable/specs/trait.Component.html)] type itself is completely serializable &ndash; the data is self-contained:
+This guide explains how to enable a [`[Component]`(https://docs.amethyst.rs/stable/specs/trait.Component.html)] to be used in a [`[Prefab]`(https://docs.amethyst.rs/stable/amethyst_assets/struct.Prefab.html)]. This can be applied where the [`[Component]`(https://docs.amethyst.rs/stable/specs/trait.Component.html)] type itself is completely serializable &ndash; the data is self-contained:
 
 ```rust,no_run,noplaypen
 # extern crate amethyst;
@@ -72,7 +72,7 @@ If you are attempting to adapt a more complex type, please choose the appropriat
     pub struct Position(pub f32, pub f32, pub f32);
     ```
 
-    The [[`PrefabData`](https://docs.amethyst.rs/stable/amethyst_assets/trait.PrefabData.html#impl-PrefabData)][api_pf_derive](https://docs.amethyst.rs/stable/amethyst_derive/derive.PrefabData.html) derive implements the [`PrefabData`] trait for the type. The `#[prefab(Component)]` attribute informs the [`PrefabData`] derive that this type is a [[`Component`](https://docs.amethyst.rs/stable/specs/trait.Component.html)], as opposed to being composed of fields which implement [`PrefabData`].
+    The [`[PrefabData]`(https://docs.amethyst.rs/stable/amethyst_assets/trait.PrefabData.html#impl-PrefabData)][api_pf_derive](https://docs.amethyst.rs/stable/amethyst_derive/derive.PrefabData.html) derive implements the `[PrefabData]` trait for the type. The `#[prefab(Component)]` attribute informs the `[PrefabData]` derive that this type is a [`[Component]`(https://docs.amethyst.rs/stable/specs/trait.Component.html)], as opposed to being composed of fields which implement `[PrefabData]`.
 
     The [[`#[serde(default)]`](https://serde.rs/container-attrs.html#default)] attribute allows fields to not be specified in the prefab, and the fields' default value will be used. If this attribute is not present, then all fields must be specified in the prefab.
 


### PR DESCRIPTION
## Description

Prior to this PR, this page in the book had a number of links at the bottom that appeared to be footnotes but which were rendering in such a way as to be unreadable. I fixed this by removing the footnotes entirely and adding links in the text where appropriate.

## Additions

- No API changes

## Removals

- No API changes

## Modifications

- Only book changes

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
