### PR TITLE
Multiple bindings for a single axis

### DIFF
--- a/amethyst_input/src/axis.rs
+++ b/amethyst_input/src/axis.rs
@@ -63,6 +63,16 @@ impl Axis {
     }
 
     pub(super) fn conflicts_with_axis(&self, other: &Axis) -> Option<Conflict> {
+        if let Axis::Multiple(axes) = other {
+            if let Some(inner_conflict) = axes
+                .iter()
+                .map(|a| self.conflicts_with_axis(a))
+                .find(|x| x.is_some())
+            {
+                return inner_conflict;
+            }
+        }
+
         match self {
             Axis::Emulated {
                 pos: ref self_pos,

--- a/amethyst_input/src/axis.rs
+++ b/amethyst_input/src/axis.rs
@@ -43,3 +43,62 @@ pub enum Axis {
         horizontal: bool,
     },
 }
+
+pub(super) enum Conflict {
+    Button,
+    ControllerAxis,
+    MouseAxis,
+    MouseWheelAxis,
+}
+
+impl Axis {
+    pub(super) fn conflicts_with_axis(&self, other: &Axis) -> Option<Conflict> {
+        match self {
+            Axis::Emulated {
+                pos: ref self_pos,
+                neg: ref self_neg,
+            } => {
+                if let Axis::Emulated { pos, neg } = other {
+                    if self_pos == pos || self_pos == neg || self_neg == pos || self_neg == neg {
+                        return Some(Conflict::Button);
+                    }
+                }
+            }
+            Axis::Controller {
+                controller_id: ref self_controller_id,
+                axis: ref self_axis,
+                ..
+            } => {
+                if let Axis::Controller {
+                    controller_id,
+                    axis,
+                    ..
+                } = other
+                {
+                    if self_controller_id == controller_id && self_axis == axis {
+                        return Some(Conflict::ControllerAxis);
+                    }
+                }
+            }
+            Axis::Mouse {
+                axis: self_axis, ..
+            } => {
+                if let Axis::Mouse { axis, .. } = other {
+                    if self_axis == axis {
+                        return Some(Conflict::MouseAxis);
+                    }
+                }
+            }
+            Axis::MouseWheel {
+                horizontal: self_horizontal,
+            } => {
+                if let Axis::MouseWheel { horizontal } = other {
+                    if self_horizontal == horizontal {
+                        return Some(Conflict::MouseWheelAxis);
+                    }
+                }
+            }
+        }
+        None
+    }
+}

--- a/amethyst_input/src/bindings.rs
+++ b/amethyst_input/src/bindings.rs
@@ -95,10 +95,16 @@ impl BindingTypes for StringBindings {
 ///             pos: Key(Up),
 ///             neg: Key(Down)
 ///         ),
-///         "leftright": Emulated(
-///             pos: Key(Right),
-///             neg: Key(Left)
-///         )
+///         "leftright": Multiple([ // Multiple bindings for one axis
+///             Emulated(
+///                 pos: Key(Right),
+///                 neg: Key(Left)
+///             ),
+///             Emulated(
+///                 pos: Key(D),
+///                 neg: Key(A)
+///             )
+///         ])
 ///     },
 ///     actions: {
 ///         "fire": [ [Mouse(Left)], [Key(X)] ], // Multiple bindings for one action
@@ -426,10 +432,8 @@ impl<T: BindingTypes> Bindings<T> {
         }
         if bind.len() == 1 {
             for (k, a) in self.axes.iter() {
-                if let Axis::Emulated { pos, neg } = a {
-                    if bind[0] == *pos || bind[0] == *neg {
-                        return Err(BindingError::ButtonBoundToAxis(k.clone(), a.clone()));
-                    }
+                if a.conflicts_with_button(&bind[0]) {
+                    return Err(BindingError::ButtonBoundToAxis(k.clone(), a.clone()));
                 }
             }
         }

--- a/amethyst_input/src/bindings.rs
+++ b/amethyst_input/src/bindings.rs
@@ -12,7 +12,7 @@ use fnv::FnvHashMap as HashMap;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
-use super::{Axis, Button};
+use super::{axis, Axis, Button};
 
 /// Define a set of types used for bindings configuration.
 /// Usually defaulted to `StringBindings`, which uses `String`s.
@@ -444,72 +444,36 @@ impl<T: BindingTypes> Bindings<T> {
     }
 
     fn check_axis_invariants(&self, id: &T::Axis, axis: &Axis) -> Result<(), BindingError<T>> {
-        match axis {
-            Axis::Emulated {
-                pos: ref axis_pos,
-                neg: ref axis_neg,
-            } => {
-                for (k, a) in self.axes.iter().filter(|(k, _a)| *k != id) {
-                    if let Axis::Emulated { pos, neg } = a {
-                        if axis_pos == pos || axis_pos == neg || axis_neg == pos || axis_neg == neg
-                        {
-                            return Err(BindingError::AxisButtonAlreadyBoundToAxis(
-                                k.clone(),
-                                a.clone(),
-                            ));
-                        }
+        for (k, a) in self.axes.iter().filter(|(k, _a)| *k != id) {
+            if let Some(conflict_type) = axis.conflicts_with_axis(a) {
+                return Err(match conflict_type {
+                    axis::Conflict::Button => {
+                        BindingError::AxisButtonAlreadyBoundToAxis(k.clone(), a.clone())
                     }
-                }
-                for (k, a) in self.actions.iter() {
-                    for c in a {
-                        // Since you can't bind combos to an axis we only need to check combos with length 1.
-                        if c.len() == 1 && (c[0] == *axis_pos || c[0] == *axis_neg) {
-                            return Err(BindingError::AxisButtonAlreadyBoundToAction(
-                                k.clone(),
-                                c[0],
-                            ));
-                        }
+                    axis::Conflict::ControllerAxis => {
+                        BindingError::ControllerAxisAlreadyBound(k.clone())
                     }
-                }
+                    axis::Conflict::MouseAxis => BindingError::MouseAxisAlreadyBound(k.clone()),
+                    axis::Conflict::MouseWheelAxis => {
+                        BindingError::MouseWheelAxisAlreadyBound(k.clone())
+                    }
+                });
             }
-            Axis::Controller {
-                controller_id: ref input_controller_id,
-                axis: ref input_axis,
-                ..
-            } => {
-                for (k, a) in self.axes.iter().filter(|(k, _a)| *k != id) {
-                    if let Axis::Controller {
-                        controller_id,
-                        axis,
-                        ..
-                    } = a
-                    {
-                        if controller_id == input_controller_id && axis == input_axis {
-                            return Err(BindingError::ControllerAxisAlreadyBound(k.clone()));
-                        }
-                    }
-                }
-            }
-            Axis::Mouse { axis, .. } => {
-                for (k, a) in self.axes.iter().filter(|(k, _a)| *k != id) {
-                    if let Axis::Mouse {
-                        axis: mouse_axis, ..
-                    } = a
-                    {
-                        if axis == mouse_axis {
-                            return Err(BindingError::MouseAxisAlreadyBound(k.clone()));
-                        }
-                    }
-                }
-            }
-            Axis::MouseWheel {
-                horizontal: ref input_horizontal,
-            } => {
-                for (k, a) in self.axes.iter().filter(|(k, _a)| *k != id) {
-                    if let Axis::MouseWheel { horizontal } = a {
-                        if input_horizontal == horizontal {
-                            return Err(BindingError::MouseWheelAxisAlreadyBound(k.clone()));
-                        }
+        }
+
+        if let Axis::Emulated {
+            pos: ref axis_pos,
+            neg: ref axis_neg,
+        } = axis
+        {
+            for (k, a) in self.actions.iter() {
+                for c in a {
+                    // Since you can't bind combos to an axis we only need to check combos with length 1.
+                    if c.len() == 1 && (c[0] == *axis_pos || c[0] == *axis_neg) {
+                        return Err(BindingError::AxisButtonAlreadyBoundToAction(
+                            k.clone(),
+                            c[0],
+                        ));
                     }
                 }
             }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 - `GameDataBuilder::build_dispatcher` method returns a standalone `Dispatcher`
   instead of using `DataInit` to build a `GameData` ([#2294])
+- `amethyst_input::axis::Axis` supports a new variant, `Multiple` ([#2341])
 
 ### Changed
 
@@ -27,6 +28,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - Fixed UiButtonBuilder incorrect UiImage creation ([#2299])
 - Correctly increment texture generation tracking number. ([#2339])
 
+[#2341]: https://github.com/amethyst/amethyst/pull/2341
 [#2294]: https://github.com/amethyst/amethyst/pull/2294
 [#2210]: https://github.com/amethyst/amethyst/issues/2210
 [#2254]: https://github.com/amethyst/amethyst/issues/2254
@@ -110,7 +112,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - amethyst_network completely rewritten to provide a new baseline with which to build. ([#1917])
 - Cleaned up tiles example. Added rotation and translation tests, fixed raycast debug box. Added default zoom to PROJECT
   perspective projection since no one knew to zoom out. ([#1974])
-- TileMaps to_tile and to_world now take an Option<&Transform> that allows them to work if the entire map in 
+- TileMaps to_tile and to_world now take an Option<&Transform> that allows them to work if the entire map in
  translated. ([#1987],[#1991])
 - `AmethystApplication::with_fn` constraint relaxed from `Fn` to `FnOnce`. ([#1983])
 - ScreenDimensions now consistently reports window size in physical pixels. ([#1988])


### PR DESCRIPTION
## Description

This PR adds support for binding multiple inputs for a single axis, [as discussed in this thread](https://community.amethyst.rs/t/multiple-bindings-for-a-single-axis/1538).

## Additions

- `amethyst_input::axis::Axis` supports a new variant, `Multiple`

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
