### PR TITLE
Fix Gitlab docs CI

### DIFF
--- a/gitlab-ci-helper.sh
+++ b/gitlab-ci-helper.sh
@@ -12,7 +12,7 @@ function build_book {
   INVALIDATION_PATH=$3
 
   # Checkout the ref we were given
-  git checkout -q $REF
+  git checkout -q -f $REF
   HEAD_REV=$(git rev-parse HEAD)
 
   # Check if the existing ref matches
@@ -44,7 +44,7 @@ function build_docs_wasm {
   INVALIDATION_PATH=$3
 
   # Checkout the ref we were given
-  git checkout -q $REF
+  git checkout -q -f $REF
   HEAD_REV=$(git rev-parse HEAD)
 
   # Check if the existing ref matches
@@ -102,7 +102,7 @@ function build_docs {
   INVALIDATION_PATH=$3
 
   # Checkout the ref we were given
-  git checkout -q $REF
+  git checkout -q -f $REF
   HEAD_REV=$(git rev-parse HEAD)
 
   # Check if the existing ref matches


### PR DESCRIPTION
## Description

Fix the Gitlab docs CI so the book and docs actually are updated. 

Added the force flag to git checkout so it doesn't error on overwriting local changes.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
