### PR TITLE
Update book and examples to reflect #2395

### DIFF
--- a/amethyst_rendy/src/sprite/mod.rs
+++ b/amethyst_rendy/src/sprite/mod.rs
@@ -195,6 +195,7 @@ pub struct SpriteRender {
 }
 
 impl SpriteRender {
+    /// Create a new `SpriteRender`.
     pub fn new(sprite_sheet: Handle<SpriteSheet>, sprite_number: usize) -> SpriteRender {
         SpriteRender {
             sprite_sheet,

--- a/amethyst_ui/src/transform.rs
+++ b/amethyst_ui/src/transform.rs
@@ -29,7 +29,7 @@ impl<'a> UiFinder<'a> {
     pub fn find(&self, id: &str) -> Option<Entity> {
         (&*self.entities, &self.storage)
             .join()
-            .find(|(_, transform)| transform.id == id)
+            .find(|(_, transformb)| transform.id == id)
             .map(|(entity, _)| entity)
     }
 }

--- a/amethyst_ui/src/transform.rs
+++ b/amethyst_ui/src/transform.rs
@@ -29,7 +29,7 @@ impl<'a> UiFinder<'a> {
     pub fn find(&self, id: &str) -> Option<Entity> {
         (&*self.entities, &self.storage)
             .join()
-            .find(|(_, transformb)| transform.id == id)
+            .find(|(_, transform)| transform.id == id)
             .map(|(entity, _)| entity)
     }
 }

--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -596,7 +596,7 @@ Next we simply add the components to the paddle entities:
 # use amethyst::renderer::sprite::{SpriteSheet, SpriteRender};
 # use amethyst::prelude::*;
 # fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>) {
-# let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);
+# let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);  // paddle is the first sprite in the sprite_sheet
 // Create a left plank entity.
 world
     .create_entity()

--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -579,7 +579,7 @@ the right one is flipped horizontally.
 # use amethyst::{assets::Handle, renderer::{SpriteRender, SpriteSheet}};
 # fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>) {
 // Assign the sprites for the paddles
-let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);
+let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);  // paddle is the first sprite in the sprite_sheet
 # }
 ```
 

--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -99,7 +99,7 @@ will.
     # use amethyst::renderer::Camera;
     # use amethyst::core::Transform;
     fn initialise_camera(world: &mut World) {
-        // Setup camera in a way that our screen covers whole arena and (0, 0) is in the bottom left. 
+        // Setup camera in a way that our screen covers whole arena and (0, 0) is in the bottom left.
         let mut transform = Transform::default();
         transform.set_translation_xyz(ARENA_WIDTH * 0.5, ARENA_HEIGHT * 0.5, 1.0);
 
@@ -353,7 +353,7 @@ This is rather inconvenient &mdash; to need to manually register each component
 before it can be used. There *must* be a better way. **Hint:** there is.
 
 When we add systems to our application, any component that a `System` uses is
-automatically registered. 
+automatically registered.
 However, as we haven't got any `System`s, we have to
 live with registering the `Paddle` component manually.
 
@@ -499,8 +499,8 @@ List((
 
 > **Note:** Make sure to pay attention to the kind of parentheses in the ron file.
 > Especially, if you are used to writing JSON or similar format files, you might
-> be tempted to use curly braces there; that will however lead to very 
-> hard-to-debug errors, especially since amethyst will not warn you about that 
+> be tempted to use curly braces there; that will however lead to very
+> hard-to-debug errors, especially since amethyst will not warn you about that
 > when compiling.
 
 Finally, we load the file containing the position of each sprite on the sheet.
@@ -579,10 +579,7 @@ the right one is flipped horizontally.
 # use amethyst::{assets::Handle, renderer::{SpriteRender, SpriteSheet}};
 # fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>) {
 // Assign the sprites for the paddles
-let sprite_render = SpriteRender {
-    sprite_sheet: sprite_sheet_handle,
-    sprite_number: 0, // paddle is the first sprite in the sprite_sheet
-};
+let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);
 # }
 ```
 
@@ -599,10 +596,7 @@ Next we simply add the components to the paddle entities:
 # use amethyst::renderer::sprite::{SpriteSheet, SpriteRender};
 # use amethyst::prelude::*;
 # fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>) {
-# let sprite_render = SpriteRender {
-#   sprite_sheet: sprite_sheet_handle,
-#   sprite_number: 0, // paddle is the first sprite in the sprite_sheet
-# };
+# let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);
 // Create a left plank entity.
 world
     .create_entity()
@@ -664,4 +658,3 @@ moving!
 [sb-storage]: https://specs.amethyst.rs/docs/tutorials/05_storages.html#densevecstorage
 [2d]: https://docs.amethyst.rs/stable/amethyst_renderer/struct.Camera.html#method.standard_2d
 [ss]: ../images/pong_tutorial/pong_spritesheet.png
-

--- a/book/src/pong-tutorial/pong-tutorial-04.md
+++ b/book/src/pong-tutorial/pong-tutorial-04.md
@@ -69,11 +69,8 @@ fn initialise_ball(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>) 
     let mut local_transform = Transform::default();
     local_transform.set_translation_xyz(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
 
-    // Assign the sprite for the ball
-    let sprite_render = SpriteRender {
-        sprite_sheet: sprite_sheet_handle,
-        sprite_number: 1, // ball is the second sprite on the sprite sheet
-    };
+    // Assign the sprite for the ball. The ball is the second sprite in the sheet.
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 1);
 
     world
         .create_entity()
@@ -475,7 +472,7 @@ use amethyst::core::timing::Time;
 #     ball_spawn_timer: Option<f32>,
 #     sprite_sheet_handle: Option<Handle<SpriteSheet>>,
 # }
-# 
+#
 impl SimpleState for Pong {
     fn on_start(&mut self, data: StateData<'_, GameData<'_, '_>>) {
         let world = data.world;
@@ -524,4 +521,3 @@ and add a scoring system!
 [pong_02_drawing]: pong-tutorial-02.html#drawing
 [doc_time]: https://docs.amethyst.rs/stable/amethyst_core/timing/struct.Time.html
 [delta_timing]: https://en.wikipedia.org/wiki/Delta_timing
-

--- a/book/src/sprites/modify_the_texture.md
+++ b/book/src/sprites/modify_the_texture.md
@@ -74,7 +74,7 @@ impl ExampleState {
 #         let mut sprite_transform = Transform::default();
 #         sprite_transform.set_translation_xyz(width / 2., height / 2., 0.);
 #
-#         let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);
+#         let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);  // First sprite
 
         // White shows the sprite as normal.
         // You can change the color at any point to modify the sprite's tint.

--- a/book/src/sprites/modify_the_texture.md
+++ b/book/src/sprites/modify_the_texture.md
@@ -41,7 +41,7 @@ struct ExampleState;
 impl SimpleState for ExampleState {
     fn on_start(&mut self, mut data: StateData<'_, GameData<'_, '_>>) {
 #         let texture_handle = load_texture("texture/sprite_sheet.png", &data.world);
-# 
+#
 #         let sprite_sheet = load_sprite_sheet(texture_handle);
 #         let sprite_sheet_handle = {
 #             let loader = data.world.read_resource::<Loader>();
@@ -69,15 +69,12 @@ impl ExampleState {
 #             let dim = world.read_resource::<ScreenDimensions>();
 #             (dim.width(), dim.height())
 #         };
-# 
+#
 #         // Move the sprite to the middle of the window
 #         let mut sprite_transform = Transform::default();
 #         sprite_transform.set_translation_xyz(width / 2., height / 2., 0.);
-# 
-#         let sprite_render = SpriteRender {
-#             sprite_sheet: sprite_sheet_handle,
-#             sprite_number: 0, // First sprite
-#         };
+#
+#         let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);
 
         // White shows the sprite as normal.
         // You can change the color at any point to modify the sprite's tint.

--- a/book/src/sprites/sprite_render_component.md
+++ b/book/src/sprites/sprite_render_component.md
@@ -116,7 +116,7 @@ impl ExampleState {
         sprite_transform.set_translation_xyz(width / 2., height / 2., 0.);
 
         // 0 indicates the first sprite in the sheet.
-        let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);
+        let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);  // First sprite
 
         world
             .create_entity()

--- a/book/src/sprites/sprite_render_component.md
+++ b/book/src/sprites/sprite_render_component.md
@@ -84,7 +84,7 @@ struct ExampleState;
 impl SimpleState for ExampleState {
     fn on_start(&mut self, mut data: StateData<'_, GameData<'_, '_>>) {
 #         let texture_handle = load_texture("texture/sprite_sheet.png", &data.world);
-# 
+#
 #         let sprite_sheet = load_sprite_sheet(texture_handle);
 #         let sprite_sheet_handle = {
 #             let loader = data.world.read_resource::<Loader>();
@@ -115,10 +115,8 @@ impl ExampleState {
         let mut sprite_transform = Transform::default();
         sprite_transform.set_translation_xyz(width / 2., height / 2., 0.);
 
-        let sprite_render = SpriteRender {
-            sprite_sheet: sprite_sheet_handle,
-            sprite_number: 0, // First sprite
-        };
+        // 0 indicates the first sprite in the sheet.
+        let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);
 
         world
             .create_entity()

--- a/examples/mouse_raycast/main.rs
+++ b/examples/mouse_raycast/main.rs
@@ -202,10 +202,7 @@ fn init_sprite(
     let mut transform = Transform::default();
     transform.set_translation(position);
 
-    let sprite = SpriteRender {
-        sprite_sheet: sprite_sheet.clone(),
-        sprite_number,
-    };
+    let sprite = SpriteRender::new(sprite_sheet.clone(), sprite_number);
     world
         .create_entity()
         .with(transform)

--- a/examples/pong_tutorial_02/pong.rs
+++ b/examples/pong_tutorial_02/pong.rs
@@ -101,10 +101,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
     right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Assign the sprites for the paddles
-    let sprite_render = SpriteRender {
-        sprite_sheet: sprite_sheet_handle,
-        sprite_number: 0, // paddle is the first sprite in the sprite_sheet
-    };
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);
 
     // Create a left plank entity.
     world

--- a/examples/pong_tutorial_02/pong.rs
+++ b/examples/pong_tutorial_02/pong.rs
@@ -101,7 +101,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
     right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Assign the sprites for the paddles
-    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);  // paddle is the first sprite in the sprite_sheet
 
     // Create a left plank entity.
     world

--- a/examples/pong_tutorial_02/pong.rs
+++ b/examples/pong_tutorial_02/pong.rs
@@ -101,7 +101,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
     right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Assign the sprites for the paddles
-    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);  // paddle is the first sprite in the sprite_sheet
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0); // paddle is the first sprite in the sprite_sheet
 
     // Create a left plank entity.
     world

--- a/examples/pong_tutorial_03/pong.rs
+++ b/examples/pong_tutorial_03/pong.rs
@@ -102,7 +102,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
     right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Assign the sprites for the paddles
-    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);  // paddle is the first sprite in the sprite_sheet
 
     // Create a left plank entity.
     world

--- a/examples/pong_tutorial_03/pong.rs
+++ b/examples/pong_tutorial_03/pong.rs
@@ -102,10 +102,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
     right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Assign the sprites for the paddles
-    let sprite_render = SpriteRender {
-        sprite_sheet: sprite_sheet_handle,
-        sprite_number: 0, // paddle is the first sprite in the sprite_sheet
-    };
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);
 
     // Create a left plank entity.
     world

--- a/examples/pong_tutorial_03/pong.rs
+++ b/examples/pong_tutorial_03/pong.rs
@@ -102,7 +102,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
     right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Assign the sprites for the paddles
-    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);  // paddle is the first sprite in the sprite_sheet
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0); // paddle is the first sprite in the sprite_sheet
 
     // Create a left plank entity.
     world

--- a/examples/pong_tutorial_04/pong.rs
+++ b/examples/pong_tutorial_04/pong.rs
@@ -142,7 +142,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
     right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Assign the sprites for the paddles
-    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);  // paddle is the first sprite in the sprite_sheet
 
     // Create a left plank entity.
     world

