### PR TITLE
Fix #2083 - [BUG] FrameLimiter Sleep strategy sleeps too long

### DIFF
--- a/amethyst_core/src/frame_limiter.rs
+++ b/amethyst_core/src/frame_limiter.rs
@@ -178,7 +178,7 @@ impl FrameLimiter {
 
     /// Sets the maximum fps and frame rate limiting strategy.
     pub fn set_rate(&mut self, strategy: FrameRateLimitStrategy, fps: u32) {
-        assert!(fps > 0, "FrameLimiter::set_rate parameter `fps` is {}. This parameter must be greater than zero!");
+        assert!(fps > 0, "FrameLimiter::set_rate parameter `fps` is {}. This parameter must be greater than zero!", fps);
         self.strategy = strategy;
         self.frame_duration = Duration::from_secs(1) / fps;
         self.sleep_barrier = self.frame_duration / 2;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ### Fixed
 
+[#2083]: https://github.com/amethyst/amethyst/pull/2478
+
 ## [0.15.3] - 2020-08-22
 
 0.15.3 is a corrected version of 0.15.2, which was inadvertently published based off of an incorrect (and broken) commit.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ### Fixed
 
-[#2083]: https://github.com/amethyst/amethyst/pull/2478
+[#2083]: https://github.com/amethyst/amethyst/pull/2479
 
 ## [0.15.3] - 2020-08-22
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,7 +16,9 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ### Fixed
 
-[#2083]: https://github.com/amethyst/amethyst/pull/2479
+- Fix `FrameRateLimitStrategy::Sleep` strategy sleeps too long ([#2479])
+
+[#2479]: https://github.com/amethyst/amethyst/pull/2479
 
 ## [0.15.3] - 2020-08-22
 

--- a/examples/events/main.rs
+++ b/examples/events/main.rs
@@ -98,7 +98,7 @@ fn main() -> amethyst::Result<()> {
     let game_data = GameDataBuilder::default().with_bundle(MyBundle)?;
 
     let mut game = Application::build(assets_dir, GameplayState)?
-        .with_frame_limit(FrameRateLimitStrategy::Sleep, 1)
+        .with_frame_limit(FrameRateLimitStrategy::SleepAndYield, 1)
         .build(game_data)?;
 
     game.run();

--- a/examples/events_custom_state_event/main.rs
+++ b/examples/events_custom_state_event/main.rs
@@ -24,7 +24,7 @@ fn main() -> amethyst::Result<()> {
         assets_dir,
         GameplayState::default(),
     )?
-    .with_frame_limit(FrameRateLimitStrategy::Sleep, 1)
+    .with_frame_limit(FrameRateLimitStrategy::SleepAndYield, 1)
     .build(game_data)?;
 
     game.run();

--- a/examples/net_client/main.rs
+++ b/examples/net_client/main.rs
@@ -39,7 +39,7 @@ fn main() -> Result<()> {
 
     let mut game = Application::build(assets_dir, GameState)?
         .with_frame_limit(
-            FrameRateLimitStrategy::SleepAndYield(Duration::from_millis(2)),
+            FrameRateLimitStrategy::SleepAndYieldDuration(Duration::from_millis(2)),
             144,
         )
         .build(game_data)?;

--- a/examples/net_server/main.rs
+++ b/examples/net_server/main.rs
@@ -40,7 +40,7 @@ fn main() -> Result<()> {
 
     let mut game = Application::build(assets_dir, GameState)?
         .with_frame_limit(
-            FrameRateLimitStrategy::SleepAndYield(Duration::from_millis(2)),
+            FrameRateLimitStrategy::SleepAndYieldDuration(Duration::from_millis(2)),
             60,
         )
         .build(game_data)?;

--- a/examples/pong_tutorial_06/main.rs
+++ b/examples/pong_tutorial_06/main.rs
@@ -87,7 +87,7 @@ fn main() -> amethyst::Result<()> {
 
     let mut game = Application::build(assets_dir, Pong::default())?
         .with_frame_limit(
-            FrameRateLimitStrategy::SleepAndYield(Duration::from_millis(2)),
+            FrameRateLimitStrategy::SleepAndYieldDuration(Duration::from_millis(2)),
             144,
         )
         .build(game_data)?;


### PR DESCRIPTION
## Description

This PR is a proposed fix for issue https://github.com/amethyst/amethyst/issues/2083 that has observed an apparent problem with `FrameLimiter`'s implementation of `FrameRateLimitStrategy::Sleep`. As mentioned in the issue, this is highly likely to over-sleep due to the imprecise nature of operating system sleeps. The proposed fix is a halfway house between sleeping and yielding, not unlike `FrameRateLimitStrategy::SleepAndYield(Duration)` did but with an automatic duration equal to half the requested frame time.

The primary reasoning behind this change is to reduce the complexity of the struct for end-users who are unfamiliar with the undesirable intricacies of operating system sleeps, from a game development point of view. These users may consider `FrameRateLimitStrategy::Sleep` a sensible choice due to its labelling as the more pro battery-life approach and may not understand why their game may suffer from inconsistent timing issues as a result. This fix attempts to strike a balance between `Sleep` and `Yield` without requiring the user to be aware of the intricacies of sleeping, so that `Sleep` becomes a sensible default go-to option.

`FrameRateLimitStrategy::Sleep` has been removed. It is now called `FrameRateLimitStrategy::SleepAndYield`. The prior `FrameRateLimitStrategy::SleepAndYield` is now called `FrameRateLimitStrategy::SleepAndYieldDuration`.

The new `FrameRateLimitStrategy::SleepAndYield` implementation will attempt to sleep for the first 50% of the desired frame time and yield for the remaining 50%. This is done automatically for the end-user of the struct when they invoke `set_rate`. The new `FrameRateLimitStrategy::SleepAndYield` should now offer a sensible default behavior in place of `FrameRateLimitStrategy::Yield`, albeit this change has not been made in this PR.

This demotes `FrameRateLimitStrategy::SleepAndYieldDuration(Duration)` to being nothing more than an alternate version of `FrameRateLimitStrategy::SleepAndYield` that grants the end-user more control over the sleep-to-yield ratio should they need it.

## Additions

This PR adds a new function `pub fn FrameLimiter::get_frame_duration(&self) -> Duration` that returns `self.frame_duration`.

## Removals

`FrameRateLimitStrategy::Sleep` has been removed. It is now called `FrameRateLimitStrategy::SleepAndYield`. The prior `FrameRateLimitStrategy::SleepAndYield` is now called `FrameRateLimitStrategy::SleepAndYieldDuration`.

## Modifications

The `FrameLimiter` struct has a new member `sleep_barrier` that is assigned in `FrameLimiter::set_rate` to half of the desired frame duration. The implementation of `FrameRateLimitStrategy::SleepAndYield` in `FrameLimiter::wait` has been changed to yield once the `sleep_barrier` has been breached.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [X] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [X] Ran `cargo +stable fmt --all`
- [X] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [X] Ran `cargo build --features "empty"`
- [X] Ran `cargo test --workspace --features "empty"`
