### PR TITLE
Remove Workflow Name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ env:
 jobs:
 
   tests:
-    name: Tests
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true


### PR DESCRIPTION
No working bors examples have workflow names, so remove it in hopes of fixing bors.