### PR TITLE
Remove redundant sentence in `TileMap` docs

### DIFF
--- a/amethyst_tiles/src/map.rs
+++ b/amethyst_tiles/src/map.rs
@@ -102,7 +102,7 @@ pub trait MapStorage<T: Tile> {
 /// Concrete implementation of a generic 3D `TileMap` component. Accepts a `Tile` type and `CoordinateEncoder` type,
 /// creating a flat 1D array storage which is spatially partitioned utilizing the provided encoding scheme.
 ///
-/// The defualt encoding scheme is `MortonEncoder2D`, which allows for arbitrary X, Y and Z coordinate sizes while
+/// The default encoding scheme is `MortonEncoder2D`, which allows for arbitrary X, Y and Z coordinate sizes while
 /// still spatially partitioning each z-level. For more efficient Z-order encoding, use `MortonEncoder` which requires
 /// cubic map dimensions but provides for much greater spatial efficiency.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/amethyst_tiles/src/map.rs
+++ b/amethyst_tiles/src/map.rs
@@ -101,7 +101,6 @@ pub trait MapStorage<T: Tile> {
 
 /// Concrete implementation of a generic 3D `TileMap` component. Accepts a `Tile` type and `CoordinateEncoder` type,
 /// creating a flat 1D array storage which is spatially partitioned utilizing the provided encoding scheme.
-/// creating a flat 1D array storage which is spatially partitioned utilizing the provided encoding scheme.
 ///
 /// The defualt encoding scheme is `MortonEncoder2D`, which allows for arbitrary X, Y and Z coordinate sizes while
 /// still spatially partitioning each z-level. For more efficient Z-order encoding, use `MortonEncoder` which requires


### PR DESCRIPTION
## Description

A duplicated line exists in the documentation for `TileMap` - delete it.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
