### PR TITLE
Update pong-tutorial-02.md

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -423,7 +423,7 @@ First, let's declare the function and load the sprite sheet's image data.
 # use amethyst::{
 #     assets::{AssetStorage, Loader, Handle},
 #     core::transform::Transform,
-#     ecs::prelude::{Component, DenseVecStorage},
+#     ecs::{Component, DenseVecStorage},
 #     prelude::*,
 #     renderer::{
 #         camera::Camera,
@@ -511,7 +511,7 @@ Finally, we load the file containing the position of each sprite on the sheet.
 # use amethyst::{
 #     assets::{AssetStorage, Handle, Loader},
 #     core::transform::Transform,
-#     ecs::prelude::{Component, DenseVecStorage},
+#     ecs::{Component, DenseVecStorage},
 #     prelude::*,
 #     renderer::{
 #         camera::Camera,

--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -31,7 +31,7 @@ initialization code from the Pong code.
     use amethyst::{
         assets::{AssetStorage, Loader, Handle},
         core::transform::Transform,
-        ecs::prelude::{Component, DenseVecStorage},
+        ecs::{Component, DenseVecStorage},
         prelude::*,
         renderer::{Camera, ImageFormat, SpriteRender, SpriteSheet, SpriteSheetFormat, Texture},
     };

--- a/book/src/pong-tutorial/pong-tutorial-04.md
+++ b/book/src/pong-tutorial/pong-tutorial-04.md
@@ -24,7 +24,7 @@ In `pong.rs`, let's create the `Ball` Component.
 
 ```rust,edition2018,no_run,noplaypen
 # extern crate amethyst;
-# use amethyst::ecs::prelude::{Component, DenseVecStorage};
+# use amethyst::ecs::{Component, DenseVecStorage};
 pub struct Ball {
     pub velocity: [f32; 2],
     pub radius: f32,
@@ -45,9 +45,8 @@ Then let's add an `initialise_ball` function the same way we wrote the
 # use amethyst::prelude::*;
 # use amethyst::assets::{Loader, AssetStorage, Handle};
 # use amethyst::renderer::{Texture, SpriteRender, Sprite, SpriteSheet};
-# use amethyst::ecs::World;
 # use amethyst::core::transform::Transform;
-# use amethyst::ecs::prelude::{Component, DenseVecStorage};
+# use amethyst::ecs::{Component, DenseVecStorage, World};
 # pub struct Ball {
 #    pub velocity: [f32; 2],
 #    pub radius: f32,
@@ -96,14 +95,14 @@ Finally, let's make sure the code is working as intended by updating the `on_sta
 # use amethyst::prelude::*;
 # use amethyst::assets::Handle;
 # use amethyst::renderer::{Texture, SpriteSheet};
-# use amethyst::ecs::World;
+# use amethyst::ecs::{Component, World, VecStorage};
 # struct Paddle;
-# impl amethyst::ecs::Component for Paddle {
-#   type Storage = amethyst::ecs::VecStorage<Self>;
+# impl Component for Paddle {
+#   type Storage = VecStorage<Self>;
 # }
 # struct Ball;
-# impl amethyst::ecs::Component for Ball {
-#   type Storage = amethyst::ecs::VecStorage<Self>;
+# impl Component for Ball {
+#   type Storage = VecStorage<Self>;
 # }
 # fn initialise_ball(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>) { }
 # fn initialise_paddles(world: &mut World, spritesheet: Handle<SpriteSheet>) { }
@@ -138,7 +137,7 @@ We're now ready to implement the `MoveBallsSystem` in `systems/move_balls.rs`:
 
 ```rust,edition2018,no_run,noplaypen
 # extern crate amethyst;
-# use amethyst::ecs::prelude::{Component, DenseVecStorage};
+# use amethyst::ecs::{Component, DenseVecStorage};
 #
 # mod pong {
 #     use amethyst::ecs::prelude::*;
@@ -157,7 +156,7 @@ use amethyst::{
     core::transform::Transform,
     core::SystemDesc,
     derive::SystemDesc,
-    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, World, WriteStorage},
+    ecs::{Join, Read, ReadStorage, System, SystemData, World, WriteStorage},
 };
 
 use crate::pong::Ball;
@@ -205,7 +204,7 @@ by negating the velocity of the `Ball` component on the `x` or `y` axis.
 
 ```rust,edition2018,no_run,noplaypen
 # extern crate amethyst;
