### PR TITLE
Cow takeover

### DIFF
--- a/amethyst_controls/src/bundles.rs
+++ b/amethyst_controls/src/bundles.rs
@@ -1,8 +1,7 @@
-use std::marker::PhantomData;
+use std::borrow::Cow;
 
 use amethyst_core::{ecs::*, math::one, shrev::EventChannel};
 use amethyst_error::Error;
-use amethyst_input::BindingTypes;
 
 use winit::Event;
 
@@ -30,21 +29,21 @@ use super::*;
 /// * `MouseFocusUpdateSystem`
 /// * `CursorHideSystem`
 #[derive(Debug)]
-pub struct FlyControlBundle<T: BindingTypes> {
+pub struct FlyControlBundle {
     sensitivity_x: f32,
     sensitivity_y: f32,
     speed: f32,
-    horizontal_axis: Option<T::Axis>,
-    vertical_axis: Option<T::Axis>,
-    longitudinal_axis: Option<T::Axis>,
+    horizontal_axis: Option<Cow<'static, str>>,
+    vertical_axis: Option<Cow<'static, str>>,
+    longitudinal_axis: Option<Cow<'static, str>>,
 }
 
-impl<T: BindingTypes> FlyControlBundle<T> {
+impl FlyControlBundle {
     /// Builds a new fly control bundle using the provided axes as controls.
     pub fn new(
-        horizontal_axis: Option<T::Axis>,
-        vertical_axis: Option<T::Axis>,
-        longitudinal_axis: Option<T::Axis>,
+        horizontal_axis: Option<Cow<'static, str>>,
+        vertical_axis: Option<Cow<'static, str>>,
+        longitudinal_axis: Option<Cow<'static, str>>,
     ) -> Self {
         FlyControlBundle {
             sensitivity_x: 1.0,
@@ -70,14 +69,14 @@ impl<T: BindingTypes> FlyControlBundle<T> {
     }
 }
 
-impl<T: BindingTypes> SystemBundle for FlyControlBundle<T> {
+impl SystemBundle for FlyControlBundle {
     fn load(
         &mut self,
         _world: &mut World,
         resources: &mut Resources,
         builder: &mut DispatcherBuilder,
     ) -> Result<(), Error> {
-        builder.add_system(build_fly_movement_system::<T>(
+        builder.add_system(build_fly_movement_system(
             self.speed,
             self.horizontal_axis.clone(),
             self.vertical_axis.clone(),
@@ -119,19 +118,17 @@ impl<T: BindingTypes> SystemBundle for FlyControlBundle<T> {
 ///
 /// See the `arc_ball_camera` example to see how to use the arc ball camera.
 #[derive(Debug)]
-pub struct ArcBallControlBundle<T: BindingTypes> {
+pub struct ArcBallControlBundle {
     sensitivity_x: f32,
     sensitivity_y: f32,
-    _marker: PhantomData<T>,
 }
 
-impl<T: BindingTypes> ArcBallControlBundle<T> {
+impl ArcBallControlBundle {
     /// Builds a new `ArcBallControlBundle` with a default sensitivity of 1.0
     pub fn new() -> Self {
         ArcBallControlBundle {
             sensitivity_x: 1.0,
             sensitivity_y: 1.0,
-            _marker: PhantomData,
         }
     }
 
@@ -143,13 +140,13 @@ impl<T: BindingTypes> ArcBallControlBundle<T> {
     }
 }
 
-impl<T: BindingTypes> Default for ArcBallControlBundle<T> {
+impl Default for ArcBallControlBundle {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<T: BindingTypes> SystemBundle for ArcBallControlBundle<T> {
+impl SystemBundle for ArcBallControlBundle {
     fn load(
         &mut self,
         _world: &mut World,

--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -10,9 +10,10 @@ use amethyst_core::{
     timing::Time,
     transform::Transform,
 };
+use std::borrow::Cow;
 use std::collections::HashMap;
 
-use amethyst_input::{get_input_axis_simple, BindingTypes, InputHandler};
+use amethyst_input::{get_input_axis_simple, InputHandler};
 
 use crate::{
     components::{ArcBallControl, FlyControl},
@@ -24,15 +25,15 @@ use crate::{
 /// # Type parameters
 ///
 /// * `T`: This are the keys the `InputHandler` is using for axes and actions. Often, this is a `StringBindings`.
-pub fn build_fly_movement_system<T: BindingTypes>(
+pub fn build_fly_movement_system(
     speed: f32,
-    horizontal_axis: Option<T::Axis>,
-    vertical_axis: Option<T::Axis>,
-    longitudinal_axis: Option<T::Axis>,
+    horizontal_axis: Option<Cow<'static, str>>,
+    vertical_axis: Option<Cow<'static, str>>,
+    longitudinal_axis: Option<Cow<'static, str>>,
 ) -> impl Runnable {
     SystemBuilder::new("FlyMovementSystem")
         .read_resource::<Time>()
-        .read_resource::<InputHandler<T>>()
+        .read_resource::<InputHandler>()
         .with_query(<(&FlyControl, &mut Transform)>::query())
         .build(move |_commands, world, (time, input), controls| {
             #[cfg(feature = "profiler")]

--- a/amethyst_core/src/transform/transform_system.rs
+++ b/amethyst_core/src/transform/transform_system.rs
@@ -11,11 +11,13 @@ pub fn build() -> impl Runnable {
     SystemBuilder::new("TransformSystem")
         // Entities at the hierarchy root (no parent component)
         .with_query(
-            <(Entity, &mut Transform)>::query().filter(maybe_changed::<Transform>() & !component::<Parent>()),
+            <(Entity, &mut Transform)>::query()
+                .filter(maybe_changed::<Transform>() & !component::<Parent>()),
         )
         // Entities that are children of some entity
         .with_query(
-            <(Entity, &mut Transform)>::query().filter(maybe_changed::<Transform>() & component::<Parent>()),
+            <(Entity, &mut Transform)>::query()
+                .filter(maybe_changed::<Transform>() & component::<Parent>()),
         )
         .with_query(<(Entity, &Parent)>::query())
         .write_component::<Transform>()

--- a/amethyst_input/src/bindings.rs
+++ b/amethyst_input/src/bindings.rs
@@ -76,8 +76,7 @@ pub enum BindingError {
     MouseWheelAxisAlreadyBound(Cow<'static, str>),
 }
 
-impl Display for BindingError
-{
+impl Display for BindingError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match *self {
             BindingError::ComboContainsDuplicates(ref id) => write!(
@@ -303,11 +302,7 @@ impl Bindings {
         Ok(())
     }
 
-    fn check_action_invariants(
-        &self,
-        id: &str,
-        bind: &[Button],
-    ) -> Result<(), BindingError> {
+    fn check_action_invariants(&self, id: &str, bind: &[Button]) -> Result<(), BindingError> {
         // Guarantee each button is unique.
         for i in 0..bind.len() {
             for j in (i + 1)..bind.len() {
@@ -386,10 +381,7 @@ mod tests {
                 [Button::Mouse(MouseButton::Left)].iter().cloned(),
             )
             .unwrap();
-        assert_eq!(
-            bindings.actions().collect::<Vec<_>>(),
-            vec![&TEST_ACTION]
-        );
+        assert_eq!(bindings.actions().collect::<Vec<_>>(), vec![&TEST_ACTION]);
         let action_bindings = bindings.action_bindings(&TEST_ACTION).collect::<Vec<_>>();
         assert_eq!(action_bindings, vec![[Button::Mouse(MouseButton::Left)]]);
         bindings
@@ -409,10 +401,7 @@ mod tests {
                 .cloned(),
             )
             .unwrap();
-        assert_eq!(
-            bindings.actions().collect::<Vec<_>>(),
-            vec![&TEST_ACTION],
-        );
+        assert_eq!(bindings.actions().collect::<Vec<_>>(), vec![&TEST_ACTION],);
         let action_bindings = bindings.action_bindings(&TEST_ACTION).collect::<Vec<_>>();
         assert_eq!(
             action_bindings,
@@ -679,19 +668,13 @@ mod tests {
         );
         assert_eq!(
             bindings
-                .insert_axis(
-                    TEST_MOUSEWHEEL_AXIS,
-                    Axis::MouseWheel { horizontal: true },
-                )
+                .insert_axis(TEST_MOUSEWHEEL_AXIS, Axis::MouseWheel { horizontal: true },)
                 .unwrap(),
             None
         );
         assert_eq!(
             bindings
-                .insert_axis(
-                    TEST_MOUSEWHEEL_AXIS,
-                    Axis::MouseWheel { horizontal: false },
-                )
+                .insert_axis(TEST_MOUSEWHEEL_AXIS, Axis::MouseWheel { horizontal: false },)
                 .unwrap(),
             Some(Axis::MouseWheel { horizontal: true })
         );
@@ -712,8 +695,10 @@ mod tests {
         const NORMAL_AXIS: Cow<'static, str> = Cow::Borrowed("normal_axis");
         const MULTIPLE_AXIS: Cow<'static, str> = Cow::Borrowed("multiple_axis");
         const NORMAL_CONTROLLER_AXIS: Cow<'static, str> = Cow::Borrowed("normal_controller_axis");
-        const MULTIPLE_CONTROLLER_AXIS: Cow<'static, str> = Cow::Borrowed("multiple_controller_axis");
-        const MULTIPLE_CONTROLLER_AXIS_2: Cow<'static, str> = Cow::Borrowed("multiple_controller_axis_2");
+        const MULTIPLE_CONTROLLER_AXIS: Cow<'static, str> =
+            Cow::Borrowed("multiple_controller_axis");
+        const MULTIPLE_CONTROLLER_AXIS_2: Cow<'static, str> =
+            Cow::Borrowed("multiple_controller_axis_2");
 
         let mut bindings = Bindings::new();
         assert_eq!(
@@ -907,10 +892,7 @@ mod tests {
         );
         assert_eq!(
             bindings
-                .insert_axis(
-                    TEST_MOUSEWHEEL_AXIS,
-                    Axis::MouseWheel { horizontal: false },
-                )
+                .insert_axis(TEST_MOUSEWHEEL_AXIS, Axis::MouseWheel { horizontal: false },)
                 .unwrap(),
             None
         );

--- a/amethyst_input/src/bundle.rs
+++ b/amethyst_input/src/bundle.rs
@@ -46,10 +46,7 @@ impl InputBundle {
     }
 
     /// Load bindings from file
-    pub fn with_bindings_from_file<P: AsRef<Path>>(
-        self,
-        file: P,
-    ) -> Result<Self, BindingsFileError>
+    pub fn with_bindings_from_file<P: AsRef<Path>>(self, file: P) -> Result<Self, BindingsFileError>
     where
         Bindings: Config,
     {
@@ -120,8 +117,7 @@ pub enum BindingsFileError {
     BindingError(BindingError),
 }
 
-impl fmt::Display for BindingsFileError
-{
+impl fmt::Display for BindingsFileError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             BindingsFileError::ConfigError(..) => write!(f, "Configuration error"),
@@ -130,8 +126,7 @@ impl fmt::Display for BindingsFileError
     }
 }
 
-impl error::Error for BindingsFileError
-{
+impl error::Error for BindingsFileError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
             BindingsFileError::ConfigError(ref e) => Some(e),

--- a/amethyst_input/src/bundle.rs
+++ b/amethyst_input/src/bundle.rs
@@ -1,6 +1,6 @@
 //! ECS input bundle
 
-use crate::{build_input_system, BindingError, BindingTypes, Bindings, InputHandler};
+use crate::{build_input_system, BindingError, Bindings, InputHandler};
 use amethyst_config::{Config, ConfigError};
 use amethyst_core::{ecs::*, shrev::EventChannel};
 use amethyst_error::Error;
@@ -13,7 +13,7 @@ use crate::sdl_events_system::ControllerMappings;
 
 /// Bundle for adding the `InputHandler`.
 ///
-/// This also adds the Winit EventHandler and the `InputEvent<T>` EventHandler
+/// This also adds the Winit EventHandler and the `InputEvent` EventHandler
 /// where `T::Action` is the type for Actions you have assigned here.
 ///
 /// ## Type parameters
@@ -26,22 +26,21 @@ use crate::sdl_events_system::ControllerMappings;
 ///
 /// No errors returned from this bundle.
 ///
-#[derive(Debug, Derivative)]
-#[derivative(Default(bound = ""))]
-pub struct InputBundle<T: BindingTypes> {
-    bindings: Option<Bindings<T>>,
+#[derive(Debug, Default)]
+pub struct InputBundle {
+    bindings: Option<Bindings>,
     #[cfg(feature = "sdl_controller")]
     controller_mappings: Option<ControllerMappings>,
 }
 
-impl<T: BindingTypes> InputBundle<T> {
+impl InputBundle {
     /// Create a new input bundle with no bindings
     pub fn new() -> Self {
         Default::default()
     }
 
     /// Use the provided bindings with the `InputHandler`
-    pub fn with_bindings(mut self, bindings: Bindings<T>) -> Self {
+    pub fn with_bindings(mut self, bindings: Bindings) -> Self {
         self.bindings = Some(bindings);
         self
     }
@@ -50,9 +49,9 @@ impl<T: BindingTypes> InputBundle<T> {
     pub fn with_bindings_from_file<P: AsRef<Path>>(
         self,
         file: P,
-    ) -> Result<Self, BindingsFileError<T>>
+    ) -> Result<Self, BindingsFileError>
     where
-        Bindings<T>: Config,
+        Bindings: Config,
     {
         let mut bindings = Bindings::load(file)?;
         bindings.check_invariants()?;
@@ -77,7 +76,7 @@ impl<T: BindingTypes> InputBundle<T> {
     }
 }
 
-impl<T: BindingTypes> SystemBundle for InputBundle<T> {
+impl SystemBundle for InputBundle {
     fn load(
         &mut self,
         _world: &mut World,
@@ -89,7 +88,7 @@ impl<T: BindingTypes> SystemBundle for InputBundle<T> {
             use super::SdlEventsSystem;
             builder.add_thread_local(
                 // TODO: improve errors when migrating to failure
-                SdlEventsSystem::<T>::new(world, self.controller_mappings).unwrap(),
+                SdlEventsSystem::new(world, self.controller_mappings).unwrap(),
             );
         }
 
@@ -98,14 +97,14 @@ impl<T: BindingTypes> SystemBundle for InputBundle<T> {
             .expect("Window event channel not found in resources")
             .register_reader();
 
-        let mut handler = InputHandler::<T>::new();
+        let mut handler = InputHandler::new();
         if let Some(bindings) = self.bindings.as_ref() {
             handler.bindings = bindings.clone();
         }
 
         resources.insert(handler);
 
-        builder.add_system(build_input_system::<T>(reader));
+        builder.add_system(build_input_system(reader));
 
         Ok(())
     }
@@ -114,17 +113,14 @@ impl<T: BindingTypes> SystemBundle for InputBundle<T> {
 /// An error occurred while loading the bindings file.
 #[derive(Derivative)]
 #[derivative(Debug(bound = ""))]
-pub enum BindingsFileError<T: BindingTypes> {
+pub enum BindingsFileError {
     /// Problem in amethyst_config
     ConfigError(ConfigError),
     /// Problem with the bindings themselves.
-    BindingError(BindingError<T>),
+    BindingError(BindingError),
 }
 
-impl<T: BindingTypes> fmt::Display for BindingsFileError<T>
-where
-    T::Axis: fmt::Display,
-    T::Action: fmt::Display,
+impl fmt::Display for BindingsFileError
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -134,10 +130,7 @@ where
     }
 }
 
-impl<T: BindingTypes> error::Error for BindingsFileError<T>
-where
-    T::Axis: fmt::Display,
-    T::Action: fmt::Display,
+impl error::Error for BindingsFileError
 {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
@@ -147,13 +140,13 @@ where
     }
 }
 
-impl<T: BindingTypes> From<BindingError<T>> for BindingsFileError<T> {
-    fn from(error: BindingError<T>) -> Self {
+impl From<BindingError> for BindingsFileError {
+    fn from(error: BindingError) -> Self {
         BindingsFileError::BindingError(error)
     }
 }
 
-impl<T: BindingTypes> From<ConfigError> for BindingsFileError<T> {
+impl From<ConfigError> for BindingsFileError {
     fn from(error: ConfigError) -> Self {
         BindingsFileError::ConfigError(error)
     }

--- a/amethyst_input/src/controller.rs
+++ b/amethyst_input/src/controller.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{bindings::BindingTypes, event::InputEvent};
+use crate::event::InputEvent;
 
 /// Controller axes matching SDL controller model
 #[derive(Eq, PartialEq, Debug, Copy, Clone, Serialize, Deserialize)]
@@ -118,11 +118,9 @@ pub enum ControllerEvent {
     },
 }
 
-impl<'a, T> Into<InputEvent<T>> for &'a ControllerEvent
-where
-    T: BindingTypes,
+impl<'a> Into<InputEvent> for &'a ControllerEvent
 {
-    fn into(self) -> InputEvent<T> {
+    fn into(self) -> InputEvent {
         use self::ControllerEvent::*;
         match *self {
             ControllerAxisMoved { which, axis, value } => {

--- a/amethyst_input/src/controller.rs
+++ b/amethyst_input/src/controller.rs
@@ -118,8 +118,7 @@ pub enum ControllerEvent {
     },
 }
 
-impl<'a> Into<InputEvent> for &'a ControllerEvent
-{
+impl<'a> Into<InputEvent> for &'a ControllerEvent {
     fn into(self) -> InputEvent {
         use self::ControllerEvent::*;
         match *self {

--- a/amethyst_input/src/event.rs
+++ b/amethyst_input/src/event.rs
@@ -14,8 +14,7 @@ use super::{
 /// Type parameter T is the type assigned to your Actions for your
 /// InputBundle or InputHandler.
 #[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
-pub enum InputEvent
-{
+pub enum InputEvent {
     /// A key was pressed down, sent exactly once per key press.
     KeyPressed {
         /// `VirtualKeyCode`, used for semantic info. i.e. "W" was pressed

--- a/amethyst_input/src/event.rs
+++ b/amethyst_input/src/event.rs
@@ -1,9 +1,9 @@
-use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 use winit::{MouseButton, VirtualKeyCode};
 
+use std::borrow::Cow;
+
 use super::{
-    bindings::BindingTypes,
     button::Button,
     controller::{ControllerAxis, ControllerButton},
     scroll_direction::ScrollDirection,
@@ -13,11 +13,8 @@ use super::{
 ///
 /// Type parameter T is the type assigned to your Actions for your
 /// InputBundle or InputHandler.
-#[derive(PartialEq, Serialize, Deserialize, Debug, Derivative)]
-#[derivative(Clone(bound = ""))]
-pub enum InputEvent<T>
-where
-    T: BindingTypes,
+#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
+pub enum InputEvent
 {
     /// A key was pressed down, sent exactly once per key press.
     KeyPressed {
@@ -65,7 +62,7 @@ where
     /// Note that this variant is used for `BindingTypes::Axis`, not a `ControllerAxis`.
     AxisMoved {
         /// The axis that moved on the controller.
-        axis: T::Axis,
+        axis: Cow<'static, str>,
         /// The amount that the axis moved.
         value: f32,
     },
@@ -108,12 +105,12 @@ where
     ///
     /// If a combination is bound to an action, it will be pressed
     /// if all buttons within are pressed.
-    ActionPressed(T::Action),
+    ActionPressed(Cow<'static, str>),
     /// The associated action had any related button or combination released.
     ///
     /// If a combination is bound to an action, it will be released
     /// if any of the buttons within is released while all others are pressed.
-    ActionReleased(T::Action),
+    ActionReleased(Cow<'static, str>),
     /// The associated action has its mouse wheel moved.
-    ActionWheelMoved(T::Action),
+    ActionWheelMoved(Cow<'static, str>),
 }

--- a/amethyst_input/src/input_handler.rs
+++ b/amethyst_input/src/input_handler.rs
@@ -18,8 +18,7 @@ use winit::{
 /// For example, if a key is pressed on the keyboard, this struct will record
 /// that the key is pressed until it is released again.
 #[derive(Debug, Default)]
-pub struct InputHandler
-{
+pub struct InputHandler {
     /// Maps inputs to actions and axes.
     pub bindings: Bindings,
     /// Encodes the VirtualKeyCode and corresponding scancode.
@@ -38,8 +37,7 @@ pub struct InputHandler
     mouse_wheel_horizontal: f32,
 }
 
-impl InputHandler
-{
+impl InputHandler {
     /// Creates a new input handler.
     pub fn new() -> Self {
         Default::default()
@@ -491,7 +489,11 @@ impl InputHandler
             .pressed_mouse_buttons
             .iter()
             .map(|&mb| Button::Mouse(mb));
-        let keys = self.pressed_keys.iter().flat_map(|v| Some(Button::Key(v.0)).into_iter().chain(Some(Button::ScanCode(v.1)).into_iter()));
+        let keys = self.pressed_keys.iter().flat_map(|v| {
+            Some(Button::Key(v.0))
+                .into_iter()
+                .chain(Some(Button::ScanCode(v.1)).into_iter())
+        });
         let controller_buttons = self
             .pressed_controller_buttons
             .iter()
@@ -577,16 +579,14 @@ impl InputHandler
     }
 
     /// Returns the value of an axis by the id, if the id doesn't exist this returns None.
-    pub fn axis_value(&self, id: &str) -> Option<f32>
-    {
+    pub fn axis_value(&self, id: &str) -> Option<f32> {
         self.bindings.axes.get(id).map(|a| self.axis_value_impl(a))
     }
 
     /// Returns true if any of the actions bindings is down.
     ///
     /// If a binding represents a combination of buttons, all of them need to be down.
-    pub fn action_is_down(&self, action: &str) -> Option<bool>
-    {
+    pub fn action_is_down(&self, action: &str) -> Option<bool> {
         self.bindings.actions.get(action).map(|combinations| {
             combinations.iter().any(|combination| {
                 combination
@@ -787,7 +787,7 @@ mod tests {
         let mut events = EventChannel::<InputEvent>::new();
         let mut reader = events.register_reader();
 
-        const TEST_KEY_ACTION: Cow::<'static, str> = Cow::Borrowed("test_key_action");
+        const TEST_KEY_ACTION: Cow<'static, str> = Cow::Borrowed("test_key_action");
 
         handler
             .bindings
@@ -885,7 +885,7 @@ mod tests {
         let mut events = EventChannel::<InputEvent>::new();
         let mut reader = events.register_reader();
 
-        const TEST_COMBO_ACTION: Cow::<'static, str> = Cow::Borrowed("test_combo_action");
+        const TEST_COMBO_ACTION: Cow<'static, str> = Cow::Borrowed("test_combo_action");
 
         handler
             .bindings
@@ -974,7 +974,7 @@ mod tests {
         let mut events = EventChannel::<InputEvent>::new();
         let mut reader = events.register_reader();
 
-        const TEST_AXIS: Cow::<'static, str> = Cow::Borrowed("test_axis");
+        const TEST_AXIS: Cow<'static, str> = Cow::Borrowed("test_axis");
 
         handler
             .bindings

--- a/amethyst_input/src/lib.rs
+++ b/amethyst_input/src/lib.rs
@@ -13,7 +13,7 @@
 pub use self::sdl_events_system::SdlEventsSystem;
 pub use self::{
     axis::Axis,
-    bindings::{BindingError, BindingTypes, Bindings, StringBindings},
+    bindings::{BindingError, Bindings},
     bundle::{BindingsFileError, InputBundle},
     button::Button,
     controller::{ControllerAxis, ControllerButton, ControllerEvent},
@@ -45,29 +45,3 @@ mod util;
 
 #[cfg(feature = "sdl_controller")]
 mod sdl_events_system;
-
-struct KeyThenCode {
-    value: (VirtualKeyCode, u32),
-    index: u8,
-}
-
-impl KeyThenCode {
-    pub fn new(value: (VirtualKeyCode, u32)) -> KeyThenCode {
-        KeyThenCode { value, index: 0 }
-    }
-}
-
-impl Iterator for KeyThenCode {
-    type Item = Button;
-    fn next(&mut self) -> Option<Button> {
-        let index = self.index;
-        if self.index < 2 {
-            self.index += 1;
-        }
-        match index {
-            0 => Some(Button::Key(self.value.0)),
-            1 => Some(Button::ScanCode(self.value.1)),
-            _ => None,
-        }
-    }
-}

--- a/amethyst_input/src/system.rs
+++ b/amethyst_input/src/system.rs
@@ -1,7 +1,7 @@
 //! Input system
 use winit::Event;
 
-use crate::{BindingTypes, InputEvent, InputHandler};
+use crate::{InputEvent, InputHandler};
 use amethyst_core::{
     ecs::*,
     shrev::{EventChannel, ReaderId},
@@ -15,11 +15,11 @@ use thread_profiler::profile_scope;
 ///
 /// Will read `winit::Event` from `EventHandler<winit::Event>`, process them with `InputHandler`,
 /// and push the results in `EventHandler<InputEvent>`.
-pub fn build_input_system<T: BindingTypes>(mut reader: ReaderId<Event>) -> impl Runnable {
+pub fn build_input_system(mut reader: ReaderId<Event>) -> impl Runnable {
     SystemBuilder::new("InputSystem")
         .read_resource::<EventChannel<Event>>()
-        .write_resource::<InputHandler<T>>()
-        .write_resource::<EventChannel<InputEvent<T>>>()
+        .write_resource::<InputHandler>()
+        .write_resource::<EventChannel<InputEvent>>()
         .read_resource::<ScreenDimensions>()
         .build(
             move |_commands, _world, (input, handler, output, screen_dimensions), _query| {

--- a/amethyst_input/src/util.rs
+++ b/amethyst_input/src/util.rs
@@ -1,4 +1,6 @@
-use crate::{input_handler::InputHandler, BindingTypes};
+use std::borrow::Cow;
+
+use crate::input_handler::InputHandler;
 use winit::{ElementState, Event, KeyboardInput, MouseButton, VirtualKeyCode, WindowEvent};
 
 /// If this event was for manipulating a keyboard key then this will return the `VirtualKeyCode`
@@ -54,9 +56,9 @@ pub fn is_close_requested(event: &Event) -> bool {
 
 /// Gets the input axis value from the `InputHandler`.
 /// If the name is None, it will return the default value of the axis (0.0).
-pub fn get_input_axis_simple<T: BindingTypes>(
-    name: &Option<T::Axis>,
-    input: &InputHandler<T>,
+pub fn get_input_axis_simple(
+    name: &Option<Cow<'static, str>>,
+    input: &InputHandler,
 ) -> f32 {
     name.as_ref()
         .and_then(|ref n| input.axis_value(n))
@@ -65,9 +67,9 @@ pub fn get_input_axis_simple<T: BindingTypes>(
 
 /// Gets the action active status from the `InputHandler`.
 /// If the action name is None, it will default to false.
-pub fn get_action_simple<T: BindingTypes>(
-    name: &Option<T::Action>,
-    input: &InputHandler<T>,
+pub fn get_action_simple(
+    name: &Option<Cow<'static, str>>,
+    input: &InputHandler,
 ) -> bool {
     name.as_ref()
         .and_then(|ref n| input.action_is_down(n))

--- a/amethyst_input/src/util.rs
+++ b/amethyst_input/src/util.rs
@@ -56,10 +56,7 @@ pub fn is_close_requested(event: &Event) -> bool {
 
 /// Gets the input axis value from the `InputHandler`.
 /// If the name is None, it will return the default value of the axis (0.0).
-pub fn get_input_axis_simple(
-    name: &Option<Cow<'static, str>>,
-    input: &InputHandler,
-) -> f32 {
+pub fn get_input_axis_simple(name: &Option<Cow<'static, str>>, input: &InputHandler) -> f32 {
     name.as_ref()
         .and_then(|ref n| input.axis_value(n))
         .unwrap_or(0.0)
@@ -67,10 +64,7 @@ pub fn get_input_axis_simple(
 
 /// Gets the action active status from the `InputHandler`.
 /// If the action name is None, it will default to false.
-pub fn get_action_simple(
-    name: &Option<Cow<'static, str>>,
-    input: &InputHandler,
-) -> bool {
+pub fn get_action_simple(name: &Option<Cow<'static, str>>, input: &InputHandler) -> bool {
     name.as_ref()
         .and_then(|ref n| input.action_is_down(n))
         .unwrap_or(false)

--- a/amethyst_rendy/src/pass/base_3d.rs
+++ b/amethyst_rendy/src/pass/base_3d.rs
@@ -209,12 +209,8 @@ impl<B: Backend, T: Base3DPassDef> RenderGroup<B, GraphAuxData> for DrawBase3D<B
         {
             profile_scope_impl!("prepare");
 
-            let mut query = <(
-                &Handle<Material>,
-                &Handle<Mesh>,
-                &Transform,
-                Option<&Tint>,
-            )>::query();
+            let mut query =
+                <(&Handle<Material>, &Handle<Mesh>, &Transform, Option<&Tint>)>::query();
 
             visibility
                 .visible_unordered
@@ -552,12 +548,8 @@ impl<B: Backend, T: Base3DPassDef> RenderGroup<B, GraphAuxData> for DrawBase3DTr
         {
             profile_scope_impl!("prepare");
 
-            let mut query = <(
-                &Handle<Material>,
-                &Handle<Mesh>,
-                &Transform,
-                Option<&Tint>,
-            )>::query();
+            let mut query =
+                <(&Handle<Material>, &Handle<Mesh>, &Transform, Option<&Tint>)>::query();
 
             visibility
                 .visible_ordered

--- a/src/state_event.rs
+++ b/src/state_event.rs
@@ -14,8 +14,7 @@ use crate::{
 /// `handle_event` method.
 #[derive(Clone, Debug, EventReader)]
 #[reader(StateEventReader)]
-pub enum StateEvent
-{
+pub enum StateEvent {
     /// Events sent by the winit window.
     Window(Event),
     /// Events sent by the ui system.

--- a/src/state_event.rs
+++ b/src/state_event.rs
@@ -1,4 +1,3 @@
-use derivative::Derivative;
 use winit::Event;
 
 use crate::{
@@ -8,17 +7,14 @@ use crate::{
         EventReader,
     },
     derive::EventReader,
-    input::{BindingTypes, InputEvent, StringBindings},
+    input::InputEvent,
 };
 
 /// The enum holding the different types of event that can be received in a `State` in the
 /// `handle_event` method.
-#[derive(Debug, Derivative, EventReader)]
-#[derivative(Clone(bound = ""))]
+#[derive(Clone, Debug, EventReader)]
 #[reader(StateEventReader)]
-pub enum StateEvent<T = StringBindings>
-where
-    T: BindingTypes,
+pub enum StateEvent
 {
     /// Events sent by the winit window.
     Window(Event),
@@ -26,5 +22,5 @@ where
     #[cfg(feature = "ui")]
     Ui(ui::UiEvent),
     /// Events sent by the input system.
-    Input(InputEvent<T>),
+    Input(InputEvent),
 }


### PR DESCRIPTION
## Description

Moo.

![image](https://user-images.githubusercontent.com/6182002/92313644-45dfaa00-ef8b-11ea-943e-f62dfd062e3b.png)

On a more serious note, this PR removes a bunch of generics from the `amethyst_input` crate, obsoleting the `BindingTypes` trait.

This new approach has a few benefits.

1. Almost all of our users were using constant strings anyways. This is a performance optimization for that use case, while also permitting runtime strings.
2. No more of these generics propagating throughout Amethyst.

## Additions

None

## Removals

- amethyst_input::BindingTypes

## Modifications

- Most of `amethyst_input`. The changes were primarily to substitute `Cow<'static, str>` for generic types.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [ ] Ran `cargo test --workspace --features "empty"`
