### PR TITLE
Added new package to install for Debian* in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ If you are compiling on Linux, make sure to install the dependencies below.
 ### Debian/Ubuntu
 
 ```
-# apt install gcc pkg-config openssl libasound2-dev cmake build-essential python3 libfreetype6-dev libexpat1-dev libxcb-composite0-dev libssl-dev libx11-dev
+# apt install gcc pkg-config openssl libasound2-dev cmake build-essential python3 libfreetype6-dev libexpat1-dev libxcb-composite0-dev libssl-dev libx11-dev libfontconfig1-dev
 ```
 
 ### Fedora


### PR DESCRIPTION
Added the package `libfontconfig1-dev` to install for Debian* systems in order to avoid a linker error when compiling a project.

## Description

When installing the default Debian* packages, listed in the README file, a simple toy amethyst project fails to compile due to linker error: `missing -lfontconfig`.  
This has been reported two years ago [here](https://github.com/amethyst/amethyst/issues/1202), and I proposed the change directly in the README to install the missing package.
This has been tested on latest Ubuntu 20.04.

## Additions

- Added a missing package in the README, for Debian* systems.