### PR TITLE
Documenting TransformBundle as a UiBundle dependency

### DIFF
--- a/amethyst_ui/src/bundle.rs
+++ b/amethyst_ui/src/bundle.rs
@@ -23,7 +23,7 @@ use std::marker::PhantomData;
 /// Will register all necessary components and systems needed for UI, along with any resources.
 /// The generic type T represent the T generic parameter of the InputHandler<T>.
 ///
-/// Will fail with error 'No resource with the given id' if the InputBundle is not added.
+/// Will fail with error 'No resource with the given id' if either the InputBundle or TransformBundle are not added.
 #[derive(new, Debug)]
 pub struct UiBundle<T: BindingTypes, C = NoCustomUi, W = u32, G = ()> {
     #[new(default)]

--- a/book/src/ui/introduction.md
+++ b/book/src/ui/introduction.md
@@ -13,9 +13,10 @@ Please note that not all aforementioned widgets exist in Amethyst yet.
 
 The first thing you need to add to your systems is the [UiBundle](https://docs.amethyst.rs/master/amethyst_ui/struct.UiBundle.html). The `UiBundle` registers
 all the needed components,systems and resources in order to be able use the UI. Another **very important thing**
-is that you want to add the [InputBundle](https://docs.amethyst.rs/master/amethyst_input/struct.InputBundle.html) 
+is that you want to add [InputBundle](https://docs.amethyst.rs/master/amethyst_input/struct.InputBundle.html)
+and [TransformBundle](https://docs.amethyst.rs/master/amethyst_core/transform/bundle/struct.TransformBundle.html)
 **before** the `UiBundle`,
-otherwise the application will panic, since it is a dependency for the `UiBundle`!
+otherwise the application will panic, since they are both dependencies for the `UiBundle`!
 
 Now you are able to create your widgets! Unfortunately you won't be able to see them. That's why you also need 
 to add a plugin to your rendering bundle called [RenderUi](https://docs.amethyst.rs/master/amethyst_ui/struct.RenderUi.html) in order

--- a/book/src/ui/introduction.md
+++ b/book/src/ui/introduction.md
@@ -28,6 +28,7 @@ A minimalistic game data would now look like this:
 # extern crate amethyst;
 # use amethyst::{
 #     GameDataBuilder,
+#     core::transform::TransformBundle,
 #     input::{InputBundle, StringBindings},
 #     renderer::{types::DefaultBackend, RenderingBundle, RenderToWindow},
 #     Result,
@@ -36,6 +37,7 @@ A minimalistic game data would now look like this:
 # 
 # pub fn main() -> Result<()> {
     let game_data = GameDataBuilder::default()
+        .with_bundle(TransformBundle::new())?
         .with_bundle(InputBundle::<StringBindings>::new())?
         .with_bundle(UiBundle::<StringBindings>::new())?
         .with_bundle(


### PR DESCRIPTION
## Description

Added TransformBundle as a dep of UiBundle.
I was trying to use Ui and couldn't even get my code to compile after adding the UiBundle as described in section _13. User Interface_ of the book. Turns out I also needed TransformBundle added before UiBundle, same as InputBundle.

## Modifications

- TransformBundle as a dependency of UiBundle in both /// docs and the book

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --workspace --features "empty"`
