### PR TITLE
Require compiling examples

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -244,6 +244,45 @@ page, we can do this inline.
 [al]: https://another.url/
 ```
 
+Code snippets in markdown files should be surrounded by triple backticks with the modifier `rust,edition2018,no_run,noplaypen`. Use `#` to hide lines that are necessary to compile in doctests but aren't relevant to the example, use `//` for in-code comments.  For example: 
+
+````
+```rust,edition2018,no_run,noplaypen
+# extern crate amethyst;
+use amethyst::ecs::{World, WorldExt};
+
+// A simple struct with no data.
+struct MyResource;
+
+fn main() {
+    // We create a new `World` instance.
+    let mut world = World::new();
+    
+    // We create our resource.
+    let my = MyResource;
+    
+    // We add the resource to the world.
+    world.insert(my);
+}
+```
+````
+
+Examples in `book/` can be tested with the following:
+
+```shell
+# First, clean up amethyst artifacts and rebuild to ensure there is only one copy of the artifacts in
+# the amethyst repo, otherwise mdbook complains. You only need to do this once, unless you change code
+# in the actual amethyst library.
+rm -rf ./target/debug/deps/libamethyst*
+cargo test --workspace --features=empty --no-run
+
+# Then, test the book.  You can edit, run this command, and then repeat until you get everything passing.
+# This is what the book tests in CI do, so the snippets in the book must pass before you can push.
+mdbook test -L ./target/debug/deps book
+```
+
+Examples in the API can be tested with `cargo test`.  Examples in top-level markdown files (like the one we are currently in) are not tested.
+
 When submitting your pull requests, please follow the same procedures described
 in the [Pull Requests](#pull-requests) section above.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -233,6 +233,7 @@ Documentation of any kind should adhere to the following standard:
    style* Markdown links, as shown in the example below. However, if the link
    points to an anchor that exists on the same page, the *inline style* should
    be used instead.
+3. Rust code snippets should be compilable whenever reasonably possible.
 
 ```markdown
 Here is some [example text][et] with a link in it. While we are at it, here is

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -279,6 +279,8 @@ cargo test --workspace --features=empty --no-run
 # Then, test the book.  You can edit, run this command, and then repeat until you get everything passing.
 # This is what the book tests in CI do, so the snippets in the book must pass before you can push.
 mdbook test -L ./target/debug/deps book
+# This serves your book so you can view it locally in a browser and see what it actually looks like
+mdbook serve book
 ```
 
 Examples in the API can be tested with `cargo test`.  Examples in top-level markdown files (like the one we are currently in) are not tested.


### PR DESCRIPTION
## Description

Require compiling examples, spurred from discussion in https://github.com/amethyst/amethyst/issues/2365

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
