### PR TITLE
Add release-drafter action to CI

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,31 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+template: |
+  # What's Changed
+
+  $CHANGES
+categories:
+  - title: '🚀 Features and Improvements'
+    labels: 'type: feature'
+    labels: 'type: improvement'
+  - title: '🐛 Bug Fixes'
+    labels: 'type: bug'
+  - title: '🧰 Maintenance'
+    label: 'type: maintenance'
+
+version-resolver:
+  major:
+    labels:
+      - 'type: breaking'
+  minor:
+    labels:
+      - 'type: feature'
+      - 'type: improvement'
+  patch:
+    labels:
+      - 'type: bug'
+      - 'type: maintenance'
+      - 'team: documentation'
+
+exclude-labels:
+  - 'skip-changelog'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,14 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Separate Additions, Removals and Modifications -->
this will add [Release Drafter](https://github.com/marketplace/actions/release-drafter) to the repository, keeping our release changelog up to date.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
it is extra work that can be avoided and will allow us to release new versions more easily and with comprehensive changelogs

eventually we can use auto labeling based on crate to separate changes for different components

our manual changelog in docs/CHANGELOG.md is manually kept up to date which delays pull requests when we ask for changes and is missing contributor names.  it also has broken links and the text is a rephrasing of the PR names.  we should just enforce better PR naming.