### PR TITLE
Improve issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,40 +1,43 @@
 ---
 name: Bug Report
 about: Found a bug? Create a report and help us improve!
-title: "[BUG] Brief Description Here"
-labels: 'status: needs triage, type: bug'
-assignees: ''
-
+labels: 'type: bug'
 ---
 
 ## Description
+<!-- A clear and concise description of what the bug is. -->
 
-A clear and concise description of what the bug is.
+
 
 ## Reproduction Steps
 
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+1. 
+2. 
+3. 
+4. 
 
 ## What You Expected to Happen
+<!-- A clear and concise description of what you expected to happen. -->
 
-A clear and concise description of what you expected to happen.
+
 
 ## What Actually Happened
+<!-- A clear and concise description of what actually happened. -->
 
-A clear and concise description of what actually happened.
+
 
 ## Screenshots and Logs
+<!-- If applicable, add screenshots to help explain your problem. Any relevant logs would be helpful as well. -->
 
-If applicable, add screenshots to help explain your problem. Any relevant logs would be helpful as well.
+
 
 ## Your Environment
 
-1. Operating System
-2. Operating System Version
-3. Version of Amethyst
+Operating System: 
+Operating System Version: 
+Version of Amethyst: 
 
 ## Additional Context
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->
+
+

--- a/.github/ISSUE_TEMPLATE/feature-modification-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-modification-request.md
@@ -1,28 +1,25 @@
 ---
-name: Feature Modification Request
+name: Improvement
 about: Have a suggestion to make an existing feature better? Let us know!
-title: "[FEATURE MODIFICATION] Brief Description Here"
-labels: 'status: needs triage, type: modification'
-assignees: ''
-
+labels: 'type: improvement'
 ---
 
 ## Feature
+<!-- Which feature would you like to modify? -->
 
-Which feature would you like to modify?
+
 
 ## Change
+<!-- What change would you like to make to it? -->
 
-What change would you like to make to it?
+
 
 ## Reason
+<!-- Why do you want to make this change? -->
 
-Why do you want to make this change?
 
-## Impact
-
-What impact would this change have? Do you think it would impact more features than just the one being modified?
 
 ## Additional Notes
+<!-- Anything else relevant to add can go here -->
 
-Anything else relevant to add can go here
+

--- a/.github/ISSUE_TEMPLATE/maintenance-request.md
+++ b/.github/ISSUE_TEMPLATE/maintenance-request.md
@@ -1,28 +1,19 @@
 ---
-name: Maintenance Request
-about: See something that isn't quite a bug, but could be made better? Use this!
-title: "[MAINTENANCE] Brief Description Here"
-labels: 'status: needs triage, type: maintenance'
-assignees: ''
-
+name: Maintenance
+about: Documentation Updates, Tooling Issues, Ergonomics Improvements, Showcase, Feedback, Out of Date Dependencies etc.
+labels: 'type: maintenance'
 ---
 
-## Note
-
-This type of request is for things like `unwrap()`s that snuck into production. They aren't likely to cause problems and aren't really a bug, but should be updated. Other examples include formatting updates, dependency updates, or code simplification. 
-
 ## Description
+<!-- This type of request is for things that aren't likely to break builds, but should be improved. Examples include documentation updates, dependency updates, or code simplification.  -->
 
-What do you see that needs to be updated? Include a link to the code if possible.
 
 ## Reason
+<!-- Why should this change be made? -->
 
-Why should this change be made?
 
-## Impact
-
-Do you think this change will have a negative impact on anything else?
 
 ## Additional Information
+<!-- Any extra info you want to add can go here. -->
 
-Any extra info you want to add can go here
+

--- a/.github/ISSUE_TEMPLATE/new-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/new-feature-request.md
@@ -1,24 +1,30 @@
 ---
-name: New Feature Request
-about: Have an idea that could improve this project? We want to hear it!
-title: "[NEW FEATURE] Title Goes Here"
-labels: 'status: needs triage, type: feature'
-assignees: ''
-
+name: New Feature
+about: Have an idea for a new feature? We want to hear it!
+labels: 'type: feature'
 ---
 
 ## Description
+<!-- Propose something that does not yet exist. -->
 
-Please note this is not for modifications to existing features. There is another Issue type for that. This is for proposing something that does not yet exist.
+
 
 ## What problem does this solve? What need does it fill?
-A clear and concise description of what the problem/need is. Ex. I'm frustrated when I lose work due to a lack of auto-save.
+<!-- A clear and concise description of what the problem/need is. For example: "I'm frustrated when I lose work due to a lack of auto-save." -->
+
+
 
 ## Describe the solution you'd like
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
+
+
 
 ## Describe alternatives you've considered
-A clear and concise description of any alternative solutions or features you've considered.
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+
 
 ## Additional context
-Add any other context, logs, or screenshots about the feature request here.
+<!-- Add any other context, logs, or screenshots about the feature request here. -->
+
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,34 +1,31 @@
 <!--- Provide a general summary of your changes in the Title above -->
-
 ## Description
 <!--- Describe your changes in detail -->
 <!--- Separate Additions, Removals and Modifications -->
+
+
 
 ## Motivation and Context
 <!--- Why is this change required? What problem does it solve? -->
 <!--- If it fixes an open issue, please link to the issue here. -->
 
+
+
 ## How Has This Been Tested?
 <!--- Please describe in detail how you tested your changes. -->
-<!--- Include details of your testing environment, and the tests you ran to -->
-<!--- see how your change affects other areas of the code, etc. -->
+
+
 
 ## Screenshots (if appropriate):
 
-## Types of changes
-<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
 
 ## Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
-- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
 - [ ] My code follows the code style of this project.
-- [ ] My change requires a change to the documentation.
-- [ ] I have updated the documentation accordingly.
-- [ ] Updated the content of the book if this PR would make the book outdated.
+- [ ] If my change required a change to the documentation I have updated the documentation accordingly.
+- [ ] I have updated the content of the book if this PR would make the book outdated.
 - [ ] I have added tests to cover my changes.
 - [ ] My code is used in an example.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Separate Additions, Removals and Modifications -->
This will make the issue and pull request templates more friendly and faster/easier to use.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously the issue templates required deleting existing text to enter your own which was a waste of time and resulted in reading the default text frequently when looking at filed issues.

The `status: needs triage` label on every issue served no purpose and issues that had been triaged never had the label removed.

Nobody had ever filed and `type: modification` issue in the history of the project as I could tell.

The checkboxes for PR type were redundant and we should use the GitHub label system as it works in tandem with our release drafter github action to create a nice changelog.

The templates now breathe with whitespace so you can just click and start typing.