### PR TITLE
Bind different TileMapArgs for each TileMap being rendered

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,8 +23,10 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 - Corrected an issue where fixed updates were tied to time scale. ([#2254])
 - Fixed asset handle reuse bug in renderer. ([#2258])
+- Fixed issue where all `TileMap`s were rendered with the same transformation. ([#2210])
 
 [#2294]: https://github.com/amethyst/amethyst/pull/2294
+[#2210]: https://github.com/amethyst/amethyst/issues/2210
 [#2254]: https://github.com/amethyst/amethyst/issues/2254
 [#2258]: https://github.com/amethyst/amethyst/pull/2258
 [#2264]: https://github.com/amethyst/amethyst/pull/2264


### PR DESCRIPTION
## Description

Fixes #2210. In `prepare` only one `TileMapArgs` was constructed for all `TileMap`s. Thus the transformations of the last `TileMap` were applied to all `TileMap`s.

This PR changes the `prepare` and `draw_inline` to keep track of a `Vec` of `TileMapArgs` (one for reach `TileMap`). `draw_inline` then binds a different one for each `TileMap`. I'm not completely sure, if this is the best approach. Feel free to improve this - but this works for me :)

I also moved some code into `compute_region` to please clippy (`prepare` had too many lines :unamused: )

This PR doesn't change any APIs.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [X] Updated the content of the book if this PR would make the book outdated.
- [X] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [X] Ran `cargo +stable fmt --all`
- [X] Ran `cargo clippy --all --features "empty"`
- [X] Ran `cargo test --all --features "empty"`