--- a/examples/pong_tutorial_04/pong.rs
+++ b/examples/pong_tutorial_04/pong.rs
@@ -172,7 +172,7 @@ fn initialise_ball(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>) 
     );
 
     // Assign the sprite for the ball
-    let sprite_render = SpriteRender::new(sprite_sheet_handle, 1);
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 1);  // ball is the second sprite on the sprite_sheet
 
     world
         .create_entity()

--- a/examples/pong_tutorial_04/pong.rs
+++ b/examples/pong_tutorial_04/pong.rs
@@ -142,7 +142,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
     right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Assign the sprites for the paddles
-    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);  // paddle is the first sprite in the sprite_sheet
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0); // paddle is the first sprite in the sprite_sheet
 
     // Create a left plank entity.
     world
@@ -172,7 +172,7 @@ fn initialise_ball(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>) 
     );
 
     // Assign the sprite for the ball
-    let sprite_render = SpriteRender::new(sprite_sheet_handle, 1);  // ball is the second sprite on the sprite_sheet
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 1); // ball is the second sprite on the sprite_sheet
 
     world
         .create_entity()

--- a/examples/pong_tutorial_04/pong.rs
+++ b/examples/pong_tutorial_04/pong.rs
@@ -142,10 +142,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
     right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Assign the sprites for the paddles
