### PR TITLE
Autoselect Graphics Backend for Rendy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,6 @@ travis-ci = { repository = "amethyst/amethyst", branch = "master" }
 # TODO: include animation, ui
 default = ["audio", "locale", "network", "parallel", "renderer"]
 
-vulkan = ["amethyst_rendy/vulkan", "amethyst_rendy/vulkan-x11"]
-metal = ["amethyst_rendy/metal"]
 empty = ["amethyst_rendy/empty"]
 
 ui = [
@@ -340,4 +338,4 @@ path = "examples/tiles/main.rs"
 required-features = [ "tiles" ]
 
 [package.metadata.docs.rs]
-features = ["animation", "audio", "gltf", "tiles", "json", "locale", "network", "sdl_controller", "vulkan"]
+features = ["animation", "audio", "gltf", "tiles", "json", "locale", "network", "sdl_controller"]

--- a/amethyst_animation/Cargo.toml
+++ b/amethyst_animation/Cargo.toml
@@ -35,8 +35,6 @@ thread_profiler = { version = "0.3", optional = true }
 [dev-dependencies]
 
 [features]
-vulkan = ["amethyst_rendy/vulkan", "amethyst_rendy/vulkan-x11"]
-metal = ["amethyst_rendy/metal"]
 empty = ["amethyst_rendy/empty"]
 
 profiler = [ "thread_profiler/thread_profiler" ]

--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -35,8 +35,6 @@ image = "0.22.2"
 derivative = "2.1.1"
 
 [features]
-vulkan = ["amethyst_rendy/vulkan", "amethyst_rendy/vulkan-x11"]
-metal = ["amethyst_rendy/metal"]
 empty = ["amethyst_rendy/empty"]
 
 profiler = [ "thread_profiler/thread_profiler" ]

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -40,11 +40,11 @@ approx = "0.3.2"
 [target.'cfg(target_os = "macos")'.dependencies]
 rendy = { version = "0.4.1", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1", "metal"] }
 
-# [target.'cfg(target_os = "windows")'.dependencies]
-# rendy = { version = "0.4.1", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1", "vulkan"] }
+[target.'cfg(target_os = "windows")'.dependencies]
+rendy = { version = "0.4.1", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1", "vulkan"] }
 
-# [target.'cfg(all(not(target_os = "windows"), not(target_os = "macos")))'.dependencies]
-# rendy = { version = "0.4.1", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1", "vulkan", "vulkan-x11"] }
+[target.'cfg(all(not(target_os = "windows"), not(target_os = "macos")))'.dependencies]
+rendy = { version = "0.4.1", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1", "vulkan", "vulkan-x11"] }
 
 [dev-dependencies]
 rayon = "1.4.0"

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["rendering", "rendering::engine"]
 license = "MIT/Apache-2.0"
 
 [package.metadata.docs.rs]
-features = ["shader-compiler", "test-support", "winit", "vulkan"]
+features = ["shader-compiler", "test-support", "winit"]
 
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.15.3" }
@@ -26,7 +26,6 @@ gltf = { version = "0.15", features = ["KHR_lights_punctual"] }
 lazy_static = "1.4"
 log = "0.4"
 palette = { version = "0.4", features = ["serde"] }
-rendy = { version = "0.4.1", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1"] }
 ron = "0.5"
 serde = { version = "1", features = ["serde_derive"] }
 fnv = "1"
@@ -38,6 +37,15 @@ indexmap = { version = "1.3", features = ["rayon"] }
 thread_profiler = { version = "0.3", optional = true }
 approx = "0.3.2"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+rendy = { version = "0.4.1", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1", "metal"] }
+
+# [target.'cfg(target_os = "windows")'.dependencies]
+# rendy = { version = "0.4.1", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1", "vulkan"] }
+
+# [target.'cfg(all(not(target_os = "windows"), not(target_os = "macos")))'.dependencies]
+# rendy = { version = "0.4.1", default-features = false, features = ["base", "mesh-obj", "texture-image", "texture-palette", "serde-1", "vulkan", "vulkan-x11"] }
+
 [dev-dependencies]
 rayon = "1.4.0"
 more-asserts = "0.2.1"
@@ -45,10 +53,9 @@ criterion = "0.3.0"
 winit = "0.19"
 approx = "0.3"
 
+
+
 [features]
-metal = ["rendy/metal"]
-vulkan = ["rendy/vulkan"]
-vulkan-x11 = ["rendy/vulkan-x11"]
 empty = ["rendy/empty"]
 profiler = [ "thread_profiler/thread_profiler", "rendy/profiler" ]
 no-slow-safety-checks = ["rendy/no-slow-safety-checks"]
@@ -56,6 +63,8 @@ shader-compiler =  ["rendy/shader-compiler"]
 test-support =  []
 experimental-spirv-reflection = ["rendy/spirv-reflection"]
 window = ["rendy/wsi-winit", "amethyst_window"]
+
+
 
 [[bench]]
 name = "camera"

--- a/amethyst_test/Cargo.toml
+++ b/amethyst_test/Cargo.toml
@@ -26,8 +26,6 @@ serde = "1.0"
 [features]
 default = ["animation", "audio", "locale", "network", "renderer"]
 
-vulkan = ["amethyst/vulkan"]
-metal = ["amethyst/metal"]
 empty = ["amethyst/empty"]
 tiles = ["amethyst/tiles"]
 animation = ["amethyst/animation"]

--- a/amethyst_tiles/Cargo.toml
+++ b/amethyst_tiles/Cargo.toml
@@ -41,8 +41,6 @@ more-asserts = "0.2"
 approx = "0.3"
 
 [features]
-vulkan = ["amethyst_rendy/vulkan", "amethyst_rendy/vulkan-x11"]
-metal = ["amethyst_rendy/metal"]
 empty = ["amethyst_rendy/empty"]
 
 profiler = [ "thread_profiler/thread_profiler" ]

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -42,8 +42,6 @@ glyph_brush = "0.6.0"
 thread_profiler = { version = "0.3", optional = true }
 
 [features]
-vulkan = ["amethyst_rendy/vulkan", "amethyst_rendy/vulkan-x11"]
-metal = ["amethyst_rendy/metal"]
 empty = ["amethyst_rendy/empty"]
 
 profiler = [ "thread_profiler/thread_profiler" ]

--- a/amethyst_utils/Cargo.toml
+++ b/amethyst_utils/Cargo.toml
@@ -32,8 +32,6 @@ dunce = "1"
 thread_profiler = { version = "0.3", optional = true }
 
 [features]
-#vulkan = ["amethyst_rendy/vulkan", "amethyst_rendy/vulkan-x11"]
-#metal = ["amethyst_rendy/metal"]
-#empty = ["amethyst_rendy/empty"]
+empty = ["amethyst_rendy/empty"]
 
 profiler = [ "thread_profiler/thread_profiler" ]

--- a/book/src/appendices/c_feature_gates.md
+++ b/book/src/appendices/c_feature_gates.md
@@ -31,12 +31,11 @@ The available features might change from time to time.
 
 ## Graphics features
 
-Whenever you run your game, you'll need to enable one graphics backend. The following features are
-available for the backend:
+By default the metal graphics backend will be used for macOS and iOS, and the vulkan backend will be
+used for all other platforms. If you wish to disable graphics for your game, you can use the
+following feature:
 
 * `empty`
-* `metal`
-* `vulkan`
 
 Rendy has multiple safety checks built-in to detect bugs in the data it gets submitted. However,
 those checks can become too costly for a smooth experience with larger games; you can disable

--- a/book/src/pong-tutorial.md
+++ b/book/src/pong-tutorial.md
@@ -15,13 +15,11 @@ starting with the tutorial / running the examples.
 If you've cloned the Amethyst repo, you can run any of the examples like so:
 
 ```norun
-cargo run --example pong_tutorial_01 --features "vulkan"
+cargo run --example pong_tutorial_01
 ```
 
 The example named `pong_tutorial_xy` contains the code which you should have
 after following all tutorials from 1 to xy.
-
-> **Note:** On macOS, you might want to use `"metal"` instead of `"vulkan"`.
 
 The main difference between real game code and the example code is where the 
 `config` and `assets` folders are located.

--- a/book/src/pong-tutorial/pong-tutorial-01.md
+++ b/book/src/pong-tutorial/pong-tutorial-01.md
@@ -20,15 +20,6 @@ edition = "2018"
 
 [dependencies.amethyst]
 version = "0.15"
-features = ["vulkan"]
-```
-
-Alternatively, if you are developing on macOS, you might want to use the `metal` rendering backend instead of `vulkan`. In this case, you should change the `features` entry in the `amethyst` dependency table.
-
-```toml
-[dependencies.amethyst]
-version = "0.15"
-features = ["metal"]
 ```
 
 We can start with editing the `main.rs` file inside `src` directory.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,9 +1,9 @@
 # Examples
 
-All examples can be run with the following command, where `{{name}}` is the name of the example, and `{{backend}}` is your graphics backend (usually `metal` on MacOS and `vulkan` on everything else.) Note that some examples require the additional `gltf` feature.
+All examples can be run with the following command, where `{{name}}` is the name of the example. Note that some examples require the additional `gltf` feature (add `--features "gltf"`).
 
 ```
-cargo run --example {{name}} --features "{{backend}}"
+cargo run --example {{name}}
 ```
 
 ---

--- a/script/publish-docs.sh
+++ b/script/publish-docs.sh
@@ -10,14 +10,6 @@ set -euxo pipefail
 CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 LATEST_RELEASE=$(git tag -l 'v*' | sort -V | tail -n 1)
 
-
-if [[ $(uname) == "Darwin" ]] ; then
-  BACKEND="metal"
-else
-  BACKEND="vulkan"
-fi
-
-
 # Cloudfront distribution ids
 if [[ -z "$AWS_DOCS_DISTRIBUTION_ID" ]]; then
   die "AWS_DOCS_DISTRIBUTION_ID must be set"
@@ -103,7 +95,7 @@ function build_docs_wasm {
   echo "Building wasm docs for $REF..."
 
   # TODO: build wasm branch here
-  # cargo doc --no-deps --workspace --features="animation gltf ${BACKEND}"
+  # cargo doc --no-deps --workspace --features="animation gltf"
 
   # taken from run.sh for future reference:
   # # (cd amethyst_animation && cargo doc --no-deps)
@@ -158,7 +150,7 @@ function build_docs {
   rm -rf "$DIR"
   mkdir -p "$DIR"
   echo "Building docs for $REF..."
-  cargo doc --no-deps --workspace --features="animation gltf ${BACKEND}"
+  cargo doc --no-deps --workspace --features="animation gltf"
   mv target/doc/* "$DIR"/
 
   # Write the newly built rev to the rev file

--- a/script/publish.sh
+++ b/script/publish.sh
@@ -1,12 +1,6 @@
 #! /bin/bash
 set -e
 
-BACKEND="vulkan"
-if [[ `uname` == "Darwin" ]] ; then
-  BACKEND="metal"
-fi
-
-# Wave one -- crates without `amethyst_rendy` dependency.
 # The order is important because of inter-dependencies (see docs/PUBLISHING.md)
 crates=(
   amethyst_config
@@ -20,22 +14,6 @@ crates=(
   amethyst_locale
   amethyst_input
   amethyst_controls
-)
-
-for crate in "${crates[@]}"
-do
-  echo "Publishing ${crate}"
-
-  (cd $crate && cargo publish)
-
-  # Rate limit ourselves as `crates.io` takes a while to update cache.
-  sleep 30
-done
-
-# Wave two -- crates with `amethyst_rendy` dependency.
-#
-# Must be built with a graphics backend to publish.
-crates=(
   amethyst_rendy
   amethyst_tiles
   amethyst_ui
@@ -52,11 +30,10 @@ do
 
   if test "${crate}" = "amethyst"
   then
-    cargo publish --features $BACKEND
+    cargo publish
   else
-    (cd $crate && cargo publish --features $BACKEND)
+    (cd $crate && cargo publish)
   fi
-
   # Rate limit ourselves as `crates.io` takes a while to update cache.
   sleep 30
 done


### PR DESCRIPTION
## Description

The mandatory requirement to specify `--features=metal` (or `vulkan` or `empty`) is a thorn in the side.  It is a constant obstacle for users, and it causes problems in development as well.

Here's my initial (so far unsuccessful) attempt at having the features auto-detected by platform at the amethyst level (complicated by the fact that it's features at rendy's level).

- I found a way to conditionally specify an entire dependency in Cargo.toml based on platform, _but_ you can't look at `features` in that logic, which means dealing with `empty` has to be done elsewhere.  I had more comprehensive patterns in an earlier (uncommitted) revision.  In this revision things like iOS aren't addressed.
- I tried to alter the macros to accept entire `cfg` patterns (so I could deal with `empty` at the macro level), but macros refuse to take a literal for a `cfg` pattern for whatever reason.  

At the time of writing this, this PR is in a broken state. I need some way to deal with both backend default auto-detection and the ability to override the auto-detection via a feature. Anyone got any ideas?

## Additions

N/A

## Removals

- Remove `metal` and `vulkan` features from everywhere.  Auto-detect them based on operating system.

## Modifications

- List changes to existing structures and functions here if any

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [ ] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [ ] Ran `cargo build --features "empty"`
- [ ] Ran `cargo test --workspace --features "empty"`
