### PR TITLE
Improve debug lines example

### DIFF
--- a/examples/debug_lines/README.md
+++ b/examples/debug_lines/README.md
@@ -1,6 +1,21 @@
 ## Debug Lines
 
-Renders debug lines with a 3D perspective.
+Renders debug lines with a 3D perspective via two separate methods: The
+[`DebugLines`] [resource] and the [`DebugLinesComponent`] [component].
+Internally, `DebugLines` is just a wrapper around a `DebugLinesComponent`, but
+they each have their separate, specific use cases.
+
+The resource method is useful for rendering moving lines such as the purple ones
+swinging in the middle of the example scene. This is because the `DebugLines`
+resource is cleared immediately after being rendered (see its documentation),
+allowing it to be updated easily frame-by-frame.
+
+The component method, however, is useful for rendering persistent lines, such as
+the grid pattern shown below. `DebugLinesComponent` is _not_ automatically
+cleared on render, so one doesn't have to manually reset it with the same data
+every frame if they desire static lines. The [`RenderDebugLines`]
+[`RenderPlugin`] includes the necessary rendering [`System`] to automatically
+render entities with a `DebugLinesComponent`.
 
 Keybindings:
 
@@ -13,3 +28,11 @@ Keybindings:
 * `mouse` - Rotate view
 
 ![debug lines example screenshot](./screenshot.png)
+
+[component]: https://docs-src.amethyst.rs/stable/specs/trait.Component.html
+[`DebugLines`]: https://docs-src.amethyst.rs/stable/amethyst_rendy/debug_drawing/struct.DebugLines.html
+[`DebugLinesComponent`]: https://docs-src.amethyst.rs/stable/amethyst_rendy/debug_drawing/struct.DebugLinesComponent.html
+[`RenderDebugLines`]: https://docs-src.amethyst.rs/stable/amethyst_rendy/struct.RenderDebugLines.html
+[`RenderPlugin`]: https://docs-src.amethyst.rs/stable/amethyst_rendy/trait.RenderPlugin.html
+[resource]: https://book-src.amethyst.rs/master/concepts/resource.html
+[`System`]: https://docs-src.amethyst.rs/stable/specs/trait.System.html

--- a/examples/debug_lines/main.rs
+++ b/examples/debug_lines/main.rs
@@ -40,14 +40,14 @@ impl<'s> System<'s> for ExampleLinesSystem {
         let t = (time.absolute_time_seconds() as f32).cos();
 
         debug_lines_resource.draw_direction(
-            [t, 0.0, 0.5].into(),
-            [0.0, 0.3, 0.0].into(),
+            Point3::new(t, 0.0, 0.5),
+            Vector3::new(0.0, 0.3, 0.0),
             Srgba::new(0.5, 0.05, 0.65, 1.0),
         );
 
         debug_lines_resource.draw_line(
-            [t, 0.0, 0.5].into(),
-            [0.0, 0.0, 0.2].into(),
+            Point3::new(t, 0.0, 0.5),
+            Point3::new(0.0, 0.0, 0.2),
             Srgba::new(0.5, 0.05, 0.65, 1.0),
         );
     }
@@ -66,22 +66,22 @@ impl SimpleState for ExampleState {
 
         // X-axis (red)
         debug_lines_component.add_direction(
-            [0.0, 0.0001, 0.0].into(),
-            [0.2, 0.0, 0.0].into(),
+            Point3::new(0.0, 0.0001, 0.0),
+            Vector3::new(0.2, 0.0, 0.0),
             Srgba::new(1.0, 0.0, 0.23, 1.0),
         );
 
         // Y-axis (yellowish-green)
         debug_lines_component.add_direction(
-            [0.0, 0.0, 0.0].into(),
-            [0.0, 0.2, 0.0].into(),
+            Point3::new(0.0, 0.0, 0.0),
+            Vector3::new(0.0, 0.2, 0.0),
             Srgba::new(0.5, 0.85, 0.1, 1.0),
         );
 
         // Z-axis (blue)
         debug_lines_component.add_direction(
-            [0.0, 0.0001, 0.0].into(),
-            [0.0, 0.0, 0.2].into(),
+            Point3::new(0.0, 0.0001, 0.0),
+            Vector3::new(0.0, 0.0, 0.2),
             Srgba::new(0.2, 0.75, 0.93, 1.0),
         );
 

--- a/examples/debug_lines/main.rs
+++ b/examples/debug_lines/main.rs
@@ -1,4 +1,7 @@
-//! Displays several lines with both methods.
+//! Displays dynamic and static debug lines via the resource and component
+//! methods respectively. A pendulum of sorts is drawn using the resource
+//! method, while a grid pattern is drawn on the floor using the component
+//! method.
 
 use amethyst::{
     controls::{FlyControlBundle, FlyControlTag},
@@ -33,7 +36,7 @@ impl<'s> System<'s> for ExampleLinesSystem {
     );
 
     fn run(&mut self, (mut debug_lines_resource, time): Self::SystemData) {
-        // Drawing debug lines, as a resource
+        // Drawing debug lines as a resource
         let t = (time.absolute_time_seconds() as f32).cos();
 
         debug_lines_resource.draw_direction(
@@ -58,18 +61,24 @@ impl SimpleState for ExampleState {
         // Configure width of lines. Optional step
         data.world.insert(DebugLinesParams { line_width: 2.0 });
 
-        // Setup debug lines as a component and add lines to render axis&grid
+        // Setup debug lines as a component and add lines to render axes & grid
         let mut debug_lines_component = DebugLinesComponent::with_capacity(100);
+
+        // X-axis (red)
         debug_lines_component.add_direction(
             [0.0, 0.0001, 0.0].into(),
             [0.2, 0.0, 0.0].into(),
             Srgba::new(1.0, 0.0, 0.23, 1.0),
         );
+
+        // Y-axis (yellowish-green)
         debug_lines_component.add_direction(
             [0.0, 0.0, 0.0].into(),
             [0.0, 0.2, 0.0].into(),
             Srgba::new(0.5, 0.85, 0.1, 1.0),
         );
+
+        // Z-axis (blue)
         debug_lines_component.add_direction(
             [0.0, 0.0001, 0.0].into(),
             [0.0, 0.0, 0.2].into(),
@@ -125,6 +134,9 @@ impl SimpleState for ExampleState {
                 }
             }
         }
+
+        // Debug lines are automatically rendered by including the debug lines
+        // rendering plugin
         data.world.register::<DebugLinesComponent>();
         data.world
             .create_entity()


### PR DESCRIPTION
## Description

The documentation on the debug lines example is quite lacking, and takes some doc-searching and source-code-reading to understand the overall structure of the example. This PR adds a high-level explanation of how debug lines work in Amethyst, and explicitly types some arguments for readability and good practice.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [X] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [X] Ran `cargo +stable fmt --all`
- [X] Ran `cargo clippy --all --features "empty"`
- [X] Ran `cargo test --all --features "empty"`