### PR TITLE
Add doc comments that explain functions/tuples that take linear RGBA

### DIFF
--- a/amethyst_rendy/src/plugins.rs
+++ b/amethyst_rendy/src/plugins.rs
@@ -66,14 +66,17 @@ mod window {
         /// Clear window with specified color every frame.
         /// This function takes linear RGBA. You can convert rgba to linear rgba like so (where your_r, your_g, your_b, and your_g are all u32):
         ///
-        /// ```no_run
+        /// ```
         /// use amethyst::renderer::palette::Srgba;
+        /// use amethyst::renderer::RenderToWindow;
         ///
-        /// let (r, g, b, a) = Srgba::new(your_r / 255., your_g / 255., your_b / 255., your_a)
-        ///  .into_linear()
-        ///  .into_components();
+        /// # fn main() {
+        ///     let (r, g, b, a) = Srgba::new(your_r / 255., your_g / 255., your_b / 255., your_a)
+        ///         .into_linear()
+        ///         .into_components();
         ///
-        /// RenderToWindow{ ... }.with_clear([r, g, b, a]);
+        ///     RenderToWindow::from_config_path(display_config)?.with_clear([r, g, b, a]);
+        /// # }
         /// ```
         pub fn with_clear(mut self, clear: impl Into<ClearColor>) -> Self {
             self.clear = Some(clear.into());

--- a/amethyst_rendy/src/plugins.rs
+++ b/amethyst_rendy/src/plugins.rs
@@ -64,6 +64,17 @@ mod window {
         }
 
         /// Clear window with specified color every frame.
+        /// This function takes linear RGBA. You can convert rgba to linear rgba like so (where your_r, your_g, your_b, and your_g are all u32):
+        ///
+        /// ```no_run
+        /// use amethyst::renderer::palette::Srgba;
+        ///
+        /// let (r, g, b, a) = Srgba::new(your_r / 255., your_g / 255., your_b / 255., your_a)
+        ///  .into_linear()
+        ///  .into_components();
+        ///
+        /// RenderToWindow{ ... }.with_clear([r, g, b, a]);
+        /// ```
         pub fn with_clear(mut self, clear: impl Into<ClearColor>) -> Self {
             self.clear = Some(clear.into());
             self

--- a/amethyst_rendy/src/plugins.rs
+++ b/amethyst_rendy/src/plugins.rs
@@ -66,10 +66,10 @@ mod window {
         /// Clear window with specified color every frame.
         /// This function takes linear RGBA. You can convert rgba to linear rgba like so (where your_r, your_g, your_b, and your_g are all u32):
         ///
-        /// ```no_run
+        /// ```
         /// use amethyst_rendy::palette::Srgba;
         /// use amethyst_rendy::RenderToWindow;
-        /// # use std::path::PathBuf;
+        /// use amethyst_window::DisplayConfig;
         ///
         /// let your_red: f32 = 255.;
         /// let your_green: f32 = 160.;
@@ -80,9 +80,7 @@ mod window {
         ///     .into_linear()
         ///     .into_components();
         ///
-        /// # let display_config = PathBuf::new().join("display_config.ron");
-        ///
-        /// RenderToWindow::from_config_path(display_config).unwrap().with_clear([r, g, b, a]);
+        /// RenderToWindow::from_config(DisplayConfig::default()).with_clear([r, g, b, a]);
         /// ```
         pub fn with_clear(mut self, clear: impl Into<ClearColor>) -> Self {
             self.clear = Some(clear.into());

--- a/amethyst_rendy/src/plugins.rs
+++ b/amethyst_rendy/src/plugins.rs
@@ -64,7 +64,7 @@ mod window {
         }
 
         /// Clear window with specified color every frame.
-        /// This function takes linear RGBA. You can convert rgba to linear rgba like so (where your_r, your_g, your_b, and your_g are all u32):
+        /// This function takes linear RGBA. You can convert rgba to linear rgba like so:
         ///
         /// ```
         /// use amethyst_rendy::palette::Srgba;

--- a/amethyst_rendy/src/plugins.rs
+++ b/amethyst_rendy/src/plugins.rs
@@ -66,17 +66,23 @@ mod window {
         /// Clear window with specified color every frame.
         /// This function takes linear RGBA. You can convert rgba to linear rgba like so (where your_r, your_g, your_b, and your_g are all u32):
         ///
-        /// ```
-        /// use amethyst::renderer::palette::Srgba;
-        /// use amethyst::renderer::RenderToWindow;
+        /// ```no_run
+        /// use amethyst_rendy::palette::Srgba;
+        /// use amethyst_rendy::RenderToWindow;
+        /// # use std::path::PathBuf;
         ///
-        /// # fn main() {
-        ///     let (r, g, b, a) = Srgba::new(your_r / 255., your_g / 255., your_b / 255., your_a)
-        ///         .into_linear()
-        ///         .into_components();
+        /// let your_red: f32 = 255.;
+        /// let your_green: f32 = 160.;
+        /// let your_blue: f32 = 122.;
+        /// let your_alpha: f32 = 1.0;
         ///
-        ///     RenderToWindow::from_config_path(display_config)?.with_clear([r, g, b, a]);
-        /// # }
+        /// let (r, g, b, a) = Srgba::new(your_red / 255., your_green / 255., your_blue / 255., your_alpha)
+        ///     .into_linear()
+        ///     .into_components();
+        ///
+        /// # let display_config = PathBuf::new().join("display_config.ron");
+        ///
+        /// RenderToWindow::from_config_path(display_config).unwrap().with_clear([r, g, b, a]);
         /// ```
         pub fn with_clear(mut self, clear: impl Into<ClearColor>) -> Self {
             self.clear = Some(clear.into());

--- a/amethyst_ui/src/image.rs
+++ b/amethyst_ui/src/image.rs
@@ -48,14 +48,17 @@ pub enum UiImage {
     /// An image entirely covered by single solid color
     /// This tuple takes linear RGBA. You can convert rgba to linear rgba like so (where your_r, your_g, your_b, and your_g are all u32):
     ///
-    /// ```no_run
+    /// ```
     /// use amethyst::renderer::palette::Srgba;
+    /// use amethyst::ui::UiImage;
     ///
-    /// let (r, g, b, a) = Srgba::new(your_r / 255., your_g / 255., your_b / 255., your_a)
-    ///  .into_linear()
-    ///  .into_components();
-    ///  
-    /// UiImage::SolidColor(r, g, b, a);
+    /// # fn main() {
+    ///     let (r, g, b, a) = Srgba::new(your_r / 255., your_g / 255., your_b / 255., your_a)
+    ///         .into_linear()
+    ///         .into_components();
+    ///
+    ///     UiImage::SolidColor([r, g, b, a]);
+    /// # }
     /// ```
     SolidColor([f32; 4]),
 }

--- a/amethyst_ui/src/image.rs
+++ b/amethyst_ui/src/image.rs
@@ -46,6 +46,17 @@ pub enum UiImage {
         texture_dimensions: [u32; 2],
     },
     /// An image entirely covered by single solid color
+    /// This tuple takes linear RGBA. You can convert rgba to linear rgba like so (where your_r, your_g, your_b, and your_g are all u32):
+    ///
+    /// ```no_run
+    /// use amethyst::renderer::palette::Srgba;
+    ///
+    /// let (r, g, b, a) = Srgba::new(your_r / 255., your_g / 255., your_b / 255., your_a)
+    ///  .into_linear()
+    ///  .into_components();
+    ///  
+    /// UiImage::SolidColor(r, g, b, a);
+    /// ```
     SolidColor([f32; 4]),
 }
 

--- a/amethyst_ui/src/image.rs
+++ b/amethyst_ui/src/image.rs
@@ -46,19 +46,22 @@ pub enum UiImage {
         texture_dimensions: [u32; 2],
     },
     /// An image entirely covered by single solid color
-    /// This tuple takes linear RGBA. You can convert rgba to linear rgba like so (where your_r, your_g, your_b, and your_g are all u32):
+    /// This tuple takes linear RGBA. You can convert rgba to linear rgba like so:
     ///
     /// ```
-    /// use amethyst::renderer::palette::Srgba;
-    /// use amethyst::ui::UiImage;
+    /// use amethyst_rendy::palette::Srgba;
+    /// use amethyst_ui::UiImage;
     ///
-    /// # fn main() {
-    ///     let (r, g, b, a) = Srgba::new(your_r / 255., your_g / 255., your_b / 255., your_a)
-    ///         .into_linear()
-    ///         .into_components();
+    /// let your_red: f32 = 255.;
+    /// let your_green: f32 = 160.;
+    /// let your_blue: f32 = 122.;
+    /// let your_alpha: f32 = 1.0;
     ///
-    ///     UiImage::SolidColor([r, g, b, a]);
-    /// # }
+    /// let (r, g, b, a) = Srgba::new(your_red / 255., your_green / 255., your_blue / 255., your_alpha)
+    ///     .into_linear()
+    ///     .into_components();
+    ///
+    /// UiImage::SolidColor([r, g, b, a]);
     /// ```
     SolidColor([f32; 4]),
 }


### PR DESCRIPTION
## Description

Functions/tuples that take linear RGBA can be extremely confusing as there is no documentation that indicates what type of color format they take. I have added doc comments to 2 common methods/tuples that take linear RGBA with a code example explaining how to convert rgba to linear rgba.

If you have any changes feel free to request and I'll make them.

## Additions

- Added doc comments to `with_clear` and `UiImage::SolidColor`

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
