### PR TITLE
[LEGION] Port sprites ordered example, Named and FrameLimiter docs

### DIFF
--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -18,7 +18,7 @@ derive-new = "0.5.8"
 getset = "0.1.1"
 legion = { version = "0.3.1", default-features = false, features = ["serialize", "crossbeam-events", "codegen"] }
 log = "0.4"
-nalgebra = { version = "0.23.0", features = ["serde-serialize"] }
+nalgebra = { version = "0.23.1", features = ["serde-serialize"] }
 num-traits = "0.2"
 rayon = "1.5"
 serde = { version = "1", features = ["derive"] }
@@ -29,7 +29,7 @@ smallvec = "1.4"
 thread_profiler = { version = "0.3", optional = true }
 
 [dev-dependencies]
-#amethyst = { path = "..", version = "0.15.3" }
+amethyst = { path = "..", version = "0.15.3" }
 ron = "0.5.1"
 
 [features]

--- a/amethyst_core/src/frame_limiter.rs
+++ b/amethyst_core/src/frame_limiter.rs
@@ -20,19 +20,16 @@
 //! ```
 //! use std::time::Duration;
 //!
-//! use amethyst::prelude::*;
-//! use amethyst::core::frame_limiter::FrameRateLimitStrategy;
+//! use amethyst::{core::frame_limiter::FrameRateLimitStrategy, prelude::*};
 //!
 //! # struct GameState;
 //! # impl SimpleState for GameState {}
 //! # fn main() -> amethyst::Result<()> {
 //! let assets_dir = "./";
+//! let mut builder = DispatcherBuilder::default();
 //! let mut game = Application::build(assets_dir, GameState)?
-//!     .with_frame_limit(
-//!         FrameRateLimitStrategy::SleepAndYield(Duration::from_millis(2)),
-//!         144,
-//!     )
-//!     .build(GameDataBuilder::new())?;
+//!     .with_frame_limit(FrameRateLimitStrategy::Sleep, 60)
+//!     .build(builder)?;
 //! # Ok(())
 //! # }
 //! ```
@@ -115,8 +112,7 @@ impl Default for FrameRateLimitStrategy {
 /// # Examples
 ///
 /// ```no_run
-/// use amethyst::prelude::*;
-/// use amethyst::core::frame_limiter::FrameRateLimitConfig;
+/// use amethyst::{core::frame_limiter::FrameRateLimitConfig, prelude::*};
 ///
 /// let config = FrameRateLimitConfig::load("./config/frame_limiter.ron");
 /// ```

--- a/amethyst_core/src/geometry.rs
+++ b/amethyst_core/src/geometry.rs
@@ -137,7 +137,7 @@ where
 
 #[cfg(test)]
 pub mod tests {
-    use approx::{assert_ulps_eq, relative_eq};
+    use approx::{assert_relative_eq, assert_ulps_eq};
 
     use super::*;
 
@@ -165,13 +165,13 @@ pub mod tests {
 
     #[test]
     fn at_distance() {
-        relative_eq!(
+        assert_relative_eq!(
             Ray {
-                origin: Point3::new(0.020_277_506, -0.033_236_53, 51.794),
-                direction: Vector3::new(0.179_559_51, -0.294_313_04, -0.938_689_65),
+                origin: Point3::new(0.0, 0.0, 50.0),
+                direction: Vector3::new(0.2, -0.3, -0.9),
             }
             .at_distance(5.0),
-            Point3::new(0.918_075_1, -1.504_801_8, 47.100_55)
-        );
+            Point3::new(-1., 1.5, 54.5)
+        )
     }
 }

--- a/amethyst_core/src/named.rs
+++ b/amethyst_core/src/named.rs
@@ -27,57 +27,40 @@ use shrinkwraprs::Shrinkwrap;
 /// Creating a name from string constant:
 ///
 /// ```
-/// use amethyst::core::{Named, WithNamed};
-/// use amethyst::ecs::prelude::*;
+/// use amethyst::{core::Named, ecs::*};
 ///
-/// let mut world = World::new();
-/// world.register::<Named>();
-///
-/// world
-///     .create_entity()
-///     .named("Super Cool Entity")
-///     .build();
+/// let mut world = World::default();
+/// let entity: Entity = world.push((Named {
+///     name: "Reginald".into(),
+/// },));
 /// ```
 ///
 /// Creating a name from a dynamically generated string:
 ///
 /// ```
-/// use amethyst::core::{Named, WithNamed};
-/// use amethyst::ecs::prelude::*;
+/// use amethyst::{core::Named, ecs::*};
 ///
-/// let mut world = World::new();
-/// world.register::<Named>();
-///
+/// let mut world = World::default();
+
 /// for entity_num in 0..10 {
-///     world
-///         .create_entity()
-///         .named(format!("Entity Number {}", entity_num))
-///         .build();
+///     world.push((Named { name: format!("Entity Number {}", entity_num).into() },));
 /// }
 /// ```
-///
+/// 
 /// Accessing a named entity in a system:
-///
 /// ```
 /// use amethyst::core::Named;
-/// use amethyst::ecs::prelude::*;
+/// use amethyst::ecs::*;
 ///
-/// pub struct NameSystem;
-///
-/// impl<'s> System<'s> for NameSystem {
-///     type SystemData = (
-///         Entities<'s>,
-///         ReadStorage<'s, Named>,
-///     );
-///
-///     fn run(&mut self, (entities, names): Self::SystemData) {
-///         for (entity, name) in (&*entities, &names).join() {
+/// SystemBuilder::new("NamedSystem")
+///   .with_query(<(Entity, Read<Named>)>::query())
+///   .build(move |_commands, world, _resource, query| {
+///         for (entity, name) in query.iter(world) {
 ///             println!("Entity {:?} is named {}", entity, name.name);
 ///         }
-///     }
-/// }
+/// });
 /// ```
-#[derive(Shrinkwrap, Debug, Clone, Serialize, Deserialize)]
+#[derive(Shrinkwrap, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[shrinkwrap(mutable)]
 pub struct Named {
     /// The name of the entity this component is attached to.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,3 +2,4 @@ unstable_features = true
 reorder_imports = true
 merge_imports = true
 group_imports = "StdExternalCrate"
+format_code_in_doc_comments = true


### PR DESCRIPTION
## Description

Fixes broken code in Named and FrameLimiter docs
Ports sprites_ordered example to legion (WORKING!)
Adds rustfmt rule to fmt code in docs comments
fix broken geometry test

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment
- [x] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --workspace --features "empty"`
