### PR TITLE
Allow building a standalone Dispatcher with GameDataBuilder

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- `GameDataBuilder::build_dispatcher` method returns a standalone `Dispatcher`
+  instead of using `DataInit` to build a `GameData` ([#2294])
+
 ### Changed
 
 - `amethyst_rendy::shape::Shape::upload` takes `&ShapeUpload`. ([#2264])
@@ -19,6 +24,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - Corrected an issue where fixed updates were tied to time scale. ([#2254])
 - Fixed asset handle reuse bug in renderer. ([#2258])
 
+[#2294]: https://github.com/amethyst/amethyst/pull/2294
 [#2254]: https://github.com/amethyst/amethyst/issues/2254
 [#2258]: https://github.com/amethyst/amethyst/pull/2258
 [#2264]: https://github.com/amethyst/amethyst/pull/2264

--- a/src/game_data.rs
+++ b/src/game_data.rs
@@ -458,10 +458,10 @@ impl<'a, 'b> GameDataBuilder<'a, 'b> {
     //         self.with_bundle(RenderBundle::new(pipe, Some(config)))
     //     }
     // }
-}
 
-impl<'a, 'b> DataInit<GameData<'a, 'b>> for GameDataBuilder<'a, 'b> {
-    fn build(self, mut world: &mut World) -> GameData<'a, 'b> {
+    /// Instead of using `DataInit` for constructing `GameData`, build a standalone `Dispatcher`,
+    /// which will be the same dispatcher that would have been created for the `GameData`.
+    pub fn build_dispatcher(self, mut world: &mut World) -> Dispatcher<'a, 'b> {
         #[cfg(not(no_threading))]
         let pool = (*world.read_resource::<ArcThreadPool>()).clone();
 
@@ -479,7 +479,14 @@ impl<'a, 'b> DataInit<GameData<'a, 'b>> for GameDataBuilder<'a, 'b> {
         #[cfg(no_threading)]
         let mut dispatcher = dispatcher_builder.build();
         dispatcher.setup(&mut world);
-        GameData::new(dispatcher)
+
+        dispatcher
+    }
+}
+
+impl<'a, 'b> DataInit<GameData<'a, 'b>> for GameDataBuilder<'a, 'b> {
+    fn build(self, world: &mut World) -> GameData<'a, 'b> {
+        GameData::new(self.build_dispatcher(world))
     }
 }
 


### PR DESCRIPTION
## Description

Expose a new `build_dispatcher` method on the `GameDataBuilder`; this is useful for building dispatchers that can be managed outside of the `GameData`.

## Additions

- `GameDataBuilder::build_dispatcher` method

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
