### PR TITLE
Fix grammar mistakes in amethyst_assets/storage.rs documentation

### DIFF
--- a/amethyst_assets/src/storage.rs
+++ b/amethyst_assets/src/storage.rs
@@ -139,7 +139,7 @@ impl<A: Asset> AssetStorage<A> {
         }
     }
 
-    /// Get an asset and it's version from a given asset handle.
+    /// Get an asset and its version from a given asset handle.
     pub fn get_with_version(&self, handle: &Handle<A>) -> Option<&(A, u32)> {
         if self.bitset.contains(handle.id()) {
             Some(unsafe { self.assets.get(handle.id()) })
@@ -197,7 +197,7 @@ impl<A: Asset> AssetStorage<A> {
     }
 
     /// Get an asset by its handle id without checking the internal bitset.
-    /// Use `contains_id` to manually check it's status before access.
+    /// Use `contains_id` to manually check its status before access.
     ///
     /// # Safety
     /// You must manually verify that given asset id is valid.

--- a/amethyst_assets/src/storage.rs
+++ b/amethyst_assets/src/storage.rs
@@ -63,7 +63,7 @@ where
 {
     /// Asset is not fully loaded yet, need to wait longer
     Loading(A::Data),
-    /// Asset have finished loading, can now be inserted into storage and tracker notified
+    /// Asset has finished loading, can now be inserted into storage and tracker notified
     Loaded(A),
 }
 
@@ -148,7 +148,7 @@ impl<A: Asset> AssetStorage<A> {
         }
     }
 
-    /// Get an asset by it's handle id.
+    /// Get an asset by its handle id.
     pub fn get_by_id(&self, id: u32) -> Option<&A> {
         if self.bitset.contains(id) {
             Some(unsafe { &self.assets.get(id).0 })
@@ -196,7 +196,7 @@ impl<A: Asset> AssetStorage<A> {
         self.bitset.contains(id)
     }
 
-    /// Get an asset by it's handle id without checking the internal bitset.
+    /// Get an asset by its handle id without checking the internal bitset.
     /// Use `contains_id` to manually check it's status before access.
     ///
     /// # Safety


### PR DESCRIPTION
## Description
Fix various grammar mistakes in amethyst_assets/storage.rs documentation. One mistake is the usage of the wrong form of the verb "have" and the others are incorrect uses of "it's" instead of "its".

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
