### PR TITLE
Fix frustum culling for user defined BoundingSpheres

### DIFF
--- a/amethyst_rendy/src/visibility.rs
+++ b/amethyst_rendy/src/visibility.rs
@@ -137,12 +137,14 @@ impl System<'static> for VisibilitySortingSystem {
                             entity_query
                                 .iter(world)
                                 .map(|(entity, transform, transparent, sphere)| {
-                                    let pos = sphere.clone().map_or(origin, |s| s.center);
                                     let matrix = transform.global_matrix();
+                                    let pos = sphere
+                                        .clone()
+                                        .map_or(matrix.transform_point(&origin), |s| s.center);
                                     (
                                         *entity,
                                         transparent.is_some(),
-                                        matrix.transform_point(&pos),
+                                        pos,
                                         sphere.map_or(1.0, |s| s.radius)
                                             * matrix[(0, 0)]
                                                 .max(matrix[(1, 1)])

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,12 +22,14 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - Make `TextEditingPrefab` public ([#2492])
 - Replace `clipboard` crate with `copypasta` (see #2438)
 - Make ui a default but optional feature ([#2490])
+- Fixed frustum culling when using user-defined BoundingSpheres ([#2565])
 
 ### Fixed
 
 [#2489]: https://github.com/amethyst/amethyst/pull/2489
 [#2492]: https://github.com/amethyst/amethyst/pull/2492
 [#2521]: https://github.com/amethyst/amethyst/pull/2521
+[#2565]: https://github.com/amethyst/amethyst/pull/2565
 
 ## [0.15.3] - 2020-08-22
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,14 +22,14 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - Make `TextEditingPrefab` public ([#2492])
 - Replace `clipboard` crate with `copypasta` (see #2438)
 - Make ui a default but optional feature ([#2490])
-- Fixed frustum culling when using user-defined BoundingSpheres ([#2565])
+- Fixed frustum culling when using user-defined BoundingSpheres ([#2568])
 
 ### Fixed
 
 [#2489]: https://github.com/amethyst/amethyst/pull/2489
 [#2492]: https://github.com/amethyst/amethyst/pull/2492
 [#2521]: https://github.com/amethyst/amethyst/pull/2521
-[#2565]: https://github.com/amethyst/amethyst/pull/2565
+[#2568]: https://github.com/amethyst/amethyst/pull/2568
 
 ## [0.15.3] - 2020-08-22
 


### PR DESCRIPTION
## Description

There was an issue with frustum culling where the camera transform was transforming the
points of the center of bounding spheres that should have remained stationary.

This addresses that by only transforming the default point, which uses the origin.

Supersedes: #2565 

## Additions

- No additions

## Removals

- No removals

## Modifications

- Modifies the frustum culling in `amethyst_rendy::visibility::VisibilitySortingSystem`

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [x] Updated the content of the book if this PR would make the book outdated.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --workspace --features "empty"` (may require `cargo clean` before)
- [x] Ran `cargo build --features "empty"`
- [x] Ran `cargo test --workspace --features "empty"`