-# use amethyst::ecs::prelude::{Component, DenseVecStorage};
+# use amethyst::ecs::{Component, DenseVecStorage};
 #
 # mod pong {
 #     use amethyst::ecs::prelude::*;
@@ -239,7 +238,7 @@ by negating the velocity of the `Ball` component on the `x` or `y` axis.
 use amethyst::{
     core::{Transform, SystemDesc},
     derive::SystemDesc,
-    ecs::prelude::{Join, ReadStorage, System, SystemData, World, WriteStorage},
+    ecs::{Join, ReadStorage, System, SystemData, World, WriteStorage},
 };
 
 use crate::pong::{Ball, Side, Paddle, ARENA_HEIGHT};

--- a/book/src/pong-tutorial/pong-tutorial-05.md
+++ b/book/src/pong-tutorial/pong-tutorial-05.md
@@ -46,7 +46,7 @@ use amethyst::{
     core::transform::Transform,
     core::SystemDesc,
     derive::SystemDesc,
-    ecs::prelude::{Join, System, SystemData, World, WriteStorage},
+    ecs::{Join, System, SystemData, World, WriteStorage},
 };
 
 use crate::pong::{Ball, ARENA_WIDTH, ARENA_HEIGHT};
@@ -243,7 +243,7 @@ game. We'll start by creating some structures in `pong.rs`:
 # extern crate amethyst;
 use amethyst::{
     // --snip--
-    ecs::prelude::{Component, DenseVecStorage, Entity},
+    ecs::{Component, DenseVecStorage, Entity},
 };
 
 /// ScoreBoard contains the actual score data
@@ -411,7 +411,7 @@ use amethyst::{
 #     core::SystemDesc,
 #     derive::SystemDesc,
     // --snip--
-    ecs::prelude::{Join, ReadExpect, System, SystemData, World, Write, WriteStorage},
+    ecs::{Join, ReadExpect, System, SystemData, World, Write, WriteStorage},
     ui::UiText,
 };
 

--- a/examples/pong_tutorial_02/pong.rs
+++ b/examples/pong_tutorial_02/pong.rs
@@ -1,7 +1,7 @@
 use amethyst::{
     assets::{AssetStorage, Handle, Loader},
     core::transform::Transform,
-    ecs::prelude::{Component, DenseVecStorage},
+    ecs::{Component, DenseVecStorage},
     prelude::*,
     renderer::{Camera, ImageFormat, SpriteRender, SpriteSheet, SpriteSheetFormat, Texture},
 };

--- a/examples/pong_tutorial_03/pong.rs
+++ b/examples/pong_tutorial_03/pong.rs
@@ -1,7 +1,7 @@
 use amethyst::{
     assets::{AssetStorage, Handle, Loader},
     core::transform::Transform,
-    ecs::prelude::{Component, DenseVecStorage},
+    ecs::{Component, DenseVecStorage},
     prelude::*,
     renderer::{Camera, ImageFormat, SpriteRender, SpriteSheet, SpriteSheetFormat, Texture},
 };

--- a/examples/pong_tutorial_03/systems/paddle.rs
+++ b/examples/pong_tutorial_03/systems/paddle.rs
@@ -2,7 +2,7 @@ use crate::pong::{Paddle, Side, ARENA_HEIGHT, PADDLE_HEIGHT};
 use amethyst::{
     core::transform::Transform,
     derive::SystemDesc,
-    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
+    ecs::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
     input::{InputHandler, StringBindings},
 };
 

