### PR TITLE
Ui is a default but optional dependency, fixes #2490

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT/Apache-2.0"
 travis-ci = { repository = "amethyst/amethyst", branch = "master" }
 
 [features]
-default = ["animation", "audio", "locale", "network", "renderer"]
+default = ["animation", "audio", "locale", "network", "renderer", "ui"]
 
 vulkan = ["amethyst_rendy/vulkan", "amethyst_rendy/vulkan-x11"]
 metal = ["amethyst_rendy/metal"]
@@ -47,6 +47,10 @@ network = [
 
 renderer = [
     "amethyst_rendy",
+]
+
+ui = [
+    "amethyst_ui",
 ]
 
 profiler = [
@@ -125,7 +129,7 @@ amethyst_network = { path = "amethyst_network", version = "0.15.3", optional = t
 amethyst_locale = { path = "amethyst_locale", version = "0.15.3", optional = true }
 amethyst_rendy = { path = "amethyst_rendy", version = "0.15.3", features = ["window"], optional = true }
 amethyst_input = { path = "amethyst_input", version = "0.15.3" }
-amethyst_ui = { path = "amethyst_ui", version = "0.15.3" }
+amethyst_ui = { path = "amethyst_ui", version = "0.15.3", optional = true}
 amethyst_utils = { path = "amethyst_utils", version = "0.15.3" }
 amethyst_window = { path = "amethyst_window", version = "0.15.3" }
 amethyst_tiles = { path = "amethyst_tiles", version = "0.15.3", optional = true }
@@ -337,4 +341,4 @@ path = "examples/tiles/main.rs"
 required-features = [ "tiles" ]
 
 [package.metadata.docs.rs]
-features = ["animation", "audio", "gltf", "tiles", "json", "locale", "network", "sdl_controller", "vulkan"]
+features = ["animation", "audio", "gltf", "tiles", "json", "locale", "network", "ui", "sdl_controller", "vulkan"]

--- a/book/src/appendices/c_feature_gates.md
+++ b/book/src/appendices/c_feature_gates.md
@@ -22,6 +22,7 @@ At the time of writing, the list of features of this type is the following:
 * `network`
 * `renderer`
 * `saveload`
+* `ui`
 * `sdl_controller`
 
 The full list of available features is available in the [Cargo.toml] file.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 - Upgraded from `rayon 1.3.0` to `rayon 1.4.0`, drastically decreasing idle CPU usage in some situations ([#2489])
 - Make `TextEditingPrefab` public ([#2492])
+- Make ui a default but optional feature ([#2490])
 
 ### Fixed
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -27,8 +27,10 @@ use crate::{
     game_data::{DataDispose, DataInit},
     state::{State, StateData, StateMachine, TransEvent},
     state_event::{StateEvent, StateEventReader},
-    ui::UiEvent,
 };
+
+#[cfg(feature = "ui")]
+use crate::ui::UiEvent;
 
 /// `CoreApplication` is the application implementation for the game engine. This is fully generic
 /// over the state type and event type.
@@ -545,6 +547,7 @@ where
         world.insert(Loader::new(path.as_ref().to_owned(), pool.clone()));
         world.insert(pool);
         world.insert(EventChannel::<Event>::with_capacity(2000));
+        #[cfg(feature = "ui")]
         world.insert(EventChannel::<UiEvent>::with_capacity(40));
         world.insert(EventChannel::<TransEvent<T, StateEvent>>::with_capacity(2));
         world.insert(FrameLimiter::default());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ pub use amethyst_network as network;
 pub use amethyst_rendy as renderer;
 #[cfg(feature = "tiles")]
 pub use amethyst_tiles as tiles;
+#[cfg(feature = "ui")]
 pub use amethyst_ui as ui;
 pub use amethyst_utils as utils;
 pub use amethyst_window as window;

--- a/src/state_event.rs
+++ b/src/state_event.rs
@@ -9,8 +9,10 @@ use crate::{
     },
     derive::EventReader,
     input::{BindingTypes, InputEvent, StringBindings},
-    ui::UiEvent,
 };
+
+#[cfg(feature = "ui")]
+use crate::ui::UiEvent;
 
 /// The enum holding the different types of event that can be received in a `State` in the
 /// `handle_event` method.
@@ -24,6 +26,7 @@ where
     /// Events sent by the winit window.
     Window(Event),
     /// Events sent by the ui system.
+    #[cfg(feature = "ui")]
     Ui(UiEvent),
     /// Events sent by the input system.
     Input(InputEvent<T>),


### PR DESCRIPTION
## Description

Fixes #2490 by making ui an optional but default feature

## Additions

## Removals


## Modifications


## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment. (Please check the CHANGELOG twice, i was not familiar with it, it might be incomplete)
- [x] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --workspace --features "empty"`
