### PR TITLE
Replace let _ = std::mem::replace() with assignment

### DIFF
--- a/amethyst_rendy/src/submodules/vertex.rs
+++ b/amethyst_rendy/src/submodules/vertex.rs
@@ -159,7 +159,7 @@ impl<B: Backend, V: VertexDataBufferType, T: 'static> DynamicVertexData<B, V, T>
                 let tmp = std::mem::replace(&mut slice, &mut []);
                 let (dst_slice, rest) = tmp.split_at_mut(data_slice.len());
                 dst_slice.copy_from_slice(data_slice);
-                let _ = std::mem::replace(&mut slice, rest);
+                slice = rest;
             });
             allocated
         } else {


### PR DESCRIPTION
## Description

`std::mem::replace` is [effectively](https://github.com/rust-lang/rust/blob/332369110919ac27c8a0bc0b21bf9d2f9fd9829d/library/core/src/mem/mod.rs#L831-L835):

```rust
pub fn replace<T>(dest: &mut T, mut src: T) -> T {
    swap(dest, &mut src);
    src
}
```

We could use swap instead of that, but here the original warning properly suggested the best solution:
```
if you don't need the old value, you can just assign the new value directly
```

cc #2444 

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --all --features "empty"` (may require `cargo clean` before)
- [ ] Ran `cargo build --features "empty"`
- [ ] Ran `cargo test --all --features "empty"`