--- a/examples/pong_tutorial_04/pong.rs
+++ b/examples/pong_tutorial_04/pong.rs
@@ -1,7 +1,7 @@
 use amethyst::{
     assets::{AssetStorage, Handle, Loader},
     core::{timing::Time, transform::Transform},
-    ecs::prelude::{Component, DenseVecStorage, WorldExt},
+    ecs::{Component, DenseVecStorage, WorldExt},
     prelude::*,
     renderer::{Camera, ImageFormat, SpriteRender, SpriteSheet, SpriteSheetFormat, Texture},
 };

--- a/examples/pong_tutorial_04/systems/bounce.rs
+++ b/examples/pong_tutorial_04/systems/bounce.rs
@@ -1,7 +1,7 @@
 use amethyst::{
     core::transform::Transform,
     derive::SystemDesc,
-    ecs::prelude::{Join, ReadStorage, System, SystemData, WriteStorage},
+    ecs::{Join, ReadStorage, System, SystemData, WriteStorage},
 };
 
 use crate::pong::{Ball, Paddle, Side, ARENA_HEIGHT};

--- a/examples/pong_tutorial_04/systems/move_balls.rs
+++ b/examples/pong_tutorial_04/systems/move_balls.rs
@@ -1,7 +1,7 @@
 use amethyst::{
     core::{timing::Time, transform::Transform},
     derive::SystemDesc,
-    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
+    ecs::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
 };
 
 use crate::pong::Ball;

--- a/examples/pong_tutorial_04/systems/paddle.rs
+++ b/examples/pong_tutorial_04/systems/paddle.rs
@@ -2,7 +2,7 @@ use crate::pong::{Paddle, Side, ARENA_HEIGHT, PADDLE_HEIGHT};
 use amethyst::{
     core::transform::Transform,
     derive::SystemDesc,
-    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
+    ecs::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
     input::{InputHandler, StringBindings},
 };
 

