### PR TITLE
give examples their own cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,12 +134,6 @@ legion = { version = "0.3", default-features = false, features = [
 
 [dev-dependencies]
 rusty-hook = { git = "https://git@github.com/swellaby/rusty-hook", branch = "master" }
-derive-new = "0.5.8"
-ron = "0.6.4"
-type-uuid = "0.1"
-serde-diff = "0.4"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
 
 [build-dependencies]
 dirs = "2.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ repository = "https://github.com/amethyst/amethyst"
 readme = "README.md"
 license = "MIT/Apache-2.0"
 
-# FIXME: remove after all existing examples working
-autoexamples = false
+autoexamples = false # Our examples come with their own Cargo.toml and are in the [workspace] section
 
 [features]
 default = ["parallel", "renderer", "utils", "no-slow-safety-checks"]
@@ -36,9 +35,7 @@ audio = ["amethyst_audio"]
 locale = ["amethyst_locale"]
 network = ["amethyst_network"]
 utils = ["amethyst_utils"]
-
 renderer = ["amethyst_rendy"]
-
 ui = ["amethyst_ui"] #, "amethyst_animation/ui"]
 
 profiler = [
@@ -67,8 +64,35 @@ experimental-spirv-reflection = ["amethyst_rendy/experimental-spirv-reflection"]
 parallel = ["amethyst_core/parallel"]
 
 [workspace]
-members = ["amethyst_*"]
-exclude = ["amethyst_gltf", "amethyst_animation", "amethyst_test"]
+members = ["examples/*", "amethyst_*"]
+exclude = [
+    "amethyst_gltf",
+    "amethyst_animation",
+    "amethyst_test",
+    "examples/Cargo.toml",
+    "examples/_unused_assets",
+    "examples/animation",
+    "examples/spotlights",
+    "examples/renderable",
+    "examples/renderable_custom",
+    "examples/rendy",
+    "examples/states_ui",
+    "examples/state_dispatcher",
+    "examples/pong_tutorial_06",
+    "examples/sprite_animation",
+    "examples/prefab_basic",
+    "examples/prefab_multi",
+    "examples/prefab_custom",
+    "examples/prefab_adapter",
+    "examples/mouse_raycast",
+    "examples/ui",
+    "examples/custom_ui",
+    "examples/debug_lines",
+    "examples/debug_lines_ortho",
+    "examples/auto_fov",
+    "examples/custom_game_data",
+    "examples/gltf",
+]
 
 [dependencies]
 #amethyst_animation = { path = "amethyst_animation", version = "0.15.3", optional = true }
@@ -120,164 +144,6 @@ prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106
 [build-dependencies]
 dirs = "2.0.2"
 vergen = "3.1.0"
-
-[[example]]
-name = "hello_world"
-
-[[example]]
-name = "window"
-
-[[example]]
-name = "sphere"
-
-# [[example]]
-# name = "renderable"
-
-# [[example]]
-# name = "renderable_custom"
-
-[[example]]
-name = "optional_graphics"
-
-[[example]]
-name = "asset_custom"
-
-[[example]]
-name = "asset_loading"
-
-[[example]]
-name = "material"
-
-# [[example]]
-# name = "gltf"
-# required-features = ["animation", "gltf"]
-
-# [[example]]
-# name = "ui"
-# required-features = ["audio"]
-
-[[example]]
-name = "ui_from_code"
-required-features = ["ui", "audio"]
-
-# [[example]]
-# name = "states_ui"
-# required-features = ["audio"]
-
-[[example]]
-name = "custom_render_pass"
-
-# [[example]]
-# name = "custom_ui"
-# required-features = ["audio"]
-
-# [[example]]
-# name = "animation"
-# required-features = ["animation"]
-
-[[example]]
-name = "fly_camera"
-
-# [[example]]
-# name = "sprite_animation"
-# required-features = ["animation"]
-
-[[example]]
-name = "sprites_ordered"
-
-[[example]]
-name = "pong_tutorial_01"
-
-[[example]]
-name = "pong_tutorial_02"
-
-[[example]]
-name = "pong_tutorial_03"
-
-[[example]]
-name = "pong_tutorial_04"
-
-[[example]]
-name = "pong_tutorial_05"
-required-features = ["ui"]
-
-# [[example]]
-# name = "pong_tutorial_06"
-# required-features = ["audio"]
-
-[[example]]
-name = "net_client"
-required-features = ["network"]
-
-[[example]]
-name = "net_server"
-required-features = ["network"]
-
-[[example]]
-name = "locale"
-required-features = ["locale"]
-
-# [[example]]
-# name = "custom_game_data"
-
-[[example]]
-name = "arc_ball_camera"
-
-[[example]]
-name = "prefab_atelier"
-
-[[example]]
-name = "prefab"
-
-# [[example]]
-# name = "prefab_adapter"
-
-# [[example]]
-# name = "prefab_basic"
-
-# [[example]]
-# name = "prefab_multi"
-
-# [[example]]
-# name = "prefab_custom"
-
-# [[example]]
-# name = "debug_lines"
-
-# [[example]]
-# name = "debug_lines_ortho"
-
-# [[example]]
-# name = "state_dispatcher"
-
-# [[example]]
-# name = "spotlights"
-
-[[example]]
-name = "sprite_camera_follow"
-
-# [[example]]
-# name = "auto_fov"
-
-[[example]]
-name = "events"
-
-[[example]]
-name = "events_custom_state_event"
-
-# [[example]]
-# name = "state_dispatcher"
-
-# [[example]]
-# name = "mouse_raycast"
-
-# [[example]]
-# name = "rendy"
-# required-features = ["animation", "gltf"]
-
-[[example]]
-name = "tiles"
-required-features = ["tiles"]
 
 [package.metadata.docs.rs]
 features = [

--- a/book/src/pong-tutorial.md
+++ b/book/src/pong-tutorial.md
@@ -23,26 +23,6 @@ after following all tutorials from 1 to xy.
 
 > **Note:** On macOS, you might want to use `"metal"` instead of `"vulkan"`.
 
-The main difference between real game code and the example code is where the 
-`config` and `assets` folders are located.
-
-For instance, in the pong_tutorial_01 example we have:
-
-```rust,ignore
-let display_config_path =
-    app_root.join("examples/pong_tutorial_01/config/display.ron");
-
-let assets_dir = app_root.join("examples/assets/");
-```
-
-But for your own project you'll probably want something like this:
-
-```rust,ignore
-let display_config_path = app_root.join("config/display.ron");
-
-let assets_dir = app_root.join("assets/");
-```
-
 [pong]: https://github.com/amethyst/amethyst/tree/master/examples/pong_tutorial_06
 [examples]: https://github.com/amethyst/amethyst/tree/master/examples
 

--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -387,7 +387,7 @@ fn main() -> amethyst::Result<()> {
 #
 #   let app_root = application_root_dir()?;
 #   let display_config_path =
-#       app_root.join("examples/pong_tutorial_02/config/display.ron");
+#       app_root.join("config/display.ron");
 #
     // ...
     let game_data = GameDataBuilder::default()

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,9 +1,9 @@
 # Examples
 
-All examples can be run with the following command, where `{{name}}` is the name of the example, and `{{backend}}` is your graphics backend (usually `metal` on MacOS and `vulkan` on everything else.) Note that some examples require the additional `gltf` feature.
+All examples can be run with the following command, where `$NAME` is the name of the example, and `$BACKEND` is your graphics backend (usually `metal` on MacOS and `vulkan` on everything else.) Note that some examples require the additional `gltf` feature.
 
 ```
-cargo run --example {{name}} --features "{{backend}}"
+cargo run -p $NAME --features $BACKEND
 ```
 
 ---

--- a/examples/_unused_assets/Cargo.toml
+++ b/examples/_unused_assets/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "_unused_assets"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "_unused_assets"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/animation/Cargo.toml
+++ b/examples/animation/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "animation"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "animation"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/animation/main.rs
+++ b/examples/animation/main.rs
@@ -221,8 +221,8 @@ fn main() -> amethyst::Result<()> {
     .start();
 
     let app_root = application_root_dir()?;
-    let display_config_path = app_root.join("examples/animation/config/display.ron");
-    let assets_dir = app_root.join("examples/animation/assets/");
+    let display_config_path = app_root.join("config/display.ron");
+    let assets_dir = app_root.join("assets/");
 
     let mut game_data = DispatcherBuilder::default()
         //.with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])

--- a/examples/arc_ball_camera/Cargo.toml
+++ b/examples/arc_ball_camera/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "arc_ball_camera"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "arc_ball_camera"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/arc_ball_camera/main.rs
+++ b/examples/arc_ball_camera/main.rs
@@ -158,9 +158,9 @@ fn main() -> Result<(), Error> {
 
     let app_root = application_root_dir()?;
 
-    let assets_dir = app_root.join("examples/arc_ball_camera/assets");
-    let display_config_path = app_root.join("examples/arc_ball_camera/config/display.ron");
-    let key_bindings_path = app_root.join("examples/arc_ball_camera/config/input.ron");
+    let assets_dir = app_root.join("assets");
+    let display_config_path = app_root.join("config/display.ron");
+    let key_bindings_path = app_root.join("config/input.ron");
 
     let mut builder = DispatcherBuilder::default();
     builder

--- a/examples/asset_custom/Cargo.toml
+++ b/examples/asset_custom/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "asset_custom"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "asset_custom"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/asset_custom/main.rs
+++ b/examples/asset_custom/main.rs
@@ -51,6 +51,7 @@ impl Format<EnergyBlast> for MyLangFormat {
     }
 }
 
+use amethyst::assets as amethyst_assets;
 register_asset_type!(EnergyBlast => EnergyBlast; AssetProcessorSystem<EnergyBlast>);
 
 impl SimpleState for LoadingState {
@@ -95,7 +96,7 @@ fn main() -> amethyst::Result<()> {
     amethyst::start_logger(config);
 
     let app_root = application_root_dir()?;
-    let assets_dir = app_root.join("examples/asset_custom/assets/");
+    let assets_dir = app_root.join("assets/");
 
     let mut builder = DispatcherBuilder::default();
 

--- a/examples/asset_loading/Cargo.toml
+++ b/examples/asset_loading/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "asset_loading"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "asset_loading"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/asset_loading/main.rs
+++ b/examples/asset_loading/main.rs
@@ -34,6 +34,7 @@ use type_uuid::TypeUuid;
 #[uuid = "f245dc2b-88a9-413e-bd51-f6c341c32017"]
 struct Custom;
 
+use amethyst::assets as amethyst_assets;
 amethyst::assets::register_importer!(".custom", Custom);
 impl Format<MeshData> for Custom {
     fn name(&self) -> &'static str {
@@ -145,9 +146,9 @@ fn main() -> Result<(), Error> {
 
     let app_root = application_root_dir()?;
     // Add our meshes directory to the asset loader.
-    let assets_dir = app_root.join("examples/asset_loading/assets/");
+    let assets_dir = app_root.join("assets/");
 
-    let display_config_path = app_root.join("examples/asset_loading/config/display.ron");
+    let display_config_path = app_root.join("config/display.ron");
 
     let mut dispatcher_builder = DispatcherBuilder::default();
     dispatcher_builder

--- a/examples/auto_fov/Cargo.toml
+++ b/examples/auto_fov/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "auto_fov"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "auto_fov"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/custom_game_data/Cargo.toml
+++ b/examples/custom_game_data/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "custom_game_data"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "custom_game_data"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/custom_game_data/main.rs
+++ b/examples/custom_game_data/main.rs
@@ -203,9 +203,9 @@ fn main() -> Result<(), Error> {
     let app_root = application_root_dir()?;
 
     // Add our meshes directory to the asset loader.
-    let assets_dir = app_root.join("examples/custom_game_data/assets");
+    let assets_dir = app_root.join("assets");
 
-    let display_config_path = app_root.join("examples/custom_game_data/config/display.ron");
+    let display_config_path = app_root.join("config/display.ron");
 
     let mut game_data = CustomDispatcherBuilder::default()
         .with_base(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])

--- a/examples/custom_render_pass/Cargo.toml
+++ b/examples/custom_render_pass/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "custom_render_pass"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "custom_render_pass"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/custom_render_pass/main.rs
+++ b/examples/custom_render_pass/main.rs
@@ -76,8 +76,8 @@ fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
 
     let app_root = application_root_dir()?;
-    let display_config_path = app_root.join("examples/custom_render_pass/config/display.ron");
-    let assets_dir = app_root.join("examples/custom_render_pass/assets/");
+    let display_config_path = app_root.join("config/display.ron");
+    let assets_dir = app_root.join("assets/");
 
     let mut game_data = DispatcherBuilder::default();
     game_data

--- a/examples/custom_ui/Cargo.toml
+++ b/examples/custom_ui/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "custom_ui"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "custom_ui"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/custom_ui/main.rs
+++ b/examples/custom_ui/main.rs
@@ -96,8 +96,8 @@ fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
 
     let app_root = application_root_dir()?;
-    let display_config_path = app_root.join("examples/custom_ui/config/display.ron");
-    let assets_dir = app_root.join("examples/custom_ui/assets");
+    let display_config_path = app_root.join("config/display.ron");
+    let assets_dir = app_root.join("assets");
 
     let mut game_data = DispatcherBuilder::default()
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])

--- a/examples/debug_lines/Cargo.toml
+++ b/examples/debug_lines/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "debug_lines"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "debug_lines"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/debug_lines/main.rs
+++ b/examples/debug_lines/main.rs
@@ -176,9 +176,9 @@ fn main() -> amethyst::Result<()> {
 
     let app_root = application_root_dir()?;
 
-    let display_config_path = app_root.join("examples/debug_lines/config/display.ron");
-    let key_bindings_path = app_root.join("examples/debug_lines/config/input.ron");
-    let assets_dir = app_root.join("examples/debug_lines/assets/");
+    let display_config_path = app_root.join("config/display.ron");
+    let key_bindings_path = app_root.join("config/input.ron");
+    let assets_dir = app_root.join("assets/");
 
     let fly_control_bundle = FlyControlBundle::<StringBindings>::new(
         Some(String::from("move_x")),

--- a/examples/debug_lines_ortho/Cargo.toml
+++ b/examples/debug_lines_ortho/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "debug_lines_ortho"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "debug_lines_ortho"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/debug_lines_ortho/main.rs
+++ b/examples/debug_lines_ortho/main.rs
@@ -112,8 +112,8 @@ fn main() -> amethyst::Result<()> {
 
     let app_root = application_root_dir()?;
 
-    let display_config_path = app_root.join("examples/debug_lines_ortho/config/display.ron");
-    let assets_dir = app_root.join("examples/debug_lines_ortho/assets/");
+    let display_config_path = app_root.join("config/display.ron");
+    let assets_dir = app_root.join("assets/");
 
     let mut game_data = DispatcherBuilder::default()
         .with(ExampleLinesSystem::new(), "example_lines_system", &[])

--- a/examples/events/Cargo.toml
+++ b/examples/events/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "events"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "events"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/events/main.rs
+++ b/examples/events/main.rs
@@ -90,7 +90,7 @@ impl SimpleState for GameplayState {}
 fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
 
-    let assets_dir = application_root_dir()?.join("examples/events/assets");
+    let assets_dir = application_root_dir()?.join("assets");
 
     let mut game_data = DispatcherBuilder::default();
     game_data.add_bundle(MyBundle);

--- a/examples/events_custom_state_event/Cargo.toml
+++ b/examples/events_custom_state_event/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "events_custom_state_event"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "events_custom_state_event"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/events_custom_state_event/event.rs
+++ b/examples/events_custom_state_event/event.rs
@@ -6,6 +6,7 @@ use amethyst::{
     derive::EventReader,
     ecs::Resources,
     input::InputEvent,
+    winit::event::Event,
 };
 
 /// Here's a copy of the original StateEvent with our own type added
@@ -13,7 +14,7 @@ use amethyst::{
 #[reader(MyExtendedStateEventReader)]
 pub enum MyExtendedStateEvent {
     /// Events sent by the winit window.
-    Window(winit::event::Event<'static, ()>),
+    Window(Event<'static, ()>),
     /// Events sent by the input system.
     Input(InputEvent),
     /// Our own events for our own game logic

--- a/examples/events_custom_state_event/main.rs
+++ b/examples/events_custom_state_event/main.rs
@@ -16,7 +16,7 @@ mod system;
 fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
 
-    let assets_dir = application_root_dir()?.join("examples/events_custom_state_event/assets");
+    let assets_dir = application_root_dir()?.join("assets");
 
     let mut game_data = DispatcherBuilder::default();
     game_data.add_bundle(system::MyBundle);

--- a/examples/examples.sh
+++ b/examples/examples.sh
@@ -1,0 +1,26 @@
+for folder in */; do
+cat >$folder/Cargo.toml <<EOF
+[package]
+name = "$(basename $folder)"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "$(basename $folder)"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+EOF
+done

--- a/examples/fly_camera/Cargo.toml
+++ b/examples/fly_camera/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "fly_camera"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "fly_camera"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/fly_camera/main.rs
+++ b/examples/fly_camera/main.rs
@@ -160,9 +160,9 @@ fn main() -> Result<(), Error> {
 
     let app_root = application_root_dir()?;
 
-    let assets_dir = app_root.join("examples/fly_camera/assets");
-    let display_config_path = app_root.join("examples/fly_camera/config/display.ron");
-    let key_bindings_path = app_root.join("examples/fly_camera/config/input.ron");
+    let assets_dir = app_root.join("assets");
+    let display_config_path = app_root.join("config/display.ron");
+    let key_bindings_path = app_root.join("config/input.ron");
 
     let mut builder = DispatcherBuilder::default();
     builder

--- a/examples/gltf/Cargo.toml
+++ b/examples/gltf/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "gltf"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "gltf"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/gltf/main.rs
+++ b/examples/gltf/main.rs
@@ -174,8 +174,8 @@ fn main() -> Result<(), amethyst::Error> {
 
     let app_root = application_root_dir()?;
 
-    let display_config_path = app_root.join("examples/gltf/config/display.ron");
-    let assets_dir = app_root.join("examples/gltf/assets/");
+    let display_config_path = app_root.join("config/display.ron");
+    let assets_dir = app_root.join("assets/");
 
     let mut game_data = DispatcherBuilder::default()
         .with(AutoFovSystem::default(), "auto_fov", &[])

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "hello_world"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "hello_world"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -21,7 +21,7 @@ impl EmptyState for Example {
 
 fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
-    let assets_dir = application_root_dir()?.join("examples/hello_world/assets");
+    let assets_dir = application_root_dir()?.join("assets");
     let game = Application::build(assets_dir, Example)?.build(())?;
     game.run();
 

--- a/examples/locale/Cargo.toml
+++ b/examples/locale/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "locale"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "locale"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/locale/main.rs
+++ b/examples/locale/main.rs
@@ -5,9 +5,7 @@ use amethyst::{
     ecs::*,
     locale::*,
     prelude::*,
-    renderer::{
-        rendy::hal::command::ClearColor, types::DefaultBackend, RenderToWindow, RenderingBundle,
-    },
+    renderer::{types::DefaultBackend, RenderingBundle},
     utils::application_root_dir,
     Error,
 };
@@ -66,8 +64,8 @@ fn main() -> Result<(), Error> {
     amethyst::start_logger(Default::default());
 
     let app_root = application_root_dir()?;
-    let assets_dir = app_root.join("examples/locale/assets");
-    let display_config_path = app_root.join("examples/ui_from_code/config/display.ron");
+    let assets_dir = app_root.join("assets");
+    let display_config_path = app_root.join("config/display.ron");
 
     let mut builder = DispatcherBuilder::default();
 

--- a/examples/material/Cargo.toml
+++ b/examples/material/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "material"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "material"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/material/main.rs
+++ b/examples/material/main.rs
@@ -133,8 +133,8 @@ fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
 
     let app_root = application_root_dir()?;
-    let display_config_path = app_root.join("examples/material/config/display.ron");
-    let assets_dir = app_root.join("examples/material/assets/");
+    let display_config_path = app_root.join("config/display.ron");
+    let assets_dir = app_root.join("assets/");
 
     let mut builder = DispatcherBuilder::default();
     builder

--- a/examples/mouse_raycast/Cargo.toml
+++ b/examples/mouse_raycast/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "mouse_raycast"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "mouse_raycast"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/mouse_raycast/main.rs
+++ b/examples/mouse_raycast/main.rs
@@ -256,8 +256,8 @@ fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
 
     let app_root = application_root_dir()?;
-    let assets_dir = app_root.join("examples/mouse_raycast/assets/");
-    let display_config_path = app_root.join("examples/mouse_raycast/config/display.ron");
+    let assets_dir = app_root.join("assets/");
+    let display_config_path = app_root.join("config/display.ron");
 
     let mut game_data = DispatcherBuilder::default()
         .add_bundle(TransformBundle::new())?

--- a/examples/net_client/Cargo.toml
+++ b/examples/net_client/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "net_client"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "net_client"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/net_client/main.rs
+++ b/examples/net_client/main.rs
@@ -17,7 +17,7 @@ use systems::ParallelRunnable;
 fn main() -> Result<()> {
     amethyst::start_logger(Default::default());
 
-    let assets_dir = application_root_dir()?.join("examples/net_client/");
+    let assets_dir = application_root_dir()?.join("");
 
     let mut game_data = DispatcherBuilder::default();
     game_data

--- a/examples/net_server/Cargo.toml
+++ b/examples/net_server/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "net_server"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "net_server"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/optional_graphics/Cargo.toml
+++ b/examples/optional_graphics/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "optional_graphics"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "optional_graphics"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/optional_graphics/main.rs
+++ b/examples/optional_graphics/main.rs
@@ -27,12 +27,12 @@ fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
 
     let app_root = application_root_dir()?;
-    let assets_dir = app_root.join("examples/optional_graphics/assets/");
+    let assets_dir = app_root.join("assets/");
     let mut game_data = DispatcherBuilder::default();
     let game: CoreApplication<GameData>;
 
     if !cfg!(feature = "empty") {
-        let display_config_path = app_root.join("examples/optional_graphics/config/display.ron");
+        let display_config_path = app_root.join("config/display.ron");
         game_data.add_bundle(WindowBundle::from_config_path(display_config_path)?);
         game = Application::build(assets_dir, ExampleState)?.build(game_data)?;
     } else {

--- a/examples/pong_tutorial_01/Cargo.toml
+++ b/examples/pong_tutorial_01/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "pong_tutorial_01"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "pong_tutorial_01"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/pong_tutorial_01/main.rs
+++ b/examples/pong_tutorial_01/main.rs
@@ -20,11 +20,11 @@ fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
 
     let app_root = application_root_dir()?;
-    let display_config_path = app_root.join("examples/pong_tutorial_01/config/display.ron");
+    let display_config_path = app_root.join("config/display.ron");
 
     // This line is not mentioned in the pong tutorial as it is specific to the context
     // of the git repository. It only is a different location to load the assets from.
-    let assets_dir = app_root.join("examples/pong_tutorial_01/assets/");
+    let assets_dir = app_root.join("assets/");
 
     let mut dispatcher = DispatcherBuilder::default();
     dispatcher.add_bundle(LoaderBundle).add_bundle(

--- a/examples/pong_tutorial_02/Cargo.toml
+++ b/examples/pong_tutorial_02/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "pong_tutorial_02"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "pong_tutorial_02"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/pong_tutorial_02/main.rs
+++ b/examples/pong_tutorial_02/main.rs
@@ -21,11 +21,11 @@ fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
 
     let app_root = application_root_dir()?;
-    let display_config_path = app_root.join("examples/pong_tutorial_02/config/display.ron");
+    let display_config_path = app_root.join("config/display.ron");
 
     // This line is not mentioned in the pong tutorial as it is specific to the context
     // of the git repository. It only is a different location to load the assets from.
-    let assets_dir = app_root.join("examples/pong_tutorial_02/assets/");
+    let assets_dir = app_root.join("assets/");
 
     let mut dispatcher = DispatcherBuilder::default();
     dispatcher

--- a/examples/pong_tutorial_03/Cargo.toml
+++ b/examples/pong_tutorial_03/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "pong_tutorial_03"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "pong_tutorial_03"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/pong_tutorial_03/main.rs
+++ b/examples/pong_tutorial_03/main.rs
@@ -24,19 +24,19 @@ fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
 
     let app_root = application_root_dir()?;
-    let display_config_path = app_root.join("examples/pong_tutorial_03/config/display.ron");
+    let display_config_path = app_root.join("config/display.ron");
 
     // This line is not mentioned in the pong tutorial as it is specific to the context
     // of the git repository. It only is a different location to load the assets from.
-    let assets_dir = app_root.join("examples/pong_tutorial_03/assets/");
+    let assets_dir = app_root.join("assets/");
 
     let mut dispatcher = DispatcherBuilder::default();
     dispatcher
         .add_bundle(LoaderBundle)
         .add_bundle(TransformBundle)
-        .add_bundle(InputBundle::new().with_bindings_from_file(
-            app_root.join("examples/pong_tutorial_03/config/bindings.ron"),
-        )?)
+        .add_bundle(
+            InputBundle::new().with_bindings_from_file(app_root.join("config/bindings.ron"))?,
+        )
         // We have now added our own system, the PaddleSystem, defined in systems/paddle.rs
         .add_system(Box::new(PaddleSystem))
         .add_bundle(

--- a/examples/pong_tutorial_04/Cargo.toml
+++ b/examples/pong_tutorial_04/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "pong_tutorial_04"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "pong_tutorial_04"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/pong_tutorial_04/main.rs
+++ b/examples/pong_tutorial_04/main.rs
@@ -24,20 +24,20 @@ fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
 
     let app_root = application_root_dir()?;
-    let display_config_path = app_root.join("examples/pong_tutorial_04/config/display.ron");
+    let display_config_path = app_root.join("config/display.ron");
 
     // This line is not mentioned in the pong tutorial as it is specific to the context
     // of the git repository. It only is a different location to load the assets from.
-    let assets_dir = app_root.join("examples/pong_tutorial_04/assets/");
+    let assets_dir = app_root.join("assets/");
 
     let mut dispatcher = DispatcherBuilder::default();
     dispatcher
         .add_bundle(LoaderBundle)
         // Add the transform bundle which handles tracking entity positions
         .add_bundle(TransformBundle)
-        .add_bundle(InputBundle::new().with_bindings_from_file(
-            app_root.join("examples/pong_tutorial_04/config/bindings.ron"),
-        )?)
+        .add_bundle(
+            InputBundle::new().with_bindings_from_file(app_root.join("config/bindings.ron"))?,
+        )
         // We have now added our own systems, defined in the systems module
         .add_system(Box::new(PaddleSystem))
         .add_system(Box::new(BallSystem))

--- a/examples/pong_tutorial_05/Cargo.toml
+++ b/examples/pong_tutorial_05/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "pong_tutorial_05"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "pong_tutorial_05"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/pong_tutorial_05/main.rs
+++ b/examples/pong_tutorial_05/main.rs
@@ -29,20 +29,20 @@ fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
 
     let app_root = application_root_dir()?;
-    let display_config_path = app_root.join("examples/pong_tutorial_05/config/display.ron");
+    let display_config_path = app_root.join("config/display.ron");
 
     // This line is not mentioned in the pong tutorial as it is specific to the context
     // of the git repository. It only is a different location to load the assets from.
-    let assets_dir = app_root.join("examples/pong_tutorial_05/assets/");
+    let assets_dir = app_root.join("assets/");
 
     let mut dispatcher = DispatcherBuilder::default();
     dispatcher
         .add_bundle(LoaderBundle)
         // Add the transform bundle which handles tracking entity positions
         .add_bundle(TransformBundle)
-        .add_bundle(InputBundle::new().with_bindings_from_file(
-            app_root.join("examples/pong_tutorial_05/config/bindings.ron"),
-        )?)
+        .add_bundle(
+            InputBundle::new().with_bindings_from_file(app_root.join("config/bindings.ron"))?,
+        )
         // We have now added our own systems, defined in the systems module
         .add_system(Box::new(PaddleSystem))
         .add_system(Box::new(BallSystem))

--- a/examples/pong_tutorial_06/Cargo.toml
+++ b/examples/pong_tutorial_06/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "pong_tutorial_06"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "pong_tutorial_06"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/pong_tutorial_06/main.rs
+++ b/examples/pong_tutorial_06/main.rs
@@ -49,17 +49,17 @@ fn main() -> amethyst::Result<()> {
 
     let app_root = application_root_dir()?;
 
-    let display_config_path = app_root.join("examples/pong_tutorial_06/config/display.ron");
+    let display_config_path = app_root.join("config/display.ron");
 
     let key_bindings_path = {
         if cfg!(feature = "sdl_controller") {
-            app_root.join("examples/pong_tutorial_06/config/input_controller.ron")
+            app_root.join("config/input_controller.ron")
         } else {
-            app_root.join("examples/pong_tutorial_06/config/input.ron")
+            app_root.join("config/input.ron")
         }
     };
 
-    let assets_dir = app_root.join("examples/pong_tutorial_06/assets/");
+    let assets_dir = app_root.join("assets/");
 
     let mut game_data = DispatcherBuilder::default()
         // Add the transform bundle which handles tracking entity positions

--- a/examples/prefab/Cargo.toml
+++ b/examples/prefab/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "prefab"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "prefab"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/prefab/main.rs
+++ b/examples/prefab/main.rs
@@ -101,9 +101,9 @@ fn main() -> Result<(), Error> {
     let app_root = application_root_dir()?;
 
     // Add our meshes directory to the asset loader.
-    let assets_dir = app_root.join("examples/prefab/assets");
+    let assets_dir = app_root.join("assets");
 
-    let display_config_path = app_root.join("examples/prefab/config/display.ron");
+    let display_config_path = app_root.join("config/display.ron");
 
     let mut dispatcher_builder = DispatcherBuilder::default();
     dispatcher_builder

--- a/examples/prefab_adapter/Cargo.toml
+++ b/examples/prefab_adapter/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "prefab_adapter"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "prefab_adapter"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/prefab_adapter/main.rs
+++ b/examples/prefab_adapter/main.rs
@@ -173,7 +173,7 @@ fn main() -> Result<(), Error> {
     let app_root = application_root_dir()?;
 
     // Add our meshes directory to the asset loader.
-    let assets_dir = app_root.join("examples/prefab_adapter/assets");
+    let assets_dir = app_root.join("assets");
 
     let mut game_data = DispatcherBuilder::default().with_system_desc(
         PrefabLoaderSystemDesc::<PositionPrefab>::default(),

--- a/examples/prefab_atelier/Cargo.toml
+++ b/examples/prefab_atelier/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "prefab_atelier"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "prefab_atelier"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/prefab_atelier/main.rs
+++ b/examples/prefab_atelier/main.rs
@@ -131,9 +131,9 @@ fn main() -> Result<(), Error> {
     let app_root = application_root_dir()?;
 
     // Add our meshes directory to the asset loader.
-    let assets_dir = app_root.join("examples/prefab_atelier/assets");
+    let assets_dir = app_root.join("assets");
 
-    let display_config_path = app_root.join("examples/prefab_atelier/config/display.ron");
+    let display_config_path = app_root.join("config/display.ron");
 
     let mut dispatcher_builder = DispatcherBuilder::default();
     dispatcher_builder

--- a/examples/prefab_basic/Cargo.toml
+++ b/examples/prefab_basic/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "prefab_basic"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "prefab_basic"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/prefab_basic/main.rs
+++ b/examples/prefab_basic/main.rs
@@ -141,7 +141,7 @@ fn main() -> Result<(), Error> {
     let app_root = application_root_dir()?;
 
     // Add our meshes directory to the asset loader.
-    let assets_dir = app_root.join("examples/prefab_basic/assets");
+    let assets_dir = app_root.join("assets");
 
     let mut game_data = DispatcherBuilder::default().with_system_desc(
         PrefabLoaderSystemDesc::<Position>::default(),

--- a/examples/prefab_custom/Cargo.toml
+++ b/examples/prefab_custom/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "prefab_custom"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "prefab_custom"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/prefab_custom/main.rs
+++ b/examples/prefab_custom/main.rs
@@ -182,7 +182,7 @@ fn main() -> Result<(), Error> {
     let app_root = application_root_dir()?;
 
     // Add our meshes directory to the asset loader.
-    let assets_dir = app_root.join("examples/prefab_custom/assets");
+    let assets_dir = app_root.join("assets");
 
     let mut game_data = DispatcherBuilder::default().with_system_desc(
         PrefabLoaderSystemDesc::<CustomPrefabData>::default(),

--- a/examples/prefab_multi/Cargo.toml
+++ b/examples/prefab_multi/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "prefab_multi"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "prefab_multi"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/prefab_multi/main.rs
+++ b/examples/prefab_multi/main.rs
@@ -155,7 +155,7 @@ fn main() -> Result<(), Error> {
     let app_root = application_root_dir()?;
 
     // Add our meshes directory to the asset loader.
-    let assets_dir = app_root.join("examples/prefab_multi/assets");
+    let assets_dir = app_root.join("assets");
 
     let mut game_data = DispatcherBuilder::default().with_system_desc(
         PrefabLoaderSystemDesc::<Player>::default(),

--- a/examples/renderable/Cargo.toml
+++ b/examples/renderable/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "renderable"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "renderable"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/renderable/main.rs
+++ b/examples/renderable/main.rs
@@ -189,13 +189,9 @@ fn main() -> Result<(), Error> {
     let app_root = application_root_dir()?;
 
     // Add our meshes directory to the asset loader.
-    let assets_dir = app_root.join("examples").join("renderable").join("assets");
+    let assets_dir = app_root.join("assets");
 
-    let display_config_path = app_root
-        .join("examples")
-        .join("renderable")
-        .join("config")
-        .join("display.ron");
+    let display_config_path = app_root.join("config").join("display.ron");
 
     let mut game_data = DispatcherBuilder::default()
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])

--- a/examples/renderable_custom/Cargo.toml
+++ b/examples/renderable_custom/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "renderable_custom"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "renderable_custom"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/renderable_custom/main.rs
+++ b/examples/renderable_custom/main.rs
@@ -190,16 +190,9 @@ fn main() -> Result<(), Error> {
     let app_root = application_root_dir()?;
 
     // Add our meshes directory to the asset loader.
-    let assets_directory = app_root
-        .join("examples")
-        .join("renderable_custom")
-        .join("assets");
+    let assets_directory = app_root.join("assets");
 
-    let display_config_path = app_root
-        .join("examples")
-        .join("renderable")
-        .join("config")
-        .join("display.ron");
+    let display_config_path = app_root.join("config").join("display.ron");
 
     let mut game_data = DispatcherBuilder::default()
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])

--- a/examples/rendy/Cargo.toml
+++ b/examples/rendy/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "rendy"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "rendy"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/rendy/main.rs
+++ b/examples/rendy/main.rs
@@ -569,12 +569,8 @@ fn main() -> amethyst::Result<()> {
 
     let app_root = application_root_dir()?;
 
-    let display_config_path = app_root
-        .join("examples")
-        .join("rendy")
-        .join("config")
-        .join("display.ron");
-    let assets_dir = app_root.join("examples").join("rendy").join("assets");
+    let display_config_path = app_root.join("config").join("display.ron");
+    let assets_dir = app_root.join("assets");
 
     let mut bindings = Bindings::new();
     bindings.insert_axis(

--- a/examples/sphere/Cargo.toml
+++ b/examples/sphere/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "sphere"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "sphere"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/sphere/main.rs
+++ b/examples/sphere/main.rs
@@ -7,6 +7,7 @@ use amethyst::{
     renderer::{
         light::{Light, PointLight},
         loaders::load_from_linear_rgba,
+        palette::{LinSrgba, Srgb},
         plugins::{RenderShaded3D, RenderToWindow},
         rendy::{
             hal::command::ClearColor,
@@ -19,7 +20,6 @@ use amethyst::{
     utils::application_root_dir,
     window::ScreenDimensions,
 };
-use palette::{LinSrgba, Srgb};
 
 struct SphereExample;
 
@@ -108,8 +108,8 @@ fn main() -> amethyst::Result<()> {
 
     let app_root = application_root_dir()?;
 
-    let display_config_path = app_root.join("examples/sphere/config/display.ron");
-    let assets_dir = app_root.join("examples/sphere/assets");
+    let display_config_path = app_root.join("config/display.ron");
+    let assets_dir = app_root.join("assets");
 
     let mut game_data = DispatcherBuilder::default();
     game_data

--- a/examples/spotlights/Cargo.toml
+++ b/examples/spotlights/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "spotlights"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "spotlights"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/spotlights/main.rs
+++ b/examples/spotlights/main.rs
@@ -32,8 +32,8 @@ fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
 
     let app_root = application_root_dir()?;
-    let display_config_path = app_root.join("examples/spotlights/config/display.ron");
-    let assets_dir = app_root.join("examples/spotlights/assets/");
+    let display_config_path = app_root.join("config/display.ron");
+    let assets_dir = app_root.join("assets/");
 
     let mut game_data = DispatcherBuilder::default()
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])

--- a/examples/sprite_animation/Cargo.toml
+++ b/examples/sprite_animation/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "sprite_animation"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "sprite_animation"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/sprite_animation/main.rs
+++ b/examples/sprite_animation/main.rs
@@ -133,8 +133,8 @@ fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
 
     let app_root = application_root_dir()?;
-    let assets_dir = app_root.join("examples/sprite_animation/assets/");
-    let display_config_path = app_root.join("examples/sprite_animation/config/display.ron");
+    let assets_dir = app_root.join("assets/");
+    let display_config_path = app_root.join("config/display.ron");
 
     let mut game_data = DispatcherBuilder::default()
         .with_system_desc(

--- a/examples/sprite_camera_follow/Cargo.toml
+++ b/examples/sprite_camera_follow/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "sprite_camera_follow"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "sprite_camera_follow"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/sprite_camera_follow/main.rs
+++ b/examples/sprite_camera_follow/main.rs
@@ -159,16 +159,14 @@ fn main() -> amethyst::Result<()> {
         .start();
 
     let app_root = application_root_dir()?;
-    let assets_directory = app_root.join("examples/sprite_camera_follow/assets");
-    let display_config_path = app_root.join("examples/sprite_camera_follow/config/display.ron");
+    let assets_directory = app_root.join("assets");
+    let display_config_path = app_root.join("config/display.ron");
 
     let mut game_data = DispatcherBuilder::default();
     game_data
         .add_bundle(LoaderBundle)
         .add_bundle(TransformBundle)
-        .add_bundle(InputBundle::new().with_bindings_from_file(
-            app_root.join("examples/sprite_camera_follow/config/input.ron"),
-        )?)
+        .add_bundle(InputBundle::new().with_bindings_from_file(app_root.join("config/input.ron"))?)
         .add_system(Box::new(MovementSystem))
         .add_bundle(
             RenderingBundle::<DefaultBackend>::new()

--- a/examples/sprites_ordered/Cargo.toml
+++ b/examples/sprites_ordered/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "sprites_ordered"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "sprites_ordered"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/sprites_ordered/main.rs
+++ b/examples/sprites_ordered/main.rs
@@ -356,9 +356,9 @@ fn main() -> amethyst::Result<()> {
 
     let app_root = application_root_dir()?;
 
-    let display_config_path = app_root.join("examples/sprites_ordered/config/display.ron");
+    let display_config_path = app_root.join("config/display.ron");
 
-    let assets_dir = app_root.join("examples/sprites_ordered/assets/");
+    let assets_dir = app_root.join("assets/");
 
     let mut dispatcher = DispatcherBuilder::default();
     dispatcher

--- a/examples/state_dispatcher/Cargo.toml
+++ b/examples/state_dispatcher/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "state_dispatcher"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "state_dispatcher"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/state_dispatcher/main.rs
+++ b/examples/state_dispatcher/main.rs
@@ -55,7 +55,7 @@ impl<'a> SimpleState for StateB<'a> {
 fn main() -> Result<(), Error> {
     amethyst::start_logger(Default::default());
     let app_root = application_root_dir()?;
-    let assets_dir = app_root.join("examples/state_dispatcher/assets");
+    let assets_dir = app_root.join("assets");
     let game = Application::build(assets_dir, StateA)?.build(DispatcherBuilder::default())?;
     game.run();
     Ok(())

--- a/examples/states_ui/Cargo.toml
+++ b/examples/states_ui/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "states_ui"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "states_ui"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/states_ui/main.rs
+++ b/examples/states_ui/main.rs
@@ -35,10 +35,10 @@ pub fn main() -> amethyst::Result<()> {
     let app_root = application_root_dir()?;
 
     // our display config is in our configs folder.
-    let display_config_path = app_root.join("examples/states_ui/config/display.ron");
+    let display_config_path = app_root.join("config/display.ron");
 
     // other assets ('*.ron' files, '*.png' textures, '*.ogg' audio files, ui prefab files, ...) are here
-    let assets_dir = app_root.join("examples/states_ui/assets");
+    let assets_dir = app_root.join("assets");
 
     let mut game_data = DispatcherBuilder::default()
         // a lot of other bundles/systems depend on this (without it being explicitly clear), so it

--- a/examples/tiles/Cargo.toml
+++ b/examples/tiles/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "tiles"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "tiles"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/tiles/main.rs
+++ b/examples/tiles/main.rs
@@ -149,8 +149,8 @@ fn main() -> amethyst::Result<()> {
         .start();
 
     let app_root = application_root_dir()?;
-    let assets_directory = app_root.join("examples/tiles/assets");
-    let display_config_path = app_root.join("examples/tiles/config/display.ron");
+    let assets_directory = app_root.join("assets");
+    let display_config_path = app_root.join("config/display.ron");
 
     let mut dispatcher = DispatcherBuilder::default();
     dispatcher.add_bundle(LoaderBundle);

--- a/examples/tiles/systems/camera_movement.rs
+++ b/examples/tiles/systems/camera_movement.rs
@@ -1,10 +1,10 @@
 use amethyst::{
     core::{math::Vector3, transform::Transform},
-    ecs::{IntoQuery, ParallelRunnable, System},
+    ecs::{component, Entity, ParallelRunnable, System, SystemBuilder},
     input::InputHandler,
+    prelude::IntoQuery,
     renderer::{ActiveCamera, Camera},
 };
-use legion::{component, Entity, SystemBuilder};
 pub(crate) struct CameraMovementSystem;
 
 impl System<'static> for CameraMovementSystem {

--- a/examples/tiles/systems/camera_switch.rs
+++ b/examples/tiles/systems/camera_switch.rs
@@ -4,12 +4,11 @@ use amethyst::{
         transform::{Parent, Transform},
         Named,
     },
-    ecs::{IntoQuery, ParallelRunnable, System},
+    ecs::{component, Entity, IntoQuery, ParallelRunnable, System, SystemBuilder},
     input::InputHandler,
     renderer::{ActiveCamera, Camera},
     window::ScreenDimensions,
 };
-use legion::{component, Entity, SystemBuilder};
 
 pub struct CameraSwitchSystem {
     pressed: bool,

--- a/examples/tiles/systems/draw_selection.rs
+++ b/examples/tiles/systems/draw_selection.rs
@@ -3,13 +3,11 @@ use amethyst::{
         math::{Point3, Vector2},
         transform::Transform,
     },
-    ecs::{IntoQuery, ParallelRunnable, System},
+    ecs::{Entity, IntoQuery, ParallelRunnable, System, SystemBuilder},
     input::InputHandler,
-    renderer::{debug_drawing::DebugLinesComponent, ActiveCamera, Camera},
+    renderer::{debug_drawing::DebugLinesComponent, palette::Srgba, ActiveCamera, Camera},
     window::ScreenDimensions,
 };
-use legion::{Entity, SystemBuilder};
-use palette::Srgba;
 #[derive(Default)]
 pub struct DrawSelectionSystem {
     start_coordinate: Option<Point3<f32>>,

--- a/examples/tiles/systems/map_movement.rs
+++ b/examples/tiles/systems/map_movement.rs
@@ -1,10 +1,9 @@
 use amethyst::{
     core::{math::Vector3, transform::Transform, Time},
-    ecs::{IntoQuery, ParallelRunnable, System},
+    ecs::{IntoQuery, ParallelRunnable, System, SystemBuilder},
     input::InputHandler,
     tiles::{MortonEncoder, TileMap},
 };
-use legion::SystemBuilder;
 
 use crate::ExampleTile;
 

--- a/examples/ui/Cargo.toml
+++ b/examples/ui/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ui"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "ui"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/ui/main.rs
+++ b/examples/ui/main.rs
@@ -138,8 +138,8 @@ fn main() -> amethyst::Result<()> {
 
     let app_root = application_root_dir()?;
 
-    let display_config_path = app_root.join("examples/ui/config/display.ron");
-    let assets_dir = app_root.join("examples/ui/assets");
+    let display_config_path = app_root.join("config/display.ron");
+    let assets_dir = app_root.join("assets");
 
     let mut game_data = DispatcherBuilder::default()
         .with_system_desc(PrefabLoaderSystemDesc::<MyPrefabData>::default(), "", &[])

--- a/examples/ui_from_code/Cargo.toml
+++ b/examples/ui_from_code/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ui_from_code"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "ui_from_code"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/ui_from_code/main.rs
+++ b/examples/ui_from_code/main.rs
@@ -44,8 +44,8 @@ fn main() -> amethyst::Result<()> {
     amethyst::start_logger(config);
 
     let app_root = application_root_dir()?;
-    let display_config_path = app_root.join("examples/ui_from_code/config/display.ron");
-    let assets_dir = app_root.join("examples/ui_from_code/assets");
+    let display_config_path = app_root.join("config/display.ron");
+    let assets_dir = app_root.join("assets");
 
     let mut dispatcher = DispatcherBuilder::default();
 

--- a/examples/window/Cargo.toml
+++ b/examples/window/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "window"
+version = "0.0.1"
+authors = ["Amethyst Foundation <contact@amethyst.rs>"]
+edition = "2018"
+
+[[bin]]
+path = "main.rs"
+name = "window"
+
+[dependencies]
+amethyst = { path = "../../", features = ["optional"] }
+log = { version = "^0.4", features = ["serde"] }
+serde = "^1"
+derivative = "^2"
+lazy_static = "^1.4"
+serde-diff = "0.4"
+type-uuid = "0.1"
+glsl-layout = "0.3"
+ron = "^0.6"
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }

--- a/examples/window/main.rs
+++ b/examples/window/main.rs
@@ -25,9 +25,9 @@ fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
 
     let app_root = application_root_dir()?;
-    let display_config_path = app_root.join("examples/window/config/display.ron");
+    let display_config_path = app_root.join("config/display.ron");
 
-    let assets_dir = app_root.join("examples/window/assets/");
+    let assets_dir = app_root.join("assets/");
     let mut builder = DispatcherBuilder::default();
 
     builder.add_bundle(WindowBundle::from_config_path(display_config_path)?);


### PR DESCRIPTION
<!--- rovide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Separate Additions, Removals and Modifications -->
examples previously shared dev dependencies and paths with the main
amethyst crate.  this lead to bad import paths in examples, additional
joins needed on paths that made examples not easily portable. also it
made it difficult to copy examples as a starter project.

now that each example has a cargo.toml with dependencies we have a best
practice to start a new project packaged alongside each example and
users can copy an example folder in to their own new project with ease
and without editing anything.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This makes it easier for new users to get started.
