### PR TITLE
Update rustc_version_runtime to version 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ derivative = "2.1.1"
 fern = { version = "0.6.0", features = ["colored"] }
 log = { version = "0.4.8", features = ["serde"] }
 rayon = "1.3.0"
-rustc_version_runtime = "0.1.5"
+rustc_version_runtime = "0.2.0"
 sentry = { version = "0.18.0", optional = true }
 winit = { version = "0.19", features = ["serde", "icon_loading"] }
 serde = { version = "1.0.104", features = ["derive"] }


### PR DESCRIPTION

## Description

Part of [#2438](https://github.com/amethyst/amethyst/issues/2438)

This update is very simple since the new version just fixes the ``docs.rs`` problem by letting the script write to ``OUT_DIR`` instead of ``src``.
Nothing else have been changed.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
