### PR TITLE
Add LightPrefab to GltfPrefab

### DIFF
--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -23,7 +23,7 @@ amethyst_rendy = { path = "../amethyst_rendy", version = "0.5.0" }
 err-derive = "0.2.3"
 base64 = "0.11"
 fnv = "1"
-gltf = "0.15"
+gltf = { version = "0.15", features = ["KHR_lights_punctual"] }
 hibitset = { version = "0.6.2", features = ["parallel"] }
 itertools = "0.8"
 log = "0.4.6"

--- a/amethyst_gltf/src/format/mod.rs
+++ b/amethyst_gltf/src/format/mod.rs
@@ -13,10 +13,7 @@ use amethyst_core::{
     transform::Transform,
 };
 use amethyst_error::{format_err, Error, ResultExt};
-use amethyst_rendy::{
-    camera::CameraPrefab,
-    light::LightPrefab,
-};
+use amethyst_rendy::{camera::CameraPrefab, light::LightPrefab};
 
 use crate::{error, GltfMaterialSet, GltfNodeExtent, GltfPrefab, GltfSceneOptions, Named};
 

--- a/amethyst_gltf/src/format/mod.rs
+++ b/amethyst_gltf/src/format/mod.rs
@@ -15,7 +15,7 @@ use amethyst_core::{
 use amethyst_error::{format_err, Error, ResultExt};
 use amethyst_rendy::{
     camera::CameraPrefab,
-    light::{Light, LightPrefab},
+    light::LightPrefab,
 };
 
 use crate::{error, GltfMaterialSet, GltfNodeExtent, GltfPrefab, GltfSceneOptions, Named};

--- a/amethyst_gltf/src/format/mod.rs
+++ b/amethyst_gltf/src/format/mod.rs
@@ -13,7 +13,10 @@ use amethyst_core::{
     transform::Transform,
 };
 use amethyst_error::{format_err, Error, ResultExt};
-use amethyst_rendy::camera::CameraPrefab;
+use amethyst_rendy::{
+    camera::CameraPrefab,
+    light::{LightPrefab, Light},
+};
 
 use crate::{error, GltfMaterialSet, GltfNodeExtent, GltfPrefab, GltfSceneOptions, Named};
 
@@ -244,6 +247,13 @@ fn load_node(
                 znear: proj.znear(),
             },
         });
+    }
+
+    // Load lights
+    if let Some(light) = node.light() {
+        prefab.data_or_default(entity_index).light = Some(
+            LightPrefab::from(light),
+        );
     }
 
     // check for skinning

