### PR TITLE
Fix the Camera::screen_ray method [#2440]

### DIFF
--- a/amethyst_rendy/src/camera.rs
+++ b/amethyst_rendy/src/camera.rs
@@ -181,7 +181,7 @@ impl Camera {
         let matrix = *camera_transform.global_matrix() * self.inverse;
 
         let near = Point3::new(screen_x, screen_y, 1.0);
-        let far = Point3::new(screen_x, screen_y, 0.0);
+        let far = Point3::new(screen_x, screen_y, 0.5);
 
         let near_t = matrix.transform_point(&near);
         let far_t = matrix.transform_point(&far);
@@ -670,5 +670,37 @@ mod tests {
         let far = Point3::new(0.0, 0.0, -97.0);
         let projected_point = mvp.transform_point(&far);
         assert_abs_diff_eq!(projected_point[2], 0.0);
+    }
+
+    #[test]
+    fn screen_ray_3d() {
+        let width = 1280.0;
+        let height = 720.0;
+
+        let aspect = width / height;
+        let fov = std::f32::consts::FRAC_PI_3;
+        let znear = 0.125;
+        let camera = Camera::perspective(aspect, fov, znear);
+
+        let mut camera_transform: Transform = Transform::new(
+            Translation3::new(0.0, 0.0, 3.0),
+            UnitQuaternion::identity(),
+            [1.0, 1.0, 1.0].into(),
+        );
+        camera_transform.copy_local_to_global();
+
+        let cursor_pos = Point2::new(width, height);
+        let screen_diag = Vector2::new(width, height);
+        let ray = camera.screen_ray(cursor_pos, screen_diag, &camera_transform);
+
+        let expected_ray = Ray {
+            /// In the znear plane.
+            origin: Point3::new(0.12830007, -0.07216879, 2.875),
+            // Corresponds to 45 degree rotation to the right and 30 degree rotation up. This ray
+            // should pass through the top right corner of the screen.
+            direction: Vector3::new(0.66436374, -0.37370458, -0.6472757),
+        };
+        assert_ulps_eq!(ray.origin, expected_ray.origin);
+        assert_ulps_eq!(ray.direction, expected_ray.direction);
     }
 }


### PR DESCRIPTION
## Description

Add a regression test of Camera::screen_ray, as well as the fix to make it pass. This test was passing on 0.15.0 and broke on 0.15.1.

## Modifications

- Use z coordinate 0.5 instead of 0.0 for the "far" point of the ray before it gets transformed by the inverse perspective projection

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
