### PR TITLE
Inline ecs docs

### DIFF
--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -20,6 +20,7 @@ pub use alga;
 pub use approx;
 pub use nalgebra as math;
 pub use num_traits as num;
+#[doc(inline)]
 pub use specs as ecs;
 pub use specs::{shred, shrev};
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,6 @@
 //! Contains common types that can be glob-imported (`*`) for convenience.
 
+#[doc(no_inline)]
 pub use crate::{
     app::{Application, ApplicationBuilder, CoreApplication},
     callback_queue::{Callback, CallbackQueue},


### PR DESCRIPTION
## Description

Inline the reexported ecs docs so they are properly included.

Also disables inline on the prelude so it doesn't create redundant paths that clutter the search bar.

Fixes [#2242 ](https://github.com/amethyst/amethyst/issues/2242)

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
