### PR TITLE
Bump last versions to 0.15.1, update change log

### DIFF
--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -34,7 +34,7 @@ derivative = "2.1.1"
 thread_profiler = { version = "0.3", optional = true }
 
 [dev-dependencies]
-amethyst = { path = "..", version = "0.15.0" }
+amethyst = { path = "..", version = "0.15.1" }
 ron = "0.5.1"
 
 [features]

--- a/amethyst_test/Cargo.toml
+++ b/amethyst_test/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/amethyst/amethyst"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-amethyst = { path = "..", version = "0.15.0", default-features = false }
+amethyst = { path = "..", version = "0.15.1", default-features = false }
 derivative = "2.1.1"
 derive-new = "0.5"
 derive_deref = "1.1.0"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,13 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ### Added
 
+### Changed
+
+### Fixed
+
+
+## [0.15.0] - 2020-08-14
+
 - `GameDataBuilder::build_dispatcher` method returns a standalone `Dispatcher`
   instead of using `DataInit` to build a `GameData` ([#2294])
 - Support for text alignment in `UiButton` and `UiLabel` ([#2316])
@@ -23,7 +30,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 ### Changed
 
 - `amethyst_rendy::shape::Shape::upload` takes `&ShapeUpload`. ([#2264])
-- Examples now have assets colocated in the individual example directiories ([#2289], [#2305])
+- Examples now have assets colocated in the individual example directories ([#2289], [#2305])
 - `UiText` now requires 2 more arguments `line_mode` and `align` ([#2358])
 - `amethyst_ui::UiButtonActionRetrigger` now derives `Default` and `Clone`. ([#2388])
 
@@ -1237,7 +1244,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 - Initial release
 
-[unreleased]: https://github.com/amethyst/amethyst/compare/v0.15.0...HEAD
+[unreleased]: https://github.com/amethyst/amethyst/compare/v0.15.1...HEAD
+[0.15.1]: https://github.com/amethyst/amethyst/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/amethyst/amethyst/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/amethyst/amethyst/compare/v0.13.3...v0.14.0
 [0.13.3]: https://github.com/amethyst/amethyst/compare/v0.13.2...v0.13.3


### PR DESCRIPTION
## Description

- Bump amethyst_core and amethyst_test from depending on amethyst 0.15.0 to amethyst 0.15.1.  Looks like they got missed in https://github.com/amethyst/amethyst/commit/0c2da61772b89323af9dcfed0ed00b2a698d95b5
- Update the change log with 0.15.1

## PR Checklist

By placing an x in the boxes I certify that I have:

- N/A Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- N/A Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
