### PR TITLE
Remove world.insert(EventChannel) from concepts/event-channel#patterns

### DIFF
--- a/book/src/concepts/event-channel.md
+++ b/book/src/concepts/event-channel.md
@@ -106,24 +106,6 @@ It is the `ReaderId` that needs to be mutable to keep track of where your last r
 When using the event channel, we usually re-use the same pattern over and over again to maximize parallelism.
 It goes as follow:
 
-Create the event channel and add it to the world during `State` creation:
-
-```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
-# use amethyst::{ecs::{World, WorldExt}, shrev::EventChannel};
-# #[derive(Debug)]
-# pub enum MyEvent {
-#   A,
-#   B,
-# }
-# fn main() {
-#   let mut world = World::new();
-world.insert(EventChannel::<MyEvent>::new());
-# }
-```
-
-_Note: You can also derive `Default`, this way you don't have to manually create your resource and add it. Resources implementing `Default` are automatically added to `Resources` when a `System` uses them (`Read` or `Write` in `SystemData`)._
-
 In the **producer** `System`, get a mutable reference to your resource:
 
 ```rust,edition2018,no_run,noplaypen


### PR DESCRIPTION
## Description
Removed the paragraph to run `world.insert()` from concepts/event-channel#patterns

`EventChannel` always implements `Default` for valid event types. It is not necessary to derive Default anyway.

## Modifications

- Updated the book

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