-    let sprite_render = SpriteRender {
-        sprite_sheet: sprite_sheet_handle,
-        sprite_number: 0, // paddle is the first sprite in the sprite_sheet
-    };
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);
 
     // Create a left plank entity.
     world
@@ -175,10 +172,7 @@ fn initialise_ball(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>) 
     );
 
     // Assign the sprite for the ball
-    let sprite_render = SpriteRender {
-        sprite_sheet: sprite_sheet_handle,
-        sprite_number: 1, // ball is the second sprite on the sprite_sheet
-    };
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 1);
 
     world
         .create_entity()

--- a/examples/pong_tutorial_05/pong.rs
+++ b/examples/pong_tutorial_05/pong.rs
@@ -157,7 +157,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
     right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Assign the sprites for the paddles
-    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);  // paddle is the first sprite in the sprite_sheet
 
     // Create a left plank entity.
     world

--- a/examples/pong_tutorial_05/pong.rs
+++ b/examples/pong_tutorial_05/pong.rs
@@ -157,10 +157,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
     right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Assign the sprites for the paddles
-    let sprite_render = SpriteRender {
-        sprite_sheet: sprite_sheet_handle,
-        sprite_number: 0, // paddle is the first sprite in the sprite_sheet
-    };
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);
 
     // Create a left plank entity.
     world
