### PR TITLE
Give `Default` and `Clone` to `UiButtonActionRetrigger`

### DIFF
--- a/amethyst_ui/src/button/retrigger.rs
+++ b/amethyst_ui/src/button/retrigger.rs
@@ -16,7 +16,7 @@ pub type UiButtonActionRetriggerSystem = EventRetriggerSystem<UiButtonActionRetr
 
 /// Attach this to an entity with a `UiButton` attached to it to
 /// trigger specific events when a user interaction happens.
-#[derive(Debug)]
+#[derive(Debug, Default, Clone)]
 pub struct UiButtonActionRetrigger {
     /// The `UiButtonAction`s that should happen when the user begins a click
     /// on the `UiButton`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - `amethyst_rendy::shape::Shape::upload` takes `&ShapeUpload`. ([#2264])
 - Examples now have assets colocated in the individual example directiories ([#2289], [#2305])
 - `UiText` now requires 2 more arguments `line_mode` and `align` ([#2358])
+- `amethyst_ui::UiButtonActionRetrigger` now derives `Default` and `Clone`. ([#2388])
 
 ### Fixed
 
@@ -42,6 +43,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#2264]: https://github.com/amethyst/amethyst/pull/2264
 [#2299]: https://github.com/amethyst/amethyst/pull/2299
 [#2339]: https://github.com/amethyst/amethyst/pull/2339
+[#2388]: https://github.com/amethyst/amethyst/pull/2388
 
 ## [0.15.0] - 2020-03-24
 


### PR DESCRIPTION
## Description

This PR gives derived implementations of the `Default` and `Clone` traits to the `UiButtonActionRetrigger` struct. The type's fields are `Vec`s of a type that itself has `Clone`, so this should be harmless. `Default` makes instantiating a custom `UiButtonActionRetrigger` a bit less verbose.

## Modifications

- `UiButtonActionRetrigger` now derives `Default` and `Clone`. 

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- ~Added unit tests for new code added in this PR.~
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
