### PR TITLE
Add missing alt attribute to readme image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="docs/splash.png" />
+<img src="docs/splash.png" alt="Amethyst Game Engine" />
 
 [![Build Status][s1]][jc] [![Crates.io][s2]][ci] [![docs page][docs-badge]][docs] [![MIT/Apache][s3]][li]
 [![Join us on Discord][s4]][di] [![Community forum][s5]][ds] [![Reddit][s7]][rd]


### PR DESCRIPTION
## Description
The img tag added by #2367  was missing the mandatory 'alt' attribute. It is used in
place of the image when it can't be rendered, such as when screen reader
software used, or when using a text-based web browser.


- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.