### PR TITLE
Replace `clipboard` crate with copypasta

### DIFF
--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -21,7 +21,7 @@ amethyst_error = { path = "../amethyst_error", version = "0.15.3" }
 amethyst_input = { path = "../amethyst_input", version = "0.15.3" }
 amethyst_rendy = { path = "../amethyst_rendy", version = "0.15.3" }
 amethyst_window = { path = "../amethyst_window", version = "0.15.3" }
-clipboard = "0.5"
+copypasta = "0.7.1"
 derivative = "2.1.1"
 derive-new = "0.5.6"
 fnv = "1"

--- a/amethyst_ui/src/text_editing.rs
+++ b/amethyst_ui/src/text_editing.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use clipboard::{ClipboardContext, ClipboardProvider};
+use copypasta::{ClipboardContext, ClipboardProvider};
 use log::error;
 use unicode_normalization::{char::is_combining_mark, UnicodeNormalization};
 use unicode_segmentation::UnicodeSegmentation;
@@ -225,7 +225,7 @@ impl<'a> System<'a> for TextEditingInputSystem {
                             if ctrl_or_cmd(modifiers) {
                                 let new_clip = extract_highlighted(focused_edit, focused_text);
                                 if !new_clip.is_empty() {
-                                    match ClipboardProvider::new().and_then(
+                                    match ClipboardContext::new().and_then(
                                         |mut ctx: ClipboardContext| ctx.set_contents(new_clip),
                                     ) {
                                         Ok(_) => edit_events.single_write(UiEvent::new(
@@ -244,7 +244,7 @@ impl<'a> System<'a> for TextEditingInputSystem {
                             if ctrl_or_cmd(modifiers) {
                                 let new_clip = read_highlighted(focused_edit, focused_text);
                                 if !new_clip.is_empty() {
-                                    if let Err(e) = ClipboardProvider::new().and_then(
+                                    if let Err(e) = ClipboardContext::new().and_then(
                                         |mut ctx: ClipboardContext| {
                                             ctx.set_contents(new_clip.to_owned())
                                         },
@@ -258,7 +258,7 @@ impl<'a> System<'a> for TextEditingInputSystem {
                             if ctrl_or_cmd(modifiers) {
                                 delete_highlighted(focused_edit, focused_text);
 
-                                match ClipboardProvider::new()
+                                match ClipboardContext::new()
                                     .and_then(|mut ctx: ClipboardContext| ctx.get_contents())
                                 {
                                     Ok(contents) => {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 
 - Upgraded from `rayon 1.3.0` to `rayon 1.4.0`, drastically decreasing idle CPU usage in some situations ([#2489])
 - Make `TextEditingPrefab` public ([#2492])
+- Replace `clipboard` crate with `copypasta` (see #2438)
 
 ### Fixed
 


### PR DESCRIPTION
## Description

This updates the `xcb` dependency to `0.9.0`, allowing amethyst to build on docs.rs.

`copypasta` supports Wayland, but I'm not sure how to dynamically check whether it is being used at runtime, so for now it just uses the X11 clipboard.

## Additions

## Removals

## Modifications

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --workspace --features "empty"`
