### PR TITLE
Fix text-align problems in the book's css

### DIFF
--- a/book/style/book.css
+++ b/book/style/book.css
@@ -33,6 +33,10 @@ body {
   margin-bottom: 300px;
 }
 
+h1, h2 {
+  text-align: start;
+}
+
 h2 {
   font-size: 2.5em !important;
 }
@@ -89,6 +93,7 @@ blockquote {
 
 .chapter li.chapter-item,
 .content ul {
+  text-align: start;
   line-height: 2.2em;
   margin-top: 0.6em;
 }


### PR DESCRIPTION
## Description

This commit fixes some styling issues described by @Blisto91 in
https://github.com/amethyst/amethyst/issues/2466: `When lines are a certain length they stretch depending on the panel and window size.`

The `.chapter-item`s and `h1`s would look weird because of the
`text-align: justify` on the document's `body`. I've added `text-align: start` on the relevant selectors to fix the
issue.

### Before

<details>
<summary>Images</summary>
<br>

![Image of h1](https://user-images.githubusercontent.com/47954800/91605342-95f9b380-e970-11ea-9042-ef5fa8eeb5b8.PNG)

![Image of chapter-item](https://user-images.githubusercontent.com/47954800/91605346-98f4a400-e970-11ea-99aa-b9c1eb7193a3.PNG)
</details>

### After

<details>
<summary>Images</summary>
<br>

![h1 after changes](https://user-images.githubusercontent.com/31389099/94812214-1ba0d100-03ff-11eb-979a-7968a3b8f230.png)

![chapter-item after changes](https://user-images.githubusercontent.com/31389099/94812088-ec8a5f80-03fe-11eb-9fde-61d779cad02a.png)
</details>

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Updated the content of the book if this PR would make the book outdated.
