### PR TITLE
Add `SpriteRender::new`

### DIFF
--- a/amethyst_rendy/src/sprite/mod.rs
+++ b/amethyst_rendy/src/sprite/mod.rs
@@ -183,14 +183,24 @@ impl From<&TextureCoordinates> for [f32; 4] {
 
 /// Information for rendering a sprite.
 ///
-/// Instead of using a `Mesh` on a `DrawFlat` render pass, we can use a simpler set of shaders to
-/// render textures to quads. This struct carries the information necessary for the draw2dflat pass.
+/// Instead of using a `Mesh` on a `DrawFlat` render pass, we can use a simpler
+/// set of shaders to render textures to quads. This struct carries the
+/// information necessary for the draw2dflat pass.
 #[derive(Clone, Debug, PartialEq)]
 pub struct SpriteRender {
     /// Handle to the sprite sheet of the sprite
     pub sprite_sheet: Handle<SpriteSheet>,
     /// Index of the sprite on the sprite sheet
     pub sprite_number: usize,
+}
+
+impl SpriteRender {
+    pub fn new(sprite_sheet: Handle<SpriteSheet>, sprite_number: usize) -> SpriteRender {
+        SpriteRender {
+            sprite_sheet,
+            sprite_number,
+        }
+    }
 }
 
 impl Component for SpriteRender {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - `amethyst_input::axis::Axis` supports a new variant, `Multiple` ([#2341])
 - Support layer to be set in `UiLabelBuilder` ([#2358])
 - Support line mode to be set in `UiLabelBuilder` and `UiButtonBuilder` ([#2358])
+- `SpriteRender::new` for cleaner instantiation ([#2395])
 
 ### Changed
 
@@ -42,6 +43,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 [#2264]: https://github.com/amethyst/amethyst/pull/2264
 [#2299]: https://github.com/amethyst/amethyst/pull/2299
 [#2339]: https://github.com/amethyst/amethyst/pull/2339
+[#2395]: https://github.com/amethyst/amethyst/pull/2395
 
 ## [0.15.0] - 2020-03-24
 


### PR DESCRIPTION
## Description

This PR adds a `new` associated function to `SpriteRender`, so that instantiating the type can be a little cleaner for users.

## Additions

- `SpriteRender::new`

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- ~Added unit tests for new code added in this PR.~
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
