### PR TITLE
`UiLabelBuilder` takes in `&mut UiLabelBuilderResources`.

### DIFF
--- a/amethyst_ui/src/label.rs
+++ b/amethyst_ui/src/label.rs
@@ -188,7 +188,7 @@ where
     }
 
     /// Build this with the `UiLabelBuilderResources`.
-    pub fn build(self, mut res: UiLabelBuilderResources<'a, I>) -> (I, UiLabel) {
+    pub fn build(self, res: &mut UiLabelBuilderResources<'a, I>) -> (I, UiLabel) {
         let text_entity = res.entities.create();
         let widget = UiLabel::new(text_entity);
 
@@ -244,6 +244,6 @@ where
 
     /// Create the UiLabel based on provided configuration parameters.
     pub fn build_from_world(self, world: &World) -> (I, UiLabel) {
-        self.build(UiLabelBuilderResources::<I>::fetch(&world))
+        self.build(&mut UiLabelBuilderResources::<I>::fetch(&world))
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ### Changed
 
+- `UiLabelBuilder` takes in `&mut UiLabelBuilderResources` ([#2486]).
+
 ### Fixed
 
 ## [0.15.2] - 2020-08-22


### PR DESCRIPTION
## Description

As was done in https://github.com/amethyst/amethyst/pull/2148/files, I found myself needing the same for UiLabelBuilder.

## Modifications

- `UiLabelBuilder` takes in `&mut UiLabelBuilderResources`.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --workspace --features "empty"`
