### PR TITLE
world.write_storage should be mutable

### DIFF
--- a/book/src/ui/state_interaction.md
+++ b/book/src/ui/state_interaction.md
@@ -37,7 +37,7 @@ fn on_start(&mut self, data: StateData<()>) {
    	let btn = world.create_entity()
         .with(ui_transform)
         .with(ui_text)
-		.with(Interactable)
+	.with(Interactable)
         .build();
 
 	/* Saving the button in our state struct */
@@ -98,7 +98,7 @@ component to our button:
 
 fn on_pause(&mut self, data: StateData<'_, GameData<'_, '_>>) {
 	let world = data.world;	
-	let hiddens = world.write_storage::<Hidden>();
+	let mut hiddens = world.write_storage::<Hidden>();
 	
 	if let Some(btn) = self.button {
 		let _ = hiddens.insert(btn, Hidden);
@@ -114,7 +114,7 @@ The same goes for `on_resume` if we actually want to redisplay the button:
 
 fn on_resume(&mut self, data: StateData<'_, GameData<'_, '_>>) {
     let world = data.world; 	
-    let hiddens = world.write_storage::<Hidden>();
+    let mut hiddens = world.write_storage::<Hidden>();
 	
     if let Some(btn) = self.button {
         let _ = hiddens.remove(btn);


### PR DESCRIPTION
## Description

The UI book should be using a mutable world.write_storage.

Not sure if there are more of this. At least when using CLion, the write_storage keeps asking for everything to be mutable. Currently on master branch instead of v0.15.0. Lemme know if this was intended to be mutable.

## Modifications

Made `hidden` var mutable in book.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [X] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
