### PR TITLE
Simplify ci config a bit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,33 +51,23 @@ jobs:
           # Don't use a 'components:' entry--we don't need them with beta/nightly, plus nightly often doesn't have them
           override: true
 
-      - name: install rustfmt+clippy on stable
-        run: |
-          rustup component add rustfmt
-          rustup component add clippy
+      - run: rustup component add rustfmt clippy
         if: contains(matrix.toolchain, 'stable')
 
-      - name: run rustfmt on stable
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt
         if: contains(matrix.toolchain, 'stable')
 
-      - name: run clippy on stable
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --features=${{matrix.FEATURES}}
+      - run: cargo clippy --features=${{matrix.FEATURES}}
         if: contains(matrix.toolchain, 'stable')
 
       - name: clean clippy-generated amethyst libs
+        # Remove the clippy-generated amethyst files.
+        # They mess up `mdbook test` later on for some reason
         run: rm -rf ./target/debug/deps/libamethyst*
         if: contains(matrix.os, 'macos') || contains(matrix.os, 'linux')
 
       - name: run tests
         run: |
-          # Remove the clippy-generated amethyst files, they mess up `mdbook test` later on for some reason
           cargo test --workspace --features=${{matrix.FEATURES}}
         env:
           MACOS: ${{ matrix.MACOS }}  # Used by some tests


### PR DESCRIPTION
## Description

Simplified the config by removing actions-rs/cargo@v1
See the [uses cases](https://github.com/actions-rs/cargo#use-cases) described in its repo.
- We don't use cross, do we?
- Github annotations from ci failures are generally not that useful, most of the time we just open the job logs with red crosses near them and that's all.
Instead, we get less dependencies for our CI and less code

## Additions

- Detail API additions here if any
- Do not list changes or removals

## Removals

- List API removals here if any

## Modifications

- List changes to existing structures and functions here if any

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [ ] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"` (may require `cargo clean` before)
- [ ] Ran `cargo build --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
