### PR TITLE
Update Rayon to 1.4 to use their new scheduler.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ crossbeam-channel = "0.4.2"
 derivative = "2.1.1"
 fern = { version = "0.6.0", features = ["colored"] }
 log = { version = "0.4.8", features = ["serde"] }
-rayon = "1.3.0"
+rayon = "1.4.0"
 rustc_version_runtime = "0.2.0"
 sentry = { version = "0.18.0", optional = true }
 winit = { version = "0.19", features = ["serde", "icon_loading"] }

--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -29,7 +29,7 @@ derive-new = "0.5"
 fnv = "1"
 log = "0.4.6"
 parking_lot = "0.10"
-rayon = "1.3.0"
+rayon = "1.4.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", optional = true }
 ron = "0.5"

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -23,7 +23,7 @@ amethyst_error = { path = "../amethyst_error", version = "0.15.3" }
 fnv = "1.0.6"
 log = "0.4.8"
 num-traits = "0.2.11"
-rayon = "1.3.0"
+rayon = "1.4.0"
 serde = { version = "1", features = ["derive"] }
 specs = { version = "0.16.0", default-features = false, features = ["shred-derive", "specs-derive"] }
 specs-hierarchy = { version = "0.6", default-features = false }

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -38,7 +38,7 @@ thread_profiler = { version = "0.3", optional = true }
 approx = "0.3.2"
 
 [dev-dependencies]
-rayon = "1.3.0"
+rayon = "1.4.0"
 more-asserts = "0.2.1"
 criterion = "0.3.0"
 winit = "0.19"

--- a/amethyst_tiles/Cargo.toml
+++ b/amethyst_tiles/Cargo.toml
@@ -30,7 +30,7 @@ hibitset = { version = "0.6.2", features = ["parallel"] }
 smallvec = "1.2.0"
 failure = "0.1"
 lazy_static = "1.4"
-rayon = "1.3.0"
+rayon = "1.4.0"
 bitintr = "0.3"
 glsl-layout = "0.3"
 err-derive = "0.2.3"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,12 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ### Changed
 
+- Upgraded from `rayon 1.3.0` to `rayon 1.4.0`, drastically decreasing idle CPU usage in some situations ([#2489])
+
 ### Fixed
+
+
+[#2489]: https://github.com/amethyst/amethyst/pull/2489
 
 ## [0.15.3] - 2020-08-22
 


### PR DESCRIPTION
## Description

Rayon 1.4 was released a few weeks ago, and includes their new scheduler. This should help with the high idle CPU usage issues people have had with Amethyst.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --workspace --features "empty"`
