### PR TITLE
Fixing and refactoring prefabs

### DIFF
--- a/amethyst_assets/src/prefab/system.rs
+++ b/amethyst_assets/src/prefab/system.rs
@@ -28,7 +28,6 @@ pub fn prefab_spawning_tick(world: &mut World, resources: &mut Resources) {
         &legion_prefab::CookedPrefab,
         u32,
         HashMap<Entity, Entity, EntityHasher>,
-        Handle<Prefab>,
     )> = Vec::new();
 
     let mut entity_query = <(Entity,)>::query();
@@ -37,14 +36,18 @@ pub fn prefab_spawning_tick(world: &mut World, resources: &mut Resources) {
         world,
         |(entity, handle, instance)| {
             if let Some(Prefab {
-                prefab: Some(cooked_prefab),
+                cooked: Some(cooked_prefab),
                 version: prefab_version,
                 ..
             }) = prefab_storage.get(handle)
             {
-                let instance_version = instance.map(|instance| instance.version).unwrap_or(0);
+                let instance_version = instance
+                    .as_ref()
+                    .map(|instance| instance.version)
+                    .unwrap_or(0);
                 if instance_version < *prefab_version {
                     let mut entity_map = instance
+                        .as_ref()
                         .map(|instance| instance.entity_map.clone())
                         .unwrap_or_default();
                     if entity_map.is_empty() {
@@ -59,7 +62,7 @@ pub fn prefab_spawning_tick(world: &mut World, resources: &mut Resources) {
         },
     );
 
-    for (entity, prefab, version, prev_entity_map, handle) in prefabs.into_iter() {
+    for (entity, prefab, version, prev_entity_map) in prefabs.into_iter() {
         let entity_map = world.clone_from(
             &prefab.world,
             &query::any(),

--- a/amethyst_assets/src/processor.rs
+++ b/amethyst_assets/src/processor.rs
@@ -43,6 +43,8 @@ where
                 .write_resource::<ProcessingQueue<A::Data>>()
                 .write_resource::<AssetStorage<A>>()
                 .build(|_, _, (queue, storage), _| {
+                    // drain the changed queue
+                    while let Some(_) = queue.changed.pop() {}
                     queue.process(storage, ProcessableAsset::process);
                     storage.process_custom_drop(|_| {});
                 }),

--- a/amethyst_assets/src/storage.rs
+++ b/amethyst_assets/src/storage.rs
@@ -33,8 +33,12 @@ impl<A> AssetStorage<A> {
 
     /// Added to make api compatible with previous storage
     pub fn unload_all(&mut self) {
-        // FIXME do the unload correctly
-        self.assets.clear();
+        for (_, data) in self.uncommitted.drain() {
+            self.to_drop.push(data.asset);
+        }
+        for (_, data) in self.assets.drain() {
+            self.to_drop.push(data.asset);
+        }
     }
 
     pub(crate) fn update_asset(&mut self, handle: LoadHandle, asset: A, version: u32) {

--- a/amethyst_assets/src/storage.rs
+++ b/amethyst_assets/src/storage.rs
@@ -1,7 +1,6 @@
-use std::collections::HashMap;
-
 use atelier_assets::loader::{handle::AssetHandle, storage::IndirectionTable, LoadHandle};
 use crossbeam_queue::SegQueue;
+use fnv::FnvHashMap;
 
 struct AssetState<A> {
     version: u32,
@@ -14,8 +13,8 @@ struct AssetState<A> {
 ///
 /// * `A`: Asset Rust type.
 pub struct AssetStorage<A> {
-    assets: HashMap<LoadHandle, AssetState<A>>,
-    uncommitted: HashMap<LoadHandle, AssetState<A>>,
+    assets: FnvHashMap<LoadHandle, AssetState<A>>,
+    uncommitted: FnvHashMap<LoadHandle, AssetState<A>>,
     to_drop: SegQueue<A>,
     indirection_table: IndirectionTable,
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Tidies up and refactors some of the code in the prefab_spawning_tick function.
Drains the changed queue in the default asset processor

## Motivation and Context
Improve code legibility and reduce unnecessary copying.

## How Has This Been Tested?
cargo test

## Checklist:
- [ x Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [ ] If my change required a change to the documentation I have updated the documentation accordingly.
- [ ] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [x] My code is used in an example.
