### PR TITLE
Maintenance/bump dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ specs-derive = "0.4.1"
 
 [build-dependencies]
 dirs = "2.0.2"
-vergen = "3.0.4"
+vergen = "3.1.0"
 
 [[example]]
 name = "hello_world"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ amethyst_utils = { path = "amethyst_utils", version = "0.10.0" }
 amethyst_window = { path = "amethyst_window", version = "0.5.0" }
 amethyst_tiles = { path = "amethyst_tiles", version = "0.3.0", optional = true }
 crossbeam-channel = "0.4.0"
-derivative = "1.0.3"
+derivative = "2.1.1"
 fern = { version = "0.5.9", features = ["colored"] }
 log = { version = "0.4.8", features = ["serde"] }
 rayon = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ fern = { version = "0.6.0", features = ["colored"] }
 log = { version = "0.4.8", features = ["serde"] }
 rayon = "1.3.0"
 rustc_version_runtime = "0.1.5"
-sentry = { version = "0.17.0", optional = true }
+sentry = { version = "0.18.0", optional = true }
 winit = { version = "0.19", features = ["serde", "icon_loading"] }
 serde = { version = "1.0.104", features = ["derive"] }
 palette = { version = "0.4", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ amethyst_window = { path = "amethyst_window", version = "0.5.0" }
 amethyst_tiles = { path = "amethyst_tiles", version = "0.3.0", optional = true }
 crossbeam-channel = "0.4.0"
 derivative = "2.1.1"
-fern = { version = "0.5.9", features = ["colored"] }
+fern = { version = "0.6.0", features = ["colored"] }
 log = { version = "0.4.8", features = ["serde"] }
 rayon = "1.3.0"
 rustc_version_runtime = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ amethyst_ui = { path = "amethyst_ui", version = "0.10.0" }
 amethyst_utils = { path = "amethyst_utils", version = "0.10.0" }
 amethyst_window = { path = "amethyst_window", version = "0.5.0" }
 amethyst_tiles = { path = "amethyst_tiles", version = "0.3.0", optional = true }
-crossbeam-channel = "0.4.0"
+crossbeam-channel = "0.4.2"
 derivative = "2.1.1"
 fern = { version = "0.6.0", features = ["colored"] }
 log = { version = "0.4.8", features = ["serde"] }

--- a/amethyst_animation/Cargo.toml
+++ b/amethyst_animation/Cargo.toml
@@ -23,7 +23,7 @@ amethyst_error = { path = "../amethyst_error", version = "0.5.0" }
 amethyst_derive = { path = "../amethyst_derive", version = "0.8.0" }
 amethyst_rendy = { path = "../amethyst_rendy", version = "0.5.0" }
 amethyst_ui = { path = "../amethyst_ui", version = "0.10.0" }
-derivative = "1.0"
+derivative = "2.1.1"
 fnv = "1"
 itertools = "0.8.0"
 log = "0.4.6"

--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -24,7 +24,7 @@ amethyst_core = { path = "../amethyst_core", version = "0.10.0" }
 amethyst_derive = { path = "../amethyst_derive", version = "0.8.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.5.0" }
 crossbeam-queue = "0.1.2"
-derivative = "1.0"
+derivative = "2.1.1"
 derive-new = "0.5"
 fnv = "1"
 log = "0.4.6"

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -29,7 +29,7 @@ specs = { version = "0.16.0", default-features = false, features = ["shred-deriv
 specs-hierarchy = { version = "0.6", default-features = false }
 getset = "0.0.9"
 derive-new = "0.5.8"
-derivative = "1.0.3"
+derivative = "2.1.1"
 
 thread_profiler = { version = "0.3", optional = true }
 

--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -32,7 +32,7 @@ serde = { version = "1.0", features = ["derive"] }
 
 thread_profiler = { version = "0.3", optional = true }
 image = "0.22.2"
-derivative = "1.0"
+derivative = "2.1.1"
 
 [features]
 vulkan = ["amethyst_rendy/vulkan", "amethyst_rendy/vulkan-x11"]

--- a/amethyst_input/Cargo.toml
+++ b/amethyst_input/Cargo.toml
@@ -19,7 +19,7 @@ amethyst_core = { path = "../amethyst_core", version = "0.10.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.5.0" }
 amethyst_config = { path = "../amethyst_config/", version = "0.14.0" }
 amethyst_window = { path = "../amethyst_window", version = "0.5.0" }
-derivative = "1.0"
+derivative = "2.1.1"
 derive-new = "0.5"
 fnv = "1"
 serde = { version = "1", features = ["derive"] }

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -29,7 +29,7 @@ rendy = { version = "0.4.1", default-features = false, features = ["base", "mesh
 ron = "0.5"
 serde = { version = "1", features = ["serde_derive"] }
 fnv = "1"
-derivative = "1.0"
+derivative = "2.1.1"
 smallvec = "1.2.0"
 static_assertions = "1.1"
 

--- a/amethyst_test/Cargo.toml
+++ b/amethyst_test/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 amethyst = { path = "..", version = "0.15.0", default-features = false }
-derivative = "1.0"
+derivative = "2.1.1"
 derive-new = "0.5"
 derive_deref = "1.1.0"
 lazy_static = "1.4"

--- a/amethyst_tiles/Cargo.toml
+++ b/amethyst_tiles/Cargo.toml
@@ -25,7 +25,7 @@ log = { version = "0.4.6", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 thread_profiler = { version = "0.3", optional = true }
 fnv = "1"
-derivative = "1.0"
+derivative = "2.1.1"
 hibitset = { version = "0.6.2", features = ["parallel"] }
 smallvec = "1.2.0"
 failure = "0.1"

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -22,7 +22,7 @@ amethyst_input = { path = "../amethyst_input", version = "0.11.0" }
 amethyst_rendy = { path = "../amethyst_rendy", version = "0.5.0" }
 amethyst_window = { path = "../amethyst_window", version = "0.5.0" }
 clipboard = "0.5"
-derivative = "1.0"
+derivative = "2.1.1"
 derive-new = "0.5.6"
 fnv = "1"
 glsl-layout = "0.3"

--- a/src/app.rs
+++ b/src/app.rs
@@ -364,7 +364,7 @@ where
             {
                 self.world.write_resource::<Time>().start_fixed_update();
             }
-            while { self.world.write_resource::<Time>().step_fixed_update() } {
+            while self.world.write_resource::<Time>().step_fixed_update() {
                 self.states
                     .fixed_update(StateData::new(&mut self.world, &mut self.data));
             }


### PR DESCRIPTION
## Description

Bumps dependency versions. Notably `derivative` to `2.1.1` so that clippy may pass on Gitlab CI.

## PR Checklist

By placing an x in the boxes I certify that I have:

- **n/a** Updated the content of the book if this PR would make the book outdated.
- **n/a** Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- **n/a** Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- **n/a** Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "vulkan"`
- [x] Ran `cargo test --all --features "vulkan"`
