### PR TITLE
 Update legion dependency to crates.io published version 0.3.1

### DIFF
--- a/amethyst_assets/examples/hl.rs
+++ b/amethyst_assets/examples/hl.rs
@@ -20,7 +20,7 @@ struct App {
 
 impl App {
     fn new(path: &str, state: State) -> Self {
-        let mut world = World::new();
+        let mut world = World::default();
 
         // Note: in an actual application, you'd want to share the thread pool.
         let pool = Arc::new(ThreadPoolBuilder::new().build().expect("Invalid config"));

--- a/amethyst_audio/src/systems/audio.rs
+++ b/amethyst_audio/src/systems/audio.rs
@@ -51,7 +51,7 @@ pub fn build_audio_system() -> impl Runnable {
                     .and_then(|select_listener| {
                         // Find entity refered by SelectedListener resource
                         world
-                            .entry_ref(select_listener.0)
+                            .entry_ref(select_listener.0).ok()
                             .and_then(|entry| entry.into_component::<AudioListener>().ok())
                             .map(|audio_listener| (select_listener.0, audio_listener))
                     })
@@ -64,7 +64,7 @@ pub fn build_audio_system() -> impl Runnable {
                     })
                 {
                     if let Some(listener_transform) = world
-                        .entry_ref(entity)
+                        .entry_ref(entity).ok()
                         .and_then(|entry| entry.into_component::<Transform>().ok())
                     {
                         let listener_transform = listener_transform.global_matrix();

--- a/amethyst_audio/src/systems/audio.rs
+++ b/amethyst_audio/src/systems/audio.rs
@@ -51,7 +51,8 @@ pub fn build_audio_system() -> impl Runnable {
                     .and_then(|select_listener| {
                         // Find entity refered by SelectedListener resource
                         world
-                            .entry_ref(select_listener.0).ok()
+                            .entry_ref(select_listener.0)
+                            .ok()
                             .and_then(|entry| entry.into_component::<AudioListener>().ok())
                             .map(|audio_listener| (select_listener.0, audio_listener))
                     })
@@ -64,7 +65,8 @@ pub fn build_audio_system() -> impl Runnable {
                     })
                 {
                     if let Some(listener_transform) = world
-                        .entry_ref(entity).ok()
+                        .entry_ref(entity)
+                        .ok()
                         .and_then(|entry| entry.into_component::<Transform>().ok())
                     {
                         let listener_transform = listener_transform.global_matrix();

--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -71,7 +71,8 @@ pub fn build_arc_ball_rotation_system() -> impl Runnable {
                 .iter(world)
                 .map(|ctrl| {
                     match world
-                        .entry_ref(ctrl.target).ok()
+                        .entry_ref(ctrl.target)
+                        .ok()
                         .and_then(|e| e.into_component::<Transform>().ok())
                     {
                         Some(trans) => Some((ctrl.target, *trans)),

--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -71,9 +71,8 @@ pub fn build_arc_ball_rotation_system() -> impl Runnable {
                 .iter(world)
                 .map(|ctrl| {
                     match world
-                        .entry_ref(ctrl.target)
-                        .map(|e| e.into_component::<Transform>().ok())
-                        .flatten()
+                        .entry_ref(ctrl.target).ok()
+                        .and_then(|e| e.into_component::<Transform>().ok())
                     {
                         Some(trans) => Some((ctrl.target, *trans)),
                         None => None,

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -31,14 +31,8 @@ smallvec = "1.4"
 shrinkwraprs = "0.3"
 shrev = "1.1"
 derivative = "2.1.1"
-
+legion = { version = "0.3.1", default-features = false, features = ["serialize", "crossbeam-events", "codegen"] }
 thread_profiler = { version = "0.3", optional = true }
-
-[dependencies.legion]
-git = "https://github.com/TomGillen/legion"
-rev = "b93b636d"
-default-features = false
-features = ["serialize", "crossbeam-events", "codegen"]
 
 [dev-dependencies]
 #amethyst = { path = "..", version = "0.15.1" }

--- a/amethyst_core/src/transform/missing_previous_parent_system.rs
+++ b/amethyst_core/src/transform/missing_previous_parent_system.rs
@@ -27,7 +27,7 @@ mod test {
     #[test]
     fn previous_parent_added() {
         let mut resources = Resources::default();
-        let mut world = Universe::new().create_world();
+        let mut world = World::default();
 
         let mut schedule = Schedule::builder().add_system(build()).build();
 

--- a/amethyst_core/src/transform/parent_update_system.rs
+++ b/amethyst_core/src/transform/parent_update_system.rs
@@ -26,7 +26,7 @@ pub fn build() -> impl Runnable {
                 log::trace!("Parent was removed from {:?}", entity);
                 if let Some(previous_parent_entity) = previous_parent.0 {
                     if let Some(previous_parent_children) = left
-                        .entry_mut(previous_parent_entity)
+                        .entry_mut(previous_parent_entity).ok()
                         .and_then(|entry| entry.into_component_mut::<Children>().ok())
                     {
                         log::trace!(" > Removing {:?} from it's prev parent's children", entity);
@@ -53,7 +53,7 @@ pub fn build() -> impl Runnable {
 
                     // Remove from `PreviousParent.Children`.
                     if let Some(previous_parent_children) = left
-                        .entry_mut(previous_parent_entity)
+                        .entry_mut(previous_parent_entity).ok()
                         .and_then(|entry| entry.into_component_mut::<Children>().ok())
                     {
                         log::trace!(" > Removing {:?} from prev parent's children", entity);
@@ -68,7 +68,7 @@ pub fn build() -> impl Runnable {
                 // `children_additions`).
                 log::trace!("Adding {:?} to it's new parent {:?}", entity, parent.0);
                 if let Some(new_parent_children) = left
-                    .entry_mut(parent.0)
+                    .entry_mut(parent.0).ok()
                     .and_then(|entry| entry.into_component_mut::<Children>().ok())
                 {
                     // This is the parent

--- a/amethyst_core/src/transform/parent_update_system.rs
+++ b/amethyst_core/src/transform/parent_update_system.rs
@@ -26,7 +26,8 @@ pub fn build() -> impl Runnable {
                 log::trace!("Parent was removed from {:?}", entity);
                 if let Some(previous_parent_entity) = previous_parent.0 {
                     if let Some(previous_parent_children) = left
-                        .entry_mut(previous_parent_entity).ok()
+                        .entry_mut(previous_parent_entity)
+                        .ok()
                         .and_then(|entry| entry.into_component_mut::<Children>().ok())
                     {
                         log::trace!(" > Removing {:?} from it's prev parent's children", entity);
@@ -53,7 +54,8 @@ pub fn build() -> impl Runnable {
 
                     // Remove from `PreviousParent.Children`.
                     if let Some(previous_parent_children) = left
-                        .entry_mut(previous_parent_entity).ok()
+                        .entry_mut(previous_parent_entity)
+                        .ok()
                         .and_then(|entry| entry.into_component_mut::<Children>().ok())
                     {
                         log::trace!(" > Removing {:?} from prev parent's children", entity);
@@ -68,7 +70,8 @@ pub fn build() -> impl Runnable {
                 // `children_additions`).
                 log::trace!("Adding {:?} to it's new parent {:?}", entity, parent.0);
                 if let Some(new_parent_children) = left
-                    .entry_mut(parent.0).ok()
+                    .entry_mut(parent.0)
+                    .ok()
                     .and_then(|entry| entry.into_component_mut::<Children>().ok())
                 {
                     // This is the parent
@@ -127,7 +130,7 @@ mod test {
     #[test]
     fn correct_children() {
         let mut resources = Resources::default();
-        let mut world = Universe::new().create_world();
+        let mut world = World::default();
 
         let mut schedule = Schedule::builder()
             .add_system(missing_previous_parent_system::build())

--- a/amethyst_core/src/transform/transform_system.rs
+++ b/amethyst_core/src/transform/transform_system.rs
@@ -44,7 +44,7 @@ pub fn build() -> impl Runnable {
                         .global_matrix;
 
                     right
-                        .entry_mut(*entity)
+                        .entry_mut(*entity).ok()
                         .and_then(|entry| entry.into_component_mut::<Transform>().ok())
                         .map(|transform| {
                             transform.parent_matrix = parent_matrix;

--- a/amethyst_core/src/transform/transform_system.rs
+++ b/amethyst_core/src/transform/transform_system.rs
@@ -11,11 +11,13 @@ pub fn build() -> impl Runnable {
     SystemBuilder::new("TransformSystem")
         // Entities at the hierarchy root (no parent component)
         .with_query(
-            <(Entity, &mut Transform)>::query().filter(maybe_changed::<Transform>() & !component::<Parent>()),
+            <(Entity, &mut Transform)>::query()
+                .filter(maybe_changed::<Transform>() & !component::<Parent>()),
         )
         // Entities that are children of some entity
         .with_query(
-            <(Entity, &mut Transform)>::query().filter(maybe_changed::<Transform>() & component::<Parent>()),
+            <(Entity, &mut Transform)>::query()
+                .filter(maybe_changed::<Transform>() & component::<Parent>()),
         )
         .with_query(<(Entity, &Parent)>::query())
         .write_component::<Transform>()
@@ -44,7 +46,8 @@ pub fn build() -> impl Runnable {
                         .global_matrix;
 
                     right
-                        .entry_mut(*entity).ok()
+                        .entry_mut(*entity)
+                        .ok()
                         .and_then(|entry| entry.into_component_mut::<Transform>().ok())
                         .map(|transform| {
                             transform.parent_matrix = parent_matrix;
@@ -91,7 +94,7 @@ mod tests {
 
     fn transform_world() -> (Resources, World, Dispatcher) {
         let mut resources = Resources::default();
-        let mut world = Universe::new().create_world();
+        let mut world = World::default();
 
         let dispatcher = DispatcherBuilder::default()
             .add_bundle(TransformBundle)

--- a/amethyst_rendy/src/pass/base_3d.rs
+++ b/amethyst_rendy/src/pass/base_3d.rs
@@ -219,7 +219,7 @@ impl<B: Backend, T: Base3DPassDef> RenderGroup<B, GraphAuxData> for DrawBase3D<B
             visibility
                 .visible_unordered
                 .iter()
-                .filter_map(|entity| Some((entity, query.get(*world, *entity)?)))
+                .filter_map(|entity| Some((entity, query.get(*world, *entity).ok()?)))
                 .map(|(entity, (mat, mesh, tform, tint))| {
                     if let Some(tint) = tint {
                         (
@@ -253,7 +253,7 @@ impl<B: Backend, T: Base3DPassDef> RenderGroup<B, GraphAuxData> for DrawBase3D<B
             visibility
                 .visible_unordered
                 .iter()
-                .filter_map(|entity| Some((entity, query.get(*world, *entity)?)))
+                .filter_map(|entity| Some((entity, query.get(*world, *entity).ok()?)))
                 .map(|(_, (mat, mesh, tform, tint, joints))| {
                     if let Some(tint) = tint {
                         (
@@ -562,7 +562,7 @@ impl<B: Backend, T: Base3DPassDef> RenderGroup<B, GraphAuxData> for DrawBase3DTr
             visibility
                 .visible_ordered
                 .iter()
-                .filter_map(|entity| Some((entity, query.get(*world, *entity)?)))
+                .filter_map(|entity| Some((entity, query.get(*world, *entity).ok()?)))
                 .map(|(entity, (mat, mesh, tform, tint))| {
                     if let Some(tint) = tint {
                         (
@@ -601,7 +601,7 @@ impl<B: Backend, T: Base3DPassDef> RenderGroup<B, GraphAuxData> for DrawBase3DTr
             visibility
                 .visible_unordered
                 .iter()
-                .filter_map(|entity| Some((entity, query.get(*world, *entity)?)))
+                .filter_map(|entity| Some((entity, query.get(*world, *entity).ok()?)))
                 .map(|(_, (mat, mesh, tform, tint, joints))| {
                     if let Some(tint) = tint {
                         (

--- a/amethyst_rendy/src/pass/base_3d.rs
+++ b/amethyst_rendy/src/pass/base_3d.rs
@@ -209,12 +209,8 @@ impl<B: Backend, T: Base3DPassDef> RenderGroup<B, GraphAuxData> for DrawBase3D<B
         {
             profile_scope_impl!("prepare");
 
-            let mut query = <(
-                &Handle<Material>,
-                &Handle<Mesh>,
-                &Transform,
-                Option<&Tint>,
-            )>::query();
+            let mut query =
+                <(&Handle<Material>, &Handle<Mesh>, &Transform, Option<&Tint>)>::query();
 
             visibility
                 .visible_unordered
@@ -552,12 +548,8 @@ impl<B: Backend, T: Base3DPassDef> RenderGroup<B, GraphAuxData> for DrawBase3DTr
         {
             profile_scope_impl!("prepare");
 
-            let mut query = <(
-                &Handle<Material>,
-                &Handle<Mesh>,
-                &Transform,
-                Option<&Tint>,
-            )>::query();
+            let mut query =
+                <(&Handle<Material>, &Handle<Mesh>, &Transform, Option<&Tint>)>::query();
 
             visibility
                 .visible_ordered

--- a/amethyst_rendy/src/pass/flat2d.rs
+++ b/amethyst_rendy/src/pass/flat2d.rs
@@ -130,7 +130,7 @@ impl<B: Backend> RenderGroup<B, GraphAuxData> for DrawFlat2D<B> {
             visibility
                 .visible_unordered
                 .iter()
-                .filter_map(|entity| Some((entity, query.get(*world, *entity)?)))
+                .filter_map(|entity| Some((entity, query.get(*world, *entity).ok()?)))
                 .filter_map(|(entity, (sprite_render, global, tint))| {
                     let (batch_data, texture) = if let Some(tint) = tint {
                         SpriteArgs::from_data(
@@ -316,7 +316,7 @@ impl<B: Backend> RenderGroup<B, GraphAuxData> for DrawFlat2DTransparent<B> {
             visibility
                 .visible_ordered
                 .iter()
-                .filter_map(|entity| Some((entity, query.get(*world, *entity)?)))
+                .filter_map(|entity| Some((entity, query.get(*world, *entity).ok()?)))
                 .filter_map(|(entity, (sprite_render, global, tint))| {
                     let (batch_data, texture) = if let Some(tint) = tint {
                         SpriteArgs::from_data(


### PR DESCRIPTION
## Description

Updates legion dependency to crates.io published version 0.3.1

## Additions

## Removals

## Modifications

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [X] Ran `cargo +stable fmt --all`
- [X] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
> Has errors related to sub crates that have yet to be ported to legion
- [X] Ran `cargo build --features "empty"`
> Has errors related to sub crates that have yet to be ported to legion
- [X] Ran `cargo test --workspace --features "empty"`
> Fixed some broken tests. amethyst_derive is broken because the tests use SystemDesc with doesn't exist in legion
