### PR TITLE
Change proposal to define_the_sprite_sheet.md

### DIFF
--- a/book/src/sprites/define_the_sprite_sheet.md
+++ b/book/src/sprites/define_the_sprite_sheet.md
@@ -38,7 +38,6 @@ List((
     ],
 ))
 ```
-`offsets: Some((0.0, 0.0)),` can be replaced by `offsets: (0.0, 0.0),` if the line `#![enable(implicit_some)]` is added at the top of the definition file.
 
 Or you can use a grid based definition, for example:
 
@@ -51,28 +50,13 @@ Grid((
     // Specifies the number of columns in the sprite sheet
     columns: 2,
     // Specifies the number of sprites in the spritesheet.
-    sprite_count: 2
+    sprite_count: Some(2)
 ))
 ```
 
-It is possible sprite will not be displayed. This might be because of value wrapped into
-`Option<..>` and this happens with values specified as `Option<..>`. You can check
-for such values here [`SpriteGrid`][doc_grid] and [`SpriteList`][doc_list]
-<br>
-You can mitigate either by telling Amethyst to implicitly wrap values into `Some<..>`
-by adding `#![enable(implicit_some)]` to the very top of the file, or by specifying 
-values as `Some(xx)` where `xx` is your desired value.
+`Option` types need to be wrapped in the `Some` variant. For convenience, this can be left out if the line `#![enable(implicit_some)]` is added at the top of the definition file.  For example, `sprite_count: Some(2),` could be replaced by `sprite_count: 2,`.  Don't forget to either wrap the value in `Some` or put `#![enable(implicit_some)]` at the top of the file, otherwise your sprite sheet will fail to load and your sprites will not be displayed.
 
-E.g. following does not work:
-```rust,edition2018,no_run,noplaypen
-sprite_count: 48
-```
-And would need to be altered to
-```rust,edition2018,no_run,noplaypen
-sprite_count: Some(48)
-```
-
-For more information about list and grid based sprite sheets see [`SpriteGrid`][doc_grid] or [`SpriteList`][doc_list].
+For more information about list and grid based sprite sheets, including the types of their fields, see [`SpriteGrid`][doc_grid] or [`SpriteList`][doc_list].
 
 Once you have ron file ready, you can load it using the texture handle of the sheet's image you loaded earlier:
 

--- a/book/src/sprites/define_the_sprite_sheet.md
+++ b/book/src/sprites/define_the_sprite_sheet.md
@@ -55,10 +55,13 @@ Grid((
 ))
 ```
 
-It is possible one of attributes will get out of bounds defined by method declaration. 
-If that happens, sprite will not be displayed. You can mitigate either by adding 
-`#![enable(implicit_some)]` to the very top of the file, or by specifying value
-as `Some(xx)` where `xx` is number out of bounds.
+It is possible sprite will not be displayed. This might be because of value wrapped into
+`Option<..>` and this happens with values specified as `Option<..>`. You can check
+for such values here [`SpriteGrid`][doc_grid] and [`SpriteList`][doc_list]
+<br>
+You can mitigate either by telling Amethyst to implicitly wrap values into `Some<..>`
+by adding `#![enable(implicit_some)]` to the very top of the file, or by specifying 
+values as `Some(xx)` where `xx` is your desired value.
 
 E.g. following does not work:
 ```rust,edition2018,no_run,noplaypen

--- a/book/src/sprites/define_the_sprite_sheet.md
+++ b/book/src/sprites/define_the_sprite_sheet.md
@@ -55,9 +55,23 @@ Grid((
 ))
 ```
 
+It is possible one of attributes will get out of bounds defined by method declaration. 
+If that happens, sprite will not be displayed. You can mitigate either by adding 
+`#![enable(implicit_some)]` to the very top of the file, or by specifying value
+as `Some(xx)` where `xx` is number out of bounds.
+
+E.g. following does not work:
+```rust,edition2018,no_run,noplaypen
+sprite_count: 48
+```
+And would need to be altered to
+```rust,edition2018,no_run,noplaypen
+sprite_count: Some(48)
+```
+
 For more information about list and grid based sprite sheets see [`SpriteGrid`][doc_grid] or [`SpriteList`][doc_list].
 
-Then, you can load it using the texture handle of the sheet's image you loaded earlier:
+Once you have ron file ready, you can load it using the texture handle of the sheet's image you loaded earlier:
 
 ```rust,edition2018,no_run,noplaypen
 # extern crate amethyst;

--- a/book/src/sprites/define_the_sprite_sheet.md
+++ b/book/src/sprites/define_the_sprite_sheet.md
@@ -54,7 +54,7 @@ Grid((
 ))
 ```
 
-`Option` types need to be wrapped in the `Some` variant. For convenience, this can be left out if the line `#![enable(implicit_some)]` is added at the top of the definition file.  For example, `sprite_count: Some(2),` could be replaced by `sprite_count: 2,`.  Don't forget to either wrap the value in `Some` or put `#![enable(implicit_some)]` at the top of the file, otherwise your sprite sheet will fail to load and your sprites will not be displayed.
+`Option` types need to be wrapped in the `Some` variant. For convenience, this can be left out if the line `#![enable(implicit_some)]` is added at the top of the definition file.  For example, `sprite_count: Some(2),` could be replaced by `sprite_count: 2,`.
 
 For more information about list and grid based sprite sheets, including the types of their fields, see [`SpriteGrid`][doc_grid] or [`SpriteList`][doc_list].
 


### PR DESCRIPTION
## Description

On @CleanCut [advice](https://community.amethyst.rs/t/how-can-i-know-sprite-really-got-loaded/1556/3?u=sophisticatedspoon), this PR adds clarity to declaring values for ron files, used by [SpriteGrid](https://docs.amethyst.rs/stable/amethyst_rendy/sprite/struct.SpriteGrid.html) and [SpriteList](https://docs.amethyst.rs/stable/amethyst_rendy/sprite/struct.SpriteList.html)

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
