### PR TITLE
Use dunce::canonicalize instead of fs::canonicalize

### DIFF
--- a/amethyst_utils/Cargo.toml
+++ b/amethyst_utils/Cargo.toml
@@ -27,6 +27,7 @@ log = "0.4.6"
 serde = { version = "1.0", features = ["derive"] }
 specs-derive = "0.4.1"
 specs-hierarchy = "0.6.0"
+dunce = "1"
 
 thread_profiler = { version = "0.3", optional = true }
 

--- a/amethyst_utils/src/app_root_dir.rs
+++ b/amethyst_utils/src/app_root_dir.rs
@@ -22,7 +22,7 @@ pub fn application_root_dir() -> Result<path::PathBuf, io::Error> {
         return Ok(path::PathBuf::from(manifest_dir));
     }
 
-    let mut exe = env::current_exe()?.canonicalize()?;
+    let mut exe = dunce::canonicalize(env::current_exe()?)?;
 
     // Modify in-place to avoid an extra copy.
     if exe.pop() {


### PR DESCRIPTION
This will make `application_root_dir` work properly on Windows when
running the exe directly.

## Description

When building the release mode for Windows, reading file locations relative to the application root directory does not work properly, as `fs::canonicalize` adds a `\\?` prefix to it (UNC paths on Windows, see https://github.com/rust-lang/rust/issues/42869) that is unsupported on most places (including internal stuff like reading RON config files). To make this work and be transparent to users, I'm changing `application_root_dir` to use `dunce::canonicalize`, which should have exactly the same behaviour except it doesn't use UNC paths on Windows when it doesn't need to.

Otherwise every game that needs to be released on Windows will do a hack like https://github.com/yancouto/psycho_rust/commit/ee72e216e980d34e26db86dead77e7431b08429a. Unless I'm doing something wrong?

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment. (Should I add a changelog entry?)
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
