### PR TITLE
Clone Winit repository via HTTPS not SSH

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ amethyst_ui = { path = "amethyst_ui", version = "0.15.3", optional = true }
 amethyst_utils = { path = "amethyst_utils", version = "0.15.3", optional = true }
 amethyst_window = { path = "amethyst_window", version = "0.15.3" }
 amethyst_tiles = { path = "amethyst_tiles", version = "0.15.3", optional = true }
-winit = { git = "https://git@github.com/rust-windowing/winit", rev = "38fccebe1fbc4226c75d6180e5317bd93c024951", features = ["serde"] }
+winit = { git = "https://github.com/rust-windowing/winit", rev = "38fccebe1fbc4226c75d6180e5317bd93c024951", features = ["serde"] }
 crossbeam-channel = "0.4.2"
 derivative = "2.1.1"
 fern = { version = "0.6.0", features = ["colored"] }

--- a/amethyst_controls/Cargo.toml
+++ b/amethyst_controls/Cargo.toml
@@ -21,7 +21,7 @@ amethyst_error = { path = "../amethyst_error", version = "0.15.3" }
 amethyst_input = { path = "../amethyst_input", version = "0.15.3" }
 derive-new = "0.5"
 serde = { version = "1.0", features = ["derive"] }
-winit = { git = "https://git@github.com/rust-windowing/winit", rev = "38fccebe1fbc4226c75d6180e5317bd93c024951", features = ["serde"] }
+winit = { git = "https://github.com/rust-windowing/winit", rev = "38fccebe1fbc4226c75d6180e5317bd93c024951", features = ["serde"] }
 log = "0.4.6"
 
 thread_profiler = { version = "0.3", optional = true }

--- a/amethyst_input/Cargo.toml
+++ b/amethyst_input/Cargo.toml
@@ -23,7 +23,7 @@ derivative = "2.1.1"
 derive-new = "0.5"
 fnv = "1"
 serde = { version = "1", features = ["derive"] }
-winit = { git = "https://git@github.com/rust-windowing/winit", rev = "38fccebe1fbc4226c75d6180e5317bd93c024951", features = ["serde"] }
+winit = { git = "https://github.com/rust-windowing/winit", rev = "38fccebe1fbc4226c75d6180e5317bd93c024951", features = ["serde"] }
 sdl2 = { version = "0.33", optional = true }
 smallvec = { version = "1.2", features = ["serde"] }
 

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -46,7 +46,7 @@ rendy = { git = "https://github.com/amethyst/rendy", rev = "50667887612adc9314ac
 
 
 [dev-dependencies]
-winit = { git = "https://git@github.com/rust-windowing/winit", rev = "38fccebe1fbc4226c75d6180e5317bd93c024951", features = ["serde"] }
+winit = { git = "https://github.com/rust-windowing/winit", rev = "38fccebe1fbc4226c75d6180e5317bd93c024951", features = ["serde"] }
 rayon = "1.4.0"
 more-asserts = "0.2.1"
 criterion = "0.3.0"

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -35,7 +35,7 @@ serde = { version = "1.0", features = ["derive"] }
 smallvec = "1.2"
 unicode-normalization = "0.1"
 unicode-segmentation = "1.6"
-winit = { git = "https://git@github.com/rust-windowing/winit", rev = "38fccebe1fbc4226c75d6180e5317bd93c024951", features = ["serde"] }
+winit = { git = "https://github.com/rust-windowing/winit", rev = "38fccebe1fbc4226c75d6180e5317bd93c024951", features = ["serde"] }
 log = "0.4.6"
 font-kit = "0.10.0"
 paste = "0.1"

--- a/amethyst_window/Cargo.toml
+++ b/amethyst_window/Cargo.toml
@@ -20,7 +20,7 @@ amethyst_error = { path = "../amethyst_error", version = "0.15.3" }
 log = "0.4.6"
 serde = { version = "1", features = ["derive"] }
 thread_profiler = { version = "0.3", optional = true }
-winit = { git = "https://git@github.com/rust-windowing/winit", rev = "38fccebe1fbc4226c75d6180e5317bd93c024951", features = ["serde"] }
+winit = { git = "https://github.com/rust-windowing/winit", rev = "38fccebe1fbc4226c75d6180e5317bd93c024951", features = ["serde"] }
 
 [features]
 profiler = ["thread_profiler/thread_profiler"]


### PR DESCRIPTION
Makes it easier for cargo to clone the repo when users are behind corporate firewalls or work on systems where SSH aren't/can't be set up properly

Ran into this problem when i tried to build amethyst from my work laptop.