@@ -186,10 +183,7 @@ fn initialise_ball(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>) 
     local_transform.set_translation_xyz(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
 
     // Assign the sprite for the ball
-    let sprite_render = SpriteRender {
-        sprite_sheet: sprite_sheet_handle,
-        sprite_number: 1, // ball is the second sprite on the sprite_sheet
-    };
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 1);
 
     world
         .create_entity()

--- a/examples/pong_tutorial_05/pong.rs
+++ b/examples/pong_tutorial_05/pong.rs
@@ -183,7 +183,7 @@ fn initialise_ball(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>) 
     local_transform.set_translation_xyz(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
 
     // Assign the sprite for the ball
-    let sprite_render = SpriteRender::new(sprite_sheet_handle, 1);
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 1);  // ball is the second sprite on the sprite_sheet
 
     world
         .create_entity()

--- a/examples/pong_tutorial_05/pong.rs
+++ b/examples/pong_tutorial_05/pong.rs
@@ -157,7 +157,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
     right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Assign the sprites for the paddles
-    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);  // paddle is the first sprite in the sprite_sheet
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0); // paddle is the first sprite in the sprite_sheet
 
     // Create a left plank entity.
     world
@@ -183,7 +183,7 @@ fn initialise_ball(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>) 
     local_transform.set_translation_xyz(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
 
     // Assign the sprite for the ball
-    let sprite_render = SpriteRender::new(sprite_sheet_handle, 1);  // ball is the second sprite on the sprite_sheet
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 1); // ball is the second sprite on the sprite_sheet
 
     world
         .create_entity()

--- a/examples/pong_tutorial_06/pong.rs
+++ b/examples/pong_tutorial_06/pong.rs
@@ -104,7 +104,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
     right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Assign the sprites for the paddles
-    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);  // paddle is the first sprite in the sprite_sheet
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0); // paddle is the first sprite in the sprite_sheet
 
     // Create a left plank entity.
     world
