### PR TITLE
Fix cargo test compiler error in amethyst_rendy

### DIFF
--- a/amethyst_rendy/src/bundle.rs
+++ b/amethyst_rendy/src/bundle.rs
@@ -890,6 +890,7 @@ mod tests {
 
     #[test]
     #[ignore] // CI can't run tests requiring actual backend
+    #[cfg(feature = "window")]
     fn main_pass_surface_plan() {
         use winit::{EventsLoop, WindowBuilder};
 


### PR DESCRIPTION
The ``main_pass_surface_plan`` test in ``amethyst_rendy`` would fail compilation with ``cargo test`` when not using the optional ``window`` feature.
This attribute makes it so i`t doesn't try to compile it unless the feature is enabled.

The actual tests are still not run but i will open a separate issue for that.

Fixes [#2446 ](https://github.com/amethyst/amethyst/issues/2446)

Unsure if a change-log entry is required here?

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --workspace --features "empty"`
