### PR TITLE
Fix/fix UI deprecated

### DIFF
--- a/amethyst_ui/src/bundle.rs
+++ b/amethyst_ui/src/bundle.rs
@@ -49,6 +49,7 @@ where
         builder: &mut DispatcherBuilder,
     ) -> Result<(), Error> {
         resources.insert(EventChannel::<UiButtonAction>::new());
+        resources.insert(EventChannel::<UiEvent>::new());
         resources.insert(Widgets::<UiLabel, W>::new());
         resources.insert(CachedSelectionOrderResource::default());
 


### PR DESCRIPTION
## Description

Fixed a deprecated usage in text-editing and a missing resource


By placing an x in the boxes I certify that I have:

- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --workspace --features "empty"`
