### PR TITLE
Tcp net fix

### DIFF
--- a/amethyst_network/src/simulation/transport/tcp.rs
+++ b/amethyst_network/src/simulation/transport/tcp.rs
@@ -25,8 +25,6 @@ use std::{
     ops::DerefMut,
 };
 
-use log::{info};
-
 use std::convert::TryInto;
 
 const CONNECTION_LISTENER_SYSTEM_NAME: &str = "connection_listener";
@@ -218,11 +216,7 @@ fn write_message(
 ) {
     if let Some((_, stream)) = net.get_stream(message.destination) {
         let len : Bytes = Bytes::copy_from_slice(&(message.payload.len() as u32).to_le_bytes()); 
-        info!("Sending Packet of size .len(): {:?}", message.payload.len());
-        info!("Sending Packet of size: {:?}", len);
-        info!("Data: {:?}", message.payload);
         let msg = [len, message.payload.clone()].concat();
-        info!("{:?}", msg);
 
         if let Err(e) = stream.write(&msg) {
             channel.single_write(NetworkSimulationEvent::SendError(e, message));
@@ -266,7 +260,6 @@ impl<'s> System<'s> for TcpNetworkRecvSystem {
                     if tcp_pack_size == 0 {
                         break;
                     }
-                    info!("{:?}", tcp_pack_size);
                     let raw_size: [u8; 4] = [   
                         len[0],
                         len[1],
@@ -274,7 +267,6 @@ impl<'s> System<'s> for TcpNetworkRecvSystem {
                         len[3],
                     ];
                     pack_size = u32::from_le_bytes(raw_size.try_into().unwrap()) as usize;
-                    info!("Pack_size: {:?}", pack_size);
                 },
 
                 Err(e) => {
@@ -296,7 +288,6 @@ impl<'s> System<'s> for TcpNetworkRecvSystem {
             let mut data = vec![0; pack_size];
             match stream.read(&mut data) {
                 Ok(tcp_pack_size) => {
-                    info!("Data: {:?}", data);
                     let event = NetworkSimulationEvent::Message(
                         peer_addr,
                         Bytes::copy_from_slice(&data), 

--- a/amethyst_network/src/simulation/transport/tcp.rs
+++ b/amethyst_network/src/simulation/transport/tcp.rs
@@ -215,7 +215,7 @@ fn write_message(
     channel: &mut EventChannel<NetworkSimulationEvent>,
 ) {
     if let Some((_, stream)) = net.get_stream(message.destination) {
-        let len : Bytes = Bytes::copy_from_slice(&(message.payload.len() as u32).to_le_bytes()); 
+        let len: Bytes = Bytes::copy_from_slice(&(message.payload.len() as u32).to_le_bytes());
         let msg = [len, message.payload.clone()].concat();
 
         if let Err(e) = stream.write(&msg) {
@@ -235,12 +235,12 @@ impl<'s> System<'s> for TcpNetworkRecvSystem {
 
     fn run(&mut self, (mut net, mut event_channel): Self::SystemData) {
         let resource = net.deref_mut();
-        
+
         for (_, (active, stream)) in resource.streams.iter_mut() {
-            // let mut raw_data = [0 as u8; 4098]; // buffer size 
+            // let mut raw_data = [0 as u8; 4098]; // buffer size
             let mut ptr: usize = 0;
             let mut pack_size: usize = 0;
-            // let mut raw_data = [0 as u8; 32]; // buffer size 
+            // let mut raw_data = [0 as u8; 32]; // buffer size
 
             // If we can't get a peer_addr, there is likely something pretty wrong with the
             // connection so we'll mark it inactive.
@@ -260,14 +260,9 @@ impl<'s> System<'s> for TcpNetworkRecvSystem {
                     if tcp_pack_size == 0 {
                         break;
                     }
-                    let raw_size: [u8; 4] = [   
-                        len[0],
-                        len[1],
-                        len[2],
-                        len[3],
-                    ];
+                    let raw_size: [u8; 4] = [len[0], len[1], len[2], len[3]];
                     pack_size = u32::from_le_bytes(raw_size.try_into().unwrap()) as usize;
-                },
+                }
 
                 Err(e) => {
                     match e.kind() {
@@ -281,19 +276,16 @@ impl<'s> System<'s> for TcpNetworkRecvSystem {
                     }
                     break;
                 }
-
             }
-            
+
             // Then grab this amount of data.
             let mut data = vec![0; pack_size];
             match stream.read(&mut data) {
                 Ok(tcp_pack_size) => {
-                    let event = NetworkSimulationEvent::Message(
-                        peer_addr,
-                        Bytes::copy_from_slice(&data), 
-                    );
+                    let event =
+                        NetworkSimulationEvent::Message(peer_addr, Bytes::copy_from_slice(&data));
                     event_channel.single_write(event);
-                },
+                }
 
                 Err(e) => {
                     match e.kind() {
@@ -307,7 +299,6 @@ impl<'s> System<'s> for TcpNetworkRecvSystem {
                     }
                     break;
                 }
-
             }
         }
     }


### PR DESCRIPTION
## Description

Patched the TCP lib. Previously all the TCP packets would clump together. This places header in the pack, which is then extracted on the other side. The packets are the delivered one by one.

## Additions

- Detail API additions here if any
- Do not list changes or removals

## Removals

- List API removals here if any

## Modifications

- List changes to existing structures and functions here if any

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x ] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x ] Ran `cargo +stable fmt --all`
- [x ] Ran `cargo clippy --all --features "empty"` (may require `cargo clean` before)
- [x ] Ran `cargo build --features "empty"`
- [x ] Ran `cargo test --all --features "empty"`
