### PR TITLE
Add html_root_url doc attribute

### DIFF
--- a/amethyst_animation/src/lib.rs
+++ b/amethyst_animation/src/lib.rs
@@ -45,6 +45,10 @@
 //! [ex_ani]: https://github.com/amethyst/amethyst/tree/master/examples/animation
 //! [ex_gltf]: https://github.com/amethyst/amethyst/tree/master/examples/gltf
 
+#![doc(
+    html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",
+    html_root_url = "https://docs.amethyst.rs/stable"
+)]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/amethyst_assets/src/lib.rs
+++ b/amethyst_assets/src/lib.rs
@@ -7,6 +7,10 @@
 //! * Asynchronous & Parallel using Rayon
 //! * Allow different sources
 
+#![doc(
+    html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",
+    html_root_url = "https://docs.amethyst.rs/stable"
+)]
 #![warn(missing_docs, rust_2018_idioms, rust_2018_compatibility)]
 
 #[cfg(feature = "json")]

--- a/amethyst_audio/src/lib.rs
+++ b/amethyst_audio/src/lib.rs
@@ -1,4 +1,9 @@
 //! Loading and playing of audio files.
+
+#![doc(
+    html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",
+    html_root_url = "https://docs.amethyst.rs/stable"
+)]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/amethyst_config/src/lib.rs
+++ b/amethyst_config/src/lib.rs
@@ -1,5 +1,9 @@
 //! Loads RON files into a structure for easy / statically typed usage.
 
+#![doc(
+    html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",
+    html_root_url = "https://docs.amethyst.rs/stable"
+)]
 #![crate_name = "amethyst_config"]
 #![warn(
     missing_debug_implementations,

--- a/amethyst_controls/src/lib.rs
+++ b/amethyst_controls/src/lib.rs
@@ -1,5 +1,9 @@
 //! Amethyst control crate.
 
+#![doc(
+    html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",
+    html_root_url = "https://docs.amethyst.rs/stable"
+)]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -1,4 +1,9 @@
 //! A collection of structures and functions useful across the entire amethyst project.
+
+#![doc(
+    html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",
+    html_root_url = "https://docs.amethyst.rs/stable"
+)]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/amethyst_derive/src/lib.rs
+++ b/amethyst_derive/src/lib.rs
@@ -1,6 +1,10 @@
 //! This crate implements various derive macros for easing the use of various amethyst features.
 //! At the moment, this consists of event readers, prefab and UI widget derives.
 
+#![doc(
+    html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",
+    html_root_url = "https://docs.amethyst.rs/stable"
+)]
 #![recursion_limit = "256"]
 #![warn(
     missing_debug_implementations,

--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -9,6 +9,10 @@
 // Parts copied from failure:
 // https://github.com/rust-lang-nursery/failure
 
+#![doc(
+    html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",
+    html_root_url = "https://docs.amethyst.rs/stable"
+)]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/amethyst_gltf/src/lib.rs
+++ b/amethyst_gltf/src/lib.rs
@@ -1,5 +1,9 @@
 //! A crate for loading GLTF format scenes into Amethyst
 
+#![doc(
+    html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",
+    html_root_url = "https://docs.amethyst.rs/stable"
+)]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/amethyst_input/src/lib.rs
+++ b/amethyst_input/src/lib.rs
@@ -1,5 +1,9 @@
 //! A collection of abstractions for various input devices to be used with Amethyst.
 
+#![doc(
+    html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",
+    html_root_url = "https://docs.amethyst.rs/stable"
+)]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/amethyst_locale/src/lib.rs
+++ b/amethyst_locale/src/lib.rs
@@ -2,6 +2,10 @@
 //!
 //! Localisation binding a `Fluent` file to an Asset<Locale> via the use of amethyst_assets.
 
+#![doc(
+    html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",
+    html_root_url = "https://docs.amethyst.rs/stable"
+)]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/amethyst_network/src/lib.rs
+++ b/amethyst_network/src/lib.rs
@@ -2,5 +2,10 @@
 //! The library is segmented into the simulation module and, eventually, various client library
 //! modules. Soon, we will also provide an HTTP client library.
 
+#![doc(
+    html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",
+    html_root_url = "https://docs.amethyst.rs/stable"
+)]
+
 pub mod simulation;
 pub use bytes::*;

--- a/amethyst_rendy/src/lib.rs
+++ b/amethyst_rendy/src/lib.rs
@@ -35,6 +35,10 @@
 //! * [`JointTransforms`](skinning::JointTransforms)
 //! * [`SpriteRender`](sprite::SpriteRender)
 
+#![doc(
+    html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",
+    html_root_url = "https://docs.amethyst.rs/stable"
+)]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/amethyst_test/src/lib.rs
+++ b/amethyst_test/src/lib.rs
@@ -1,3 +1,7 @@
+#![doc(
+    html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",
+    html_root_url = "https://docs.amethyst.rs/stable"
+)]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/amethyst_tiles/src/lib.rs
+++ b/amethyst_tiles/src/lib.rs
@@ -1,6 +1,10 @@
 //! 2D/3D Tile data structures and functionality.
 //!
 
+#![doc(
+    html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",
+    html_root_url = "https://docs.amethyst.rs/stable"
+)]
 #![deny(clippy::all, clippy::pedantic, missing_docs)]
 #![allow(dead_code, clippy::module_name_repetitions)]
 

--- a/amethyst_ui/src/lib.rs
+++ b/amethyst_ui/src/lib.rs
@@ -1,5 +1,9 @@
 //! Provides components and systems to create an in game user interface.
 
+#![doc(
+    html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",
+    html_root_url = "https://docs.amethyst.rs/stable"
+)]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/amethyst_utils/src/lib.rs
+++ b/amethyst_utils/src/lib.rs
@@ -1,5 +1,9 @@
 //! A collection of useful amethyst utilities, designed to make your game dev life easier.
 
+#![doc(
+    html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",
+    html_root_url = "https://docs.amethyst.rs/stable"
+)]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/amethyst_window/src/lib.rs
+++ b/amethyst_window/src/lib.rs
@@ -1,6 +1,10 @@
 //! Crate abstracting and seperating out the window and display handling within amethyst, and as such
 //! its usage of winit.
 
+#![doc(
+    html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",
+    html_root_url = "https://docs.amethyst.rs/stable"
+)]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,10 @@
 //!     Ok(())
 //! }
 //! ```
-
-#![doc(html_logo_url = "https://amethyst.rs/brand/logo-standard.svg")]
+#![doc(
+    html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",
+    html_root_url = "https://docs.amethyst.rs/stable"
+)]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
## Description
Added:
```
#![doc(
    html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",
    html_root_url = "https://docs.amethyst.rs/stable"
)]
```
in all amethyst crates so rust-analyzer.openDocs navigates to the right documentation url.

## PR Checklist

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
