### PR TITLE
Fix renderable example after PR clash

### DIFF
--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -207,7 +207,6 @@ fn main() -> Result<(), Error> {
             &["input_system"],
         )
         .with_bundle(TransformBundle::new().with_dep(&["example_system"]))?
-        .with_bundle(InputBundle::<StringBindings>::new())?
         .with_bundle(UiBundle::<StringBindings>::new())?
         .with_bundle(HotReloadBundle::default())?
         .with_bundle(FpsCounterBundle::default())?


### PR DESCRIPTION
Just a quick fix after two PRs (#2243 and #2223) fixed the same thing and we ended up with two `InputBundle`s.