### PR TITLE
Fix clippy, don't deny warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,7 @@ on:
       - "**"
 
 env:
-  RUSTFLAGS: --deny warnings -Cdebuginfo=0
-  RUSTDOCFLAGS: --deny warnings
+  RUSTFLAGS: -Cdebuginfo=0
 
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/amethyst_animation/src/systems/sampling.rs
+++ b/amethyst_animation/src/systems/sampling.rs
@@ -217,7 +217,7 @@ where
                 .last()
                 .cloned()
                 .map(secs_to_duration)
-                .unwrap_or(Duration::from_secs(0));
+                .unwrap_or_else(|| Duration::from_secs(0));
             // duration is past last frame of sampling
             if current_dur > last_frame {
                 // Check end conditions


### PR DESCRIPTION

## Description

Fixed the new warnings introduced in 1.46.0 update.
Also had to remove `--deny warnings` as discussed: https://github.com/amethyst/amethyst/pull/2450#issuecomment-683271243

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [ ] Ran `cargo build --features "empty"`
- [ ] Ran `cargo test --workspace --features "empty"`