@@ -142,7 +142,7 @@ fn initialise_ball(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>) 
     local_transform.set_translation_xyz(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
 
     // Assign the sprite for the ball
-    let sprite_render = SpriteRender::new(sprite_sheet_handle, 1);  // ball is the second sprite on the sprite_sheet
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 1); // ball is the second sprite on the sprite_sheet
 
     world
         .create_entity()

--- a/examples/pong_tutorial_06/pong.rs
+++ b/examples/pong_tutorial_06/pong.rs
@@ -104,7 +104,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
     right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Assign the sprites for the paddles
-    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);  // paddle is the first sprite in the sprite_sheet
 
     // Create a left plank entity.
     world

--- a/examples/pong_tutorial_06/pong.rs
+++ b/examples/pong_tutorial_06/pong.rs
@@ -104,10 +104,7 @@ fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet
     right_transform.set_translation_xyz(ARENA_WIDTH - PADDLE_WIDTH * 0.5, y, 0.0);
 
     // Assign the sprites for the paddles
-    let sprite_render = SpriteRender {
-        sprite_sheet: sprite_sheet_handle,
-        sprite_number: 0, // paddle is the first sprite in the sprite_sheet
-    };
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);
 
     // Create a left plank entity.
     world
@@ -145,10 +142,7 @@ fn initialise_ball(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>) 
     local_transform.set_translation_xyz(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
 
     // Assign the sprite for the ball
-    let sprite_render = SpriteRender {
-        sprite_sheet: sprite_sheet_handle,
-        sprite_number: 1, // ball is the second sprite on the sprite_sheet
-    };
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 1);
 
     world
         .create_entity()

--- a/examples/pong_tutorial_06/pong.rs
+++ b/examples/pong_tutorial_06/pong.rs
@@ -142,7 +142,7 @@ fn initialise_ball(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>) 
     local_transform.set_translation_xyz(ARENA_WIDTH / 2.0, ARENA_HEIGHT / 2.0, 0.0);
 
     // Assign the sprite for the ball
-    let sprite_render = SpriteRender::new(sprite_sheet_handle, 1);
+    let sprite_render = SpriteRender::new(sprite_sheet_handle, 1);  // ball is the second sprite on the sprite_sheet
 
     world
         .create_entity()

