### PR TITLE
feat: Add a track of Modifiers into the Input Handler

### DIFF
--- a/amethyst_input/src/input_handler.rs
+++ b/amethyst_input/src/input_handler.rs
@@ -17,6 +17,37 @@ use super::{
     *,
 };
 
+/// This structs holds state information about keyboard modifiers
+#[derive(Debug, Default)]
+pub struct KeyboardModifiersState {
+    shift: bool,
+    ctrl: bool,
+    logo: bool,
+    alt: bool,
+}
+
+impl KeyboardModifiersState {
+    /// Return the current state of the shift modifier (either left or right)
+    pub fn shift(&self) -> bool {
+        self.shift
+    }
+
+    /// Return the current state of the ctrl modifier (either left or right)
+    pub fn ctrl(&self) -> bool {
+        self.ctrl
+    }
+
+    /// Return the current state of the logo modifier (either left or right)
+    pub fn logo(&self) -> bool {
+        self.logo
+    }
+
+    /// Return the current state of the alt modifier (either left or right, no difference made for GR)
+    pub fn alt(&self) -> bool {
+        self.alt
+    }
+}
+
 /// This struct holds state information about input devices.
 ///
 /// For example, if a key is pressed on the keyboard, this struct will record
@@ -25,6 +56,8 @@ use super::{
 pub struct InputHandler {
     /// Maps inputs to actions and axes.
     pub bindings: Bindings,
+    /// Keeps the current state of keyboard modifiers
+    modifiers: KeyboardModifiersState,
     /// Encodes the VirtualKeyCode and corresponding scancode.
     pressed_keys: SmallVec<[(VirtualKeyCode, u32); 12]>,
     pressed_mouse_buttons: SmallVec<[MouseButton; 12]>,
@@ -58,6 +91,12 @@ impl InputHandler {
     ) {
         match *event {
             Event::WindowEvent { ref event, .. } => match *event {
+                WindowEvent::ModifiersChanged(modifier) => {
+                    self.modifiers.logo = modifier.logo();
+                    self.modifiers.ctrl = modifier.ctrl();
+                    self.modifiers.alt = modifier.alt();
+                    self.modifiers.shift = modifier.shift();
+                }
                 WindowEvent::ReceivedCharacter(c) => {
                     event_handler.single_write(KeyTyped(c));
                 }

--- a/amethyst_input/src/lib.rs
+++ b/amethyst_input/src/lib.rs
@@ -26,7 +26,7 @@ pub use self::{
     button::Button,
     controller::{ControllerAxis, ControllerButton, ControllerEvent},
     event::InputEvent,
-    input_handler::InputHandler,
+    input_handler::{InputHandler, KeyboardModifiersState},
     mouse::MouseAxis,
     scroll_direction::ScrollDirection,
     system::InputSystem,


### PR DESCRIPTION
## Description

Following the recent winit upgrade that introduce the new 'ModifiersChanged' event, I needed it in different places for UI. 
I think it will be useful to keep a track of the current modifiers state. Moreover, it will help to detect key combination with these modifiers easily (without the need to do 'shift left is down OR shift right is down AND my other key is down) 

## Additions

- KeyboarModifiersState
- modifiers on InputHandler

## PR Checklist

By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [ ] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --workspace --features "empty"`
