### PR TITLE
Update category

### DIFF
--- a/amethyst_audio/Cargo.toml
+++ b/amethyst_audio/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 description = "Audio support for Amethyst"
 exclude = ["examples/*"]
 keywords = ["game", "engine", "audio","amethyst"]
-categories = ["audio"]
+categories = ["multimedia::audio"]
 
 documentation = "https://docs.amethyst.rs/stable/amethyst_audio/"
 homepage = "https://amethyst.rs/"

--- a/amethyst_error/Cargo.toml
+++ b/amethyst_error/Cargo.toml
@@ -8,7 +8,7 @@ description = """
 Internal error handling for Amethyst.
 """
 keywords = ["game", "error", "amethyst"]
-categories = ["error"]
+categories = ["rust-patterns"]
 license = "MIT/Apache-2.0"
 
 documentation = "https://docs.amethyst.rs/stable/amethyst_error/"

--- a/amethyst_locale/Cargo.toml
+++ b/amethyst_locale/Cargo.toml
@@ -10,7 +10,7 @@ Localisation bindings.
 exclude = ["examples/*"]
 license = "MIT/Apache-2.0"
 keywords = ["game", "localisation", "resource", "management", "amethyst"]
-categories = ["filesystem,localisation"]
+categories = ["localization"]
 
 documentation = "https://docs.amethyst.rs/stable/amethyst_locale/"
 homepage = "https://amethyst.rs/"


### PR DESCRIPTION
During the 0.15.1 release in #2437, crates.io warned that our category was not on [the allowed list](https://crates.io/category_slugs).  The most relevant category I could find on the list was `rust-patterns`.

