### PR TITLE
Move cargo fmt checks and some other jobs to stable, ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,45 +51,44 @@ jobs:
           # Don't use a 'components:' entry--we don't need them with beta/nightly, plus nightly often doesn't have them
           override: true
 
-      - run: rustup component add rustfmt clippy
-        if: contains(matrix.toolchain, 'stable')
+      - run: rustup component add clippy
+        if: matrix.toolchain == 'stable'
+
+      - run: rustup component add rustfmt
+        if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
 
       - run: cargo fmt --all -- --check
-        if: contains(matrix.toolchain, 'stable')
+        if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
 
       - run: cargo clippy --features=${{matrix.FEATURES}} --workspace
-        if: contains(matrix.toolchain, 'stable')
+        if: matrix.toolchain == 'stable'
 
       - name: clean clippy-generated amethyst libs
         # Remove the clippy-generated amethyst files.
         # They mess up `mdbook test` later on for some reason
         run: rm -rf ./target/debug/deps/libamethyst*
-        if: contains(matrix.os, 'macos') || contains(matrix.os, 'linux')
+        if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
 
-      - name: run tests
-        run: |
-          cargo test --workspace --features=${{matrix.FEATURES}}
+      - run: cargo test --workspace --features=${{matrix.FEATURES}}
         env:
-          MACOS: ${{ matrix.MACOS }}  # Used by some tests
+          MACOS: ${{ matrix.MACOS }} # Used by some tests
 
       - name: install mdbook on stable macos
         uses: peaceiris/actions-mdbook@v1
         with:
           mdbook-version: 'latest'
-        if: contains(matrix.toolchain, 'stable') && contains(matrix.os, 'macos')
+        if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
 
 # Should be working, but postponing until after we go live with GitHub Actions
-#      - name: install mdbook-linkcheck on stable macos
+#      - name: install mdbook-linkcheck on stable, ubuntu-latest
 #        run: |
 #          curl -L https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.7.0/mdbook-linkcheck-v0.7.0-x86_64-apple-darwin.tar.gz | tar -xz && mv mdbook-linkcheck /Users/runner/.cargo/bin/mdbook-linkcheck
 #          chmod a+x /Users/runner/.cargo/bin/mdbook-linkcheck
 #          echo -e "\n\n[output.linkcheck]" >> book/book.toml ## PROBABLY REMOVE THIS IN FAVOR OF ALWAYS HAVING IT AS OPTIONAL IN THE CONFIG
-#        if: contains(matrix.toolchain, 'stable') && contains(matrix.os, 'macos')
+#        if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
 
-      - name: build mdbook on stable macos
-        run: mdbook build book
-        if: contains(matrix.toolchain, 'stable') && contains(matrix.os, 'macos')
+      - run: mdbook build book
+        if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
 
-      - name: run mdbook tests on stable macos
-        run: mdbook test -L ./target/debug/deps book
-        if: contains(matrix.toolchain, 'stable') && contains(matrix.os, 'macos')
+      - run: mdbook test -L ./target/debug/deps book
+        if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,13 +79,14 @@ jobs:
           mdbook-version: 'latest'
         if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
 
-      - name: install mdbook-linkcheck on stable, ubuntu-latest
-        env:
-          LINKCHECK_URL: https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.7.0/mdbook-linkcheck-v0.7.0-x86_64-unknown-linux-gnu.tar.gz
-        run: |
-          curl -L ${{ env.LINKCHECK_URL }} | tar -C ~/.cargo/bin -xzf -
-          echo -e "\n\n[output.linkcheck]" >> book/book.toml ## PROBABLY REMOVE THIS IN FAVOR OF ALWAYS HAVING IT AS OPTIONAL IN THE CONFIG
-        if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
+      # Should be working, but postponing until after we go live with GitHub Actions
+      # - name: install mdbook-linkcheck on stable, ubuntu-latest
+      #   env:
+      #     LINKCHECK_URL: https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.7.0/mdbook-linkcheck-v0.7.0-x86_64-unknown-linux-gnu.tar.gz
+      #   run: |
+      #     curl -L ${{ env.LINKCHECK_URL }} | tar -C ~/.cargo/bin -xzf -
+      #     echo -e "\n\n[output.linkcheck]" >> book/book.toml ## PROBABLY REMOVE THIS IN FAVOR OF ALWAYS HAVING IT AS OPTIONAL IN THE CONFIG
+      #   if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
 
       - run: mdbook build book
         if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,19 +73,19 @@ jobs:
         env:
           MACOS: ${{ matrix.MACOS }} # Used by some tests
 
-      - name: install mdbook on stable macos
+      - name: install mdbook on stable, ubuntu-latest
         uses: peaceiris/actions-mdbook@v1
         with:
           mdbook-version: 'latest'
         if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
 
-# Should be working, but postponing until after we go live with GitHub Actions
-#      - name: install mdbook-linkcheck on stable, ubuntu-latest
-#        run: |
-#          curl -L https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.7.0/mdbook-linkcheck-v0.7.0-x86_64-apple-darwin.tar.gz | tar -xz && mv mdbook-linkcheck /Users/runner/.cargo/bin/mdbook-linkcheck
-#          chmod a+x /Users/runner/.cargo/bin/mdbook-linkcheck
-#          echo -e "\n\n[output.linkcheck]" >> book/book.toml ## PROBABLY REMOVE THIS IN FAVOR OF ALWAYS HAVING IT AS OPTIONAL IN THE CONFIG
-#        if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
+      - name: install mdbook-linkcheck on stable, ubuntu-latest
+        env:
+          LINKCHECK_URL: https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.7.0/mdbook-linkcheck-v0.7.0-x86_64-unknown-linux-gnu.tar.gz
+        run: |
+          curl -L ${{ env.LINKCHECK_URL }} | tar -C ~/.cargo/bin -xzf -
+          echo -e "\n\n[output.linkcheck]" >> book/book.toml ## PROBABLY REMOVE THIS IN FAVOR OF ALWAYS HAVING IT AS OPTIONAL IN THE CONFIG
+        if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
 
       - run: mdbook build book
         if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
## Description

See https://github.com/amethyst/amethyst/pull/2443#issuecomment-677934141

## Modifications

- Now a bunch of jobs that were previously selected to be run on `macos` switched to `ubuntu-latest`, cargo fmt check is one of them

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [ ] Ran `cargo build --features "empty"`
- [ ] Ran `cargo test --workspace --features "empty"`
