### PR TITLE
Fix broken links and small book clean

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -9,3 +9,8 @@ additional-css = ["style/book.css"]
 additional-js = ["style/book.js"]
 
 #[output.linkcheck]
+#optional = true
+#follow-web-links = true
+
+#[output.linkcheck.http-headers]
+#   'crates\.io' = ["Accept: text/html"]

--- a/book/src/animation/definition.md
+++ b/book/src/animation/definition.md
@@ -12,4 +12,4 @@ Right now we do not have a tutorial for defining an animation from scratch, but 
 [ex_ani]: https://github.com/amethyst/amethyst/tree/master/examples/animation
 [ex_gltf]: https://github.com/amethyst/amethyst/tree/master/examples/gltf
 [ex_sprite]: https://github.com/amethyst/amethyst/tree/master/examples/sprite_animation
-[api]: https://docs.amethyst.rs/stable/amethyst_animation/
+[api]: https://docs.amethyst.rs/master/amethyst_animation

--- a/book/src/appendices/a_config_files.md
+++ b/book/src/appendices/a_config_files.md
@@ -45,9 +45,9 @@ For this project, we'll be placing a `config.ron` file in the same location as t
 * [Adding a Ball Config][1]
 * [Adding Paddle Configs][2]
 
-[pong]: https://github.com/amethyst/amethyst/tree/master/examples/pong
-[ron]: https://docs.rs/ron/0.3.0/ron/
-[config]: https://docs.rs/amethyst_config/0.6.0/amethyst_config/trait.Config.html
+[pong]: https://github.com/amethyst/amethyst/tree/master/examples/pong_tutorial_06
+[ron]: https://docs.rs/ron/~0.5/ron/
+[config]: https://docs.amethyst.rs/master/amethyst_config/trait.Config.html
 [0]: ./a_config_files/arena_config.html
 [1]: ./a_config_files/ball_config.html
 [2]: ./a_config_files/paddle_configs.html

--- a/book/src/appendices/a_config_files/arena_config.md
+++ b/book/src/appendices/a_config_files/arena_config.md
@@ -111,9 +111,5 @@ arena: (
 )
 ```
 
-
-[config]: https://docs.rs/amethyst_config/0.6.0/amethyst_config/trait.Config.html
-[ecsbundle]: https://docs.rs/amethyst_core/0.2.0/amethyst_core/bundle/trait.ECSBundle.html
-[ecsbuild]: https://docs.rs/amethyst_core/0.2.0/amethyst_core/bundle/trait.ECSBundle.html#tymethod.build
 [serde_default]: https://serde.rs/attr-default.html
 [default]: https://doc.rust-lang.org/std/default/trait.Default.html

--- a/book/src/appendices/a_config_files/paddle_configs.md
+++ b/book/src/appendices/a_config_files/paddle_configs.md
@@ -56,8 +56,8 @@ and modify the `main.rs`'s `run()` function to add our `PaddleConfig`s.
 ```
 
 We add the `PaddlesConfig` to the `World`, rather than as separate `left` and `right` configurations because
-`System`s can only access resources with ID 0. Any resource added using [`World::add_resource`][add_resource]
-is added using a default ID of 0. You must use [`World::add_resource_with_id`][add_with_id] to add multiple
+`System`s can only access resources with ID 0. Any resource added using `World::add_resource`
+is added using a default ID of 0. You must use `World::add_resource_with_id` to add multiple
 resources of the same type, but then the `System`s cannot properly differentiate between them.
 
 ## Replacing Constants with Configs
@@ -160,9 +160,3 @@ keep the left paddle blue so the final `config.ron` file will be as follows:
     )
 )
 ```
-
-
-[add_resource]: https://docs.rs/specs/0.12.0/specs/struct.World.html#method.insert
-[add_with_id]: https://docs.rs/specs/0.12.0/specs/struct.World.html#method.insert_with_id
-
-

--- a/book/src/appendices/b_migration_notes.md
+++ b/book/src/appendices/b_migration_notes.md
@@ -4,6 +4,6 @@ At times Amethyst goes through non-trivial changes which may impose additional e
 
 * [0.9 to 0.10](b_migration_notes/cgmath_to_nalgebra.html): `cgmath` to `nalgebra` migration
 * [0.10 to 0.12](b_migration_notes/rendy_migration.html): Rendy migration guide
-* [0.10 to 0.11](b_migration_notes/transform_api_changes.html): Transform API Changes
-* [0.11 to 0.12] Float type removed. Search and replace with 'f32'
+* 0.10 to 0.11 Transform API Changes
+* 0.11 to 0.12 Float type removed. Search and replace with 'f32'
 * [0.12 to 0.13](b_migration_notes/specs_migration.html): `specs` upgraded to `0.15`.

--- a/book/src/appendices/b_migration_notes/rendy_migration.md
+++ b/book/src/appendices/b_migration_notes/rendy_migration.md
@@ -52,7 +52,7 @@
 
 ## Window
 
-* `DisplayConfig`'s `fullscreen` field is now an `Option<MonitorIdent>`. `MonitorIdent` is `MonitorIdent(u16, String)`, indicating the native monitor display ID, and its [name](https://docs.rs/winit/0.19.1/winit/struct.MonitorId.html#method.get_name).
+* `DisplayConfig`'s `fullscreen` field is now an `Option<MonitorIdent>`. `MonitorIdent` is `MonitorIdent(u16, String)`, indicating the native monitor display ID, and its [name][monID].
 * `WindowBundle` is now separate from `amethyst_renderer`.
 
     ```rust,ignore
@@ -181,7 +181,7 @@
 
     This system is added automatically by the `RenderFlat2D` render plugin.
 
