### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -286,7 +286,7 @@ Then you can hit load button and choose `thread_profile.json` file.
 [bs]: https://www.kth.se/social/upload/5289cb3ff276542440dd668c/bitsquid-behind-the-scenes.pdf
 [fr]: http://twvideo01.ubm-us.net/o1/vault/gdc2012/slides/Programming%20Track/Persson_Tobias_Flexible_Rendering.pdf.pdf
 [ma]: https://www.yumpu.com/en/document/view/43374261/mantle-programming-guide-and-api-reference
-[mo]: http://shaneenishry.com/blog/2014/12/27/misconceptions-of-component-based-entity-systems/
+[mo]: https://shanee.io/blog/2014/12/27/misconceptions-of-component-based-entity-systems/
 [ni]: http://www.gdcvault.com/play/1020706/Nitrous-Mantle-Combining-Efficient-Engine
 [pa]: http://gameprogrammingpatterns.com/state.html#pushdown-automata
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -87,12 +87,9 @@ Note that if you do not have mdbook already installed you may do so with `cargo 
 If you find dependency resolution problems when testing mdbook, 
 you may have to run `cargo clean` and `cargo build` again before retrying the `mdbook test` command.
 
-> If you want to be publicly known as an author, feel free to add your name
-> and/or GitHub username to the AUTHORS.md file in your pull request.
-
 Once you have submitted your pull request, please wait for a reviewer to give
 feedback on it. If no one responds, feel free to @-mention a developer or post
-publicly on the [appropriate chat room][gi] on Gitter or on Discord asking for a review. Once
+publicly on [Discord][di] asking for a review. Once
 your code has been reviewed, revised if necessary, and then signed-off by a
 developer, it will be merged into the source tree.
 
@@ -288,7 +285,7 @@ Then you can hit load button and choose `thread_profile.json` file.
 [di]: https://discord.gg/amethyst
 [bs]: https://www.kth.se/social/upload/5289cb3ff276542440dd668c/bitsquid-behind-the-scenes.pdf
 [fr]: http://twvideo01.ubm-us.net/o1/vault/gdc2012/slides/Programming%20Track/Persson_Tobias_Flexible_Rendering.pdf.pdf
-[ma]: http://www.amd.com/Documents/Mantle-Programming-Guide-and-API-Reference.pdf
+[ma]: https://www.yumpu.com/en/document/view/43374261/mantle-programming-guide-and-api-reference
 [mo]: http://shaneenishry.com/blog/2014/12/27/misconceptions-of-component-based-entity-systems/
 [ni]: http://www.gdcvault.com/play/1020706/Nitrous-Mantle-Combining-Efficient-Engine
 [pa]: http://gameprogrammingpatterns.com/state.html#pushdown-automata


### PR DESCRIPTION
## Description

Update a few minor issues I found in `CONTRIBUTING.md` while reading it.

* Remove outdated language about AUTHORS.md, which is now just a pointer to GitHub's list of contributors
* Remove reference to Gitter (AFAIK Amethyst doesn't use it?)
* Fix broken link to Discord
* Fix broken link to Mantle PDF

Two open questions I would like more input on:
1. I was unable to find an alternate link to fix the broken link in "Useful Resources" for `Misconceptions of Component-Based Entity Systems (2014)` -- does anyone know what this blog post was like, if it exists elsewhere, or if there is something else it should be replaced with?  If not, maybe we should remove this entry.
2. According to Wikipedia, Mantle has been completely discontinued. Should we replace Mantle links with equivalents about Vulkan?
```
In 2015, Mantle's public development was suspended and in 2019 completely discontinued, as DirectX 12 and the Mantle-derived Vulkan rose in popularity.
```

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
  - **I don't feel like this impacts users, so I haven't added a changelog entry -- but if anyone feels differently just let me know.**
- [x]  Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`

/cc @amethyst/documentation @amethyst/engine-developers 
