### PR TITLE
Migrate SystemExt pauseable to Legion

### DIFF
--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -58,6 +58,5 @@ mod hidden;
 mod named;
 pub mod system_ext;
 
-
 /// A rayon thread pool wrapped in an `Arc`. This should be used as resource in `World`.
 pub type ArcThreadPool = Arc<rayon::ThreadPool>;

--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -56,6 +56,8 @@ mod event;
 mod hidden;
 //mod hide_system;
 mod named;
+pub mod system_ext;
+
 
 /// A rayon thread pool wrapped in an `Arc`. This should be used as resource in `World`.
 pub type ArcThreadPool = Arc<rayon::ThreadPool>;

--- a/amethyst_core/src/system_ext.rs
+++ b/amethyst_core/src/system_ext.rs
@@ -1,0 +1,190 @@
+#[cfg(feature = "profiler")]
+use thread_profiler::profile_scope;
+
+use crate::legion::{
+    storage::ComponentTypeId,
+    systems::{
+        CommandBuffer, QuerySet, Resource, ResourceSet, ResourceTypeId, Runnable, System, SystemFn,
+        SystemId, UnsafeResources,
+    },
+    world::*,
+    Read,
+};
+
+/// Extension functionality associated systems.
+pub trait SystemExt {
+    /// Make a system pausable by tying it to a specific value of a resource.
+    ///
+    /// When the value of the resource differs from `value` the system is considered "paused",
+    /// and the `run` method of the pausable system will not be called.
+    ///
+    /// # Notes
+    ///
+    /// Special care must be taken not to read from an `EventChannel` with pausable systems.
+    /// Since `run` is never called, there is no way to consume the reader side of a channel, and
+    /// it may grow indefinitely leaking memory while the system is paused.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use amethyst::{
+    ///     ecs::{System, Write, system},
+    ///     shred::DispatcherBuilder,
+    ///     prelude::*,
+    /// };
+    ///
+    /// #[derive(PartialEq)]
+    /// enum CurrentState {
+    ///     Disabled,
+    ///     Enabled,
+    /// }
+    ///
+    /// impl Default for CurrentState {
+    ///     fn default() -> Self {
+    ///         CurrentState::Disabled
+    ///     }
+    /// }
+    ///
+    /// struct AddNumber(u32);
+    ///
+    /// impl<'s> System<'s> for AddNumber {
+    ///     type SystemData = Write<'s, u32>;
+    ///
+    ///     fn run(&mut self, mut number: Self::SystemData) {
+    ///         *number += self.0;
+    ///     }
+    /// }
+    ///
+    /// let mut world = World::new();
+    ///
+    /// let mut dispatcher = DispatcherBuilder::default()
+    ///     .with(AddNumber(1), "set_number", &[])
+    ///     .with(AddNumber(2).pausable(CurrentState::Enabled), "set_number_2", &[])
+    ///     .build();
+    ///
+    /// dispatcher.setup(&mut world);
+    /// 
+    ///
+    /// // we only expect the u32 resource to be modified _if_ the system is enabled,
+    /// // the system should only be enabled on CurrentState::Enabled.
+    ///
+    /// *world.write_resource() = 0u32;
+    /// dispatcher.dispatch(&mut world);
+    /// assert_eq!(1, *world.read_resource::<u32>());
+    ///
+    /// *world.write_resource() = 0u32;
+    /// *world.write_resource() = CurrentState::Enabled;
+    /// dispatcher.dispatch(&mut world);
+    /// assert_eq!(1 + 2, *world.read_resource::<u32>());
+    /// ```
+    fn pausable<V>(self, value: V) -> Pausable<Self, V>
+    where
+        Self: Sized,
+        V: Resource + Default + PartialEq;
+}
+
+impl<S> SystemExt for S
+where
+    S: Runnable,
+{
+    fn pausable<V>(self, value: V) -> Pausable<Self, V>
+    where
+        Self: Sized,
+        V: Resource + Default + PartialEq,
+    {
+        /* 
+         * We're required to provide a &[ResourceTypeId] which means we need to append our V to the current 
+         * ResourceSet while also allocating a continuous slice of memory that can be returned by reference.
+         * This precludes doing something like constructing the vec in Runnable.reads() below as we'd have to 
+         * return a reference to the local Vec that's being deallocated.
+         */
+        let (resource_reads, _) = self.reads();
+        let resource_reads = resource_reads
+            .into_iter()
+            .map(|id| *id)
+            .chain(std::iter::once(ResourceTypeId::of::<V>()))
+            .collect::<Vec<_>>();
+        Pausable {
+            system: self,
+            value,
+            resource_reads,
+        }
+    }
+}
+
+/// A system that is enabled when `V` has a specific value.
+///
+/// This is created using the [`SystemExt::pausable`] method.
+///
+/// [`SystemExt::pausable`]: trait.SystemExt.html#tymethod.pausable
+#[derive(Debug)]
+pub struct Pausable<S, V> {
+    system: S,
+    value: V,
+    resource_reads: Vec<ResourceTypeId>,
+}
+
+impl<S, V> Runnable for Pausable<S, V>
+where
+    S: Runnable,
+    V: Resource + PartialEq,
+{
+    fn reads(&self) -> (&[ResourceTypeId], &[ComponentTypeId]) {
+        let (_, components) = self.system.reads();
+        // Return our local copy of systems resources that's been appended with permission for Read<V>
+        (&self.resource_reads[..], components)
+    }
+
+    unsafe fn run_unsafe(&mut self, world: &World, resources: &UnsafeResources) {
+        let resources_static = &*(resources as *const UnsafeResources);
+        let resource_to_check = Read::<V>::fetch_unchecked(resources_static);
+
+        if self.value != *resource_to_check {
+            return;
+        }
+
+        self.system.run_unsafe(world, resources);
+    }
+
+    // Default passthrough impls
+    fn name(&self) -> Option<&SystemId> {
+        self.system.name()
+    }
+
+    fn prepare(&mut self, world: &World) {
+        self.system.prepare(world)
+    }
+
+    fn accesses_archetypes(&self) -> &ArchetypeAccess {
+        self.system.accesses_archetypes()
+    }
+
+    fn writes(&self) -> (&[ResourceTypeId], &[ComponentTypeId]) {
+        self.system.writes()
+    }
+
+    fn command_buffer_mut(&mut self, world: WorldId) -> Option<&mut CommandBuffer> {
+        self.system.command_buffer_mut(world)
+    }
+}
+/* WIP Example, not currently compiling */
+use legion::{system, Schedule};
+
+#[derive(PartialEq)]
+enum CurrentState {
+    Disabled,
+    Enabled,
+}
+
+#[system]
+fn add_number(#[state] n: &u32, #[resource] sum: &mut u32) {
+    *sum += n;
+}
+
+fn emample() {
+    let add_2 = add_number_system(2);
+
+    Schedule::builder()
+        .add_system(add_number_system(1))
+        .add_system(add_2.pauseable(CurrentState::Enabled));
+}

