### PR TITLE
Fix Clippy pedantic error 'option_if_let_else'

### DIFF
--- a/amethyst_tiles/src/map.rs
+++ b/amethyst_tiles/src/map.rs
@@ -293,14 +293,10 @@ fn to_world(
     map_transform: Option<&Transform>,
 ) -> Vector3<f32> {
     let coord_f = Point3::new(coord.x as f32, -1.0 * coord.y as f32, coord.z as f32);
-    if let Some(map_trans) = map_transform {
-        map_trans
-            .global_matrix()
-            .transform_point(&transform.transform_point(&coord_f))
-            .coords
-    } else {
-        transform.transform_point(&coord_f).coords
-    }
+    let point = transform.transform_point(&coord_f);
+    map_transform.map_or(point.coords, |map_trans| {
+        map_trans.global_matrix().transform_point(&point).coords
+    })
 }
 
 #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
@@ -310,13 +306,10 @@ fn to_tile(
     max_dimensions: &Vector3<u32>,
     map_transform: Option<&Transform>,
 ) -> Result<Point3<u32>, TileOutOfBoundsError> {
-    let point = if let Some(map_trans) = map_transform {
-        map_trans
-            .global_view_matrix()
-            .transform_point(&Point3::from(*coord))
-    } else {
-        Point3::from(*coord)
-    };
+    let point = Point3::from(*coord);
+    let point = map_transform.map_or(point, |map_trans| {
+        map_trans.global_view_matrix().transform_point(&point)
+    });
 
     let mut inverse = transform
         .try_inverse()

--- a/amethyst_tiles/src/pass.rs
+++ b/amethyst_tiles/src/pass.rs
@@ -227,11 +227,11 @@ impl<B: Backend, T: Tile, E: CoordinateEncoder, Z: DrawTiles2DBounds> RenderGrou
 
             let tilemap_args_index = tilemap_args.len();
             let map_coordinate_transform: [[f32; 4]; 4] = (*tile_map.transform()).into();
-            let map_transform: [[f32; 4]; 4] = if let Some(transform) = transform {
-                (*transform.global_matrix()).into()
-            } else {
-                Matrix4::identity().into()
-            };
+            let map_transform: [[f32; 4]; 4] = transform.map_or_else(
+                || Matrix4::identity().into(),
+                |transform| (*transform.global_matrix()).into(),
+            );
+
             tilemap_args.push(TileMapArgs {
                 proj: projview.proj,
                 view: projview.view,


### PR DESCRIPTION
## Description

The current build fails because of a pedantic Clippy error [option_if_let_else](https://rust-lang.github.io/rust-clippy/master/index.html#option_if_let_else). This change fixes that issue by replacing the 'if let else' construct into option.map_or()

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --workspace --features "empty"`
