### PR TITLE
Introduce cargo deny check to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,22 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
+  cargo-deny-check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        command: check ${{ matrix.checks }}
 
   tests:
     name: Tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ glsl-layout = "0.3.2"
 derive-new = "0.5.8"
 env_logger = "0.7.1"
 genmesh = "0.6.2"
-ron = "0.5.1"
+ron = "0.6"
 specs-derive = "0.4.1"
 
 [build-dependencies]

--- a/amethyst_animation/Cargo.toml
+++ b/amethyst_animation/Cargo.toml
@@ -25,7 +25,6 @@ amethyst_rendy = { path = "../amethyst_rendy", version = "0.15.3" }
 amethyst_ui = { path = "../amethyst_ui", version = "0.15.3" }
 derivative = "2.1.1"
 fnv = "1"
-itertools = "0.8.0"
 log = "0.4.6"
 minterpolate = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -21,7 +21,6 @@ travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
 amethyst_core = { path = "../amethyst_core", version = "0.15.3" }
-amethyst_derive = { path = "../amethyst_derive", version = "0.15.3" }
 amethyst_error = { path = "../amethyst_error", version = "0.15.3" }
 crossbeam-queue = "0.2.2"
 derivative = "2.1.1"

--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -23,7 +23,7 @@ travis-ci = { repository = "amethyst/amethyst" }
 amethyst_core = { path = "../amethyst_core", version = "0.15.3" }
 amethyst_derive = { path = "../amethyst_derive", version = "0.15.3" }
 amethyst_error = { path = "../amethyst_error", version = "0.15.3" }
-crossbeam-queue = "0.1.2"
+crossbeam-queue = "0.2.2"
 derivative = "2.1.1"
 derive-new = "0.5"
 fnv = "1"
@@ -32,7 +32,7 @@ parking_lot = "0.10"
 rayon = "1.3.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", optional = true }
-ron = "0.5"
+ron = "0.6"
 thread_profiler = { version = "0.3", optional = true }
 err-derive = "0.2.3"
 objekt = "0.1.2"

--- a/amethyst_config/Cargo.toml
+++ b/amethyst_config/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT/Apache-2.0"
 travis-ci = { repository = "amethyst/amethyst" }
 
 [dependencies]
-ron = "0.5"
+ron = "0.6"
 serde = "1.0"
 log = "0.4.6"
 

--- a/amethyst_config/Cargo.toml
+++ b/amethyst_config/Cargo.toml
@@ -18,7 +18,6 @@ travis-ci = { repository = "amethyst/amethyst" }
 [dependencies]
 ron = "0.6"
 serde = "1.0"
-log = "0.4.6"
 
 thread_profiler = { version = "0.3", optional = true }
 

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -17,7 +17,6 @@ travis-ci = { repository = "amethyst/amethyst" }
 [dependencies]
 nalgebra = { version = "0.19.0", features = ["serde-serialize", "mint"] }
 alga = { version = "0.9.2", default-features = false }
-alga_derive = "0.9.1"
 approx = "0.3.2"
 amethyst_error = { path = "../amethyst_error", version = "0.15.3" }
 fnv = "1.0.6"
@@ -35,7 +34,7 @@ thread_profiler = { version = "0.3", optional = true }
 
 [dev-dependencies]
 amethyst = { path = "..", version = "0.15.3" }
-ron = "0.5.1"
+ron = "0.6"
 
 [features]
 default = ["specs/parallel", "specs-hierarchy/parallel"]

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -19,7 +19,6 @@ nalgebra = { version = "0.19.0", features = ["serde-serialize", "mint"] }
 alga = { version = "0.9.2", default-features = false }
 approx = "0.3.2"
 amethyst_error = { path = "../amethyst_error", version = "0.15.3" }
-fnv = "1.0.6"
 log = "0.4.8"
 num-traits = "0.2.11"
 rayon = "1.3.0"

--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -25,7 +25,6 @@ base64 = "0.11"
 fnv = "1"
 gltf = { version = "0.15", features = ["KHR_lights_punctual"] }
 hibitset = { version = "0.6.2", features = ["parallel"] }
