### PR TITLE
Compile with 'tiles' feature

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -269,7 +269,7 @@ Examples in `book/` can be tested with the following:
 # the amethyst repo, otherwise mdbook complains. You only need to do this once, unless you change code
 # in the actual amethyst library.
 rm -rf ./target/debug/deps/libamethyst*
-cargo test --workspace --features=empty --no-run
+cargo test --workspace --features=empty,tiles --no-run
 
 # Then, test the book.  You can edit, run this command, and then repeat until you get everything passing.
 # This is what the book tests in CI do, so the snippets in the book must pass before you can push.


### PR DESCRIPTION
## Description

Now that the book has `tiles` examples, we need to enable the `tiles` feature when compiling Amethyst before running `mdbook test ...`

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
