### PR TITLE
Fix broken link to font download

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-05.md
+++ b/book/src/pong-tutorial/pong-tutorial-05.md
@@ -356,7 +356,7 @@ game window. You'll notice that the scores don't update yet when the ball makes
 it to either side, so we'll add that next!
 
 
-[font-download]: https://github.com/amethyst/amethyst/raw/master/examples/assets/font/square.ttf
+[font-download]: https://github.com/amethyst/amethyst/raw/master/examples/pong_tutorial_05/assets/font/square.ttf
 [input-handler]: https://docs.amethyst.rs/stable/amethyst_input/struct.InputHandler.html
 [ui-bundle]: https://docs.amethyst.rs/stable/amethyst_ui/struct.UiBundle.html
 


### PR DESCRIPTION
## Description

I am just doing the pong tutorial and found a broken link to the font download.

## Modifications

- Change outdated link to a working one

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
