### PR TITLE
Add option to opt-out of thread-pool

### DIFF
--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -29,7 +29,6 @@ derive-new = "0.5"
 fnv = "1"
 log = "0.4.6"
 parking_lot = "0.10"
-rayon = "1.3.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", optional = true }
 ron = "0.5"

--- a/amethyst_assets/examples/hl.rs
+++ b/amethyst_assets/examples/hl.rs
@@ -2,9 +2,6 @@
 
 #![allow(unused)]
 
-use std::sync::Arc;
-
-use rayon::{ThreadPool, ThreadPoolBuilder};
 use serde::{Deserialize, Serialize};
 
 use amethyst_assets::*;
@@ -13,7 +10,7 @@ use amethyst_core::{
         Builder, Dispatcher, DispatcherBuilder, Read, ReadExpect, System, VecStorage, World,
         WorldExt, Write,
     },
-    Time,
+    ThreadPool, Time,
 };
 use amethyst_error::{format_err, Error, ResultExt};
 
@@ -28,7 +25,7 @@ impl App {
         let mut world = World::new();
 
         // Note: in an actual application, you'd want to share the thread pool.
-        let pool = Arc::new(ThreadPoolBuilder::new().build().expect("Invalid config"));
+        let pool = ThreadPool::new(None);
 
         world.register::<MeshHandle>();
 
@@ -100,7 +97,7 @@ impl<'a> System<'a> for RenderingSystem {
     type SystemData = (
         Write<'a, AssetStorage<MeshAsset>>,
         Read<'a, Time>,
-        ReadExpect<'a, Arc<ThreadPool>>,
+        ReadExpect<'a, ThreadPool>,
         Option<Read<'a, HotReloadStrategy>>,
         /* texture storage, transforms, .. */
     );

--- a/amethyst_assets/examples/ll.rs
+++ b/amethyst_assets/examples/ll.rs
@@ -2,10 +2,8 @@
 
 use std::{str::from_utf8, sync::Arc, thread::sleep, time::Duration};
 
-use rayon::ThreadPoolBuilder;
-
 use amethyst_assets::*;
-use amethyst_core::ecs::prelude::VecStorage;
+use amethyst_core::{ecs::prelude::VecStorage, ThreadPool};
 use amethyst_error::Error;
 
 #[derive(Clone, Debug)]
@@ -40,8 +38,8 @@ impl Format<String> for DummyFormat {
 fn main() {
     let path = format!("{}/examples/assets", env!("CARGO_MANIFEST_DIR"));
 
-    let builder = ThreadPoolBuilder::new().num_threads(8);
-    let pool = Arc::new(builder.build().expect("Invalid config"));
+    let num_threads = 8;
+    let pool = ThreadPool::new(Some(num_threads));
 
     let loader = Loader::new(&path, pool.clone());
     let mut storage: AssetStorage<DummyAsset> = AssetStorage::new();

--- a/amethyst_assets/src/lib.rs
+++ b/amethyst_assets/src/lib.rs
@@ -27,7 +27,7 @@ pub use crate::{
     storage::{AssetStorage, Handle, ProcessingState, Processor, WeakHandle},
 };
 
-pub use rayon::ThreadPool;
+pub use amethyst_core::ThreadPool;
 
 mod asset;
 mod cache;

--- a/amethyst_assets/src/loader.rs
+++ b/amethyst_assets/src/loader.rs
@@ -2,7 +2,6 @@ use std::{borrow::Borrow, hash::Hash, path::PathBuf, sync::Arc};
 
 use fnv::FnvHashMap;
 use log::debug;
-use rayon::ThreadPool;
 
 use amethyst_error::ResultExt;
 #[cfg(feature = "profiler")]
@@ -11,20 +10,20 @@ use thread_profiler::profile_scope;
 use crate::{
     error::Error,
     storage::{AssetStorage, Handle, Processed},
-    Asset, Directory, Format, FormatValue, Progress, Source,
+    Asset, Directory, Format, FormatValue, Progress, Source, ThreadPool,
 };
 
 /// The asset loader, holding the sources and a reference to the `ThreadPool`.
 pub struct Loader {
     hot_reload: bool,
-    pool: Arc<ThreadPool>,
+    pool: ThreadPool,
     sources: FnvHashMap<String, Arc<dyn Source>>,
 }
 
 impl Loader {
     /// Creates a new asset loader, initializing the directory store with the
     /// given path.
-    pub fn new<P>(directory: P, pool: Arc<ThreadPool>) -> Self
+    pub fn new<P>(directory: P, pool: ThreadPool) -> Self
     where
         P: Into<PathBuf>,
     {
@@ -32,7 +31,7 @@ impl Loader {
     }
 
     /// Creates a new asset loader, using the provided source
-    pub fn with_default_source<S>(source: S, pool: Arc<ThreadPool>) -> Self
+    pub fn with_default_source<S>(source: S, pool: ThreadPool) -> Self
     where
         S: Source,
     {

--- a/amethyst_assets/src/prefab/mod.rs
+++ b/amethyst_assets/src/prefab/mod.rs
@@ -467,11 +467,9 @@ where
 mod tests {
     use std::sync::Arc;
 
-    use rayon::ThreadPoolBuilder;
-
     use amethyst_core::{
         ecs::{Builder, RunNow, World, WorldExt},
-        SystemDesc, Time, Transform,
+        SystemDesc, ThreadPool, Time, Transform,
     };
 
     use crate::Loader;
@@ -483,7 +481,7 @@ mod tests {
     #[test]
     fn test_prefab_load() {
         let mut world = World::new();
-        let pool = Arc::new(ThreadPoolBuilder::default().build().unwrap());
+        let pool = ThreadPool::new(None);
         world.insert(pool.clone());
         world.insert(Loader::new(".", pool));
         world.insert(Time::default());

--- a/amethyst_assets/src/prefab/system.rs
+++ b/amethyst_assets/src/prefab/system.rs
@@ -8,7 +8,7 @@ use amethyst_core::{
         storage::ComponentEvent, BitSet, Entities, Entity, Join, Read, ReadExpect, ReadStorage,
         ReaderId, System, SystemData, World, Write, WriteStorage,
     },
-    ArcThreadPool, Parent, SystemDesc, Time,
+    Parent, SystemDesc, ThreadPool, Time,
 };
 use amethyst_error::{format_err, Error, ResultExt};
 
@@ -80,7 +80,7 @@ where
         Write<'a, AssetStorage<Prefab<T>>>,
         ReadStorage<'a, Handle<Prefab<T>>>,
         Read<'a, Time>,
-        ReadExpect<'a, ArcThreadPool>,
+        ReadExpect<'a, ThreadPool>,
         Option<Read<'a, HotReloadStrategy>>,
         WriteStorage<'a, Parent>,
         WriteStorage<'a, PrefabTag<T>>,
@@ -124,7 +124,7 @@ where
                 }
             },
             time.frame_number(),
-            &**pool,
+            &*pool,
             strategy,
         );
         prefab_handles

--- a/amethyst_assets/src/storage.rs
+++ b/amethyst_assets/src/storage.rs
@@ -9,7 +9,6 @@ use std::{
 use crossbeam_queue::SegQueue;
 use derivative::Derivative;
 use log::{debug, error, trace, warn};
-use rayon::ThreadPool;
 
 use amethyst_core::{
     ecs::{
@@ -17,7 +16,7 @@ use amethyst_core::{
         prelude::{Component, Read, ReadExpect, System, SystemData, VecStorage, World, Write},
         storage::UnprotectedStorage,
     },
-    SystemDesc, Time,
+    SystemDesc, ThreadPool, Time,
 };
 use amethyst_error::{Error, ResultExt};
 
@@ -532,7 +531,7 @@ where
 {
     type SystemData = (
         Write<'a, AssetStorage<A>>,
-        ReadExpect<'a, Arc<ThreadPool>>,
+        ReadExpect<'a, ThreadPool>,
         Read<'a, Time>,
         Option<Read<'a, HotReloadStrategy>>,
     );
@@ -544,7 +543,7 @@ where
         storage.process(
             ProcessableAsset::process,
             time.frame_number(),
-            &**pool,
+            &*pool,
             strategy.as_deref(),
         );
     }

--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -23,8 +23,6 @@ pub use num_traits as num;
 pub use specs as ecs;
 pub use specs::{shred, shrev};
 
-use std::sync::Arc;
-
 pub use crate::{
     bundle::SystemBundle,
     event::EventReader,
@@ -55,6 +53,7 @@ mod hide_system;
 mod named;
 mod system_desc;
 mod system_ext;
+mod thread_pool;
 
-/// A rayon thread pool wrapped in an `Arc`. This should be used as resource in `World`.
-pub type ArcThreadPool = Arc<rayon::ThreadPool>;
+/// A rayon thread pool proxy. This should be used as resource in `World`.
+pub type ThreadPool = thread_pool::ThreadPool;

--- a/amethyst_core/src/thread_pool.rs
+++ b/amethyst_core/src/thread_pool.rs
@@ -1,0 +1,53 @@
+use amethyst_error::Error;
+#[cfg(not(no_threading))]
+use std::sync::Arc;
+
+#[cfg(not(no_threading))]
+#[derive(Debug, Clone)]
+pub struct ThreadPool {
+    pool: Arc<rayon::ThreadPool>,
+}
+
+#[cfg(no_threading)]
+#[derive(Debug, Clone)]
+pub struct ThreadPool {}
+
+impl ThreadPool {
+    #[cfg(not(no_threading))]
+    pub fn new(thread_count: Option<usize>) -> Result<Self, Error> {
+        use rayon::ThreadPoolBuilder;
+        let thread_pool_builder = ThreadPoolBuilder::new();
+        #[cfg(feature = "profiler")]
+        let thread_pool_builder = thread_pool_builder.start_handler(|_index| {
+            register_thread_with_profiler();
+        });
+        let pool = if let Some(thread_count) = thread_count {
+            thread_pool_builder.num_threads(thread_count).build()
+        } else {
+            thread_pool_builder.build()
+        };
+        Ok(Self {
+            pool: Arc::new(pool?),
+        })
+    }
+
+    #[cfg(no_threading)]
+    pub fn new(_: Option<usize>) -> Result<Self, Error> {
+        Ok(Self {})
+    }
+
+    #[cfg(not(no_threading))]
+    pub fn rayon(&self) -> Arc<rayon::ThreadPool> {
+        self.pool.clone()
+    }
+
+    pub fn spawn<OP>(&self, op: OP)
+    where
+        OP: FnOnce() + Send + 'static,
+    {
+        #[cfg(not(no_threading))]
+        self.pool.spawn(op);
+        #[cfg(no_threading)]
+        op();
+    }
+}

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -37,7 +37,6 @@ thread_profiler = { version = "0.3", optional = true }
 approx = "0.3.2"
 
 [dev-dependencies]
-rayon = "1.3.0"
 more-asserts = "0.2.1"
 criterion = "0.3.0"
 winit = "0.19"

--- a/amethyst_rendy/src/sprite/mod.rs
+++ b/amethyst_rendy/src/sprite/mod.rs
@@ -581,11 +581,10 @@ mod test {
     fn create_texture() -> Handle<Texture> {
         use crate::formats::texture::TextureGenerator;
         use amethyst_assets::{AssetStorage, Loader};
-        use rayon::ThreadPoolBuilder;
+        use amethyst_core::ThreadPool;
         use std::sync::Arc;
 
-        let pool = Arc::new(ThreadPoolBuilder::new().build().expect("Invalid config"));
-        let loader = Loader::new("/examples/assets", pool);
+        let loader = Loader::new("/examples/assets", ThreadPool::new(None).unwrap());
         let generator = TextureGenerator::Srgba(1.0, 1., 1., 1.);
 
         let storage: AssetStorage<Texture> = AssetStorage::default();

--- a/amethyst_rendy/src/sprite/prefab.rs
+++ b/amethyst_rendy/src/sprite/prefab.rs
@@ -263,8 +263,7 @@ mod tests {
         Texture,
     };
     use amethyst_assets::{Handle, Loader};
-    use amethyst_core::ecs::{Builder, Read, ReadExpect, World, WorldExt};
-    use rayon::ThreadPoolBuilder;
+    use amethyst_core::ecs::{Builder, Read, ReadExpect, ThreadPool, World, WorldExt};
     use std::sync::Arc;
 
     use approx::assert_ulps_eq;
@@ -272,7 +271,7 @@ mod tests {
     fn setup_sprite_world() -> World {
         let mut world = World::new();
         world.register::<SpriteRender>();
-        let loader = Loader::new(".", Arc::new(ThreadPoolBuilder::new().build().unwrap()));
+        let loader = Loader::new(".", ThreadPool::new(None).unwrap());
         let tex_storage = AssetStorage::<Texture>::default();
         let ss_storage = AssetStorage::<SpriteSheet>::default();
         world.insert(tex_storage);

--- a/amethyst_rendy/src/system.rs
+++ b/amethyst_rendy/src/system.rs
@@ -25,7 +25,7 @@ use rendy::{
     graph::{Graph, GraphBuilder},
     texture::palette::{load_from_linear_rgba, load_from_srgba},
 };
-use std::{marker::PhantomData, sync::Arc};
+use std::marker::PhantomData;
 
 #[cfg(feature = "profiler")]
 use thread_profiler::profile_scope;
@@ -191,7 +191,7 @@ impl<'a, B: Backend> System<'a> for MeshProcessorSystem<B> {
         Write<'a, AssetStorage<Mesh>>,
         ReadExpect<'a, QueueId>,
         Read<'a, Time>,
-        ReadExpect<'a, Arc<ThreadPool>>,
+        ReadExpect<'a, ThreadPool>,
         Option<Read<'a, HotReloadStrategy>>,
         ReadExpect<'a, Factory<B>>,
     );
@@ -214,7 +214,7 @@ impl<'a, B: Backend> System<'a> for MeshProcessorSystem<B> {
                     .map_err(|e| e.compat().into())
             },
             time.frame_number(),
-            &**pool,
+            &*pool,
             strategy.as_deref(),
         );
     }
@@ -229,7 +229,7 @@ impl<'a, B: Backend> System<'a> for TextureProcessorSystem<B> {
         Write<'a, AssetStorage<Texture>>,
         ReadExpect<'a, QueueId>,
         Read<'a, Time>,
-        ReadExpect<'a, Arc<ThreadPool>>,
+        ReadExpect<'a, ThreadPool>,
         Option<Read<'a, HotReloadStrategy>>,
         WriteExpect<'a, Factory<B>>,
     );
@@ -261,7 +261,7 @@ impl<'a, B: Backend> System<'a> for TextureProcessorSystem<B> {
                 .map_err(|e| e.compat().into())
             },
             time.frame_number(),
-            &**pool,
+            &*pool,
             strategy.as_deref(),
         );
     }

--- a/book/src/controlling_system_execution/custom_game_data.md
+++ b/book/src/controlling_system_execution/custom_game_data.md
@@ -68,7 +68,7 @@ a builder that implements `DataInit`, as well as implement `DataDispose` for our
 #     running_dispatcher: Option<Dispatcher<'a, 'b>>,
 # }
 #
-use amethyst::core::ArcThreadPool;
+use amethyst::core::ThreadPool;
 
 pub struct CustomGameDataBuilder<'a, 'b> {
     pub core: DispatcherBuilder<'a, 'b>,
@@ -109,10 +109,10 @@ impl<'a, 'b> CustomGameDataBuilder<'a, 'b> {
 impl<'a, 'b> DataInit<CustomGameData<'a, 'b>> for CustomGameDataBuilder<'a, 'b> {
     fn build(self, world: &mut World) -> CustomGameData<'a, 'b> {
         // Get a handle to the `ThreadPool`.
-        let pool = (*world.read_resource::<ArcThreadPool>()).clone();
+        let pool = world.read_resource::<ThreadPool>();
 
-        let mut core_dispatcher = self.core.with_pool(pool.clone()).build();
-        let mut running_dispatcher = self.running.with_pool(pool.clone()).build();
+        let mut core_dispatcher = self.core.with_pool(pool.rayon()).build();
+        let mut running_dispatcher = self.running.with_pool(pool.rayon()).build();
         core_dispatcher.setup(world);
         running_dispatcher.setup(world);
 

--- a/book/src/controlling_system_execution/state-specific_dispatcher.md
+++ b/book/src/controlling_system_execution/state-specific_dispatcher.md
@@ -67,7 +67,7 @@ The `DispatcherBuilder` can be initialized and populated wherever desired, be it
 # use amethyst::{
 #     ecs::prelude::*,
 #     prelude::*,
-#     core::ArcThreadPool,
+#     core::ThreadPool,
 # };
 #
 # struct MoveBallsSystem; struct MovePaddlesSystem;
@@ -91,7 +91,7 @@ impl<'a, 'b> SimpleState for CustomState<'a, 'b> {
 
         // Build and setup the `Dispatcher`.
         let mut dispatcher = dispatcher_builder
-            .with_pool((*world.read_resource::<ArcThreadPool>()).clone())
+            .with_pool(world.read_resource::<ThreadPool>().rayon())
             .build();
         dispatcher.setup(world);
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -56,6 +56,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - ***Breaking:*** `UiBundle` depends on `InputBundle` being registered with the dispatcher first. ([#2151])
 - Re-export `UiImageLoadPrefab` from `amethyst_ui`. ([#2169], [#2181])
 - Don't remove `HiddenPropagate` components set by users manually. ([#2155])
+* Replace `amethyst::core::ArcThreadPool` with `amethyst::core::ThreadPool` which proxies to it. ([#2354])
+* `amethyst::assets::ThreadPool` exports `amethyst::core::ThreadPool` instead of `rayon::ThreadPool`. ([#2354])
 
 ### Removed
 

--- a/examples/custom_game_data/game_data.rs
+++ b/examples/custom_game_data/game_data.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use amethyst::{
-    core::{ArcThreadPool, SystemBundle, SystemDesc},
+    core::{SystemBundle, SystemDesc, ThreadPool},
     ecs::prelude::{Dispatcher, DispatcherBuilder, System, World, WorldExt},
     error::Error,
     DataDispose, DataInit,
@@ -130,11 +130,7 @@ fn build_dispatcher<'a, 'b>(
 ) -> Dispatcher<'a, 'b> {
     let mut dispatcher_builder = DispatcherBuilder::new();
 
-    #[cfg(not(no_threading))]
-    {
-        let pool = world.read_resource::<ArcThreadPool>().clone();
-        dispatcher_builder = dispatcher_builder.with_pool((*pool).clone());
-    }
+    dispatcher_builder = dispatcher_builder.with_pool(world.read_resource::<ThreadPool>().rayon());
 
     dispatcher_operations
         .into_iter()


### PR DESCRIPTION
## Description

This is useful for rare cases where threading is not available and for some cases of debugging. `cfg(no_threading)` was already used in the codebase; just not consistently. It should be noted that in specs and shred threading is behind a feature called `parallel` instead.

## Modifications

`ArcThreadPool` got renamed to `ThreadPool`. It's now a structure that wraps the `Arc<ThreadPool>` and proxies its `spawn` method so no more deref required. It was used inconsistently thus far as the type alias was often omitted. Most users should've never touched this resource before.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Modified unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