--- a/amethyst_core/src/system_ext.rs
+++ b/amethyst_core/src/system_ext.rs
@@ -5,10 +5,9 @@
 use crate::legion::{
     storage::ComponentTypeId,
     systems::{
-        CommandBuffer, Resource, ResourceSet, ResourceTypeId, Runnable,
-        SystemId, UnsafeResources,
+        CommandBuffer, Resource, ResourceSet, ResourceTypeId, Runnable, SystemId, UnsafeResources,
     },
-    world::{WorldId, ArchetypeAccess, World},
+    world::{ArchetypeAccess, World, WorldId},
     Read,
 };
 
@@ -26,13 +25,13 @@ use crate::legion::{
 /// # Examples
 /// ```rust
 /// use legion::{system, Schedule, World, Resources};
-/// 
+///
 /// #[derive(PartialEq)]
 /// enum CurrentState {
 ///     Disabled,
 ///     Enabled,
 /// }
-/// 
+///
 /// #[system]
 /// fn add_number(#[state] n: &u32, #[resource] sum: &mut u32) {
 ///     *sum += n;
@@ -60,7 +59,8 @@ use crate::legion::{
 /// ```
 pub fn pauseable<V>(runnable: impl Runnable, value: V) -> Pauseable<impl Runnable, V>
 where
-    V: Resource + PartialEq {
+    V: Resource + PartialEq,
+{
     let (resource_reads, _) = runnable.reads();
     let resource_reads = resource_reads
         .into_iter()

--- a/amethyst_core/src/system_ext.rs
+++ b/amethyst_core/src/system_ext.rs
@@ -76,9 +76,9 @@ where
 
 /// A system that is enabled when `V` has a specific value.
 ///
-/// This is created using the [`pausable`] method.
+/// This is created using the [`pauseable`] method.
 ///
-/// [`pausable`]: fn.pauseable.html
+/// [`pauseable`]: fn.pauseable.html
 #[derive(Debug)]
 pub struct Pauseable<S, V> {
     system: S,

--- a/amethyst_core/src/system_ext.rs
+++ b/amethyst_core/src/system_ext.rs
@@ -1,114 +1,76 @@
-#[cfg(feature = "profiler")]
-use thread_profiler::profile_scope;
+//! Extension system utilities
+//!
+//! This module contains useful functions to extend and transform existing systems.
 
 use crate::legion::{
     storage::ComponentTypeId,
     systems::{
-        CommandBuffer, QuerySet, Resource, ResourceSet, ResourceTypeId, Runnable, System, SystemFn,
+        CommandBuffer, Resource, ResourceSet, ResourceTypeId, Runnable,
         SystemId, UnsafeResources,
     },
-    world::*,
+    world::{WorldId, ArchetypeAccess, World},
     Read,
 };
 
-/// Extension functionality associated systems.
-pub trait SystemExt {
-    /// Make a system pausable by tying it to a specific value of a resource.
-    ///
-    /// When the value of the resource differs from `value` the system is considered "paused",
-    /// and the `run` method of the pausable system will not be called.
-    ///
-    /// # Notes
-    ///
-    /// Special care must be taken not to read from an `EventChannel` with pausable systems.
-    /// Since `run` is never called, there is no way to consume the reader side of a channel, and
-    /// it may grow indefinitely leaking memory while the system is paused.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use amethyst::{
-    ///     ecs::{System, Write, system},
-    ///     shred::DispatcherBuilder,
-    ///     prelude::*,
-    /// };
-    ///
-    /// #[derive(PartialEq)]
-    /// enum CurrentState {
-    ///     Disabled,
-    ///     Enabled,
-    /// }
-    ///
-    /// impl Default for CurrentState {
-    ///     fn default() -> Self {
-    ///         CurrentState::Disabled
-    ///     }
-    /// }
-    ///
-    /// struct AddNumber(u32);
-    ///
-    /// impl<'s> System<'s> for AddNumber {
-    ///     type SystemData = Write<'s, u32>;
-    ///
-    ///     fn run(&mut self, mut number: Self::SystemData) {
-    ///         *number += self.0;
-    ///     }
-    /// }
-    ///
-    /// let mut world = World::new();
-    ///
-    /// let mut dispatcher = DispatcherBuilder::default()
-    ///     .with(AddNumber(1), "set_number", &[])
-    ///     .with(AddNumber(2).pausable(CurrentState::Enabled), "set_number_2", &[])
-    ///     .build();
-    ///
-    /// dispatcher.setup(&mut world);
-    /// 
-    ///
-    /// // we only expect the u32 resource to be modified _if_ the system is enabled,
-    /// // the system should only be enabled on CurrentState::Enabled.
-    ///
-    /// *world.write_resource() = 0u32;
-    /// dispatcher.dispatch(&mut world);
-    /// assert_eq!(1, *world.read_resource::<u32>());
-    ///
-    /// *world.write_resource() = 0u32;
-    /// *world.write_resource() = CurrentState::Enabled;
-    /// dispatcher.dispatch(&mut world);
-    /// assert_eq!(1 + 2, *world.read_resource::<u32>());
-    /// ```
-    fn pausable<V>(self, value: V) -> Pausable<Self, V>
-    where
-        Self: Sized,
-        V: Resource + Default + PartialEq;
-}
-
-impl<S> SystemExt for S
+/// Make a system pausable by tying it to a specific value of a resource.
+///
+/// When the value of the resource differs from `value` the system is considered "paused",
+/// and the `run` method of the pausable system will not be called.
+///
+/// # Notes
+///
+/// Special care must be taken not to read from an `EventChannel` with pausable systems.
+/// Since `run` is never called, there is no way to consume the reader side of a channel, and
+/// it may grow indefinitely leaking memory while the system is paused.
+///
+/// # Examples
+/// ```rust
+/// use legion::{system, Schedule, World, Resources};
+/// 
+/// #[derive(PartialEq)]
+/// enum CurrentState {
+///     Disabled,
+///     Enabled,
+/// }
+/// 
+/// #[system]
+/// fn add_number(#[state] n: &u32, #[resource] sum: &mut u32) {
+///     *sum += n;
+/// }
+///
+/// let mut schedule = Schedule::builder()
+///     .add_system(add_number_system(1))
+///     .add_system(pauseable(add_number_system(2), CurrentState::Enabled))
+///     .build();
+///
+/// let mut world = World::default();
+/// let mut resources = Resources::default();
+///
+/// // we only expect the u32 resource to be modified _if_ the system is enabled,
+/// // the system should only be enabled on CurrentState::Enabled.
+/// resources.insert(0u32);
+/// resources.insert(CurrentState::Disabled);
+/// schedule.execute(&mut world, &mut resources);
+/// assert_eq!(1, resources.get::<u32>().unwrap());
+///
+/// resources.insert(0u32);
+/// resources.insert(CurrentState::Enabled);
+/// schedule.execute(&mut world, &mut resources);
+/// assert_eq!(1 + 2, resources.get::<u32>().unwrap());
+/// ```
+pub fn pauseable<V>(runnable: impl Runnable, value: V) -> Pauseable<impl Runnable, V>
 where
-    S: Runnable,
-{
-    fn pausable<V>(self, value: V) -> Pausable<Self, V>
-    where
-        Self: Sized,
-        V: Resource + Default + PartialEq,
-    {
-        /* 
-         * We're required to provide a &[ResourceTypeId] which means we need to append our V to the current 
-         * ResourceSet while also allocating a continuous slice of memory that can be returned by reference.
-         * This precludes doing something like constructing the vec in Runnable.reads() below as we'd have to 
-         * return a reference to the local Vec that's being deallocated.
-         */
-        let (resource_reads, _) = self.reads();
-        let resource_reads = resource_reads
-            .into_iter()
-            .map(|id| *id)
-            .chain(std::iter::once(ResourceTypeId::of::<V>()))
-            .collect::<Vec<_>>();
-        Pausable {
-            system: self,
-            value,
-            resource_reads,
-        }
+    V: Resource + PartialEq {
+    let (resource_reads, _) = runnable.reads();
+    let resource_reads = resource_reads
+        .into_iter()
+        .map(|id| *id)
+        .chain(std::iter::once(ResourceTypeId::of::<V>()))
+        .collect::<Vec<_>>();
+    Pauseable {
+        system: runnable,
+        value,
+        resource_reads,
     }
 }
 
@@ -118,13 +80,13 @@ where
 ///
 /// [`SystemExt::pausable`]: trait.SystemExt.html#tymethod.pausable
 #[derive(Debug)]
-pub struct Pausable<S, V> {
+pub struct Pauseable<S, V> {
     system: S,
     value: V,
     resource_reads: Vec<ResourceTypeId>,
 }
 
-impl<S, V> Runnable for Pausable<S, V>
+impl<S, V> Runnable for Pauseable<S, V>
 where
     S: Runnable,
     V: Resource + PartialEq,
@@ -166,25 +128,4 @@ where
     fn command_buffer_mut(&mut self, world: WorldId) -> Option<&mut CommandBuffer> {
         self.system.command_buffer_mut(world)
     }
-}
-/* WIP Example, not currently compiling */
-use legion::{system, Schedule};
-
-#[derive(PartialEq)]
-enum CurrentState {
-    Disabled,
-    Enabled,
-}
-
-#[system]
-fn add_number(#[state] n: &u32, #[resource] sum: &mut u32) {
-    *sum += n;
-}
-
-fn emample() {
-    let add_2 = add_number_system(2);
-
-    Schedule::builder()
-        .add_system(add_number_system(1))
-        .add_system(add_2.pauseable(CurrentState::Enabled));
 }

--- a/amethyst_core/src/system_ext.rs
+++ b/amethyst_core/src/system_ext.rs
@@ -76,9 +76,9 @@ where
 
 /// A system that is enabled when `V` has a specific value.
 ///
-/// This is created using the [`SystemExt::pausable`] method.
+/// This is created using the [`pausable`] method.
 ///
-/// [`SystemExt::pausable`]: trait.SystemExt.html#tymethod.pausable
+/// [`pausable`]: fn.pauseable.html
 #[derive(Debug)]
 pub struct Pauseable<S, V> {
     system: S,

--- a/amethyst_core/src/system_ext.rs
+++ b/amethyst_core/src/system_ext.rs
@@ -63,8 +63,8 @@ where
 {
     let (resource_reads, _) = runnable.reads();
     let resource_reads = resource_reads
-        .into_iter()
-        .map(|id| *id)
+        .iter()
+        .copied()
         .chain(std::iter::once(ResourceTypeId::of::<V>()))
         .collect::<Vec<_>>();
     Pauseable {

--- a/amethyst_core/src/transform/missing_previous_parent_system.rs
+++ b/amethyst_core/src/transform/missing_previous_parent_system.rs
@@ -27,7 +27,7 @@ mod test {
     #[test]
     fn previous_parent_added() {
         let mut resources = Resources::default();
-        let mut world = Universe::new().create_world();
+        let mut world = World::default();
 
         let mut schedule = Schedule::builder().add_system(build()).build();
 

--- a/amethyst_core/src/transform/parent_update_system.rs
+++ b/amethyst_core/src/transform/parent_update_system.rs
@@ -127,7 +127,8 @@ mod test {
     #[test]
     fn correct_children() {
         let mut resources = Resources::default();
-        let mut world = Universe::new().create_world();
+        let mut world = World::default();
+
 
         let mut schedule = Schedule::builder()
             .add_system(missing_previous_parent_system::build())

--- a/amethyst_core/src/transform/parent_update_system.rs
+++ b/amethyst_core/src/transform/parent_update_system.rs
@@ -129,7 +129,6 @@ mod test {
         let mut resources = Resources::default();
         let mut world = World::default();
 
-
         let mut schedule = Schedule::builder()
             .add_system(missing_previous_parent_system::build())
             .flush()

--- a/amethyst_core/src/transform/transform_system.rs
+++ b/amethyst_core/src/transform/transform_system.rs
@@ -11,11 +11,13 @@ pub fn build() -> impl Runnable {
     SystemBuilder::new("TransformSystem")
         // Entities at the hierarchy root (no parent component)
         .with_query(
-            <(Entity, &mut Transform)>::query().filter(maybe_changed::<Transform>() & !component::<Parent>()),
+            <(Entity, &mut Transform)>::query()
+                .filter(maybe_changed::<Transform>() & !component::<Parent>()),
         )
         // Entities that are children of some entity
         .with_query(
-            <(Entity, &mut Transform)>::query().filter(maybe_changed::<Transform>() & component::<Parent>()),
+            <(Entity, &mut Transform)>::query()
+                .filter(maybe_changed::<Transform>() & component::<Parent>()),
         )
         .with_query(<(Entity, &Parent)>::query())
         .write_component::<Transform>()
@@ -91,7 +93,7 @@ mod tests {
 
     fn transform_world() -> (Resources, World, Dispatcher) {
         let mut resources = Resources::default();
-        let mut world = Universe::new().create_world();
+        let mut world = World::default();
 
         let dispatcher = DispatcherBuilder::default()
             .add_bundle(TransformBundle)

--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -122,7 +122,7 @@ impl Error {
     /// assert_eq!("wrapped", e.source().expect("no source").to_string());
     /// ```
     pub fn source(&self) -> Option<&Error> {
-        self.inner.source.as_ref().map(|e| &**e)
+        self.inner.source.as_deref()
     }
 
     /// Iterate over all causes, including this one.

--- a/amethyst_rendy/src/pass/base_3d.rs
+++ b/amethyst_rendy/src/pass/base_3d.rs
@@ -209,12 +209,8 @@ impl<B: Backend, T: Base3DPassDef> RenderGroup<B, GraphAuxData> for DrawBase3D<B
         {
             profile_scope_impl!("prepare");
 
-            let mut query = <(
-                &Handle<Material>,
-                &Handle<Mesh>,
-                &Transform,
-                Option<&Tint>,
-            )>::query();
+            let mut query =
+                <(&Handle<Material>, &Handle<Mesh>, &Transform, Option<&Tint>)>::query();
 
             visibility
                 .visible_unordered
@@ -552,12 +548,8 @@ impl<B: Backend, T: Base3DPassDef> RenderGroup<B, GraphAuxData> for DrawBase3DTr
         {
             profile_scope_impl!("prepare");
 
-            let mut query = <(
-                &Handle<Material>,
-                &Handle<Mesh>,
-                &Transform,
-                Option<&Tint>,
-            )>::query();
+            let mut query =
+                <(&Handle<Material>, &Handle<Mesh>, &Transform, Option<&Tint>)>::query();
 
             visibility
                 .visible_ordered


### PR DESCRIPTION
## Description

Migrate the Pauseable system wrapper from specs to legion.

I was unable to keep the SystemExt trait for the pauseable method. Legion's `#[system]` macro produces a function that returns an opaque `impl Runnable`. While this is technically fine, Pauseable only relies on Runnables interface, opaque types do not recognize extra trait impls (or I do not know how to make them recognized). Instead of a trait I've exposed a bare method `pauseable` that takes an `impl Runnable` as input and returns a `Pauseable` struct. This struct then also impls Runnable and behaves as expected.

I couldn't find any unit tests for this code in master, I'm assuming the doc acts as a kind of example/unit test combo? While updating the docs I wrote the code snippet as a unit test and confirmed behaves as expected. This can be found embedded in the docs for `pauseable`, I'd be happy to re add it as an explicit unit test if desired.

I ran the given commands but `build` and `test` failed with unrelated errors. I'm assuming that's expected given this branch is mid-migration. Please let me know if that's not the case and I can look harder at resolving things. I included some trivial fixes for what appeared to be code not yet migrated to legion 0.3 under transform/ this was mainly replacing `Universe::new().create_world()` with `World::default()`

## Additions

- amethyst::core::system_ext::pauseable

## Removals

- amethyst::core::system_exit::SystemExt (this was already gone on this branch but I was unable to re-add it)

## PR Checklist

By placing an x in the boxes I certify that I have:

- [X] Added unit tests for new code added in this PR.
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [X] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [X] Ran `cargo build --features "empty"`
- [X] Ran `cargo test --workspace --features "empty"`
