### PR TITLE
Disable the rustfmt merge_imports feature

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,4 @@
 reorder_imports = true
-merge_imports = true
+
+# Disabled until stable or unstable features can be used with stable rust
+# merge_imports = true


### PR DESCRIPTION
## Description

Disabled the unstable merge_imports feature in rustfmt to stop warning spam when using fmt on non nightly rust.
Currently the CI runs on stable and we don't have a requirement that lints must be run from nightly rust.
The feature can be enabled again once reaching stable status or unstable features are allowed on non nightly builds.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.