--- a/amethyst_gltf/src/format/mod.rs
+++ b/amethyst_gltf/src/format/mod.rs
@@ -15,7 +15,7 @@ use amethyst_core::{
 use amethyst_error::{format_err, Error, ResultExt};
 use amethyst_rendy::{
     camera::CameraPrefab,
-    light::{LightPrefab, Light},
+    light::{Light, LightPrefab},
 };
 
 use crate::{error, GltfMaterialSet, GltfNodeExtent, GltfPrefab, GltfSceneOptions, Named};
@@ -251,9 +251,7 @@ fn load_node(
 
     // Load lights
     if let Some(light) = node.light() {
-        prefab.data_or_default(entity_index).light = Some(
-            LightPrefab::from(light),
-        );
+        prefab.data_or_default(entity_index).light = Some(LightPrefab::from(light));
     }
 
     // check for skinning

--- a/amethyst_gltf/src/lib.rs
+++ b/amethyst_gltf/src/lib.rs
@@ -22,8 +22,8 @@ use amethyst_core::{
 };
 use amethyst_error::Error;
 use amethyst_rendy::{
-    camera::CameraPrefab, formats::mtl::MaterialPrefab, rendy::mesh::MeshBuilder, types::Mesh, light::LightPrefab,
-    visibility::BoundingSphere,
+    camera::CameraPrefab, formats::mtl::MaterialPrefab, light::LightPrefab,
+    rendy::mesh::MeshBuilder, types::Mesh, visibility::BoundingSphere,
 };
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};

--- a/amethyst_gltf/src/lib.rs
+++ b/amethyst_gltf/src/lib.rs
@@ -22,7 +22,7 @@ use amethyst_core::{
 };
 use amethyst_error::Error;
 use amethyst_rendy::{
-    camera::CameraPrefab, formats::mtl::MaterialPrefab, rendy::mesh::MeshBuilder, types::Mesh,
+    camera::CameraPrefab, formats::mtl::MaterialPrefab, rendy::mesh::MeshBuilder, types::Mesh, light::LightPrefab,
     visibility::BoundingSphere,
 };
 use derivative::Derivative;
@@ -51,6 +51,8 @@ pub struct GltfPrefab {
     pub transform: Option<Transform>,
     /// `Camera` will always be placed
     pub camera: Option<CameraPrefab>,
+    /// Lights can be added to a prefab with the `KHR_lights_punctual` feature enabled
+    pub light: Option<LightPrefab>,
     /// `MeshData` is placed on all `Entity`s with graphics primitives
     pub mesh: Option<MeshBuilder<'static>>,
     /// Mesh handle after sub asset loading is done
@@ -218,6 +220,7 @@ impl<'a> PrefabData<'a> for GltfPrefab {
         <Transform as PrefabData<'a>>::SystemData,
         <Named as PrefabData<'a>>::SystemData,
         <CameraPrefab as PrefabData<'a>>::SystemData,
+        <LightPrefab as PrefabData<'a>>::SystemData,
         <MaterialPrefab as PrefabData<'a>>::SystemData,
         <AnimatablePrefab<usize, Transform> as PrefabData<'a>>::SystemData,
         <SkinnablePrefab as PrefabData<'a>>::SystemData,
@@ -240,6 +243,7 @@ impl<'a> PrefabData<'a> for GltfPrefab {
             transforms,
             names,
             cameras,
+            lights,
             materials,
             animatables,
             skinnables,
@@ -257,6 +261,9 @@ impl<'a> PrefabData<'a> for GltfPrefab {
         }
         if let Some(camera) = &self.camera {
             camera.add_to_entity(entity, cameras, entities, children)?;
+        }
+        if let Some(light) = &self.light {
+            light.add_to_entity(entity, lights, entities, children)?;
         }
         if let Some(name) = &self.name {
             name.add_to_entity(entity, names, entities, children)?;
@@ -281,7 +288,7 @@ impl<'a> PrefabData<'a> for GltfPrefab {
         progress: &mut ProgressCounter,
         system_data: &mut Self::SystemData,
     ) -> Result<bool, Error> {
-        let (_, _, _, materials, animatables, _, _, _, meshes_storage, loader, mat_set) =
+        let (_, _, _, _, materials, animatables, _, _, _, meshes_storage, loader, mat_set) =
             system_data;
 
         let mut ret = false;

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -22,6 +22,7 @@ derive-new = "0.5.6"
 failure = "0.1"
 genmesh = "0.6"
 glsl-layout = "0.3"
+gltf = { version = "0.15", features = ["KHR_lights_punctual"] }
 lazy_static = "1.4"
 log = "0.4"
 palette = { version = "0.4", features = ["serde"] }

--- a/amethyst_rendy/src/light.rs
+++ b/amethyst_rendy/src/light.rs
@@ -194,3 +194,47 @@ pub struct LightPrefab {
     light: Option<Light>,
     ambient_color: Option<AmbientColor>,
 }
+
+use gltf::khr_lights_punctual::Kind;
+use gltf::khr_lights_punctual;
+
+/// Import a gltf light into a LightPrefab
+impl From<khr_lights_punctual::Light<'_>> for LightPrefab {
+    fn from(light: khr_lights_punctual::Light<'_>) -> Self {
+        let color = {
+            let parts = light.color();
+            palette::Srgb::new(parts[0], parts[1], parts[2])
+        };
+        let intensity = light.intensity();
+        let range = light.range();
+        LightPrefab {
+            light: Some(
+                match light.kind() {
+                    Kind::Directional => {
+                        let mut directional = DirectionalLight::default();
+                        directional.color = color;
+                        directional.intensity = intensity;
+                        Light::Directional(directional)
+                    },
+                    Kind::Point => {
+                        let mut point = PointLight::default();
+                        point.color = color;
+                        point.intensity = intensity;
+                        if let Some(r) = range {
+                            point.radius = r;
+                        }
+                        Light::Point(point)
+                    },
+                    Kind::Spot { inner_cone_angle, outer_cone_angle } => {
+                        let mut spot = SpotLight::default();
+                        spot.angle = outer_cone_angle;
+                        spot.color = color;
+                        spot.intensity = intensity;
+                        Light::Spot(spot)
+                    },
+                }
+            ),
+            ambient_color: None,
+        }
+    }
+}

--- a/amethyst_rendy/src/light.rs
+++ b/amethyst_rendy/src/light.rs
@@ -195,8 +195,8 @@ pub struct LightPrefab {
     ambient_color: Option<AmbientColor>,
 }
 
-use gltf::khr_lights_punctual::Kind;
 use gltf::khr_lights_punctual;
+use gltf::khr_lights_punctual::Kind;
 
 /// Import a gltf light into a LightPrefab
 impl From<khr_lights_punctual::Light<'_>> for LightPrefab {
@@ -208,32 +208,33 @@ impl From<khr_lights_punctual::Light<'_>> for LightPrefab {
         let intensity = light.intensity();
         let range = light.range();
         LightPrefab {
-            light: Some(
-                match light.kind() {
-                    Kind::Directional => {
-                        let mut directional = DirectionalLight::default();
-                        directional.color = color;
-                        directional.intensity = intensity;
-                        Light::Directional(directional)
-                    },
-                    Kind::Point => {
-                        let mut point = PointLight::default();
-                        point.color = color;
-                        point.intensity = intensity;
-                        if let Some(r) = range {
-                            point.radius = r;
-                        }
-                        Light::Point(point)
-                    },
-                    Kind::Spot { inner_cone_angle, outer_cone_angle } => {
-                        let mut spot = SpotLight::default();
-                        spot.angle = outer_cone_angle;
-                        spot.color = color;
-                        spot.intensity = intensity;
-                        Light::Spot(spot)
-                    },
+            light: Some(match light.kind() {
+                Kind::Directional => {
+                    let mut directional = DirectionalLight::default();
+                    directional.color = color;
+                    directional.intensity = intensity;
+                    Light::Directional(directional)
                 }
-            ),
+                Kind::Point => {
+                    let mut point = PointLight::default();
+                    point.color = color;
+                    point.intensity = intensity;
+                    if let Some(r) = range {
+                        point.radius = r;
+                    }
+                    Light::Point(point)
+                }
+                Kind::Spot {
+                    inner_cone_angle,
+                    outer_cone_angle,
+                } => {
+                    let mut spot = SpotLight::default();
+                    spot.angle = outer_cone_angle;
+                    spot.color = color;
+                    spot.intensity = intensity;
+                    Light::Spot(spot)
+                }
+            }),
             ambient_color: None,
         }
     }


### PR DESCRIPTION
Resolves #2348

## Description

Add LightPrefabs to the GltfPrefab parser.

Edit: If any maintainers have ideas about how to unit test this let me know! I would love to add some automated tests -- I just didn't see any existing tests to add to.

## Additions

- Add a public `light: Option<LightPrefab>,` member to the `GltfPrefab` public struct.
- Add the `gltf` crate to `amethyst_rendy` with the `KHR_lights_punctual` feature enabled.
- Implement `From<khr_lights_punctual::Light<'_>>` for `amethyst_rendy::light::LightPrefab.

## Removals

N/A

## Modifications

- Enable the `KHR_lights_punctual` feature for the `gltf` dependency in `amethyst_gltf`.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
