### PR TITLE
remove defunct badges section from cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,6 @@ repository = "https://github.com/amethyst/amethyst"
 readme = "README.md"
 license = "MIT/Apache-2.0"
 
-[badges]
-travis-ci = { repository = "amethyst/amethyst", branch = "master" }
-
 [features]
 # TODO: include animation, ui
 default = ["audio", "locale", "network", "parallel", "renderer"]

--- a/amethyst_animation/Cargo.toml
+++ b/amethyst_animation/Cargo.toml
@@ -13,9 +13,6 @@ repository = "https://github.com/amethyst/amethyst"
 readme = "README.md"
 license = "MIT/Apache-2.0"
 
-[badges]
-travis-ci = { repository = "amethyst/amethyst" }
-
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.15.3" }
 amethyst_core = { path = "../amethyst_core", version = "0.15.3" }

--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -16,9 +16,6 @@ documentation = "https://docs.amethyst.rs/stable/amethyst_assets/"
 homepage = "https://amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 
-[badges]
-travis-ci = { repository = "amethyst/amethyst" }
-
 [dependencies]
 amethyst_core = { path = "../amethyst_core", version = "0.15.3" }
 amethyst_derive = { path = "../amethyst_derive", version = "0.15.3" }

--- a/amethyst_audio/Cargo.toml
+++ b/amethyst_audio/Cargo.toml
@@ -15,9 +15,6 @@ repository = "https://github.com/amethyst/amethyst"
 readme = "README.md"
 license = "MIT/Apache-2.0"
 
-[badges]
-travis-ci = { repository = "amethyst/amethyst" }
-
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.15.3" }
 amethyst_core = { path = "../amethyst_core", version = "0.15.3" }

--- a/amethyst_config/Cargo.toml
+++ b/amethyst_config/Cargo.toml
@@ -12,9 +12,6 @@ repository = "https://github.com/amethyst/amethyst"
 
 license = "MIT/Apache-2.0"
 
-[badges]
-travis-ci = { repository = "amethyst/amethyst" }
-
 [dependencies]
 ron = "0.5"
 serde = "1.0"

--- a/amethyst_controls/Cargo.toml
+++ b/amethyst_controls/Cargo.toml
@@ -11,9 +11,6 @@ repository = "https://github.com/amethyst/amethyst"
 
 license = "MIT/Apache-2.0"
 
-[badges]
-travis-ci = { repository = "amethyst/amethyst" }
-
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.15.3" }
 amethyst_core = { path = "../amethyst_core", version = "0.15.3" }

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -11,9 +11,6 @@ repository = "https://github.com/amethyst/amethyst"
 
 license = "MIT/Apache-2.0"
 
-[badges]
-travis-ci = { repository = "amethyst/amethyst" }
-
 [dependencies]
 amethyst_error = { path = "../amethyst_error", version = "0.15.3" }
 approx = "0.4"

--- a/amethyst_derive/Cargo.toml
+++ b/amethyst_derive/Cargo.toml
@@ -11,9 +11,6 @@ repository = "https://github.com/amethyst/amethyst"
 
 license = "MIT/Apache-2.0"
 
-[badges]
-travis-ci = { repository = "amethyst/amethyst" }
-
 [dependencies]
 heck = "0.3.1"
 syn = { version = "1.0", features = ["full", "visit"] }

--- a/amethyst_error/Cargo.toml
+++ b/amethyst_error/Cargo.toml
@@ -15,8 +15,5 @@ documentation = "https://docs.amethyst.rs/stable/amethyst_error/"
 homepage = "https://amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 
-[badges]
-travis-ci = { repository = "amethyst/amethyst" }
-
 [dependencies]
 backtrace = "0.3.44"

--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -11,9 +11,6 @@ repository = "https://github.com/amethyst/amethyst"
 
 license = "MIT/Apache-2.0"
 
-[badges]
-travis-ci = { repository = "amethyst/amethyst" }
-
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.15.3" }
 amethyst_animation = { path = "../amethyst_animation", version = "0.15.3" }

--- a/amethyst_input/Cargo.toml
+++ b/amethyst_input/Cargo.toml
@@ -11,9 +11,6 @@ repository = "https://github.com/amethyst/amethyst"
 
 license = "MIT/Apache-2.0"
 
-[badges]
-travis-ci = { repository = "amethyst/amethyst" }
-
 [dependencies]
 amethyst_core = { path = "../amethyst_core", version = "0.15.3" }
 amethyst_error = { path = "../amethyst_error", version = "0.15.3" }

--- a/amethyst_locale/Cargo.toml
+++ b/amethyst_locale/Cargo.toml
@@ -16,9 +16,6 @@ documentation = "https://docs.amethyst.rs/stable/amethyst_locale/"
 homepage = "https://amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 
-[badges]
-travis-ci = { repository = "amethyst/amethyst" }
-
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.15.3" }
 amethyst_core = { path = "../amethyst_core", version = "0.15.3" }

--- a/amethyst_utils/Cargo.toml
+++ b/amethyst_utils/Cargo.toml
@@ -11,9 +11,6 @@ repository = "https://github.com/amethyst/amethyst"
 
 license = "MIT/Apache-2.0"
 
-[badges]
-travis-ci = { repository = "amethyst/amethyst" }
-
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.15.3" }
 #amethyst_controls = { path = "../amethyst_controls", version = "0.15.3" }

--- a/amethyst_window/Cargo.toml
+++ b/amethyst_window/Cargo.toml
@@ -9,9 +9,6 @@ homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 license = "MIT/Apache-2.0"
 
-[badges]
-travis-ci = { repository = "amethyst/amethyst" }
-
 [dependencies]
 amethyst_core = { path = "../amethyst_core", version = "0.15.3" }
 amethyst_config = { path = "../amethyst_config", version = "0.15.3" }


### PR DESCRIPTION
Removes badges sections that are no longer rendered by crates.io and are defunct because we don't use travis any more.