### PR TITLE
[LEGION] fix: Add a component-conditional clause on the parent/children transform system

### DIFF
--- a/amethyst_core/src/transform/transform_system.rs
+++ b/amethyst_core/src/transform/transform_system.rs
@@ -38,19 +38,27 @@ pub fn build() -> impl Runnable {
                 // Update parent transforms for entities in the hierarchy
                 let (left, mut right) = world.split_for_query(query_parent);
                 for (entity, parent) in query_parent.iter(&left) {
-                    let parent_matrix = right
-                        .entry_ref(**parent)
+                    let parent_has_transform = right
+                        .entry_ref(parent.0)
                         .unwrap()
                         .into_component::<Transform>()
-                        .unwrap()
-                        .global_matrix;
+                        .is_ok();
 
-                    if let Some(transform) = right
-                        .entry_mut(*entity)
-                        .ok()
-                        .and_then(|entry| entry.into_component_mut::<Transform>().ok())
-                    {
-                        transform.parent_matrix = parent_matrix;
+                    if parent_has_transform {
+                        let parent_matrix = right
+                            .entry_ref(**parent)
+                            .unwrap()
+                            .into_component::<Transform>()
+                            .unwrap()
+                            .global_matrix;
+
+                        if let Some(transform) = right
+                            .entry_mut(*entity)
+                            .ok()
+                            .and_then(|entry| entry.into_component_mut::<Transform>().ok())
+                        {
+                            transform.parent_matrix = parent_matrix;
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Description

The transform system was wrongly thinking that a Parent always have a Transform component by unwraping it without any check.
That's a wrong statement as the Parent/Children Hierarchy can be used without Transform or with a UiTransform component.

There may be a better way to do that check but we need that global_matrix value so ..

## Additions

- Condition

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [ ] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [ ] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [ ] Ran `cargo build --features "empty"`
- [ ] Ran `cargo test --workspace --features "empty"`