--- a/examples/pong_tutorial_05/pong.rs
+++ b/examples/pong_tutorial_05/pong.rs
@@ -1,7 +1,7 @@
 use amethyst::{
     assets::{AssetStorage, Handle, Loader},
     core::{timing::Time, transform::Transform},
-    ecs::prelude::{Component, DenseVecStorage, Entity},
+    ecs::{Component, DenseVecStorage, Entity},
     prelude::*,
     renderer::{Camera, ImageFormat, SpriteRender, SpriteSheet, SpriteSheetFormat, Texture},
     ui::{Anchor, LineMode, TtfFormat, UiText, UiTransform},

--- a/examples/pong_tutorial_05/systems/bounce.rs
+++ b/examples/pong_tutorial_05/systems/bounce.rs
@@ -1,7 +1,7 @@
 use amethyst::{
     core::transform::Transform,
     derive::SystemDesc,
-    ecs::prelude::{Join, ReadStorage, System, SystemData, WriteStorage},
+    ecs::{Join, ReadStorage, System, SystemData, WriteStorage},
 };
 
 use crate::pong::{Ball, Paddle, Side, ARENA_HEIGHT};

--- a/examples/pong_tutorial_05/systems/move_balls.rs
+++ b/examples/pong_tutorial_05/systems/move_balls.rs
@@ -1,7 +1,7 @@
 use amethyst::{
     core::{timing::Time, transform::Transform},
     derive::SystemDesc,
-    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
+    ecs::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
 };
 
 use crate::pong::Ball;

--- a/examples/pong_tutorial_05/systems/paddle.rs
+++ b/examples/pong_tutorial_05/systems/paddle.rs
@@ -2,7 +2,7 @@ use crate::pong::{Paddle, Side, ARENA_HEIGHT, PADDLE_HEIGHT};
 use amethyst::{
     core::transform::Transform,
     derive::SystemDesc,
-    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
+    ecs::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
     input::{InputHandler, StringBindings},
 };
 

--- a/examples/pong_tutorial_05/systems/winner.rs
+++ b/examples/pong_tutorial_05/systems/winner.rs
@@ -1,7 +1,7 @@
 use amethyst::{
     core::Transform,
     derive::SystemDesc,
-    ecs::prelude::{Join, ReadExpect, System, SystemData, Write, WriteStorage},
+    ecs::{Join, ReadExpect, System, SystemData, Write, WriteStorage},
     ui::UiText,
 };
 

--- a/examples/pong_tutorial_06/bundle.rs
+++ b/examples/pong_tutorial_06/bundle.rs
@@ -1,7 +1,7 @@
 use crate::systems::{BounceSystem, MoveBallsSystem, PaddleSystem, WinnerSystem};
 use amethyst::{
     core::bundle::SystemBundle,
-    ecs::prelude::{DispatcherBuilder, World},
+    ecs::{DispatcherBuilder, World},
     error::Error,
 };
 

--- a/examples/pong_tutorial_06/pong.rs
+++ b/examples/pong_tutorial_06/pong.rs
@@ -2,7 +2,6 @@ use crate::{systems::ScoreText, Ball, Paddle, Side, ARENA_HEIGHT, ARENA_WIDTH};
 use amethyst::{
     assets::{AssetStorage, Handle, Loader},
     core::{timing::Time, transform::Transform},
-    ecs::prelude::World,
     prelude::*,
     renderer::{Camera, ImageFormat, SpriteRender, SpriteSheet, SpriteSheetFormat, Texture},
     ui::{Anchor, LineMode, TtfFormat, UiText, UiTransform},

--- a/examples/pong_tutorial_06/systems/bounce.rs
+++ b/examples/pong_tutorial_06/systems/bounce.rs
@@ -7,7 +7,7 @@ use amethyst::{
     audio::{output::Output, Source},
     core::transform::Transform,
     derive::SystemDesc,
-    ecs::prelude::{Join, Read, ReadExpect, ReadStorage, System, SystemData, WriteStorage},
+    ecs::{Join, Read, ReadExpect, ReadStorage, System, SystemData, WriteStorage},
 };
 
 /// This system is responsible for detecting collisions between balls and

--- a/examples/pong_tutorial_06/systems/move_balls.rs
+++ b/examples/pong_tutorial_06/systems/move_balls.rs
@@ -2,7 +2,7 @@ use crate::Ball;
 use amethyst::{
     core::{timing::Time, transform::Transform},
     derive::SystemDesc,
-    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
+    ecs::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
 };
 
 /// This system is responsible for moving all balls according to their speed

--- a/examples/pong_tutorial_06/systems/paddle.rs
+++ b/examples/pong_tutorial_06/systems/paddle.rs
@@ -2,7 +2,7 @@ use crate::Paddle;
 use amethyst::{
     core::{timing::Time, transform::Transform},
     derive::SystemDesc,
-    ecs::prelude::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
+    ecs::{Join, Read, ReadStorage, System, SystemData, WriteStorage},
     input::{InputHandler, StringBindings},
 };
 

--- a/examples/pong_tutorial_06/systems/winner.rs
+++ b/examples/pong_tutorial_06/systems/winner.rs
@@ -4,7 +4,7 @@ use amethyst::{
     audio::{output::Output, Source},
     core::Transform,
     derive::SystemDesc,
-    ecs::prelude::{Entity, Join, Read, ReadExpect, System, SystemData, Write, WriteStorage},
+    ecs::{Entity, Join, Read, ReadExpect, System, SystemData, Write, WriteStorage},
     ui::UiText,
 };
 


### PR DESCRIPTION
## Description

Just a minor touch-up to an import to make it a little bit easier to remember. 

Later on in the tutorial, we reference System with just `amethyst::ecs` (without the prelude). So if we're consistent about it here as well then new people who don't know any better won't get caught up on why one needs prelude and the other doesn't.

## Additions

None

## Removals

Removed `prelude` from an import

## Modifications

Just got rid of the `prelude`, that's all.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
