### PR TITLE
Fix buggy example code in the book

### DIFF
--- a/book/src/controlling_system_execution/custom_game_data.md
+++ b/book/src/controlling_system_execution/custom_game_data.md
@@ -294,11 +294,11 @@ The only thing that remains now is to use our `CustomGameDataBuilder` when build
 #
 # fn main() -> amethyst::Result<()> {
 #
-let mut world = World::new();
+let mut app_builder = Application::build(assets_directory, Main)?;
 let game_data = CustomGameDataBuilder::default()
     .with_running(ExampleSystem, "example_system", &[])
     .with_base_bundle(
-        &mut world,
+        &mut app_builder.world,
         RenderingBundle::<DefaultBackend>::new()
             // The RenderToWindow plugin provides all the scaffolding for opening a window and
             // drawing on it
@@ -309,14 +309,14 @@ let game_data = CustomGameDataBuilder::default()
             .with_plugin(RenderFlat2D::default())
             .with_plugin(RenderUi::default()),
     )?
-    .with_base_bundle(&mut world, TransformBundle::new())?
-    .with_base_bundle(&mut world, UiBundle::<StringBindings>::new())?
+    .with_base_bundle(&mut app_builder.world, TransformBundle::new())?
+    .with_base_bundle(&mut app_builder.world, UiBundle::<StringBindings>::new())?
     .with_base_bundle(
-        &mut world,
+        &mut app_builder.world,
         InputBundle::<StringBindings>::new().with_bindings_from_file(key_bindings_path)?,
     )?;
 
-let mut game = Application::new(assets_directory, Main, game_data)?;
+let mut game = app_builder.build(game_data)?;
 game.run();
 #
 # }


### PR DESCRIPTION
## Description

The 1.15 version of the book, chapter 10.1 'Controlling system execution -> Custom game data' contains erroneous example code that, if used, will result in runtime panics. It advocates manually creating an instance of World and passing it to the CustomGameDataBuilder. However, the ApplicationBuilder also creates an instance of World and proceeds to use that instance when creating the game. It doesn't have the resource registrations of the first instance and the game will therefore panic when it tries to look for those resources.

## Additions

- No additions.

## Removals

- No removals.

## Modifications

- Modified example code in chapter 10.1 of the book.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x ] Updated the content of the book if this PR would make the book outdated.
- [x ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x ] Added unit tests for new code added in this PR.
- [x ] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x ] Ran `cargo +stable fmt --all`
- [x ] Ran `cargo clippy --all --features "empty"`
- [x ] Ran `cargo test --all --features "empty"`
