### PR TITLE
Fix sturct -> struct in ui/state_interaction.md

### DIFF
--- a/book/src/ui/state_interaction.md
+++ b/book/src/ui/state_interaction.md
@@ -6,7 +6,7 @@ Let's declare our state, and call it `MenuState`:
 # use amethyst::ecs::Entity;
 
 #[derive(Default)]
-pub sturct MenuState {
+pub struct MenuState {
     button: Option<Entity>,
 }
 ```


### PR DESCRIPTION
Description

Missed from azriel's comment in #2311 

## Modifications

- Change `sturct` to `struct`

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
