### PR TITLE
Fix documentation markup for lists in renderer::shape

### DIFF
--- a/amethyst_rendy/src/shape.rs
+++ b/amethyst_rendy/src/shape.rs
@@ -30,10 +30,11 @@ fn option_none<T>() -> Option<T> {
 /// ### Type parameters:
 ///
 /// `V`: Vertex format to use, must be one of:
-///     * `Vec<PosTex>`
-///     * `Vec<PosNormTex>`
-///     * `Vec<PosNormTangTex>`
-///     * `ComboMeshCreator`
+///
+/// - `Vec<PosTex>`
+/// - `Vec<PosNormTex>`
+/// - `Vec<PosNormTangTex>`
+/// - `ComboMeshCreator`
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(bound = "")]
 pub struct ShapePrefab<V> {
@@ -162,10 +163,11 @@ impl Shape {
     /// ### Type parameters:
     ///
     /// `V`: Vertex format to use, must to be one of:
-    ///     * `Vec<PosTex>`
-    ///     * `Vec<PosNormTex>`
-    ///     * `Vec<PosNormTangTex>`
-    ///     * `ComboMeshCreator`
+    ///
+    /// - `Vec<PosTex>`
+    /// - `Vec<PosNormTex>`
+    /// - `Vec<PosNormTangTex>`
+    /// - `ComboMeshCreator`
     /// `P`: Progress tracker type
     pub fn upload<V, P>(
         &self,
@@ -191,10 +193,11 @@ impl Shape {
     /// ### Type parameters:
     ///
     /// `V`: Vertex format to use, must to be one of:
-    ///     * `Vec<PosTex>`
-    ///     * `Vec<PosNormTex>`
-    ///     * `Vec<PosNormTangTex>`
-    ///     * `ComboMeshCreator`
+    ///
+    /// - `Vec<PosTex>`
+    /// - `Vec<PosNormTex>`
+    /// - `Vec<PosNormTangTex>`
+    /// - `ComboMeshCreator`
     pub fn generate<V>(&self, scale: Option<(f32, f32, f32)>) -> MeshBuilder<'static>
     where
         V: FromShape + Into<MeshBuilder<'static>>,
@@ -211,10 +214,11 @@ impl Shape {
     /// ### Type parameters:
     ///
     /// `V`: Vertex format to use, must to be one of:
-    ///     * `Vec<PosTex>`
-    ///     * `Vec<PosNormTex>`
-    ///     * `Vec<PosNormTangTex>`
-    ///     * `ComboMeshCreator`
+    ///
+    /// - `Vec<PosTex>`
+    /// - `Vec<PosNormTex>`
+    /// - `Vec<PosNormTangTex>`
+    /// - `ComboMeshCreator`
     pub fn generate_vertices<V>(&self, scale: Option<(f32, f32, f32)>) -> V
     where
         V: FromShape,


### PR DESCRIPTION
## Description

Lists did not display properly due to a missing newline after the previous line, also fixed formatting to be consistent with other lists

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
