### PR TITLE
Silence a warning about an unused return value

### DIFF
--- a/amethyst_rendy/src/submodules/vertex.rs
+++ b/amethyst_rendy/src/submodules/vertex.rs
@@ -159,7 +159,7 @@ impl<B: Backend, V: VertexDataBufferType, T: 'static> DynamicVertexData<B, V, T>
                 let tmp = std::mem::replace(&mut slice, &mut []);
                 let (dst_slice, rest) = tmp.split_at_mut(data_slice.len());
                 dst_slice.copy_from_slice(data_slice);
-                std::mem::replace(&mut slice, rest);
+                let _ = std::mem::replace(&mut slice, rest);
             });
             allocated
         } else {


### PR DESCRIPTION
Silence a warning about an unused return value that kept bugging me.

```
   Compiling amethyst_rendy v0.5.1 (/Users/nathan/am/amethyst-review/amethyst_rendy)
warning: unused return value of `std::mem::replace` that must be used
   --> amethyst_rendy/src/submodules/vertex.rs:162:17
    |
162 |                 std::mem::replace(&mut slice, rest);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_must_use)]` on by default
    = note: if you don't need the old value, you can just assign the new value directly
```