-* Sprite transparency is no longer a separate flag. Instead of `with_transparency`, you add a second render pass using `DrawFlat2DTransparent`. See the [`sprites_ordered` example](https://github.com/amethyst/amethyst/blob/7ed8432d8eef2b2727d0c4188b91e5823ae03548/examples/sprites_ordered/main.rs#L463-L482).
+* Sprite transparency is no longer a separate flag. Instead of `with_transparency`, you add a second render pass using `DrawFlat2DTransparent`. See the [`sprites_ordered` example][spri_ord].
 
 Camera changes:
 
@@ -219,3 +219,6 @@ Z-axis direction clarifications:
     ```
 
 * The `mark_render()` and `.run()` chained call is replaced by a single `run_isolated()` call.
+
+[monID]: https://docs.rs/winit/0.19.1/winit/struct.MonitorId.html#method.get_name
+[spri_ord]: https://github.com/amethyst/amethyst/blob/7ed8432d8eef2b2727d0c4188b91e5823ae03548/examples/sprites_ordered/main.rs#L463-L482

--- a/book/src/appendices/c_feature_gates.md
+++ b/book/src/appendices/c_feature_gates.md
@@ -24,8 +24,10 @@ At the time of writing, the list of features of this type is the following:
 * `saveload`
 * `sdl_controller`
 
-The full list of available features is available in the [Cargo.toml](https://github.com/amethyst/amethyst/blob/master/Cargo.toml) file.
+The full list of available features is available in the [Cargo.toml] file.
 The available features might change from time to time.
+
+[Cargo.toml]: https://github.com/amethyst/amethyst/blob/master/Cargo.toml
 
 ## Graphics features
 
@@ -50,7 +52,7 @@ by [shaderc]). Please note, that on Windows this feature requires [Ninja] to be 
 
 ## Using Amethyst testing utility
 
-As described in the [Testing chapter](../testing.html), Amethyst has several utilities to help you
+As described in the [Testing chapter][bk_test], Amethyst has several utilities to help you
 test an application written using Amethyst. For some cases (especially when rendering components 
 are involved in the test), you need to enable the `test-support` feature.
 
@@ -63,7 +65,7 @@ cargo (build/test/run) --features profiler
 ```
 
 The next time you will run a project, upon closing it, a file will be created at the root of the project called `thread_profile.json`.
-You can open this file using the chromium browser (or google chrome) and navigating to [chrome://tracing](chrome://tracing)
+You can open this file using the chromium browser (or google chrome) and navigating to chrome://tracing
 
 ## Nightly
 
@@ -92,3 +94,5 @@ version = "*"
 default-features = false
 features = ["audio", "animation"] # you can add more or replace those
 ```
+
+[bk_test]: ../testing.html

--- a/book/src/assets/how_to_define_custom_assets.md
+++ b/book/src/assets/how_to_define_custom_assets.md
@@ -272,7 +272,7 @@ This guide explains how to define a new asset type to be used in an Amethyst app
     If the asset data is stored in a format that is not supported by Amethyst, a [custom format][bk_custom_formats] can be implemented and provided to the `Loader` to load the asset data.
 
 [bk_custom_formats]: how_to_define_custom_formats.html
-[doc_asset]: https://docs.amethyst.rs/stable/amethyst_assets/trait.Asset.html
-[doc_processor_system]: https://docs.amethyst.rs/stable/amethyst_assets/struct.Processor.html
-[doc_processable_asset]: https://docs.amethyst.rs/stable/amethyst_assets/trait.ProcessableAsset.html
+[doc_asset]: https://docs.amethyst.rs/master/amethyst_assets/trait.Asset.html
+[doc_processor_system]: https://docs.amethyst.rs/master/amethyst_assets/struct.Processor.html
+[doc_processable_asset]: https://docs.amethyst.rs/master/amethyst_assets/trait.ProcessableAsset.html
 [gh_contributing]: https://github.com/amethyst/amethyst/blob/master/docs/CONTRIBUTING.md

--- a/book/src/assets/how_to_define_custom_formats.md
+++ b/book/src/assets/how_to_define_custom_formats.md
@@ -182,6 +182,6 @@ If you are defining a new format that may be useful to others, [please send us a
     ```
 
 [bk_custom_assets]: how_to_define_custom_assets.html
-[doc_hrs]: https://docs.amethyst.rs/stable/amethyst_assets/struct.HotReloadStrategy.html
+[doc_hrs]: https://docs.amethyst.rs/master/amethyst_assets/struct.HotReloadStrategy.html
 [doc_ron_format]: https://docs.amethyst.rs/stable/amethyst_assets/struct.RonFormat.html
 [gh_contributing]: https://github.com/amethyst/amethyst/blob/master/docs/CONTRIBUTING.md

--- a/book/src/assets/how_to_use_assets.md
+++ b/book/src/assets/how_to_use_assets.md
@@ -176,10 +176,10 @@ This guide covers the basic usage of assets into Amethyst for existing supported
     }
     ```
 
-[doc_asset]: https://docs.amethyst.rs/stable/amethyst_assets/trait.Asset.html
-[doc_asset_get]: https://docs.amethyst.rs/stable/amethyst_assets/struct.AssetStorage.html#method.get
-[doc_loader]: https://docs.amethyst.rs/stable/amethyst_assets/struct.Loader.html
-[doc_load]: https://docs.amethyst.rs/stable/amethyst_assets/struct.Loader.html#method.load
-[doc_processor_system]: https://docs.amethyst.rs/stable/amethyst_assets/struct.Processor.html
-[doc_read_resource]: https://docs.amethyst.rs/stable/specs/world/struct.World.html#method.read_resource
-[doc_search_format]: https://docs.amethyst.rs/stable/amethyst/?search=Format
+[doc_asset]: https://docs.amethyst.rs/master/amethyst_assets/trait.Asset.html
+[doc_asset_get]: https://docs.amethyst.rs/master/amethyst_assets/struct.AssetStorage.html#method.get
+[doc_loader]: https://docs.amethyst.rs/master/amethyst_assets/struct.Loader.html
+[doc_load]: https://docs.amethyst.rs/master/amethyst_assets/struct.Loader.html#method.load
+[doc_processor_system]: https://docs.amethyst.rs/master/amethyst_assets/struct.Processor.html
+[doc_read_resource]: https://docs.rs/specs/~0.16/specs/world/struct.World.html#method.read_resource
+[doc_search_format]: https://docs.amethyst.rs/master/amethyst/?search=Format

--- a/book/src/concepts/entity_and_component.md
+++ b/book/src/concepts/entity_and_component.md
@@ -149,8 +149,8 @@ There are a few storage strategies for different usage scenarios. The most commo
         </div>
 </div>
 
-For more information, see the [specs storage reference](https://docs.rs/specs/latest/specs/storage/index.html)
-and the ["Storages" section](https://specs.amethyst.rs/docs/tutorials/05_storages.html) of the specs book.
+For more information, see the [specs storage reference]
+and the ["Storages" section] of the specs book.
 
 There are a bunch more storages, and deciding which one is the best isn't trivial and should be done based on careful benchmarking. A general rule is: if your component is used in over 30% of entities, use `VecStorage`. If you don't know which one you should use, `DenseVecStorage` is a good default. It will need more memory than `VecStorage` for pointer-sized components, but it will perform well for most scenarios.
 
@@ -161,3 +161,6 @@ The usual way to do it is to create an empty struct, and implement `Component` u
 Null storage means that it is not going to take memory space to store those components.
 
 You will learn how to use those tag components in the System chapter.
+
+[specs storage reference]: https://docs.rs/specs/~0.15/specs/storage/index.html
+["Storages" section]: https://specs.amethyst.rs/docs/tutorials/05_storages.html

--- a/book/src/input/handling_input.md
+++ b/book/src/input/handling_input.md
@@ -67,7 +67,7 @@ impl<'s> System<'s> for ExampleSystem {
 }
 ```
 
-You can find all the methods from `InputHandler` [here](https://docs.amethyst.rs/stable/amethyst_input/struct.InputHandler.html#methods).
+You can find all the methods from `InputHandler` [here][input_ha].
 
 Now you have to add the `System` to the game data, just like you would do with any other `System`. A `System` that uses an `InputHandler` needs `"input_system"` inside its dependencies.
 
@@ -84,6 +84,8 @@ let game_data = GameDataBuilder::default()
     //..
 #   ;
 ```
+
+[input_ha]: https://docs.amethyst.rs/master/amethyst_input/struct.InputHandler.html#methods
 
 ## Defining Key Bindings in a File
 
@@ -114,7 +116,7 @@ The action is a boolean, which is set to true when the buttons are pressed. The 
 * The inner array specifies the buttons that must be pressed at the same time to send the action.
 * The outer array specifies different combinations of those buttons that send the action.
 
-The possible inputs you can specify for axes are listed [here](https://docs.amethyst.rs/stable/amethyst_input/enum.Axis.html). The possible inputs you can specify for actions are listed [here](https://docs.amethyst.rs/stable/amethyst_input/enum.Button.html).
+The possible inputs you can specify for axes are listed [here][in_axis]. The possible inputs you can specify for actions are listed [here][button].
 
 To add these bindings to the `InputBundle` you simply need to call the `with_bindings_from_file` function on the `InputBundle`.
 
@@ -132,7 +134,7 @@ let input_bundle = InputBundle::<StringBindings>::new()
 # Ok(()) }
 ```
 
-And now you can get the [axis](https://docs.amethyst.rs/stable/amethyst_input/struct.InputHandler.html#method.axis_value) and [action](https://docs.amethyst.rs/stable/amethyst_input/struct.InputHandler.html#method.action_is_down) values from the `InputHandler`.
+And now you can get the [axis][axis_val] and [action][is_down] values from the `InputHandler`.
 
 ```rust,edition2018,no_run,noplaypen
 # extern crate amethyst;
@@ -185,3 +187,8 @@ impl<'s> System<'s> for MovementSystem {
     }
 }
 ```
+
+[in_axis]: https://docs.amethyst.rs/master/amethyst_input/enum.Axis.html
+[button]: https://docs.amethyst.rs/master/amethyst_input/enum.Button.html
+[axis_val]: https://docs.amethyst.rs/master/amethyst_input/struct.InputHandler.html#method.axis_value
+[is_down]: https://docs.amethyst.rs/master/amethyst_input/struct.InputHandler.html#method.action_is_down

--- a/book/src/input/how_to_define_custom_control_bindings.md
+++ b/book/src/input/how_to_define_custom_control_bindings.md
@@ -54,7 +54,7 @@ impl BindingTypes for MovementBindingTypes {
 
 The `Axis` and `Action` type both need to derive all the traits listed above, the first five are used by Amethyst and the last two are for reading and writing to files correctly. They also need to implement `Display` if you want to add a bindings config file.
 
-For serializing and deserializing you need to add [serde](https://crates.io/crates/serde) to the dependencies like this:
+For serializing and deserializing you need to add [serde] to the dependencies like this:
 
 ```toml,ignore
 serde = { version = "1", features = ["derive"] }
@@ -216,3 +216,5 @@ let game_data = GameDataBuilder::default()
 //..
 #   ;
 ```
+
+[serde]: https://crates.io/crates/serde

--- a/book/src/pong-tutorial/contribution.md
+++ b/book/src/pong-tutorial/contribution.md
@@ -2,32 +2,41 @@
 
 And... that's where the pong chapter ends. We hope you found it useful!
 
-You can find the entire code with balls, score and music on the example pages available [here](https://github.com/amethyst/amethyst/tree/master/examples/pong).
+You can find the entire code with balls, score and music on the example pages available [here][src_code].
 
 Next up in this book we will explain how Amethyst does Math, Input, Assets and so on. Whenever you have a need for more learning-by-example materials just come back to this page for an overview of available resources.
 
 ## Other tutorials or examples
 
-#### [Amethyst Quickstarter](https://github.com/amethyst/amethyst-starter-2d)
+#### [Amethyst Quickstarter]
   
 Seed project for 2D games. This project template will get you from 0 to drawing something on the screen in no time.
 
-#### Showcase Game: [Evoli](https://github.com/amethyst/evoli)
+#### Showcase Game: [Evoli]
   
 An ecosystem-simulation game, 3D
   
-#### Showcase Game: [Space Menace](https://github.com/amethyst/space-menace/)
+#### Showcase Game: [Space Menace]
   
 An action 2D platformer
   
-#### Showcase Game: [Survivor](https://github.com/jaynus/survival) 
+#### Showcase Game: [Survivor]
   
 (unannounced, 2D)
 
-For more examples from the community you can check out this list of [Games made with Amethyst](https://community.amethyst.rs/t/games-made-with-amethyst/134).
+For more examples from the community you can check out this list of [Games made with Amethyst][games].
 
 ## Come talk to us
 
-You can get additional help by leaving a post on [our forum](https://community.amethyst.rs) or on our [Discord server](https://discord.gg/amethyst). We'd also love to hear your ideas for other tutorials we should consider adding to this book.
+You can get additional help by leaving a post on [our forum] or on our [Discord server]. We'd also love to hear your ideas for other tutorials we should consider adding to this book.
 
 If you want to extend this tutorial (e.g., add a main menu, add pause/resume functionality, etc.), feel free to ping us on Discord or in a GitHub issue!
+
+[src_code]: https://github.com/amethyst/amethyst/tree/master/examples/pong_tutorial_06
+[Amethyst Quickstarter]: https://github.com/amethyst/amethyst-starter-2d
+[Evoli]: https://github.com/amethyst/evoli
+[Space Menace]: https://github.com/amethyst/space-menace/
+[Survivor]: https://github.com/jaynus/survival
+[games]: https://community.amethyst.rs/t/games-made-with-amethyst/134
+[our forum]: https://community.amethyst.rs
+[Discord server]: https://discord.gg/amethyst

--- a/book/src/pong-tutorial/pong-tutorial-01.md
+++ b/book/src/pong-tutorial/pong-tutorial-01.md
@@ -272,9 +272,9 @@ get a window. It should look something like this:
 ![Step one](../images/pong_tutorial/pong_01.png)
 
 [ron]: https://github.com/ron-rs/ron
-[simplestate]: https://docs.amethyst.rs/stable/amethyst/prelude/trait.SimpleState.html
-[state]: https://docs.amethyst.rs/stable/amethyst/prelude/trait.State.html
-[ap]: https://docs.amethyst.rs/stable/amethyst/type.Application.html
-[log]: https://docs.amethyst.rs/stable/amethyst/struct.Logger.html
-[displayconf]: https://docs.amethyst.rs/stable/amethyst_renderer/struct.DisplayConfig.html
+[simplestate]: https://docs.amethyst.rs/master/amethyst/prelude/trait.SimpleState.html
+[state]: https://docs.amethyst.rs/master/amethyst/prelude/trait.State.html
+[ap]: https://docs.amethyst.rs/master/amethyst/type.Application.html
+[log]: https://docs.amethyst.rs/master/amethyst/struct.Logger.html
+[displayconf]: https://docs.amethyst.rs/master/amethyst_window/struct.DisplayConfig.html
 [graph]: https://github.com/amethyst/rendy/blob/master/docs/graph.md

--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -655,6 +655,5 @@ In the next chapter, we'll explore the "S" in ECS and actually get these paddles
 moving!
 
 [sb]: https://specs.amethyst.rs/docs/tutorials/
-[sb-storage]: https://specs.amethyst.rs/docs/tutorials/05_storages.html#densevecstorage
-[2d]: https://docs.amethyst.rs/stable/amethyst_renderer/struct.Camera.html#method.standard_2d
+[sb-storage]: https://specs.amethyst.rs/docs/tutorials/05_storages.html
 [ss]: ../images/pong_tutorial/pong_spritesheet.png

--- a/book/src/pong-tutorial/pong-tutorial-03.md
+++ b/book/src/pong-tutorial/pong-tutorial-03.md
@@ -411,5 +411,5 @@ keypresses, and move our game's paddles accordingly. In the next chapter, we'll
 explore another key concept in real-time games: time. We'll make our game aware
 of time, and add a ball for our paddles to bounce back and forth.
 
-[doc_time]: https://docs.amethyst.rs/stable/amethyst_core/timing/struct.Time.html
-[doc_bindings]: https://docs.amethyst.rs/stable/amethyst_input/struct.Bindings.html
+[doc_time]: https://docs.amethyst.rs/master/amethyst_core/timing/struct.Time.html
+[doc_bindings]: https://docs.amethyst.rs/master/amethyst_input/struct.Bindings.html

--- a/book/src/pong-tutorial/pong-tutorial-04.md
+++ b/book/src/pong-tutorial/pong-tutorial-04.md
@@ -518,5 +518,5 @@ In the next chapter, we'll add a system checking when a player loses the game,
 and add a scoring system!
 
 [pong_02_drawing]: pong-tutorial-02.html#drawing
-[doc_time]: https://docs.amethyst.rs/stable/amethyst_core/timing/struct.Time.html
+[doc_time]: https://docs.amethyst.rs/master/amethyst_core/timing/struct.Time.html
 [delta_timing]: https://en.wikipedia.org/wiki/Delta_timing

--- a/book/src/pong-tutorial/pong-tutorial-05.md
+++ b/book/src/pong-tutorial/pong-tutorial-05.md
@@ -366,8 +366,8 @@ it to either side, so we'll add that next!
 
 
 [font-download]: https://github.com/amethyst/amethyst/raw/master/examples/pong_tutorial_05/assets/font/square.ttf
-[input-handler]: https://docs.amethyst.rs/stable/amethyst_input/struct.InputHandler.html
-[ui-bundle]: https://docs.amethyst.rs/stable/amethyst_ui/struct.UiBundle.html
+[input-handler]: https://docs.amethyst.rs/master/amethyst_input/struct.InputHandler.html
+[ui-bundle]: https://docs.amethyst.rs/master/amethyst_ui/struct.UiBundle.html
 
 
 ## Updating the Scoreboard
@@ -519,9 +519,7 @@ component to the player's score, after converting it to a string.
 And that's it! Our game now keeps track of the score for us and displays it at
 the top of our window.
 
-![Pong Game with Scores][pong-screenshot]
+![Pong Game with Scores](../images/pong_tutorial/pong_05.png)
 
 Now don't go just yet, because, in the next chapter, we'll make our Pong game
 even better by adding sound effects and even some music!
-
-[pong-screenshot]: ../images/pong_tutorial/pong_05.png

--- a/book/src/prefabs/how_to_define_prefabs_adapter.md
+++ b/book/src/prefabs/how_to_define_prefabs_adapter.md
@@ -39,7 +39,7 @@ If you are attempting to adapt a more complex type, please choose the appropriat
 
 2. Define the adapter prefab data type.
 
-    Create a (de)serializable enum type with a variant for each representation. The following is an example of an adapter type for the [`Position`] component, which allows either `i32` or `f32` values to be specified in the prefab:
+    Create a (de)serializable enum type with a variant for each representation. The following is an example of an adapter type for the `Position` component, which allows either `i32` or `f32` values to be specified in the prefab:
 
     ```rust,edition2018,no_run,noplaypen
     # extern crate amethyst;
@@ -60,21 +60,31 @@ If you are attempting to adapt a more complex type, please choose the appropriat
     }
     ```
 
-    The [`#[serde(deny_unknown_fields)]`] ensures that deserialization produces an error if it encounters an unknown field. This will help expose mistakes in the prefab file, such as when there is a typo.
+    The [`#[serde(deny_unknown_fields)]`][ser_unk] ensures that deserialization produces an error if it encounters an unknown field. This will help expose mistakes in the prefab file, such as when there is a typo.
 
-    **Note:** You may already have a type that captures the multiple representations. For example, for the [`Camera`] component, the [`Projection`] enum captures the different representations:
+    **Note:** You may already have a type that captures the multiple representations. For example, for the [`Camera`] component, the [`CameraPrefab`] enum captures the different representations:
 
     ```rust,edition2018,no_run,noplaypen
     # extern crate amethyst;
     # extern crate serde;
     #
-    # use amethyst::core::math::{Orthographic3, Perspective3};
     # use serde::{Deserialize, Serialize};
     #
-    #[derive(Clone, Deserialize, PartialEq, Serialize)]
-    pub enum Projection {
-        Orthographic(Orthographic3<f32>),
-        Perspective(Perspective3<f32>),
+    #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)
+    pub enum CameraPrefab {
+        Orthographic {
+            left: f32,
+            right: f32,
+            bottom: f32,
+            top: f32,
+            znear: f32,
+            zfar: f32,
+        },
+        Perspective {
+            aspect: f32,
+            fovy: f32,
+            znear: f32,
+        },
     }
     ```
 
@@ -161,12 +171,11 @@ To see this in a complete example, run the [`prefab_adapter` example][repo_prefa
 cargo run --example prefab_adapter
 ```
 
-[`#[serde(default)]`]: https://serde.rs/container-attrs.html#default
-[`#[serde(deny_unknown_fields)]`]: https://serde.rs/container-attrs.html#deny_unknown_fields
-[`Camera`]: https://docs.amethyst.rs/stable/amethyst_renderer/struct.Camera.html
-[`Component`]: https://docs.amethyst.rs/stable/specs/trait.Component.html
-[`Prefab`]: https://docs.amethyst.rs/stable/amethyst_assets/struct.Prefab.html
-[`PrefabData`]: https://docs.amethyst.rs/stable/amethyst_assets/trait.PrefabData.html#impl-PrefabData%3C%27a%3E
-[`Projection`]: https://docs.amethyst.rs/stable/amethyst_renderer/enum.Projection.html
+[ser_unk]: https://serde.rs/container-attrs.html#deny_unknown_fields
+[`Camera`]: https://docs.amethyst.rs/master/amethyst_rendy/camera/struct.Camera.html
+[`Component`]: https://docs.rs/specs/~0.16/specs/trait.Component.html
+[`Prefab`]: https://docs.amethyst.rs/master/amethyst_assets/struct.Prefab.html
+[`PrefabData`]: https://docs.amethyst.rs/master/amethyst_assets/trait.PrefabData.html
+[`CameraPrefab`]: https://docs.amethyst.rs/master/amethyst_rendy/camera/enum.CameraPrefab.html
 [bk_prefab_prelude]: how_to_define_prefabs_prelude.html
 [repo_prefab_adapter]: https://github.com/amethyst/amethyst/tree/master/examples/prefab_adapter

--- a/book/src/prefabs/how_to_define_prefabs_adapter.md
+++ b/book/src/prefabs/how_to_define_prefabs_adapter.md
@@ -70,7 +70,7 @@ If you are attempting to adapt a more complex type, please choose the appropriat
     #
     # use serde::{Deserialize, Serialize};
     #
-    #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)
+    #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
     pub enum CameraPrefab {
         Orthographic {
             left: f32,

--- a/book/src/prefabs/how_to_define_prefabs_aggregate.md
+++ b/book/src/prefabs/how_to_define_prefabs_aggregate.md
@@ -192,9 +192,9 @@ If you intend to include a [`Component`] that has not yet got a corresponding [`
 
     The [`PrefabData`][api_pf_derive] derive implements the [`PrefabData`] trait for the type. The generated code will handle invoking the appropriate [`PrefabData`] methods when loading and attaching components to an entity. **Note:** This differs from the simple component [`PrefabData`] derive implementation &ndash; there is no `#[prefab(Component)]` attribute.
 
-    The [`#[serde(default)]`] attribute allows fields to not be specified in the prefab, and the fields' default value will be used. If this attribute is not present, then all fields must be specified in the prefab.
+    The [`#[serde(default)]`][ser_def] attribute allows fields to not be specified in the prefab, and the fields' default value will be used. If this attribute is not present, then all fields must be specified in the prefab.
 
-    Finally, the [`#[serde(deny_unknown_fields)]`] ensures that deserialization produces an error if it encounters an unknown field. This will help expose mistakes in the prefab file, such as when there is a typo.
+    Finally, the [`#[serde(deny_unknown_fields)]`][ser_unk] ensures that deserialization produces an error if it encounters an unknown field. This will help expose mistakes in the prefab file, such as when there is a typo.
 
 
 4. Now the type can be used in a prefab.
@@ -247,12 +247,12 @@ cargo run --example prefab_custom # superset prefab
 cargo run --example prefab_multi # object prefab
 ```
 
-[`#[serde(default)]`]: https://serde.rs/container-attrs.html#default
-[`#[serde(deny_unknown_fields)]`]: https://serde.rs/container-attrs.html#deny_unknown_fields
-[`Component`]: https://docs.amethyst.rs/stable/specs/trait.Component.html
-[`Prefab`]: https://docs.amethyst.rs/stable/amethyst_assets/struct.Prefab.html
-[`PrefabData`]: https://docs.amethyst.rs/stable/amethyst_assets/trait.PrefabData.html#impl-PrefabData%3C%27a%3E
-[api_pf_derive]: https://docs.amethyst.rs/stable/amethyst_derive/derive.PrefabData.html
+[ser_def]: https://serde.rs/container-attrs.html#default
+[ser_unk]: https://serde.rs/container-attrs.html#deny_unknown_fields
+[`Component`]: https://docs.rs/specs/~0.16/specs/trait.Component.html
+[`Prefab`]: https://docs.amethyst.rs/master/amethyst_assets/struct.Prefab.html
+[`PrefabData`]: https://docs.amethyst.rs/master/amethyst_assets/trait.PrefabData.html
+[api_pf_derive]: https://docs.amethyst.rs/master/amethyst_derive/derive.PrefabData.html
 [bk_prefab_prelude]: how_to_define_prefabs_prelude.html
 [repo_prefab_custom]: https://github.com/amethyst/amethyst/tree/master/examples/prefab_custom
 [repo_prefab_multi]: https://github.com/amethyst/amethyst/tree/master/examples/prefab_multi

--- a/book/src/prefabs/how_to_define_prefabs_prelude.md
+++ b/book/src/prefabs/how_to_define_prefabs_prelude.md
@@ -137,16 +137,16 @@ Component     | Serialized representation             | Example(s)            | 
 
     Applicable guide: [How to Define Prefabs: Multi-Handle][Multi-Handle].
 
-[`AudioListener`]: https://docs.amethyst.rs/stable/amethyst_audio/struct.AudioListener.html
-[`AudioPrefab`]: https://docs.amethyst.rs/stable/amethyst_audio/struct.AudioPrefab.html
-[`Camera`]: https://docs.amethyst.rs/stable/amethyst_rendy/struct.Camera.html
-[`CameraPrefab`]: https://docs.amethyst.rs/stable/amethyst_rendy/camera/enum.CameraPrefab.html
-[`Material`]: https://docs.amethyst.rs/stable/amethyst_rendy/struct.Material.html
-[`MaterialPrefab`]: https://docs.amethyst.rs/stable/amethyst_rendy/formats/mtl/struct.MaterialPrefab.html
-[`Mesh`]: https://docs.amethyst.rs/stable/amethyst_rendy/rendy/mesh/struct.Mesh.html
-[`MeshData`]: https://docs.amethyst.rs/stable/amethyst_rendy/types/struct.MeshData.html
-[`Texture`]: https://docs.amethyst.rs/stable/amethyst_rendy/rendy/texture/struct.Texture.html
-[`TexturePrefab`]: https://docs.amethyst.rs/stable/amethyst_rendy/formats/texture/enum.TexturePrefab.html
+[`AudioListener`]: https://docs.amethyst.rs/master/amethyst_audio/struct.AudioListener.html
+[`AudioPrefab`]: https://docs.amethyst.rs/master/amethyst_audio/struct.AudioPrefab.html
+[`Camera`]: https://docs.amethyst.rs/master/amethyst_rendy/struct.Camera.html
+[`CameraPrefab`]: https://docs.amethyst.rs/master/amethyst_rendy/camera/enum.CameraPrefab.html
+[`Material`]: https://docs.amethyst.rs/master/amethyst_rendy/struct.Material.html
+[`MaterialPrefab`]: https://docs.amethyst.rs/master/amethyst_rendy/formats/mtl/struct.MaterialPrefab.html
+[`Mesh`]: https://docs.amethyst.rs/master/amethyst_rendy/rendy/mesh/struct.Mesh.html
+[`MeshData`]: https://docs.amethyst.rs/master/amethyst_rendy/types/struct.MeshData.html
+[`Texture`]: https://docs.amethyst.rs/master/amethyst_rendy/rendy/texture/struct.Texture.html
+[`TexturePrefab`]: https://docs.amethyst.rs/master/amethyst_rendy/formats/texture/enum.TexturePrefab.html
 [Adapter]: how_to_define_prefabs_adapter.html
 [Asset]: how_to_define_prefabs_asset.html
 [Aggregate]: how_to_define_prefabs_aggregate.html

--- a/book/src/prefabs/how_to_define_prefabs_simple.md
+++ b/book/src/prefabs/how_to_define_prefabs_simple.md
@@ -1,6 +1,6 @@
 # How to Define Prefabs: Simple
 
-This guide explains how to enable a [`[Component]`(https://docs.amethyst.rs/stable/specs/trait.Component.html)] to be used in a [`[Prefab]`(https://docs.amethyst.rs/stable/amethyst_assets/struct.Prefab.html)]. This can be applied where the [`[Component]`(https://docs.amethyst.rs/stable/specs/trait.Component.html)] type itself is completely serializable &ndash; the data is self-contained:
+This guide explains how to enable a [`Component`] to be used in a [`Prefab`]. This can be applied where the [`Component`] type itself is completely serializable &ndash; the data is self-contained:
 
 ```rust,no_run,noplaypen
 # extern crate amethyst;
@@ -72,11 +72,11 @@ If you are attempting to adapt a more complex type, please choose the appropriat
     pub struct Position(pub f32, pub f32, pub f32);
     ```
 
-    The [`[PrefabData]`(https://docs.amethyst.rs/stable/amethyst_assets/trait.PrefabData.html#impl-PrefabData)][api_pf_derive](https://docs.amethyst.rs/stable/amethyst_derive/derive.PrefabData.html) derive implements the `[PrefabData]` trait for the type. The `#[prefab(Component)]` attribute informs the `[PrefabData]` derive that this type is a [`[Component]`(https://docs.amethyst.rs/stable/specs/trait.Component.html)], as opposed to being composed of fields which implement `[PrefabData]`.
+    The [`PrefabData`] [api_pf_derive] derive implements the [`PrefabData`] trait for the type. The `#[prefab(Component)]` attribute informs the [`PrefabData`] derive that this type is a [`Component`], as opposed to being composed of fields which implement `[PrefabData]`.
 
-    The [[`#[serde(default)]`](https://serde.rs/container-attrs.html#default)] attribute allows fields to not be specified in the prefab, and the fields' default value will be used. If this attribute is not present, then all fields must be specified in the prefab.
+    The [`#[serde(default)]`][ser_def] attribute allows fields to not be specified in the prefab, and the fields' default value will be used. If this attribute is not present, then all fields must be specified in the prefab.
 
-    Finally, the [[`#[serde(deny_unknown_fields)]`](https://serde.rs/container-attrs.html#deny_unknown_fields)] ensures that deserialization produces an error if it encounters an unknown field. This will help expose mistakes in the prefab file, such as when there is a typo.
+    Finally, the [`#[serde(deny_unknown_fields)]`][ser_unk] ensures that deserialization produces an error if it encounters an unknown field. This will help expose mistakes in the prefab file, such as when there is a typo.
 
 4. Now the type can be used in a prefab:
 
@@ -91,8 +91,17 @@ If you are attempting to adapt a more complex type, please choose the appropriat
     )
     ```
 
-To see this in a complete example, run the [`prefab_basic` example](https://github.com/amethyst/amethyst/tree/master/examples/prefab_basic) from the Amethyst repository:
+To see this in a complete example, run the [`prefab_basic` example] from the Amethyst repository:
 
 ```bash
 cargo run --example prefab_basic
 ```
+
+[`Component`]: https://docs.rs/specs/~0.16/specs/trait.Component.html
+[`Prefab`]: https://docs.amethyst.rs/master/amethyst_assets/struct.Prefab.html
+[`PrefabData`]: https://docs.amethyst.rs/master/amethyst_assets/trait.PrefabData.html#impl-PrefabData
+[api_pf_derive]: https://docs.amethyst.rs/master/amethyst_derive/derive.PrefabData.html
+[ser_def]: https://serde.rs/container-attrs.html#default
+[ser_unk]: https://serde.rs/container-attrs.html#deny_unknown_fields
+[`prefab_basic` example]: https://github.com/amethyst/amethyst/tree/master/examples/prefab_basic
+[bk_prefab_prelude]: ./how_to_define_prefabs_prelude.html

--- a/book/src/prefabs/prefabs_in_amethyst.md
+++ b/book/src/prefabs/prefabs_in_amethyst.md
@@ -283,12 +283,12 @@ cargo run --example prefab_custom
 Phew, that was long! Now that you have an understanding of how prefabs work in Amethyst, the next page covers the technical aspects in more detail.
 
 [assets]: ../assets.html
-[`Component`]: https://docs.amethyst.rs/stable/specs/trait.Component.html
-[`Entity`]: https://docs.amethyst.rs/stable/specs/struct.Entity.html
-[`Named`]: https://docs.amethyst.rs/stable/amethyst_core/struct.Named.html
+[`Component`]: https://docs.rs/specs/~0.16/specs/trait.Component.html
+[`Entity`]: https://docs.rs/specs/~0.16/specs/struct.Entity.html
+[`Named`]: https://docs.amethyst.rs/master/amethyst_core/struct.Named.html
 [`Option`]: https://doc.rust-lang.org/std/option/enum.Option.html
-[`Parent`]: https://docs.amethyst.rs/stable/amethyst_core/transform/components/struct.Parent.html
-[`Prefab`]: https://docs.amethyst.rs/stable/amethyst_assets/struct.Prefab.html
-[`PrefabData`]: https://docs.amethyst.rs/stable/amethyst_assets/trait.PrefabData.html#impl-PrefabData%3C%27a%3E
-[`PrefabEntity`]: https://github.com/amethyst/amethyst/blob/v0.10.0/amethyst_assets/src/prefab/mod.rs#L110-L115
-[`PrefabLoaderSystem`]: https://docs.amethyst.rs/stable/amethyst_assets/struct.PrefabLoaderSystem.html
+[`Parent`]: https://docs.amethyst.rs/master/amethyst_core/transform/components/struct.Parent.html
+[`Prefab`]: https://docs.amethyst.rs/master/amethyst_assets/struct.Prefab.html
+[`PrefabData`]: https://docs.amethyst.rs/master/amethyst_assets/trait.PrefabData.html#impl-PrefabData
+[`PrefabEntity`]: https://github.com/amethyst/amethyst/blob/v0.15.3/amethyst_assets/src/prefab/mod.rs#L121-L126
+[`PrefabLoaderSystem`]: https://docs.amethyst.rs/master/amethyst_assets/struct.PrefabLoaderSystem.html

--- a/book/src/sprites/define_the_sprite_sheet.md
+++ b/book/src/sprites/define_the_sprite_sheet.md
@@ -142,5 +142,5 @@ pub fn load_sprite_sheet(texture: Handle<Texture>) -> SpriteSheet {
 
 
 
-[doc_grid]: https://docs.amethyst.rs/stable/amethyst_rendy/sprite/struct.SpriteGrid.html
-[doc_list]: https://docs.amethyst.rs/stable/amethyst_rendy/sprite/struct.SpriteList.html
+[doc_grid]: https://docs.amethyst.rs/master/amethyst_rendy/sprite/struct.SpriteGrid.html
+[doc_list]: https://docs.amethyst.rs/master/amethyst_rendy/sprite/struct.SpriteList.html

--- a/book/src/sprites/load_the_texture.md
+++ b/book/src/sprites/load_the_texture.md
@@ -65,14 +65,10 @@ let my_config = ImageTextureConfig {
 };
 ```
 
-[doc_asset]: https://docs.amethyst.rs/stable/amethyst_assets/trait.Asset.html
-[doc_asset_get]: https://docs.amethyst.rs/stable/amethyst_assets/struct.AssetStorage.html#method.get
-[doc_fmt_bmp]: https://docs.amethyst.rs/stable/amethyst_renderer/struct.BmpFormat.html
-[doc_fmt_jpg]: https://docs.amethyst.rs/stable/amethyst_renderer/struct.JpgFormat.html
-[doc_fmt_png]: https://docs.amethyst.rs/stable/amethyst_renderer/struct.PngFormat.html
-[doc_fmt_tga]: https://docs.amethyst.rs/stable/amethyst_renderer/struct.TgaFormat.html
-[doc_load]: https://docs.amethyst.rs/stable/amethyst_assets/struct.Loader.html#method.load
-[doc_read_resource]: https://docs.amethyst.rs/stable/specs/world/struct.World.html#method.read_resource
-[doc_ss]: https://docs.amethyst.rs/stable/amethyst_renderer/struct.SpriteSheet.html
-[doc_tex]: https://docs.amethyst.rs/stable/amethyst_renderer/struct.Texture.html
-[doc_tex_hd]: https://docs.amethyst.rs/stable/amethyst_assets/type.Handle.html
+[doc_asset]: https://docs.amethyst.rs/master/amethyst_assets/trait.Asset.html
+[doc_asset_get]: https://docs.amethyst.rs/master/amethyst_assets/struct.AssetStorage.html#method.get
+[doc_load]: https://docs.amethyst.rs/master/amethyst_assets/struct.Loader.html#method.load
+[doc_read_resource]: https://docs.rs/specs/~0.16/specs/world/struct.World.html#method.read_resource
+[doc_ss]: https://docs.amethyst.rs/master/amethyst_rendy/struct.SpriteSheet.html
+[doc_tex]: https://docs.amethyst.rs/master/amethyst_rendy/rendy/texture/struct.Texture.html
+[doc_tex_hd]: https://docs.amethyst.rs/master/amethyst_assets/struct.Handle.html

--- a/book/src/sprites/modify_the_texture.md
+++ b/book/src/sprites/modify_the_texture.md
@@ -92,5 +92,5 @@ impl ExampleState {
 # fn main() {}
 ```
 
-[doc_tint]: https://docs.amethyst.rs/stable/amethyst_rendy/resources/struct.Tint.html
-[doc_component]: https://docs.amethyst.rs/stable/specs/trait.Component.html
+[doc_tint]: https://docs.amethyst.rs/master/amethyst_rendy/resources/struct.Tint.html
+[doc_component]: https://docs.rs/specs/~0.16/specs/trait.Component.html

--- a/book/src/sprites/orthographic_camera.md
+++ b/book/src/sprites/orthographic_camera.md
@@ -54,9 +54,8 @@ impl ExampleState {
 }
 ```
 
-And you're done! If you would like to see this in practice, check out the [*sprites*][ex_sprites] or [*sprites_ordered*][ex_ordered] examples in the [examples][ex_all] directory.
+And you're done! If you would like to see this in practice, check out the [*sprites_ordered*][ex_ordered] example in the [examples][ex_all] directory.
 
 [ex_all]: https://github.com/amethyst/amethyst/tree/master/examples
 [ex_ordered]: https://github.com/amethyst/amethyst/tree/master/examples/sprites_ordered
-[ex_sprites]: https://github.com/amethyst/amethyst/tree/master/examples/sprites
 [opengl_ortho]: https://opengl-notes.readthedocs.io/en/latest/topics/transforms/viewing.html#orthographic-projection

--- a/book/src/tiles.md
+++ b/book/src/tiles.md
@@ -9,7 +9,7 @@ In Amethyst, the [`Tile`][doc_tile] is a trait that must be implemented within y
 
 > **Note:** The code snippets in this section explain the parts of creating tile maps separately. For complete application examples, please refer to the [*tiles*][ex_tiles] example in the [examples][ex_all] directory.
 
-> **Note:** This section uses [*sprites*](../sprites.md) and assumes knowledge of loading sprites and spritesheets.
+> **Note:** This section uses [*sprites*](./sprites.md) and assumes knowledge of loading sprites and spritesheets.
 
 [doc_tile]: https://docs.amethyst.rs/stable/amethyst_tiles/trait.Tile.html
 [doc_tilemap]: https://docs.amethyst.rs/stable/amethyst_tiles/struct.TileMap.html

--- a/book/src/ui/interacting.md
+++ b/book/src/ui/interacting.md
@@ -23,13 +23,13 @@ impl<'s> System<'s> for SimpleButtonSystem {
 }
 ```
 
-This was shown in previous [chapters](../concepts/system/system_initialization.html).
+This was shown in previous [chapters][sys_ini].
 The way you will be able to read the generated 
-events is with a [ReaderId](https://docs.amethyst.rs/master/specs/prelude/struct.ReaderId.html).
+events is with a [ReaderId].
 The `ReaderId` is added as a field to the system struct.
 
-The events we want to read are of type [UiEvent](https://docs.amethyst.rs/master/amethyst_ui/struct.UiEvent.html).
-We also need to fetch the [EventChannel](https://docs.amethyst.rs/master/shrev/struct.EventChannel.html) in our `SystemData`, 
+The events we want to read are of type [UiEvent].
+We also need to fetch the [EventChannel] in our `SystemData`, 
 since the `ReaderId` actually pulls (reads) information  from the `EventChannel`.
 
 Adding it up, it should look like this: 
@@ -227,22 +227,7 @@ Eventhough possible, it is not recommended. That's why now
 we will go through managing input through the state.
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+[sys_ini]: ../concepts/system/system_initialization.html
+[ReaderId]: https://docs.rs/specs/~0.16/specs/struct.ReaderId.html
+[UiEvent]: https://docs.amethyst.rs/master/amethyst_ui/struct.UiEvent.html
+[EventChannel]: https://specs.amethyst.rs/docs/api/shrev/struct.eventchannel


### PR DESCRIPTION
## Description

- Fixed all the broken links and warnings reported by mdbook-linkcheck.
- Moved some inline links down below their text.
- Updated reference to an outdated enum in ``how_to_define_prefabs_adapter.md``.
- Added some more settings for mdbook-linkcheck.
- Made all API doc links point to the master docs instead of stable.


The API links should in general only point to the master version and then during release a script or similar can update them to point to stable. This will prevent links from becoming outdated or break when master starts to divert away from current stable.

Links to things exposed through specs now point to docs.rs since dependencies aren't included on our API doc page.
Tho since we now inline the specs docs in our own docs this could be changed back if we wish to. 

In ``b_migration_notes.md``  i removed the link to ``transform_api_changes.md`` because the page was removed from the summary a while back and wasn't working. The actual file is still included in the source because i wasn't sure what to do with it.

In ``paddle_configs.md`` there were some text that referenced the very old methods of ``World::add_resource`` & ``World::add_resource_with_id``. For now i just removed the broken links from the text because i wasn't sure if the text still made sense if ``World::add_resource`` was replaced by ``World::insert``.

mdbook-linkcheck is still commented out because we have to be very careful in how we might want to use it in CI without blowing everything up.
The way the book source and publishing is handled currently makes it a bit hard to use the linkchecker safely in every CI run. 

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.