### PR TITLE
Make TextEditingPrefab public

### DIFF
--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -35,9 +35,9 @@ pub use self::{
     layout::{Anchor, ScaleMode, Stretch, UiTransformSystem, UiTransformSystemDesc},
     pass::{DrawUi, DrawUiDesc, RenderUi},
     prefab::{
-        NoCustomUi, ToNativeWidget, UiButtonData, UiCreator, UiFormat, UiImageLoadPrefab,
-        UiImagePrefab, UiLoader, UiLoaderSystem, UiLoaderSystemDesc, UiPrefab, UiTextData,
-        UiTransformData, UiWidget,
+        NoCustomUi, TextEditingPrefab, ToNativeWidget, UiButtonData, UiCreator, UiFormat,
+        UiImageLoadPrefab, UiImagePrefab, UiLoader, UiLoaderSystem, UiLoaderSystemDesc, UiPrefab,
+        UiTextData, UiTransformData, UiWidget,
     },
     resize::{ResizeSystem, ResizeSystemDesc, UiResize},
     selection::{

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,11 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 ### Changed
 
+- Make `TextEditingPrefab` public ([#2492])
+
 ### Fixed
+
+[#2492]: https://github.com/amethyst/amethyst/pull/2492
 
 ## [0.15.3] - 2020-08-22
 


### PR DESCRIPTION
## Description

Make `TextEditingPrefab` public, so an editable `UiWidget::Label` can be build from code and not only parsed from an asset file.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] ~Added unit tests for new code added in this PR.~
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] ~Updated the content of the book if this PR would make the book outdated.~

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --workspace --features "empty"`
