### PR TITLE
[Book] Remove redundant mut in example

### DIFF
--- a/book/src/concepts/system.md
+++ b/book/src/concepts/system.md
@@ -121,7 +121,7 @@ impl<'a> System<'a> for MakeObjectsFall {
     );
 
     fn run(&mut self, (mut transforms, falling): Self::SystemData) {
-        for (mut transform, _) in (&mut transforms, &falling).join() {
+        for (transform, _) in (&mut transforms, &falling).join() {
             if transform.translation().y > 0.0 {
                 transform.prepend_translation_y(-0.1);
             }


### PR DESCRIPTION
## Description

As per #2416, the `mut` is redundant and throws a warning on compile.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"` (may require `cargo clean` before)
- [ ] Ran `cargo build --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
