### PR TITLE
Deny warnings on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,11 @@ on:
       - "**"
 
 env:
+  RUSTFLAGS: --deny warnings -Cdebuginfo=0
+  RUSTDOCFLAGS: --deny warnings
+
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-
-  RUSTFLAGS: -Cdebuginfo=0
 
 jobs:
 

--- a/amethyst_assets/src/error.rs
+++ b/amethyst_assets/src/error.rs
@@ -1,6 +1,7 @@
 use err_derive::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error(display = "Failed to load asset with name {:?}", _0)]
     Asset(String),
@@ -10,7 +11,4 @@ pub enum Error {
     Format(&'static str),
     #[error(display = "Asset was loaded but no handle to it was saved.")]
     UnusedHandle,
-    #[error(display = "Some error has occurred")]
-    #[doc(hidden)]
-    __Nonexhaustive,
 }

--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -122,7 +122,7 @@ impl Error {
     /// assert_eq!("wrapped", e.source().expect("no source").to_string());
     /// ```
     pub fn source(&self) -> Option<&Error> {
-        self.inner.source.as_ref().map(|e| &**e)
+        self.inner.source.as_deref()
     }
 
     /// Iterate over all causes, including this one.

--- a/amethyst_gltf/src/lib.rs
+++ b/amethyst_gltf/src/lib.rs
@@ -215,15 +215,19 @@ pub struct GltfSceneOptions {
     pub scene_index: Option<usize>,
 }
 
+type SysDataOf<'a, T> = <T as PrefabData<'a>>::SystemData;
+
 impl<'a> PrefabData<'a> for GltfPrefab {
+    // Looks better when defined all in one place
+    #[allow(clippy::type_complexity)]
     type SystemData = (
-        <Transform as PrefabData<'a>>::SystemData,
-        <Named as PrefabData<'a>>::SystemData,
-        <CameraPrefab as PrefabData<'a>>::SystemData,
-        <LightPrefab as PrefabData<'a>>::SystemData,
-        <MaterialPrefab as PrefabData<'a>>::SystemData,
-        <AnimatablePrefab<usize, Transform> as PrefabData<'a>>::SystemData,
-        <SkinnablePrefab as PrefabData<'a>>::SystemData,
+        SysDataOf<'a, Transform>,
+        SysDataOf<'a, Named>,
+        SysDataOf<'a, CameraPrefab>,
+        SysDataOf<'a, LightPrefab>,
+        SysDataOf<'a, MaterialPrefab>,
+        SysDataOf<'a, AnimatablePrefab<usize, Transform>>,
+        SysDataOf<'a, SkinnablePrefab>,
         WriteStorage<'a, BoundingSphere>,
         WriteStorage<'a, Handle<Mesh>>,
         Read<'a, AssetStorage<Mesh>>,


### PR DESCRIPTION
## Description

Fixe all clippy lints, added flags to ci that should make it fail if there are some warnings from clippy, rustc, rustdoc during ci run

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [ ] Ran `cargo build --features "empty"`
- [ ] Ran `cargo test --workspace --features "empty"`
