### PR TITLE
book/src/appendices: Add missing link for Serde

### DIFF
--- a/book/src/appendices/a_config_files/ball_config.md
+++ b/book/src/appendices/a_config_files/ball_config.md
@@ -143,3 +143,4 @@ This configuration sets the ball to be orange, while retaining the same size and
 example.
 
 [vec2]: https://nalgebra.org/rustdoc/nalgebra/base/type.Vector2.html
+[serde]: https://docs.serde.rs/serde/index.html


### PR DESCRIPTION
## Description

Add a missing reference-style link for Serde to Appendix A. This appears to be the first direct reference to Serde in the text, and the original author seems to have intended to make it a link to either the Serde source or documentation; I opted to link to the latter.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
