### PR TITLE
Allow one approval on a PR

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -101,8 +101,7 @@ developer, it will be merged into the source tree.
 The following rules shall be applied strictly for the `amethyst` repository. For other repositories of this organization,
 thorough review would be desirable, but no strict application is required there due to lower activity and less influence.
 
-* Pull Requests shall be approved by at least two members (two approvals from contributors can count as one member approval.)
-* Pull Requests opened by organization members may be merged if approved by one member.
+* Pull Requests shall be approved by at least one trusted contributor or member.
 * Merging a PR shall be done with `bors r+`, if possible. If there is more than one reviewer the preferred format is `bors r=@reviewer1, @reviewer2`. You can read more about this [here](https://bors.tech/documentation/).
 * You may only block merging of a PR if the changes in it are relevant to an org team you have joined. This doesn't mean you can't
 make comments, but it does mean that team may ignore your comments if they so choose. Please do not use the "Request Changes" feature if


### PR DESCRIPTION
## Description

Allow one approval on a PR as per [this post](https://community.amethyst.rs/t/2020-project-direction/1445/19?u=cleancut) in the forums. /cc @azriel91 

## Modifications

- Update the language surrounding PR approvals

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
