### PR TITLE
Added `--features empty` to README.md in `#examples`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ You can download it and read the installation instructions at [Git LFS home page
 To compile any of the examples run:
 
 ```
-$ cargo run --example name_of_example
+$ cargo run --example name_of_example --features empty
 ```
+
+> See [Graphics Features][graphics-features] for more about `--features empty`
 
 All available examples are listed under the [examples][exm] directory.
 
@@ -244,6 +246,7 @@ If for some reason we don't have any open PRs in need of a review nor any good f
 [pr]: https://github.com/amethyst/amethyst/pulls
 [it]: https://github.com/amethyst/amethyst/issues
 [gfi]: https://github.com/amethyst/amethyst/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+[graphics-features]: https://book.amethyst.rs/stable/appendices/c_feature_gates.html#graphics-features
 
 ## Backers
 


### PR DESCRIPTION
Precising graphical features is unclear

The goal of this change is to avoid newcomers stumbling into this error :
```
error: You must specify at least one graphical backend feature: "metal", "vulkan", "empty"
"See the wiki article https://book.amethyst.rs/stable/appendices/c_feature_gates.html#graphics-features for more details."
   --> amethyst_rendy\src\types.rs:112:1
    |
112 | / impl_backends!(
113 | |     // DirectX 12 is currently disabled because of incomplete gfx-hal support for it.
114 | |     // It will be re-enabled when it actually works.
115 | |     // Dx12, "dx12", rendy::dx12::Backend;
...   |
118 | |     Empty, "empty", rendy::empty::Backend;
119 | | );
    | |__^
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to previous error

error: could not compile `amethyst_rendy`.
```

> See  #2086

## Description

The need to precise graphical features is unclear.
Adding the `--feature XXX` flag in the readme could help.

## Modifications

- README.md : modified the example section's command line for build, added `--features empty` and an explanation underneath

## PR Checklist

By placing an x in the boxes I certify that I have:

- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [X] Ran `cargo build --features "empty"`