--- a/examples/rendy/main.rs
+++ b/examples/rendy/main.rs
@@ -473,10 +473,7 @@ fn load_crate_spritesheet(world: &mut World) -> Handle<SpriteSheet> {
 fn create_tinted_crates(world: &mut World) {
     let crate_spritesheet = load_crate_spritesheet(world);
 
-    let crate_sprite_render = SpriteRender {
-        sprite_sheet: crate_spritesheet.clone(),
-        sprite_number: 0,
-    };
+    let crate_sprite_render = SpriteRender::new(crate_spritesheet.clone(), 0);
 
     let crate_scale = Vector3::new(0.01, 0.01, 1.0);
 

--- a/examples/sprite_camera_follow/main.rs
+++ b/examples/sprite_camera_follow/main.rs
@@ -68,10 +68,7 @@ fn load_sprite_sheet(world: &mut World, png_path: &str, ron_path: &str) -> Handl
 fn init_background_sprite(world: &mut World, sprite_sheet: &Handle<SpriteSheet>) -> Entity {
     let mut transform = Transform::default();
     transform.set_translation_z(-10.0);
-    let sprite = SpriteRender {
-        sprite_sheet: sprite_sheet.clone(),
-        sprite_number: 0,
-    };
+    let sprite = SpriteRender::new(sprite_sheet.clone(), 0);
     world
         .create_entity()
         .with(transform)
@@ -85,10 +82,7 @@ fn init_background_sprite(world: &mut World, sprite_sheet: &Handle<SpriteSheet>)
 fn init_reference_sprite(world: &mut World, sprite_sheet: &Handle<SpriteSheet>) -> Entity {
     let mut transform = Transform::default();
     transform.set_translation_xyz(0.0, 0.0, 0.0);
-    let sprite = SpriteRender {
-        sprite_sheet: sprite_sheet.clone(),
-        sprite_number: 0,
-    };
+    let sprite = SpriteRender::new(sprite_sheet.clone(), 0);
     world
         .create_entity()
         .with(transform)
@@ -102,10 +96,7 @@ fn init_reference_sprite(world: &mut World, sprite_sheet: &Handle<SpriteSheet>) 
 fn init_screen_reference_sprite(world: &mut World, sprite_sheet: &Handle<SpriteSheet>) -> Entity {
     let mut transform = Transform::default();
     transform.set_translation_xyz(-250.0, -245.0, -11.0);
-    let sprite = SpriteRender {
-        sprite_sheet: sprite_sheet.clone(),
-        sprite_number: 0,
-    };
+    let sprite = SpriteRender::new(sprite_sheet.clone(), 0);
     world
         .create_entity()
         .with(transform)
@@ -118,10 +109,7 @@ fn init_screen_reference_sprite(world: &mut World, sprite_sheet: &Handle<SpriteS
 fn init_player(world: &mut World, sprite_sheet: &Handle<SpriteSheet>) -> Entity {
     let mut transform = Transform::default();
     transform.set_translation_xyz(0.0, 0.0, -3.0);
-    let sprite = SpriteRender {
-        sprite_sheet: sprite_sheet.clone(),
-        sprite_number: 1,
-    };
+    let sprite = SpriteRender::new(sprite_sheet.clone(), 1);
     world
         .create_entity()
         .with(transform)

--- a/examples/sprites_ordered/main.rs
+++ b/examples/sprites_ordered/main.rs
@@ -289,10 +289,7 @@ impl Example {
             // This combines multiple `Transform`ations.
             sprite_transform.concat(&common_transform);
 
-            let sprite_render = SpriteRender {
-                sprite_sheet: sprite_sheet_handle.clone(),
-                sprite_number: i as usize,
-            };
+            let sprite_render = SpriteRender::new(sprite_sheet_handle.clone(), i as usize);
 
             let mut entity_builder = world
                 .create_entity()

--- a/examples/tiles/main.rs
+++ b/examples/tiles/main.rs
@@ -280,10 +280,7 @@ fn load_sprite_sheet(world: &mut World, png_path: &str, ron_path: &str) -> Sprit
 fn init_reference_sprite(world: &mut World, sprite_sheet: &SpriteSheetHandle) -> Entity {
     let mut transform = Transform::default();
     transform.set_translation_xyz(0.0, 0.0, 0.1);
-    let sprite = SpriteRender {
-        sprite_sheet: sprite_sheet.clone(),
-        sprite_number: 0,
-    };
+    let sprite = SpriteRender::new(sprite_sheet.clone(), 0);
     world
         .create_entity()
         .with(transform)
@@ -297,10 +294,7 @@ fn init_reference_sprite(world: &mut World, sprite_sheet: &SpriteSheetHandle) ->
 fn init_screen_reference_sprite(world: &mut World, sprite_sheet: &SpriteSheetHandle) -> Entity {
     let mut transform = Transform::default();
     transform.set_translation_xyz(-250.0, -245.0, 0.1);
-    let sprite = SpriteRender {
-        sprite_sheet: sprite_sheet.clone(),
-        sprite_number: 0,
-    };
+    let sprite = SpriteRender::new(sprite_sheet.clone(), 0);
     world
         .create_entity()
         .with(transform)
@@ -313,10 +307,7 @@ fn init_screen_reference_sprite(world: &mut World, sprite_sheet: &SpriteSheetHan
 fn init_player(world: &mut World, sprite_sheet: &SpriteSheetHandle) -> Entity {
     let mut transform = Transform::default();
     transform.set_translation_xyz(0.0, 0.0, 0.1);
-    let sprite = SpriteRender {
-        sprite_sheet: sprite_sheet.clone(),
-        sprite_number: 1,
-    };
+    let sprite = SpriteRender::new(sprite_sheet.clone(), 1);
     world
         .create_entity()
         .with(transform)


### PR DESCRIPTION
## Description

This PR is a follow-up to #2395 , updating the book and everything in `examples/` to use the new `SpriteRender::new` function.

## PR Checklist

By placing an x in the boxes I certify that I have:

- ~Added unit tests for new code added in this PR.~
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- ~Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.~
- [x] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
