### PR TITLE
Fix bug with frustum culling when using user-defined BoundingSpheres

### DIFF
--- a/amethyst_rendy/src/visibility.rs
+++ b/amethyst_rendy/src/visibility.rs
@@ -151,11 +151,12 @@ impl<'a> System<'a> for VisibilitySortingSystem {
             )
                 .join()
                 .map(|(entity, transform, sphere, _, _)| {
-                    let pos = sphere.map_or(&origin, |s| &s.center);
                     let matrix = transform.global_matrix();
+                    let pos = sphere.map_or(matrix.transform_point(&origin), |s| s.center);
+
                     (
                         entity,
-                        matrix.transform_point(&pos),
+                        pos,
                         sphere.map_or(1.0, |s| s.radius)
                             * matrix[(0, 0)].max(matrix[(1, 1)]).max(matrix[(2, 2)]),
                     )

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,9 +18,11 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - Make `TextEditingPrefab` public ([#2492])
 - Replace `clipboard` crate with `copypasta` (see #2438)
 - Make ui a default but optional feature ([#2490])
+- Fixed frustum culling when using user-defined BoundingSpheres ([#2565])
 
 ### Fixed
 
+[#2565]: https://github.com/amethyst/amethyst/pull/2565
 [#2489]: https://github.com/amethyst/amethyst/pull/2489
 [#2492]: https://github.com/amethyst/amethyst/pull/2492
 


### PR DESCRIPTION
## Description

There was an issue with frustum culling where the camera transform was transforming the
points of the center of bounding spheres that should have remained stationary.

This addresses that by only transforming the default point, which uses the origin.

## Additions

- No additions

## Removals

- No removals

## Modifications

- Modifies the frustum culling in `amethyst_rendy::visibility::VisibilitySortingSystem`

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --workspace --features "empty"`
