### PR TITLE
replace cargo --all with cargo --workspace

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,6 @@ By placing an x in the boxes I certify that I have:
 If this modified or created any rs files:
 
 - [ ] Ran `cargo +stable fmt --all`
-- [ ] Ran `cargo clippy --all --features "empty"` (may require `cargo clean` before)
+- [ ] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
 - [ ] Ran `cargo build --features "empty"`
-- [ ] Ran `cargo test --all --features "empty"`
+- [ ] Ran `cargo test --workspace --features "empty"`

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -66,9 +66,9 @@ done the following things first:
    If this is not the case, run `rustup update` or install [rustfmt]
 3. All of the following commands completed without errors.
    * `cargo +stable fmt --all`
-   * `cargo clippy --all --features "empty"` (may require `cargo clean` before)
+   * `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
    * `cargo build --features "empty"`
-   * `cargo test --all --features "empty"`
+   * `cargo test --workspace --features "empty"`
    * `cargo run --example {example-name} --features YOUR_BACKEND`
 4. You have granted non-exclusive right to your source code under both the
    [MIT License][lm] and the [Apache License 2.0][la]. Unless you explicitly


### PR DESCRIPTION
## Description

``--all`` is deprecated to avoid confusion with ``--all-targets`` or ``--all-features``.
We should use ``--workspace`` instead

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.