### PR TITLE
Migrate to rendy 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ travis-ci = { repository = "amethyst/amethyst", branch = "master" }
 [features]
 default = ["animation", "audio", "locale", "network", "renderer"]
 
-vulkan = ["amethyst_rendy/vulkan", "amethyst_rendy/vulkan-x11"]
+vulkan = ["amethyst_rendy/vulkan"]
 metal = ["amethyst_rendy/metal"]
 empty = ["amethyst_rendy/empty"]
 
@@ -139,7 +139,6 @@ sentry = { version = "0.18.0", optional = true }
 winit = { version = "0.19", features = ["serde", "icon_loading"] }
 serde = { version = "1.0.104", features = ["derive"] }
 palette = { version = "0.4", features = ["serde"] }
-failure = "0.1.7"
 thread_profiler = { version = "0.3.0", optional = true }
 lazy_static = "1.4.0"
 glsl-layout = "0.3.2"

--- a/amethyst_animation/Cargo.toml
+++ b/amethyst_animation/Cargo.toml
@@ -35,7 +35,7 @@ thread_profiler = { version = "0.3", optional = true }
 [dev-dependencies]
 
 [features]
-vulkan = ["amethyst_rendy/vulkan", "amethyst_rendy/vulkan-x11"]
+vulkan = ["amethyst_rendy/vulkan"]
 metal = ["amethyst_rendy/metal"]
 empty = ["amethyst_rendy/empty"]
 

--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -35,7 +35,7 @@ image = "0.22.2"
 derivative = "2.1.1"
 
 [features]
-vulkan = ["amethyst_rendy/vulkan", "amethyst_rendy/vulkan-x11"]
+vulkan = ["amethyst_rendy/vulkan"]
 metal = ["amethyst_rendy/metal"]
 empty = ["amethyst_rendy/empty"]
 

--- a/amethyst_gltf/src/format/material.rs
+++ b/amethyst_gltf/src/format/material.rs
@@ -158,12 +158,12 @@ fn load_texture(
         ..Default::default()
     };
 
-    load_from_image(std::io::Cursor::new(&data), metadata).map_err(|e| e.compat().into())
+    load_from_image(std::io::Cursor::new(&data), metadata).map_err(|e| e.into())
 }
 
