### PR TITLE
Indicate that there can only one type of UiButtonBuilder

### DIFF
--- a/amethyst_ui/src/button/builder.rs
+++ b/amethyst_ui/src/button/builder.rs
@@ -48,6 +48,9 @@ pub struct UiButtonBuilderResources<'a, G: PartialEq + Send + Sync + 'static, I:
 }
 
 /// Convenience structure for building a button
+/// Note that since there can only be one "ui_loader" in use, and WidgetId of the UiBundle and
+/// UiButtonBuilder should match, you can only use one type of WidgetId, e.g. you cant use both
+/// UiButtonBuilder<(), u32> and UiButtonBuilder<(), String>.
 #[derive(Debug, Clone)]
 pub struct UiButtonBuilder<G, I: WidgetId> {
     id: Option<I>,


### PR DESCRIPTION
There was a confusion in the issue #2300 regarding the use of
multiple UiButtonBuilder with different WidgetId types. This commit
points that in the API doc, stating that you can only use one type of
WidgetId with UiBundle

## Description

Point the inability in the API docs

## Additions

No API additions

## Removals

No removals

## Modifications

Only addition to API documentation of UiButtonBuilder

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated. (No it wouldn't)
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment. (No it wouldn't)
- [x] Added unit tests for new code added in this PR. (Not necessary, only doc changes)
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all` (Did ran `cargo fmt` with stable version but did not add --all, as that wasnt mentioned in CONTRIBUTING.md)
- [ ] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