-itertools = "0.8"
 log = "0.4.6"
 mikktspace = "0.2.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -27,7 +27,7 @@ lazy_static = "1.4"
 log = "0.4"
 palette = { version = "0.4", features = ["serde"] }
 rendy = { version = "0.4.1", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1"] }
-ron = "0.5"
+ron = "0.6"
 serde = { version = "1", features = ["serde_derive"] }
 fnv = "1"
 derivative = "2.1.1"

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -26,7 +26,7 @@ derivative = "2.1.1"
 derive-new = "0.5.6"
 fnv = "1"
 glsl-layout = "0.3"
-ron = "0.5"
+ron = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 smallvec = "1.2"
 unicode-normalization = "0.1"

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,6 @@
 # Test suite must pass on GitHub Actions before merging into `master`.
 status = [
+    "cargo-deny-check (bans licenses sources)",
     "Tests (macos-latest, stable)",
     "Tests (macos-latest, beta)",
 #    "Tests (macos-latest, nightly)",

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,84 @@
+# See docs: https://embarkstudios.github.io/cargo-deny/checks/index.html
+
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+yanked = "deny"
+notice = "deny"
+ignore = [
+    # FIXME(#2471):
+    # The `failure` crate is officially end-of-life: it has been marked as deprecated
+    # by the former maintainer, who has announced that there will be no updates or
+    # maintenance work on it going forward.
+    # URL: https://github.com/rust-lang-nursery/failure/pull/347
+    "RUSTSEC-2020-0036",
+    # FIXME(#2472)
+    # `stb_truetype` crate has been deprecated; use `ttf-parser` instead
+    # This crate was maintained for use in rusttype which has switched to use [ttf-parser](https://crates.io/crates/ttf-parser)
+    # URL: https://gitlab.redox-os.org/redox-os/stb_truetype-rs/-/commit/f1f5be4794e87bfc80a4255bc3f23ed75dd77645
+    "RUSTSEC-2020-0020",
+
+    # FIXME: net2 is pulled in via `mio` (https://github.com/tokio-rs/mio/issues/1319#issuecomment-683496712)
+    # The [`net2`](https://crates.io/crates/net2) crate has been deprecated
+    # and users are encouraged to considered [`socket2`](https://crates.io/crates/socket2) instead.
+    # URL: https://github.com/deprecrated/net2-rs/commit/3350e3819adf151709047e93f25583a5df681091
+    "RUSTSEC-2020-0016",
+]
+
+[bans]
+multiple-versions = "deny"
+wildcards = "deny"
+skip = [
+    # FIXME: Waiting for gltf to update its base64 dep: https://github.com/gltf-rs/gltf/pull/292
+    { version = "=0.11.0", name = "base64" },
+
+    # FIXME: Waiting for alga to update its num-complex dep: https://github.com/dimforge/alga/pull/99
+    { version = "=0.2.4", name = "num-complex" },
+
+    # FIXME: Waiting for shred to update its hashbrown dep: https://github.com/amethyst/shred/pull/200
+    { version = "=0.7.2", name = "hashbrown" }
+]
+skip-tree = [
+    # FIXME: update and deduplicate all of these crates:
+
+    # There are > 27 crate duplicates pulled in by the old version of rendy we use
+    { version = "=0.4.1", name = "rendy", depth = 6 },
+
+    # There are 3 different minor versions of `rand` in the dependency
+    # tree that cause a lot of rand_* crates to be duplicated
+    { version = "=0.4.6", name = "rand", depth = 2 },
+    { version = "=0.6.5", name = "rand", depth = 2 },
+]
+deny = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+
+[licenses]
+unlicensed = "deny"
+copyleft = "deny"
+default = "deny"
+allow-osi-fsf-free = "neither"
+
+deny = []
+
+# Run `cargo deny list` to see which crates use which license
+# and add them to this array if we accept them
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Unlicense",
+    "Zlib",
+    "MPL-2.0",
+    "CC0-1.0",
+    "ISC",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "FTL",
+]
+
+# We want really high confidence when inferring licenses from text
+confidence-threshold = 0.93

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,11 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ### Changed
 
+- ***Breaking:***: updated `ron` from `0.5` to `0.6`, this changes the `amethyst_config::ConfigError` enum (#2473)
+
 ### Fixed
+
+[#2473]: https://github.com/amethyst/amethyst/pull/2473
 
 ## [0.15.3] - 2020-08-22
 


### PR DESCRIPTION
## Description

Tackles an item from https://github.com/amethyst/amethyst/issues/2407

The new job should check for RustSec advisories (there are currently two of them active for `amethyst` (#2471, #2472)
One of them is a long-standing advisory which `tokio` should fix at some point (https://github.com/tokio-rs/mio/issues/1319#issuecomment-683496712)...

This job is optional to pass because advisories are sudden and may break ci at any time.
Other things cargo-deny does is it checks for multiple versions of crates in the tree (there are a huge amount of them for now).
I have fixed some simple cases, but one of the biggest ones are the outdated `rendy` and `rand` crates.


Regarding licenses, you can see the list of them in the `deny.toml` file. There is an interesting crate here:
```
FTL (1): servo-freetype-sys@4.0.5
GPL-2.0 (1): servo-freetype-sys@4.0.5
```
It defines `license = "FTL  OR  GPL-2.0"`, not sure if this is what `amethyst` needs, I am not good at legal stuff...
## Removals

- Removed direct dependency on `itertools` crate (which was already outdated)
- Removed unused dependency `amethyst_derive` from `amethyst_assets`
- Removed unused dependency `log` from `amethyst_config`
- Removed unused dependency `fnv` from `amethyst_core`

## Modifications

- Updated `ron` crate from `v0.5` to `v0.6`. This is a **BREAKING CHANGE** since `ron` has unified it's `ser/de::Error`s to a single `Error` struct, but this error is also exposed via a public `ConfigError` enum. (See [their changelog](https://github.com/ron-rs/ron/blob/master/CHANGELOG.md#060---2020-05-21)). Surprisingly, the error changes are not mentioned in there (https://github.com/ron-rs/ron/pull/222#issuecomment-683485819)

- Updated `crossbeam-queue` from `v0.1.2` to `v0.2.2` ([changelog](https://github.com/crossbeam-rs/crossbeam/blob/master/crossbeam-queue/CHANGELOG.md))

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --workspace --features "empty"`
