### PR TITLE
Fix links and an error in amethyst_error docs

### DIFF
--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -104,8 +104,9 @@ impl Error {
     ///
     /// # Examples
     ///
-    /// The only way to set the source is through [`ResultExt`](ResultExt) using
-    /// [`with_context`](ResultExt::with_context).
+    /// The source can be set using [`with_source`](struct.Error.html#method.with_source) or
+    /// through [`ResultExt`](trait.ResultExt.html) using
+    /// [`with_context`](trait.ResultExt.html#method.with_context).
     ///
     /// ```rust
     /// use amethyst_error::{Error, ResultExt};
@@ -195,7 +196,7 @@ where
     /// Provide a context for the result in case it is an error.
     ///
     /// The context callback is expected to return a new error, which will replace the given error
-    /// and set the replaced error as its [`source`](Error::source).
+    /// and set the replaced error as its [`source`](struct.Error.html#method.source).
     ///
     /// # Examples
     ///
@@ -243,7 +244,7 @@ where
 
 /// An iterator over all the causes for this error.
 ///
-/// Created using [`Error::causes`](Error::causes).
+/// Created using [`Error::causes`](struct.Error.html#method.causes).
 #[derive(Debug, Clone)]
 pub struct Causes<'a> {
     current: Option<&'a Error>,
@@ -277,7 +278,7 @@ macro_rules! format_err {
     ($($arg:tt)*) => { $crate::Error::from_string(format!($($arg)*)) }
 }
 
-/// Constructs an [`Error`](Error) from a string.
+/// Constructs an [`Error`](struct.Error.html) from a string.
 pub fn err_msg<M>(message: M) -> Error
 where
     M: 'static + Send + Sync + fmt::Debug + fmt::Display,


### PR DESCRIPTION
## Description

I found that some links were broken and I fixed them. They had a different syntax that (*I think*) should work if running cargo doc with nightly, but obviously amethyst isn't doing that because they are also broken in the amethyst master documentation. I also changed a line which wasn't correct.

## Additions

No

## Removals

No

## Modifications

Only docs

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
I did but I only got:
```
Warning: can't set `merge_imports = true`, unstable features are only available in nightly channel.
```
Anyway these are minor changes and I wrapped the lines at ~80 characters

I didn't modify any code, so I don't think I need these?
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