-fn load_sampler_info(sampler: &gltf::texture::Sampler<'_>) -> hal::image::SamplerInfo {
+fn load_sampler_info(sampler: &gltf::texture::Sampler<'_>) -> hal::image::SamplerDesc {
     use gltf::texture::{MagFilter, MinFilter};
-    use hal::image::{Filter, SamplerInfo};
+    use hal::image::{Filter, SamplerDesc};
 
     let mag_filter = match sampler.mag_filter() {
         Some(MagFilter::Nearest) => Filter::Nearest,
@@ -184,7 +184,7 @@ fn load_sampler_info(sampler: &gltf::texture::Sampler<'_>) -> hal::image::Sample
     let wrap_s = map_wrapping(sampler.wrap_s());
     let wrap_t = map_wrapping(sampler.wrap_t());
 
-    let mut s = SamplerInfo::new(min_filter, wrap_s);
+    let mut s = SamplerDesc::new(min_filter, wrap_s);
     s.wrap_mode = (wrap_s, wrap_t, wrap_t);
     s.mag_filter = mag_filter;
     s.mip_filter = mip_filter;

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -19,14 +19,13 @@ amethyst_error = { path = "../amethyst_error", version = "0.15.3" }
 amethyst_window = { path = "../amethyst_window", version = "0.15.3", optional = true }
 amethyst_config = { path = "../amethyst_config", version = "0.15.3" }
 derive-new = "0.5.6"
-failure = "0.1"
 genmesh = "0.6"
 glsl-layout = "0.3"
 gltf = { version = "0.15", features = ["KHR_lights_punctual"] }
 lazy_static = "1.4"
 log = "0.4"
 palette = { version = "0.4", features = ["serde"] }
-rendy = { version = "0.4.1", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1"] }
+rendy = { version = "0.5.1", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1"] }
 ron = "0.5"
 serde = { version = "1", features = ["serde_derive"] }
 fnv = "1"
@@ -47,14 +46,13 @@ approx = "0.3"
 [features]
 metal = ["rendy/metal"]
 vulkan = ["rendy/vulkan"]
-vulkan-x11 = ["rendy/vulkan-x11"]
 empty = ["rendy/empty"]
 profiler = [ "thread_profiler/thread_profiler", "rendy/profiler" ]
 no-slow-safety-checks = ["rendy/no-slow-safety-checks"]
 shader-compiler =  ["rendy/shader-compiler"]
 test-support =  []
 experimental-spirv-reflection = ["rendy/spirv-reflection"]
-window = ["rendy/wsi-winit", "amethyst_window"]
+window = ["amethyst_window"]
 
 [[bench]]
 name = "camera"

--- a/amethyst_rendy/src/formats/mesh.rs
+++ b/amethyst_rendy/src/formats/mesh.rs
@@ -33,7 +33,7 @@ impl Format<MeshData> for ObjFormat {
                 }
                 builder.0.into()
             })
-            .map_err(|e| e.compat().into())
+            .map_err(|e| e.into())
     }
 }
 

--- a/amethyst_rendy/src/formats/texture.rs
+++ b/amethyst_rendy/src/formats/texture.rs
@@ -31,15 +31,15 @@ use serde::{Deserialize, Serialize};
 ///        .with_data_height(handle.height)
 ///        .with_kind(image::Kind::D2(handle.width, handle.height, 1, 1))
 ///        .with_view_kind(image::ViewKind::D2)
-///        .with_sampler_info(SamplerInfo {
+///        .with_sampler_info(SamplerDesc {
 ///        min_filter: Filter::Linear,
 ///        mag_filter: Filter::Linear,
 ///        mip_filter: Filter::Linear,
 ///        wrap_mode: (WrapMode::Clamp, WrapMode::Clamp, WrapMode::Clamp),
-///        lod_bias: 0.0.into(),
+///        lod_bias: Lod(0.0),
 ///        lod_range: std::ops::Range {
-///            start: 0.0.into(),
-///            end: 1000.0.into(),
+///            start: Lod(0.0),
+///            end: Lod(1000.0),
 ///        },
 ///        comparison: None,
 ///        border: PackedColor(0),
@@ -56,7 +56,7 @@ pub struct ImageFormat(pub ImageTextureConfig);
 impl Default for ImageFormat {
     fn default() -> Self {
         use rendy::{
-            hal::image::{Anisotropic, PackedColor, SamplerInfo, WrapMode},
+            hal::image::{Anisotropic, Lod, PackedColor, SamplerDesc, WrapMode},
             texture::image::{Repr, TextureKind},
         };
 
@@ -64,15 +64,15 @@ impl Default for ImageFormat {
             format: None,
             repr: Repr::Srgb,
             kind: TextureKind::D2,
-            sampler_info: SamplerInfo {
+            sampler_info: SamplerDesc {
                 min_filter: Filter::Nearest,
                 mag_filter: Filter::Nearest,
                 mip_filter: Filter::Nearest,
                 wrap_mode: (WrapMode::Tile, WrapMode::Tile, WrapMode::Tile),
-                lod_bias: 0.0.into(),
+                lod_bias: Lod(0.0),
                 lod_range: std::ops::Range {
-                    start: 0.0.into(),
-                    end: 1000.0.into(),
+                    start: Lod(0.0),
+                    end: Lod(1000.0),
                 },
                 comparison: None,
                 border: PackedColor(0),
@@ -96,7 +96,7 @@ impl Format<TextureData> for ImageFormat {
     fn import_simple(&self, bytes: Vec<u8>) -> Result<TextureData, Error> {
         load_from_image(std::io::Cursor::new(&bytes), self.0.clone())
             .map(|builder| builder.into())
-            .map_err(|e| e.compat().into())
+            .map_err(|e| e.into())
     }
 }
 
@@ -139,7 +139,7 @@ fn simple_builder<A: AsPixel>(data: Vec<A>, size: Size, filter: Filter) -> Textu
         .with_view_kind(ViewKind::D2)
         .with_data_width(size)
         .with_data_height(size)
-        .with_sampler_info(hal::image::SamplerInfo::new(
+        .with_sampler_info(hal::image::SamplerDesc::new(
             filter,
             hal::image::WrapMode::Clamp,
         ))

--- a/amethyst_rendy/src/pass/base_3d.rs
+++ b/amethyst_rendy/src/pass/base_3d.rs
@@ -109,7 +109,7 @@ impl<B: Backend, T: Base3DPassDef> RenderGroupDesc<B, World> for DrawBase3DDesc<
         subpass: hal::pass::Subpass<'_, B>,
         _buffers: Vec<NodeBuffer>,
         _images: Vec<NodeImage>,
-    ) -> Result<Box<dyn RenderGroup<B, World>>, failure::Error> {
+    ) -> Result<Box<dyn RenderGroup<B, World>>, pso::CreationError> {
         profile_scope_impl!("build");
 
         let env = EnvironmentSub::new(
@@ -431,7 +431,7 @@ impl<B: Backend, T: Base3DPassDef> RenderGroupDesc<B, World> for DrawBase3DTrans
         subpass: hal::pass::Subpass<'_, B>,
         _buffers: Vec<NodeBuffer>,
         _images: Vec<NodeImage>,
-    ) -> Result<Box<dyn RenderGroup<B, World>>, failure::Error> {
+    ) -> Result<Box<dyn RenderGroup<B, World>>, pso::CreationError> {
         let env = EnvironmentSub::new(
             factory,
             [
@@ -714,7 +714,7 @@ fn build_pipelines<B: Backend, T: Base3DPassDef>(
     skinning: bool,
     transparent: bool,
     layouts: Vec<&B::DescriptorSetLayout>,
-) -> Result<(Vec<B::GraphicsPipeline>, B::PipelineLayout), failure::Error> {
+) -> Result<(Vec<B::GraphicsPipeline>, B::PipelineLayout), pso::CreationError> {
     let pipeline_layout = unsafe {
         factory
             .device()

--- a/amethyst_rendy/src/pass/debug_lines.rs
+++ b/amethyst_rendy/src/pass/debug_lines.rs
@@ -53,7 +53,7 @@ impl<B: Backend> RenderGroupDesc<B, World> for DrawDebugLinesDesc {
         subpass: hal::pass::Subpass<'_, B>,
         _buffers: Vec<NodeBuffer>,
         _images: Vec<NodeImage>,
-    ) -> Result<Box<dyn RenderGroup<B, World>>, failure::Error> {
+    ) -> Result<Box<dyn RenderGroup<B, World>>, pso::CreationError> {
         #[cfg(feature = "profiler")]
         profile_scope!("build");
 
@@ -195,7 +195,7 @@ fn build_lines_pipeline<B: Backend>(
     framebuffer_width: u32,
     framebuffer_height: u32,
     layouts: Vec<&B::DescriptorSetLayout>,
-) -> Result<(B::GraphicsPipeline, B::PipelineLayout), failure::Error> {
+) -> Result<(B::GraphicsPipeline, B::PipelineLayout), pso::CreationError> {
     let pipeline_layout = unsafe {
         factory
             .device()
@@ -209,7 +209,7 @@ fn build_lines_pipeline<B: Backend>(
         .with_pipeline(
             PipelineDescBuilder::new()
                 .with_vertex_desc(&[(DebugLine::vertex(), pso::VertexInputRate::Instance(1))])
-                .with_input_assembler(pso::InputAssemblerDesc::new(hal::Primitive::TriangleStrip))
+                .with_input_assembler(pso::InputAssemblerDesc::new(pso::Primitive::TriangleStrip))
                 .with_shaders(util::simple_shader_set(
                     &shader_vertex,
                     Some(&shader_fragment),

--- a/amethyst_rendy/src/pass/flat2d.rs
+++ b/amethyst_rendy/src/pass/flat2d.rs
@@ -55,7 +55,7 @@ impl<B: Backend> RenderGroupDesc<B, World> for DrawFlat2DDesc {
         subpass: hal::pass::Subpass<'_, B>,
         _buffers: Vec<NodeBuffer>,
         _images: Vec<NodeImage>,
-    ) -> Result<Box<dyn RenderGroup<B, World>>, failure::Error> {
+    ) -> Result<Box<dyn RenderGroup<B, World>>, pso::CreationError> {
         #[cfg(feature = "profiler")]
         profile_scope!("build");
 
@@ -240,7 +240,7 @@ impl<B: Backend> RenderGroupDesc<B, World> for DrawFlat2DTransparentDesc {
         subpass: hal::pass::Subpass<'_, B>,
         _buffers: Vec<NodeBuffer>,
         _images: Vec<NodeImage>,
-    ) -> Result<Box<dyn RenderGroup<B, World>>, failure::Error> {
+    ) -> Result<Box<dyn RenderGroup<B, World>>, pso::CreationError> {
         #[cfg(feature = "profiler")]
         profile_scope!("build_trans");
 
@@ -399,7 +399,7 @@ fn build_sprite_pipeline<B: Backend>(
     framebuffer_height: u32,
     transparent: bool,
     layouts: Vec<&B::DescriptorSetLayout>,
-) -> Result<(B::GraphicsPipeline, B::PipelineLayout), failure::Error> {
+) -> Result<(B::GraphicsPipeline, B::PipelineLayout), pso::CreationError> {
     let pipeline_layout = unsafe {
         factory
             .device()
@@ -413,7 +413,7 @@ fn build_sprite_pipeline<B: Backend>(
         .with_pipeline(
             PipelineDescBuilder::new()
                 .with_vertex_desc(&[(SpriteArgs::vertex(), pso::VertexInputRate::Instance(1))])
-                .with_input_assembler(pso::InputAssemblerDesc::new(hal::Primitive::TriangleStrip))
+                .with_input_assembler(pso::InputAssemblerDesc::new(pso::Primitive::TriangleStrip))
                 .with_shaders(util::simple_shader_set(
                     &shader_vertex,
                     Some(&shader_fragment),

--- a/amethyst_rendy/src/pipeline.rs
+++ b/amethyst_rendy/src/pipeline.rs
@@ -7,12 +7,11 @@ use rendy::{
         device::Device,
         pass::Subpass,
         pso::{
-            AttributeDesc, BakedStates, BasePipeline, BlendDesc, ColorBlendDesc, DepthStencilDesc,
-            DepthTest, Face, GraphicsPipelineDesc, GraphicsShaderSet, InputAssemblerDesc,
-            Multisampling, PipelineCreationFlags, Rasterizer, Rect, VertexBufferDesc,
-            VertexInputRate, Viewport,
+            AttributeDesc, BakedStates, BasePipeline, BlendDesc, ColorBlendDesc, CreationError,
+            DepthStencilDesc, DepthTest, Face, GraphicsPipelineDesc, GraphicsShaderSet,
+            InputAssemblerDesc, Multisampling, PipelineCreationFlags, Primitive, Rasterizer, Rect,
+            VertexBufferDesc, VertexInputRate, Viewport,
         },
-        Primitive,
     },
     mesh::VertexFormat,
 };
@@ -345,7 +344,7 @@ impl<'a, B: Backend> PipelinesBuilder<'a, B> {
         self,
         factory: &Factory<B>,
         cache: Option<&B::PipelineCache>,
-    ) -> Result<Vec<B::GraphicsPipeline>, failure::Error> {
+    ) -> Result<Vec<B::GraphicsPipeline>, CreationError> {
         #[cfg(feature = "profiler")]
         profile_scope!("create_pipelines");
 
@@ -361,7 +360,7 @@ impl<'a, B: Backend> PipelinesBuilder<'a, B> {
                     factory.destroy_graphics_pipeline(p);
                 }
             }
-            failure::bail!(err);
+            return Err(err);
         }
 
         Ok(pipelines.into_iter().map(|p| p.unwrap()).collect())

--- a/amethyst_rendy/src/plugins.rs
+++ b/amethyst_rendy/src/plugins.rs
@@ -68,7 +68,7 @@ mod window {
         ///
         /// ```
         /// use amethyst_rendy::palette::Srgba;
-        /// use amethyst_rendy::RenderToWindow;
+        /// use amethyst_rendy::{RenderToWindow, rendy::hal::command::ClearColor};
         /// use amethyst_window::DisplayConfig;
         ///
         /// let your_red: f32 = 255.;
@@ -80,7 +80,7 @@ mod window {
         ///     .into_linear()
         ///     .into_components();
         ///
-        /// RenderToWindow::from_config(DisplayConfig::default()).with_clear([r, g, b, a]);
+        /// RenderToWindow::from_config(DisplayConfig::default()).with_clear(ClearColor { float32: [r, g, b, a] });
         /// ```
         pub fn with_clear(mut self, clear: impl Into<ClearColor>) -> Self {
             self.clear = Some(clear.into());
@@ -121,7 +121,9 @@ mod window {
             self.dirty = false;
 
             let window = <ReadExpect<'_, Window>>::fetch(world);
-            let surface = factory.create_surface(&window);
+            // Explicitly deref so we get a type that implements HasRawWindowHandle.
+            let window: &Window = &window;
+            let surface = factory.create_surface(window)?;
             let dimensions = self.dimensions.as_ref().unwrap();
             let window_kind = Kind::D2(dimensions.width() as u32, dimensions.height() as u32, 1, 1);
 
@@ -129,7 +131,12 @@ mod window {
                 kind: window_kind,
                 levels: 1,
                 format: Format::D32Sfloat,
-                clear: Some(ClearValue::DepthStencil(ClearDepthStencil(0.0, 0))),
+                clear: Some(ClearValue {
+                    depth_stencil: ClearDepthStencil {
+                        depth: 0.0,
+                        stencil: 0,
+                    },
+                }),
             };
 
             plan.add_root(Target::Main);
@@ -138,7 +145,7 @@ mod window {
                 crate::bundle::TargetPlanOutputs {
                     colors: vec![OutputColor::Surface(
                         surface,
-                        self.clear.map(ClearValue::Color),
+                        self.clear.map(|color| ClearValue { color }),
                     )],
                     depth: Some(depth_options),
                 },

--- a/amethyst_rendy/src/submodules/environment.rs
+++ b/amethyst_rendy/src/submodules/environment.rs
@@ -6,7 +6,12 @@ use crate::{
     rendy::{
         command::RenderPassEncoder,
         factory::Factory,
-        hal::{self, adapter::PhysicalDevice, device::Device, pso::Descriptor},
+        hal::{
+            self,
+            adapter::PhysicalDevice,
+            device::Device,
+            pso::{CreationError, Descriptor},
+        },
         memory::Write as _,
         resource::{Buffer, DescriptorSet, DescriptorSetLayout, Escape, Handle as RendyHandle},
     },
@@ -52,7 +57,7 @@ impl<B: Backend> EnvironmentSub<B> {
     pub fn new(
         factory: &Factory<B>,
         flags: [hal::pso::ShaderStageFlags; 2],
-    ) -> Result<Self, failure::Error> {
+    ) -> Result<Self, CreationError> {
         Ok(Self {
             layout: set_layout! {factory, [1] UniformBuffer flags[0], [4] UniformBuffer flags[1]},
             per_image: Vec::new(),

--- a/amethyst_rendy/src/submodules/flat_environment.rs
+++ b/amethyst_rendy/src/submodules/flat_environment.rs
@@ -21,7 +21,7 @@ pub struct FlatEnvironmentSub<B: Backend> {
 
 impl<B: Backend> FlatEnvironmentSub<B> {
     /// Create and allocate a new `EnvironmentSub` with the provided rendy `Factory`
-    pub fn new(factory: &Factory<B>) -> Result<Self, failure::Error> {
+    pub fn new(factory: &Factory<B>) -> Result<Self, rendy::hal::pso::CreationError> {
         Ok(Self {
             uniform: DynamicUniform::new(factory, rendy::hal::pso::ShaderStageFlags::VERTEX)?,
         })

--- a/amethyst_rendy/src/submodules/material.rs
+++ b/amethyst_rendy/src/submodules/material.rs
@@ -5,7 +5,12 @@ use crate::{
     rendy::{
         command::RenderPassEncoder,
         factory::Factory,
-        hal::{self, adapter::PhysicalDevice, device::Device, pso::Descriptor},
+        hal::{
+            self,
+            adapter::PhysicalDevice,
+            device::Device,
+            pso::{CreationError, Descriptor},
+        },
         memory::Write as _,
         resource::{
             Buffer, BufferInfo, DescriptorSet, DescriptorSetLayout, Escape, Handle as RendyHandle,
@@ -84,15 +89,24 @@ impl<B: Backend> SlottedBuffer<B> {
         elem_size: u64,
         capacity: usize,
         usage: hal::buffer::Usage,
-    ) -> Result<Self, failure::Error> {
+    ) -> Result<Self, CreationError> {
         Ok(Self {
-            buffer: factory.create_buffer(
-                BufferInfo {
-                    size: elem_size * (capacity as u64),
-                    usage,
-                },
-                rendy::memory::Dynamic,
-            )?,
+            buffer: factory
+                .create_buffer(
+                    BufferInfo {
+                        size: elem_size * (capacity as u64),
+                        usage,
+                    },
+                    rendy::memory::Dynamic,
+                )
+                .map_err(|e| match e {
+                    rendy::resource::CreationError::Allocate(
+                        rendy::memory::HeapsError::AllocationError(
+                            hal::device::AllocationError::OutOfMemory(oom),
+                        ),
+                    ) => oom.into(),
+                    _ => CreationError::Other,
+                })?,
             elem_size,
         })
     }
@@ -151,7 +165,7 @@ pub struct MaterialSub<B: Backend, T: for<'a> StaticTextureSet<'a>> {
 
 impl<B: Backend, T: for<'a> StaticTextureSet<'a>> MaterialSub<B, T> {
     /// Create a new `MaterialSub` using the provided rendy `Factory`
-    pub fn new(factory: &Factory<B>) -> Result<Self, failure::Error> {
+    pub fn new(factory: &Factory<B>) -> Result<Self, hal::pso::CreationError> {
         Ok(Self {
             layout: set_layout! {
                 factory,
@@ -167,7 +181,7 @@ impl<B: Backend, T: for<'a> StaticTextureSet<'a>> MaterialSub<B, T> {
         })
     }
 
-    fn create_buffer(factory: &Factory<B>) -> Result<SlottedBuffer<B>, failure::Error> {
+    fn create_buffer(factory: &Factory<B>) -> Result<SlottedBuffer<B>, hal::pso::CreationError> {
         let align = factory
             .physical()
             .limits()

--- a/amethyst_rendy/src/submodules/skinning.rs
+++ b/amethyst_rendy/src/submodules/skinning.rs
@@ -33,7 +33,7 @@ struct PerImageSkinningSub<B: Backend> {
 
 impl<B: Backend> SkinningSub<B> {
     /// Create a new `SkinningSub`, allocating using the provided `Factory`
-    pub fn new(factory: &Factory<B>) -> Result<Self, failure::Error> {
+    pub fn new(factory: &Factory<B>) -> Result<Self, hal::pso::CreationError> {
         Ok(Self {
             layout: set_layout! {factory, [1] StorageBuffer hal::pso::ShaderStageFlags::VERTEX},
             skin_offset_map: Default::default(),

--- a/amethyst_rendy/src/submodules/texture.rs
+++ b/amethyst_rendy/src/submodules/texture.rs
@@ -44,7 +44,7 @@ pub struct TextureSub<B: Backend> {
 
 impl<B: Backend> TextureSub<B> {
     /// Create a new Texture for submission, allocated using the provided `Factory`
-    pub fn new(factory: &Factory<B>) -> Result<Self, failure::Error> {
+    pub fn new(factory: &Factory<B>) -> Result<Self, hal::pso::CreationError> {
         Ok(Self {
             layout: set_layout! {factory, [1] CombinedImageSampler hal::pso::ShaderStageFlags::FRAGMENT},
             lookup: util::LookupBuilder::new(),

--- a/amethyst_rendy/src/submodules/uniform.rs
+++ b/amethyst_rendy/src/submodules/uniform.rs
@@ -44,7 +44,7 @@ where
     pub fn new(
         factory: &Factory<B>,
         flags: hal::pso::ShaderStageFlags,
-    ) -> Result<Self, failure::Error> {
+    ) -> Result<Self, hal::pso::CreationError> {
         Ok(Self {
             layout: factory
                 .create_descriptor_set_layout(util::set_layout_bindings(Some((

--- a/amethyst_rendy/src/util.rs
+++ b/amethyst_rendy/src/util.rs
@@ -14,7 +14,7 @@ use rendy::{
     hal::{self, buffer::Usage, format, pso},
     memory::MemoryUsage,
     mesh::VertexFormat,
-    resource::{BufferInfo, Escape},
+    resource::{BufferCreationError, BufferInfo, Escape},
 };
 use smallvec::SmallVec;
 
@@ -49,7 +49,7 @@ pub fn ensure_buffer<B: Backend>(
     usage: Usage,
     memory_usage: impl MemoryUsage,
     min_size: u64,
-) -> Result<bool, failure::Error> {
+) -> Result<bool, BufferCreationError> {
     #[cfg(feature = "profiler")]
     profile_scope!("ensure_buffer");
 

--- a/amethyst_tiles/Cargo.toml
+++ b/amethyst_tiles/Cargo.toml
@@ -28,7 +28,6 @@ fnv = "1"
 derivative = "2.1.1"
 hibitset = { version = "0.6.2", features = ["parallel"] }
 smallvec = "1.2.0"
-failure = "0.1"
 lazy_static = "1.4"
 rayon = "1.4.0"
 bitintr = "0.3"
@@ -41,7 +40,7 @@ more-asserts = "0.2"
 approx = "0.3"
 
 [features]
-vulkan = ["amethyst_rendy/vulkan", "amethyst_rendy/vulkan-x11"]
+vulkan = ["amethyst_rendy/vulkan"]
 metal = ["amethyst_rendy/metal"]
 empty = ["amethyst_rendy/empty"]
 

--- a/amethyst_tiles/src/pass.rs
+++ b/amethyst_tiles/src/pass.rs
@@ -121,7 +121,7 @@ impl<B: Backend, T: Tile, E: CoordinateEncoder, Z: DrawTiles2DBounds> RenderGrou
         subpass: hal::pass::Subpass<'_, B>,
         _buffers: Vec<NodeBuffer>,
         _images: Vec<NodeImage>,
-    ) -> Result<Box<dyn RenderGroup<B, World>>, failure::Error> {
+    ) -> Result<Box<dyn RenderGroup<B, World>>, pso::CreationError> {
         #[cfg(feature = "profiler")]
         profile_scope!("build");
 
@@ -369,21 +369,26 @@ fn build_tiles_pipeline<B: Backend>(
     framebuffer_width: u32,
     framebuffer_height: u32,
     layouts: Vec<&B::DescriptorSetLayout>,
-) -> Result<(B::GraphicsPipeline, B::PipelineLayout), failure::Error> {
+) -> Result<(B::GraphicsPipeline, B::PipelineLayout), pso::CreationError> {
     let pipeline_layout = unsafe {
         factory
             .device()
             .create_pipeline_layout(layouts, None as Option<(_, _)>)
     }?;
 
-    let mut shaders = SHADERS.build(factory, Default::default())?;
+    let mut shaders = SHADERS
+        .build(factory, Default::default())
+        .map_err(|e| match e {
+            hal::device::ShaderError::OutOfMemory(oom) => oom.into(),
+            _ => pso::CreationError::Other,
+        })?;
 
     let pipes = PipelinesBuilder::new()
         .with_pipeline(
             PipelineDescBuilder::new()
                 .with_vertex_desc(&[(TileArgs::vertex(), pso::VertexInputRate::Instance(1))])
-                .with_input_assembler(pso::InputAssemblerDesc::new(hal::Primitive::TriangleStrip))
-                .with_shaders(shaders.raw()?)
+                .with_input_assembler(pso::InputAssemblerDesc::new(pso::Primitive::TriangleStrip))
+                .with_shaders(shaders.raw().map_err(|_| pso::CreationError::Other)?)
                 .with_layout(&pipeline_layout)
                 .with_subpass(subpass)
                 .with_framebuffer_size(framebuffer_width, framebuffer_height)

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -37,12 +37,11 @@ font-kit = "0.5"
 paste = "0.1"
 rand = "0.7"
 lazy_static = "1.4"
-failure = "0.1"
 glyph_brush = "0.6.0"
 thread_profiler = { version = "0.3", optional = true }
 
 [features]
-vulkan = ["amethyst_rendy/vulkan", "amethyst_rendy/vulkan-x11"]
+vulkan = ["amethyst_rendy/vulkan"]
 metal = ["amethyst_rendy/metal"]
 empty = ["amethyst_rendy/empty"]
 

--- a/amethyst_ui/src/pass.rs
+++ b/amethyst_ui/src/pass.rs
@@ -153,7 +153,7 @@ impl<B: Backend> RenderGroupDesc<B, World> for DrawUiDesc {
         subpass: hal::pass::Subpass<'_, B>,
         _buffers: Vec<NodeBuffer>,
         _images: Vec<NodeImage>,
-    ) -> Result<Box<dyn RenderGroup<B, World>>, failure::Error> {
+    ) -> Result<Box<dyn RenderGroup<B, World>>, pso::CreationError> {
         #[cfg(feature = "profiler")]
         profile_scope!("build");
 
@@ -486,7 +486,7 @@ fn build_ui_pipeline<B: Backend>(
     framebuffer_width: u32,
     framebuffer_height: u32,
     layouts: Vec<&B::DescriptorSetLayout>,
-) -> Result<(B::GraphicsPipeline, B::PipelineLayout), failure::Error> {
+) -> Result<(B::GraphicsPipeline, B::PipelineLayout), pso::CreationError> {
     let pipeline_layout = unsafe {
         factory
             .device()
@@ -500,7 +500,7 @@ fn build_ui_pipeline<B: Backend>(
         .with_pipeline(
             PipelineDescBuilder::new()
                 .with_vertex_desc(&[(UiArgs::vertex(), pso::VertexInputRate::Instance(1))])
-                .with_input_assembler(pso::InputAssemblerDesc::new(hal::Primitive::TriangleStrip))
+                .with_input_assembler(pso::InputAssemblerDesc::new(pso::Primitive::TriangleStrip))
                 .with_shaders(simple_shader_set(&shader_vertex, Some(&shader_fragment)))
                 .with_layout(&pipeline_layout)
                 .with_subpass(subpass)

--- a/amethyst_utils/Cargo.toml
+++ b/amethyst_utils/Cargo.toml
@@ -32,7 +32,7 @@ dunce = "1"
 thread_profiler = { version = "0.3", optional = true }
 
 [features]
-vulkan = ["amethyst_rendy/vulkan", "amethyst_rendy/vulkan-x11"]
+vulkan = ["amethyst_rendy/vulkan"]
 metal = ["amethyst_rendy/metal"]
 empty = ["amethyst_rendy/empty"]
 

--- a/examples/animation/main.rs
+++ b/examples/animation/main.rs
@@ -9,6 +9,7 @@ use amethyst::{
     prelude::*,
     renderer::{
         plugins::{RenderPbr3D, RenderToWindow},
+        rendy::hal::command::ClearColor,
         rendy::mesh::{Normal, Position, Tangent, TexCoord},
         types::DefaultBackend,
         RenderingBundle,
@@ -23,7 +24,9 @@ type MyPrefabData = (
     Option<AnimationSetPrefab<AnimationId, Transform>>,
 );
 
-const CLEAR_COLOR: [f32; 4] = [0.0, 0.0, 0.0, 1.0];
+const CLEAR_COLOR: ClearColor = ClearColor {
+    float32: [0.0, 0.0, 0.0, 1.0],
+};
 
 #[derive(Eq, PartialOrd, PartialEq, Hash, Debug, Copy, Clone, Deserialize, Serialize)]
 enum AnimationId {

--- a/examples/auto_fov/main.rs
+++ b/examples/auto_fov/main.rs
@@ -16,6 +16,7 @@ use amethyst::{
         formats::GraphicsPrefab,
         light::LightPrefab,
         plugins::{RenderShaded3D, RenderToWindow},
+        rendy::hal::command::ClearColor,
         rendy::mesh::{Normal, Position, Tangent, TexCoord},
         types::DefaultBackend,
         RenderingBundle,
@@ -32,7 +33,9 @@ use amethyst::{
 use log::{error, info};
 use serde::{Deserialize, Serialize};
 
-const CLEAR_COLOR: [f32; 4] = [0.0, 0.0, 0.0, 1.0];
+const CLEAR_COLOR: ClearColor = ClearColor {
+    float32: [0.0, 0.0, 0.0, 1.0],
+};
 
 fn main() -> Result<(), Error> {
     amethyst::start_logger(Default::default());

--- a/examples/custom_game_data/main.rs
+++ b/examples/custom_game_data/main.rs
@@ -19,6 +19,7 @@ use amethyst::{
     renderer::{
         palette::Srgb,
         plugins::{RenderShaded3D, RenderToWindow},
+        rendy::hal::command::ClearColor,
         rendy::mesh::{Normal, Position, TexCoord},
         types::DefaultBackend,
         RenderingBundle,
@@ -213,8 +214,9 @@ fn main() -> Result<(), Error> {
         .with_base_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.0, 0.0, 0.0, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [0.0, 0.0, 0.0, 1.0],
+                    }),
                 )
                 .with_plugin(RenderShaded3D::default())
                 .with_plugin(RenderUi::default()),

--- a/examples/custom_render_pass/custom_pass.rs
+++ b/examples/custom_render_pass/custom_pass.rs
@@ -92,7 +92,7 @@ impl<B: Backend> RenderGroupDesc<B, World> for DrawCustomDesc {
         subpass: hal::pass::Subpass<'_, B>,
         _buffers: Vec<NodeBuffer>,
         _images: Vec<NodeImage>,
-    ) -> Result<Box<dyn RenderGroup<B, World>>, failure::Error> {
+    ) -> Result<Box<dyn RenderGroup<B, World>>, pso::CreationError> {
         let env = DynamicUniform::new(factory, pso::ShaderStageFlags::VERTEX)?;
         let vertex = DynamicVertexBuffer::new();
 
@@ -206,7 +206,7 @@ fn build_custom_pipeline<B: Backend>(
     framebuffer_width: u32,
     framebuffer_height: u32,
     layouts: Vec<&B::DescriptorSetLayout>,
-) -> Result<(B::GraphicsPipeline, B::PipelineLayout), failure::Error> {
+) -> Result<(B::GraphicsPipeline, B::PipelineLayout), pso::CreationError> {
     let pipeline_layout = unsafe {
         factory
             .device()
@@ -223,7 +223,7 @@ fn build_custom_pipeline<B: Backend>(
             PipelineDescBuilder::new()
                 // This Pipeline uses our custom vertex description and does not use instancing
                 .with_vertex_desc(&[(CustomArgs::vertex(), pso::VertexInputRate::Vertex)])
-                .with_input_assembler(pso::InputAssemblerDesc::new(hal::Primitive::TriangleList))
+                .with_input_assembler(pso::InputAssemblerDesc::new(pso::Primitive::TriangleList))
                 // Add the shaders
                 .with_shaders(util::simple_shader_set(
                     &shader_vertex,

--- a/examples/custom_render_pass/main.rs
+++ b/examples/custom_render_pass/main.rs
@@ -8,7 +8,10 @@ use amethyst::{
         is_close_requested, is_key_down, InputBundle, InputEvent, ScrollDirection, StringBindings,
     },
     prelude::*,
-    renderer::{plugins::RenderToWindow, types::DefaultBackend, RenderingBundle},
+    renderer::{
+        plugins::RenderToWindow, rendy::hal::command::ClearColor, types::DefaultBackend,
+        RenderingBundle,
+    },
     utils::application_root_dir,
     winit::VirtualKeyCode,
 };
@@ -97,8 +100,9 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([1.0, 1.0, 1.0, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [1.0, 1.0, 1.0, 1.0],
+                    }),
                 )
                 // Add our custom render plugin to the rendering bundle.
                 .with_plugin(RenderCustom::default()),

--- a/examples/custom_ui/main.rs
+++ b/examples/custom_ui/main.rs
@@ -8,6 +8,7 @@ use amethyst::{
     prelude::*,
     renderer::{
         plugins::RenderToWindow,
+        rendy::hal::command::ClearColor,
         rendy::mesh::{Normal, Position, TexCoord},
         types::DefaultBackend,
         RenderingBundle,
@@ -105,8 +106,9 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.34, 0.36, 0.52, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [0.34, 0.36, 0.52, 1.0],
+                    }),
                 )
                 .with_plugin(RenderUi::default()),
         )?;

--- a/examples/debug_lines_ortho/main.rs
+++ b/examples/debug_lines_ortho/main.rs
@@ -13,6 +13,7 @@ use amethyst::{
         debug_drawing::{DebugLines, DebugLinesComponent, DebugLinesParams},
         palette::Srgba,
         plugins::{RenderDebugLines, RenderToWindow},
+        rendy::hal::command::ClearColor,
         types::DefaultBackend,
         RenderingBundle,
     },
@@ -120,8 +121,9 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.0, 0.0, 0.0, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [0.0, 0.0, 0.0, 1.0],
+                    }),
                 )
                 .with_plugin(RenderDebugLines::default()),
         )?;

--- a/examples/fly_camera/main.rs
+++ b/examples/fly_camera/main.rs
@@ -9,6 +9,7 @@ use amethyst::{
     prelude::*,
     renderer::{
         plugins::{RenderShaded3D, RenderToWindow},
+        rendy::hal::command::ClearColor,
         rendy::mesh::{Normal, Position, TexCoord},
         types::DefaultBackend,
         RenderingBundle,
@@ -81,8 +82,9 @@ fn main() -> Result<(), Error> {
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.34, 0.36, 0.52, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [0.34, 0.36, 0.52, 1.0],
+                    }),
                 )
                 .with_plugin(RenderShaded3D::default()),
         )?;

--- a/examples/material/main.rs
+++ b/examples/material/main.rs
@@ -12,6 +12,7 @@ use amethyst::{
         palette::{LinSrgba, Srgb},
         plugins::{RenderPbr3D, RenderToWindow},
         rendy::{
+            hal::command::ClearColor,
             mesh::{Normal, Position, Tangent, TexCoord},
             texture::palette::load_from_linear_rgba,
         },
@@ -155,8 +156,9 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.34, 0.36, 0.52, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [0.34, 0.36, 0.52, 1.0],
+                    }),
                 )
                 .with_plugin(RenderPbr3D::default()),
         )?;

--- a/examples/mouse_raycast/main.rs
+++ b/examples/mouse_raycast/main.rs
@@ -20,6 +20,7 @@ use amethyst::{
     renderer::{
         camera::{ActiveCamera, Camera},
         plugins::{RenderFlat2D, RenderToWindow},
+        rendy::hal::command::ClearColor,
         sprite::{SpriteRender, SpriteSheet, SpriteSheetFormat},
         types::DefaultBackend,
         ImageFormat, RenderingBundle, Texture,
@@ -266,8 +267,9 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.34, 0.36, 0.52, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [0.34, 0.36, 0.52, 1.0],
+                    }),
                 )
                 .with_plugin(RenderUi::default())
                 .with_plugin(RenderFlat2D::default()),

--- a/examples/pong_tutorial_01/main.rs
+++ b/examples/pong_tutorial_01/main.rs
@@ -4,6 +4,7 @@ use amethyst::{
     prelude::*,
     renderer::{
         plugins::{RenderFlat2D, RenderToWindow},
+        rendy::hal::command::ClearColor,
         types::DefaultBackend,
         RenderingBundle,
     },
@@ -29,8 +30,9 @@ fn main() -> amethyst::Result<()> {
             // The RenderToWindow plugin provides all the scaffolding for opening a window and
             // drawing on it
             .with_plugin(
-                RenderToWindow::from_config_path(display_config_path)?
-                    .with_clear([0.0, 0.0, 0.0, 1.0]),
+                RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                    float32: [0.0, 0.0, 0.0, 1.0],
+                }),
             )
             // RenderFlat2D plugin is used to render entities with `SpriteRender` component.
             .with_plugin(RenderFlat2D::default()),

--- a/examples/pong_tutorial_02/main.rs
+++ b/examples/pong_tutorial_02/main.rs
@@ -8,6 +8,7 @@ use amethyst::{
     prelude::*,
     renderer::{
         plugins::{RenderFlat2D, RenderToWindow},
+        rendy::hal::command::ClearColor,
         types::DefaultBackend,
         RenderingBundle,
     },
@@ -32,8 +33,9 @@ fn main() -> amethyst::Result<()> {
                 // The RenderToWindow plugin provides all the scaffolding for opening a window and
                 // drawing on it
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.0, 0.0, 0.0, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [0.0, 0.0, 0.0, 1.0],
+                    }),
                 )
                 // RenderFlat2D plugin is used to render entities with `SpriteRender` component.
                 .with_plugin(RenderFlat2D::default()),

--- a/examples/pong_tutorial_03/main.rs
+++ b/examples/pong_tutorial_03/main.rs
@@ -10,6 +10,7 @@ use amethyst::{
     prelude::*,
     renderer::{
         plugins::{RenderFlat2D, RenderToWindow},
+        rendy::hal::command::ClearColor,
         types::DefaultBackend,
         RenderingBundle,
     },
@@ -41,8 +42,9 @@ fn main() -> amethyst::Result<()> {
                 // The RenderToWindow plugin provides all the scaffolding for opening a window and
                 // drawing on it
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.0, 0.0, 0.0, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [0.0, 0.0, 0.0, 1.0],
+                    }),
                 )
                 // RenderFlat2D plugin is used to render entities with `SpriteRender` component.
                 .with_plugin(RenderFlat2D::default()),

--- a/examples/pong_tutorial_04/main.rs
+++ b/examples/pong_tutorial_04/main.rs
@@ -10,6 +10,7 @@ use amethyst::{
     prelude::*,
     renderer::{
         plugins::{RenderFlat2D, RenderToWindow},
+        rendy::hal::command::ClearColor,
         types::DefaultBackend,
         RenderingBundle,
     },
@@ -47,8 +48,9 @@ fn main() -> amethyst::Result<()> {
                 // The RenderToWindow plugin provides all the scaffolding for opening a window and
                 // drawing on it
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.0, 0.0, 0.0, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [0.0, 0.0, 0.0, 1.0],
+                    }),
                 )
                 // RenderFlat2D plugin is used to render entities with `SpriteRender` component.
                 .with_plugin(RenderFlat2D::default()),

--- a/examples/pong_tutorial_05/main.rs
+++ b/examples/pong_tutorial_05/main.rs
@@ -10,6 +10,7 @@ use amethyst::{
     prelude::*,
     renderer::{
         plugins::{RenderFlat2D, RenderToWindow},
+        rendy::hal::command::ClearColor,
         types::DefaultBackend,
         RenderingBundle,
     },
@@ -50,8 +51,9 @@ fn main() -> amethyst::Result<()> {
                 // The RenderToWindow plugin provides all the scaffolding for opening a window and
                 // drawing on it
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.0, 0.0, 0.0, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [0.0, 0.0, 0.0, 1.0],
+                    }),
                 )
                 // RenderFlat2D plugin is used to render entities with `SpriteRender` component.
                 .with_plugin(RenderFlat2D::default())

--- a/examples/pong_tutorial_06/main.rs
+++ b/examples/pong_tutorial_06/main.rs
@@ -13,6 +13,7 @@ use amethyst::{
     prelude::*,
     renderer::{
         plugins::{RenderFlat2D, RenderToWindow},
+        rendy::hal::command::ClearColor,
         types::DefaultBackend,
         RenderingBundle,
     },
@@ -78,8 +79,9 @@ fn main() -> amethyst::Result<()> {
                 // The RenderToWindow plugin provides all the scaffolding for opening a window and
                 // drawing on it
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.34, 0.36, 0.52, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [0.34, 0.36, 0.52, 1.0],
+                    }),
                 )
                 .with_plugin(RenderFlat2D::default())
                 .with_plugin(RenderUi::default()),

--- a/examples/prefab/main.rs
+++ b/examples/prefab/main.rs
@@ -6,7 +6,10 @@ use amethyst::{
     prelude::*,
     renderer::{
         plugins::{RenderShaded3D, RenderToWindow},
-        rendy::mesh::{Normal, Position, TexCoord},
+        rendy::{
+            hal::command::ClearColor,
+            mesh::{Normal, Position, TexCoord},
+        },
         types::DefaultBackend,
         RenderingBundle,
     },
@@ -44,8 +47,9 @@ fn main() -> Result<(), Error> {
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.34, 0.36, 0.52, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [0.34, 0.36, 0.52, 1.0],
+                    }),
                 )
                 .with_plugin(RenderShaded3D::default()),
         )?;

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -26,7 +26,10 @@ use amethyst::{
         light::Light,
         palette::{Srgb, Srgba},
         plugins::{RenderShaded3D, RenderToWindow},
-        rendy::mesh::{Normal, Position, TexCoord},
+        rendy::{
+            hal::command::ClearColor,
+            mesh::{Normal, Position, TexCoord},
+        },
         resources::AmbientColor,
         types::DefaultBackend,
         Camera, RenderingBundle,
@@ -213,8 +216,9 @@ fn main() -> Result<(), Error> {
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.34, 0.36, 0.52, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [0.34, 0.36, 0.52, 1.0],
+                    }),
                 )
                 .with_plugin(RenderShaded3D::default())
                 .with_plugin(RenderUi::default()),

--- a/examples/renderable_custom/main.rs
+++ b/examples/renderable_custom/main.rs
@@ -312,18 +312,20 @@ impl GraphCreator<DefaultBackend> for ExampleGraph {
     ) -> GraphBuilder<DefaultBackend, World> {
         use amethyst::renderer::rendy::{
             graph::present::PresentNode,
-            hal::command::{ClearDepthStencil, ClearValue},
+            hal::command::{ClearColor, ClearDepthStencil, ClearValue},
         };
 
         self.dirty = false;
 
         // Retrieve a reference to the target window, which is created by the WindowBundle
         let window = <ReadExpect<'_, Window>>::fetch(world);
+        // Explicitly deref so we get a type that implements HasRawWindowHandle.
+        let window: &Window = &window;
         let dimensions = self.dimensions.as_ref().unwrap();
         let window_kind = Kind::D2(dimensions.width() as u32, dimensions.height() as u32, 1, 1);
 
         // Create a new drawing surface in our window
-        let surface = factory.create_surface(&window);
+        let surface = factory.create_surface(window).unwrap();
         let surface_format = factory.get_surface_format(&surface);
 
         // Begin building our RenderGraph
@@ -333,14 +335,23 @@ impl GraphCreator<DefaultBackend> for ExampleGraph {
             1,
             surface_format,
             // clear screen to black
-            Some(ClearValue::Color([0.34, 0.36, 0.52, 1.0].into())),
+            Some(ClearValue {
+                color: ClearColor {
+                    float32: [0.34, 0.36, 0.52, 1.0],
+                },
+            }),
         );
 
         let depth = graph_builder.create_image(
             window_kind,
             1,
             Format::D32Sfloat,
-            Some(ClearValue::DepthStencil(ClearDepthStencil(0.0, 0))),
+            Some(ClearValue {
+                depth_stencil: ClearDepthStencil {
+                    depth: 0.0,
+                    stencil: 0,
+                },
+            }),
         );
 
         // Create our first `Subpass`, which contains the DrawShaded and DrawUi render groups.

--- a/examples/sphere/main.rs
+++ b/examples/sphere/main.rs
@@ -7,7 +7,10 @@ use amethyst::{
     prelude::*,
     renderer::{
         plugins::{RenderShaded3D, RenderToWindow},
-        rendy::mesh::{Normal, Position, TexCoord},
+        rendy::{
+            hal::command::ClearColor,
+            mesh::{Normal, Position, TexCoord},
+        },
         types::DefaultBackend,
         RenderingBundle,
     },
@@ -41,8 +44,9 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.34, 0.36, 0.52, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [0.34, 0.36, 0.52, 1.0],
+                    }),
                 )
                 .with_plugin(RenderShaded3D::default()),
         )?;

--- a/examples/spotlights/main.rs
+++ b/examples/spotlights/main.rs
@@ -5,7 +5,10 @@ use amethyst::{
     prelude::*,
     renderer::{
         plugins::{RenderPbr3D, RenderToWindow},
-        rendy::mesh::{Normal, Position, Tangent, TexCoord},
+        rendy::{
+            hal::command::ClearColor,
+            mesh::{Normal, Position, Tangent, TexCoord},
+        },
         types::DefaultBackend,
         RenderingBundle,
     },
@@ -38,8 +41,9 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.34, 0.36, 0.52, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [0.34, 0.36, 0.52, 1.0],
+                    }),
                 )
                 .with_plugin(RenderPbr3D::default()),
         )?;

--- a/examples/sprite_animation/main.rs
+++ b/examples/sprite_animation/main.rs
@@ -16,6 +16,7 @@ use amethyst::{
     renderer::{
         camera::Camera,
         plugins::{RenderFlat2D, RenderToWindow},
+        rendy::hal::command::ClearColor,
         sprite::{prefab::SpriteScenePrefab, SpriteRender},
         types::DefaultBackend,
         RenderingBundle,
@@ -152,8 +153,9 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.34, 0.36, 0.52, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [0.34, 0.36, 0.52, 1.0],
+                    }),
                 )
                 .with_plugin(RenderFlat2D::default()),
         )?;

--- a/examples/sprite_camera_follow/main.rs
+++ b/examples/sprite_camera_follow/main.rs
@@ -10,6 +10,7 @@ use amethyst::{
     prelude::*,
     renderer::{
         plugins::{RenderFlat2D, RenderToWindow},
+        rendy::hal::command::ClearColor,
         types::DefaultBackend,
         Camera, ImageFormat, RenderingBundle, SpriteRender, SpriteSheet, SpriteSheetFormat,
         Texture, Transparent,
@@ -207,8 +208,9 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.34, 0.36, 0.52, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [0.34, 0.36, 0.52, 1.0],
+                    }),
                 )
                 .with_plugin(RenderFlat2D::default()),
         )?;

--- a/examples/sprites_ordered/main.rs
+++ b/examples/sprites_ordered/main.rs
@@ -14,6 +14,7 @@ use amethyst::{
     prelude::*,
     renderer::{
         plugins::{RenderFlat2D, RenderToWindow},
+        rendy::hal::command::ClearColor,
         types::DefaultBackend,
         Camera, ImageFormat, RenderingBundle, SpriteRender, SpriteSheet, Texture, Transparent,
     },
@@ -368,8 +369,9 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.34, 0.36, 0.52, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [0.34, 0.36, 0.52, 1.0],
+                    }),
                 )
                 .with_plugin(RenderFlat2D::default()),
         )?;

--- a/examples/states_ui/main.rs
+++ b/examples/states_ui/main.rs
@@ -4,7 +4,10 @@ use amethyst::{
     core::transform::TransformBundle,
     input::{InputBundle, StringBindings},
     prelude::*,
-    renderer::{plugins::RenderToWindow, types::DefaultBackend, RenderingBundle},
+    renderer::{
+        plugins::RenderToWindow, rendy::hal::command::ClearColor, types::DefaultBackend,
+        RenderingBundle,
+    },
     ui::{RenderUi, UiBundle},
     utils::{application_root_dir, fps_counter::FpsCounterBundle},
 };
@@ -70,8 +73,9 @@ pub fn main() -> amethyst::Result<()> {
                 // This creates the window and draws a background, if we don't specify a
                 // background in the loaded ui prefab file.
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.005, 0.005, 0.005, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [0.005, 0.005, 0.005, 1.0],
+                    }),
                 )
                 // Without this, all of our beautiful UI would not get drawn.
                 // It will work, but we won't see a thing.

--- a/examples/tiles/main.rs
+++ b/examples/tiles/main.rs
@@ -15,6 +15,7 @@ use amethyst::{
         debug_drawing::DebugLinesComponent,
         formats::texture::ImageFormat,
         palette::Srgba,
+        rendy::hal::command::ClearColor,
         sprite::{SpriteRender, SpriteSheet, SpriteSheetFormat, SpriteSheetHandle},
         transparent::Transparent,
         types::DefaultBackend,
@@ -442,8 +443,9 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.34, 0.36, 0.52, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [0.34, 0.36, 0.52, 1.0],
+                    }),
                 )
                 .with_plugin(RenderDebugLines::default())
                 .with_plugin(RenderFlat2D::default())

--- a/examples/ui/main.rs
+++ b/examples/ui/main.rs
@@ -10,7 +10,10 @@ use amethyst::{
     prelude::*,
     renderer::{
         plugins::RenderToWindow,
-        rendy::mesh::{Normal, Position, TexCoord},
+        rendy::{
+            hal::command::ClearColor,
+            mesh::{Normal, Position, TexCoord},
+        },
         types::DefaultBackend,
         RenderingBundle,
     },
@@ -153,8 +156,9 @@ fn main() -> amethyst::Result<()> {
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(
-                    RenderToWindow::from_config_path(display_config_path)?
-                        .with_clear([0.34, 0.36, 0.52, 1.0]),
+                    RenderToWindow::from_config_path(display_config_path)?.with_clear(ClearColor {
+                        float32: [0.34, 0.36, 0.52, 1.0],
+                    }),
                 )
                 .with_plugin(RenderUi::default()),
         )?;


### PR DESCRIPTION
## Description

Migrates `amethyst_rendy` (and therefore the remainder of the `amethyst` crate stack) to use `rendy 0.5`, which includes a migration to `gfx-hal 0.4`.

The most annoying change due to this is the removal of nice HAL wrappers from `gfx-hal`, in particular `ClearColor`'s `From` impls. It might make sense to alter the `RenderToWindow::with_clear` API to use an in-house wrapper.

Full disclosure: I have never used `amethyst`, `rendy`, or `gfx-hal` before, and have no idea what I'm doing. I couldn't see an obvious reason for _not_ migrating in any of the open issues, so hopefully this is somewhat useful 🙂

## Removals

- The `failure` crate was removed from `rendy`, and is no longer used in APIs here.

## Modifications

- APIs that previously returned `failure::Error` now return `rendy` error types, that can bubble back up through the `RenderGroupDesc` trait.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --workspace --features "empty"`
