### PR TITLE
test inline documentation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,5 +78,5 @@ jobs:
       - run: mdbook build book
         if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
 
-      - run: mdbook test -L ./target/debug/deps book
-        if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
+      # - run: mdbook test -L ./target/debug/deps book
+      #   if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,23 +65,18 @@ jobs:
 
       - run: cargo test --workspace --all-targets --all-features
 
-      - name: install mdbook on stable, ubuntu-latest
-        uses: peaceiris/actions-mdbook@v1
+      - uses: peaceiris/actions-mdbook@v1
         with:
           mdbook-version: 'latest'
         if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
 
-      # Should be working, but postponing until after we go live with GitHub Actions
-      # - name: install mdbook-linkcheck on stable, ubuntu-latest
-      #   env:
-      #     LINKCHECK_URL: https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.7.0/mdbook-linkcheck-v0.7.0-x86_64-unknown-linux-gnu.tar.gz
-      #   run: |
-      #     curl -L ${{ env.LINKCHECK_URL }} | tar -C ~/.cargo/bin -xzf -
-      #     echo -e "\n\n[output.linkcheck]" >> book/book.toml ## PROBABLY REMOVE THIS IN FAVOR OF ALWAYS HAVING IT AS OPTIONAL IN THE CONFIG
-      #   if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
+      - env:
+          LINKCHECK_URL: https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v0.7.0/mdbook-linkcheck-v0.7.0-x86_64-unknown-linux-gnu.tar.gz
+        run: curl -L ${{ env.LINKCHECK_URL }} | tar -C ~/.cargo/bin -xzf -
+        if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
 
       - run: mdbook build book
         if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
 
-      # - run: mdbook test -L ./target/debug/deps book
-      #   if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
+      - run: mdbook test -L ./target/debug/deps book
+        if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         run: rm -rf ./target/debug/deps/libamethyst*
         if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
 
-      - run: cargo test --workspace --all-targets --all-features
+      - run: cargo test --workspace --all-features
 
       - uses: peaceiris/actions-mdbook@v1
         with:

--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -5,7 +5,7 @@ pre-commit = [
     "cargo +nightly clippy -Z unstable-options --workspace --all-features --fix --allow-dirty --allow-staged",
     "cargo +nightly fmt --all",
 ]
-pre-push = ["cargo test --all-targets --workspace --all-features"]
+pre-push = ["cargo test --workspace --all-features"]
 
 [logging]
 verbose = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,9 @@ legion = { version = "0.3", default-features = false, features = [
 dirs-next = "2.0.0"
 vergen = "3.1.0"
 
+[dev-dependencies]
+env_logger = "0.8.2"
+
 [package.metadata.docs.rs]
 features = [
     "animation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,6 @@ exclude = [
     "examples/rendy",
     "examples/states_ui",
     "examples/state_dispatcher",
-    "examples/prefab_basic",
     "examples/prefab_multi",
     "examples/prefab_custom",
     "examples/prefab_adapter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ license = "MIT/Apache-2.0"
 
 autoexamples = false # Our examples come with their own Cargo.toml and are in the [workspace] section
 
+[lib]
+crate-type = ["lib"]
+
 [features]
 default = ["parallel", "renderer", "utils", "no-slow-safety-checks"]
 optional = ["audio", "network", "locale", "ui", "tiles", "animation"]

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ You can download it and read the installation instructions at [Git LFS home page
 
 To compile any of the examples run:
 
-```
+```shell
 $ cargo run -p name_of_example
 ```
 
@@ -123,26 +123,26 @@ If you are compiling on Linux, make sure to install the dependencies below.
 
 ### Arch Linux
 
-```
-# pacman -Syu grep gcc pkgconf openssl alsa-lib cmake make python3 freetype2 awk libxcb
+```sh
+pacman -Syu grep gcc pkgconf openssl alsa-lib cmake make python3 freetype2 awk libxcb
 ```
 
 ### Debian/Ubuntu
 
-```
-# apt install gcc pkg-config openssl libasound2-dev cmake build-essential python3 libfreetype6-dev libexpat1-dev libxcb-composite0-dev libssl-dev libx11-dev libfontconfig1-dev
+```sh
+apt install gcc pkg-config openssl libasound2-dev cmake build-essential python3 libfreetype6-dev libexpat1-dev libxcb-composite0-dev libssl-dev libx11-dev libfontconfig1-dev
 ```
 
 ### Fedora
 
-```
-# dnf install pkgconfig gcc openssl-devel alsa-lib-devel cmake make gcc-c++ freetype-devel expat-devel libxcb-devel libX11-devel
+```sh
+dnf install pkgconfig gcc openssl-devel alsa-lib-devel cmake make gcc-c++ freetype-devel expat-devel libxcb-devel libX11-devel
 ```
 
 ### openSUSE
 
-```
-# zypper install gcc pkg-config libopenssl-devel alsa-devel cmake gcc-c++ python3 freetype2-devel libexpat-devel libxcb-devel
+```sh
+zypper install gcc pkg-config libopenssl-devel alsa-devel cmake gcc-c++ python3 freetype2-devel libexpat-devel libxcb-devel
 ```
 
 ### Nix/NixOS
@@ -194,22 +194,22 @@ See your distribution-specific installation process for the equivalent dependenc
 
 You can build the book locally with:
 
-```
-$ cargo install mdbook
-$ mdbook build book
+```sh
+cargo install mdbook
+mdbook build book
 ```
 
 If you're actively editing the book, it's easiest to run:
 
-```
-$ mdbook serve book
+```shell
+mdbook serve book
 ```
 
 and navigate to `http://localhost:3000`. The text itself can be found in `book/html/index.html`. For more information, please see the [mdBook project](https://github.com/rust-lang-nursery/mdBook).
 
 To generate the API documentation locally, do:
 
-```
+```shell
 $ cargo doc
 ```
 

--- a/amethyst_animation/Cargo.toml
+++ b/amethyst_animation/Cargo.toml
@@ -20,7 +20,6 @@ license = "MIT/Apache-2.0"
 amethyst_assets = { path = "../amethyst_assets", version = "0.15.3" }
 amethyst_core = { path = "../amethyst_core", version = "0.15.3" }
 amethyst_error = { path = "../amethyst_error", version = "0.15.3" }
-amethyst_derive = { path = "../amethyst_derive", version = "0.15.3" }
 amethyst_rendy = { path = "../amethyst_rendy", version = "0.15.3" }
 amethyst_ui = { path = "../amethyst_ui", version = "0.15.3", optional = true }
 derivative = "2.1.1"

--- a/amethyst_animation/Cargo.toml
+++ b/amethyst_animation/Cargo.toml
@@ -32,6 +32,9 @@ alga = "0.9.3"
 type-uuid = "0.1.2"
 uuid = "0.8.1"
 
+[dev-dependencies]
+amethyst = { path = "../", version = "0.15.3", features = ["renderer"] }
+
 [features]
 profiler = ["thread_profiler/thread_profiler"]
 ui = ["amethyst_ui"]

--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -57,6 +57,7 @@ encoding_rs_io = "0.1"
 serde-diff = "0.4"
 
 [dev-dependencies]
+amethyst = { path = "../", version = "0.15.3", features = ["renderer"] }
 serde_json = "1"
 fern = { version = "0.6", features = ["colored"] }
 serde-diff = "0.4"

--- a/amethyst_assets/src/loader.rs
+++ b/amethyst_assets/src/loader.rs
@@ -503,7 +503,7 @@ where
 ///
 /// ```rust
 /// use serde::{Deserialize, Serialize};
-/// use amethyst_assets::{register_asset_type, Asset, AssetProcessorSystem, TypeUuid};
+/// use amethyst::assets::{register_asset_type, Asset, AssetProcessorSystem, TypeUuid};
 ///
 /// #[derive(TypeUuid)]
 /// #[uuid = "00000000-0000-0000-0000-000000000000"]

--- a/amethyst_assets/src/loader.rs
+++ b/amethyst_assets/src/loader.rs
@@ -503,29 +503,41 @@ where
 ///
 /// ```
 /// use serde::{Deserialize, Serialize};
-/// use amethyst::assets::{register_asset_type, Asset, AssetProcessorSystem, TypeUuid};
-///
-/// #[derive(TypeUuid)]
-/// #[uuid = "00000000-0000-0000-0000-000000000000"]
-/// pub struct MeshAsset {
-///     buffer: Vec<u8>,
-/// }
-///
-/// impl Asset for MeshAsset {
-///     fn name() -> &'static str {
-///         "Mesh"
-///     }
-///     type Data = VertexData;
-/// }
+/// use amethyst::assets::{register_asset_type, Asset, AssetProcessorSystem, AssetStorage, LoadHandle, ProcessableAsset, ProcessingState, TypeUuid};
+/// use amethyst::error::Error;
 ///
 /// #[derive(Serialize, Deserialize, TypeUuid)]
 /// #[uuid = "00000000-0000-0000-0000-000000000000"]
 /// pub struct VertexData {
+///     buffer: Vec<u8>,
+/// }
+///
+/// impl Asset for Vertex {
+///     fn name() -> &'static str {
+///         "Vertex"
+///     }
+///     type Data = VertexData;
+/// }
+///
+/// #[derive(Default, TypeUuid)]
+/// #[uuid = "00000000-0000-0000-0000-000000000001"]
+/// pub struct Vertex {
 ///     positions: Vec<[f32; 3]>,
 ///     tex_coords: Vec<[f32; 2]>,
 /// }
 ///
-/// register_asset_type!(VertexData => MeshAsset; AssetProcessorSystem<MeshAsset>);
+/// register_asset_type!(VertexData => Vertex; AssetProcessorSystem<Vertex>);
+///
+/// impl ProcessableAsset for Vertex {
+///    fn process(
+///        data: VertexData,
+///        _storage: &mut AssetStorage<Vertex>,
+///        _handle: &LoadHandle,
+///    ) -> Result<ProcessingState<VertexData, Vertex>, Error> {
+///        log::debug!("Loading Vertex");
+///        Ok(ProcessingState::Loaded(Vertex::default()))
+///    }
+/// }
 /// ```
 #[macro_export]
 macro_rules! register_asset_type {

--- a/amethyst_assets/src/loader.rs
+++ b/amethyst_assets/src/loader.rs
@@ -501,7 +501,7 @@ where
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use serde::{Deserialize, Serialize};
 /// use amethyst::assets::{register_asset_type, Asset, AssetProcessorSystem, TypeUuid};
 ///

--- a/amethyst_assets/src/reload.rs
+++ b/amethyst_assets/src/reload.rs
@@ -46,7 +46,7 @@ impl SystemBundle for HotReloadBundle {
 ///
 /// ## Examples
 ///
-/// ```rust
+/// ```
 /// # use amethyst::assets::HotReloadStrategy;
 /// # use amethyst::core::ecs::{World, WorldExt};
 /// #

--- a/amethyst_assets/src/reload.rs
+++ b/amethyst_assets/src/reload.rs
@@ -46,7 +46,7 @@ impl SystemBundle for HotReloadBundle {
 ///
 /// ## Examples
 ///
-/// ```
+/// ```rust
 /// # use amethyst::assets::HotReloadStrategy;
 /// # use amethyst::core::ecs::{World, WorldExt};
 /// #

--- a/amethyst_assets/src/reload.rs
+++ b/amethyst_assets/src/reload.rs
@@ -47,8 +47,8 @@ impl SystemBundle for HotReloadBundle {
 /// ## Examples
 ///
 /// ```
-/// # use amethyst_assets::HotReloadStrategy;
-/// # use amethyst_core::ecs::{World, WorldExt};
+/// # use amethyst::assets::HotReloadStrategy;
+/// # use amethyst::core::ecs::{World, WorldExt};
 /// #
 /// let mut world = World::new();
 /// // Assets will be reloaded every two seconds (in case they changed)

--- a/amethyst_assets/src/simple_importer.rs
+++ b/amethyst_assets/src/simple_importer.rs
@@ -108,7 +108,7 @@ pub fn get_source_importers(
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use amethyst::assets::Format;
 /// use amethyst::error::Error;
 /// use serde::{Deserialize, Serialize};

--- a/amethyst_assets/src/simple_importer.rs
+++ b/amethyst_assets/src/simple_importer.rs
@@ -109,8 +109,8 @@ pub fn get_source_importers(
 /// # Examples
 ///
 /// ```rust
-/// use amethyst_assets::Format;
-/// use amethyst_error::Error;
+/// use amethyst::assets::Format;
+/// use amethyst::error::Error;
 /// use serde::{Deserialize, Serialize};
 /// use type_uuid::TypeUuid;
 ///

--- a/amethyst_audio/Cargo.toml
+++ b/amethyst_audio/Cargo.toml
@@ -32,6 +32,7 @@ thread_profiler = { version = "0.3", optional = true }
 type-uuid = "0.1"
 
 [dev-dependencies]
+amethyst = { path = "../", version = "0.15.3", features = ["renderer"] }
 amethyst_utils = { path = "../amethyst_utils", version = "0.15.3" }
 
 [features]

--- a/amethyst_config/Cargo.toml
+++ b/amethyst_config/Cargo.toml
@@ -25,6 +25,7 @@ encoding_rs_io = "0.1"
 thread_profiler = { version = "0.3", optional = true }
 
 [dev-dependencies]
+amethyst = { path = "../", version = "0.15.3", features = ["renderer"] }
 serde_derive = "1"
 
 [features]

--- a/amethyst_controls/Cargo.toml
+++ b/amethyst_controls/Cargo.toml
@@ -23,8 +23,11 @@ derive-new = "0.5"
 serde = { version = "1", features = ["derive"] }
 winit = { version = "0.24", git = "https://github.com/rust-windowing/winit", rev = "38fccebe1fbc4226c75d6180e5317bd93c024951", features = ["serde"] }
 log = "0.4"
-
 thread_profiler = { version = "0.3", optional = true }
+
+[dev-dependencies]
+amethyst = { path = "../", version = "0.15.3", features = ["renderer"] }
+
 
 [features]
 profiler = ["thread_profiler/thread_profiler"]

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -39,6 +39,7 @@ thread_profiler = { version = "0.3", optional = true }
 serde-diff = "0.4"
 
 [dev-dependencies]
+amethyst = { path = "../", version = "0.15.3", features = ["renderer"] }
 ron = "0.6.4"
 
 [features]

--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -34,6 +34,7 @@ pub use self::{
     named::Named,
     shrev::EventChannel,
     timing::*,
+    transform::Transform,
 };
 
 /// legion ECS reexported with some convenience types.

--- a/amethyst_core/src/named.rs
+++ b/amethyst_core/src/named.rs
@@ -29,9 +29,7 @@ use serde::{Deserialize, Serialize};
 /// use amethyst::{core::Named, ecs::*};
 ///
 /// let mut world = World::default();
-/// let entity: Entity = world.push((Named {
-///     name: "Reginald".into(),
-/// },));
+/// let entity: Entity = world.push((Named("Reginald".into()),));
 /// ```
 ///
 /// Creating a name from a dynamically generated string:
@@ -40,24 +38,22 @@ use serde::{Deserialize, Serialize};
 /// use amethyst::{core::Named, ecs::*};
 ///
 /// let mut world = World::default();
-
 /// for entity_num in 0..10 {
-///     world.push((Named { name: format!("Entity Number {}", entity_num).into() },));
+///     world.push((Named(format!("Entity Number {}", entity_num).into()),));
 /// }
 /// ```
-/// 
+///
 /// Accessing a named entity in a system:
 /// ```
-/// use amethyst::core::Named;
-/// use amethyst::ecs::*;
+/// use amethyst::{core::Named, ecs::*};
 ///
 /// SystemBuilder::new("NamedSystem")
-///   .with_query(<(Entity, Read<Named>)>::query())
-///   .build(move |_commands, world, _resource, query| {
+///     .with_query(<(Entity, Read<Named>)>::query())
+///     .build(move |_commands, world, _resource, query| {
 ///         for (entity, name) in query.iter(world) {
-///             println!("Entity {:?} is named {}", entity, name.name);
+///             println!("Entity {:?} is named {}", entity, name);
 ///         }
-/// });
+///     });
 /// ```
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Named(

--- a/amethyst_core/src/system_ext.rs
+++ b/amethyst_core/src/system_ext.rs
@@ -24,7 +24,7 @@ use legion::{
 /// it may grow indefinitely leaking memory while the system is paused.
 ///
 /// # Examples
-/// ```rust
+/// ```
 /// use amethyst::core::{
 ///     dispatcher::DispatcherBuilder,
 ///     ecs::{ParallelRunnable, System},

--- a/amethyst_core/src/system_ext.rs
+++ b/amethyst_core/src/system_ext.rs
@@ -25,7 +25,7 @@ use legion::{
 ///
 /// # Examples
 /// ```rust
-/// use amethyst_core::{
+/// use amethyst::core::{
 ///     dispatcher::DispatcherBuilder,
 ///     ecs::{ParallelRunnable, System},
 ///     system_ext::pausable,

--- a/amethyst_core/src/system_ext.rs
+++ b/amethyst_core/src/system_ext.rs
@@ -27,10 +27,9 @@ use legion::{
 /// ```
 /// use amethyst::core::{
 ///     dispatcher::DispatcherBuilder,
-///     ecs::{ParallelRunnable, System},
+///     ecs::{system, ParallelRunnable, Resources, Schedule, System, SystemBuilder, World},
 ///     system_ext::pausable,
 /// };
-/// use legion::{system, Resources, Schedule, SystemBuilder, World};
 ///
 /// #[derive(PartialEq)]
 /// enum CurrentState {
@@ -53,25 +52,25 @@ use legion::{
 ///     }
 /// }
 ///
+/// let mut world = World::default();
+/// let mut resources = Resources::default();
+///
 /// let mut dispatcher = DispatcherBuilder::default()
 ///     .add_system(Box::new(TestSystem))
 ///     .build(&mut world, &mut resources)
 ///     .unwrap();
-///
-/// let mut world = World::default();
-/// let mut resources = Resources::default();
 ///
 /// // we only expect the u32 resource to be modified _if_ the system is enabled,
 /// // the system should only be enabled on CurrentState::Enabled.
 /// resources.insert(0u32);
 /// resources.insert(CurrentState::Disabled);
 /// dispatcher.execute(&mut world, &mut resources);
-/// assert_eq!(1, resources.get::<u32>().unwrap());
+/// assert_eq!(1, resources.get::<u32>().unwrap().deref());
 ///
 /// resources.insert(0u32);
 /// resources.insert(CurrentState::Enabled);
 /// dispatcher.execute(&mut world, &mut resources);
-/// assert_eq!(1 + 2, resources.get::<u32>().unwrap());
+/// assert_eq!(1 + 2, resources.get::<u32>().unwrap().deref());
 /// ```
 pub fn pausable<V>(runnable: impl ParallelRunnable, value: V) -> Pausable<impl ParallelRunnable, V>
 where

--- a/amethyst_core/src/system_ext.rs
+++ b/amethyst_core/src/system_ext.rs
@@ -25,6 +25,8 @@ use legion::{
 ///
 /// # Examples
 /// ```
+/// use std::ops::Deref;
+///
 /// use amethyst::core::{
 ///     dispatcher::DispatcherBuilder,
 ///     ecs::{system, ParallelRunnable, Resources, Schedule, System, SystemBuilder, World},
@@ -62,15 +64,14 @@ use legion::{
 ///
 /// // we only expect the u32 resource to be modified _if_ the system is enabled,
 /// // the system should only be enabled on CurrentState::Enabled.
-/// resources.insert(0u32);
+/// resources.insert(1u32);
 /// resources.insert(CurrentState::Disabled);
 /// dispatcher.execute(&mut world, &mut resources);
-/// assert_eq!(1, resources.get::<u32>().unwrap().deref());
+/// assert_eq!(1, *resources.get::<u32>().unwrap().deref());
 ///
-/// resources.insert(0u32);
 /// resources.insert(CurrentState::Enabled);
 /// dispatcher.execute(&mut world, &mut resources);
-/// assert_eq!(1 + 2, resources.get::<u32>().unwrap().deref());
+/// assert_eq!(2, *resources.get::<u32>().unwrap().deref());
 /// ```
 pub fn pausable<V>(runnable: impl ParallelRunnable, value: V) -> Pausable<impl ParallelRunnable, V>
 where

--- a/amethyst_core/src/transform/components/transform.rs
+++ b/amethyst_core/src/transform/components/transform.rs
@@ -57,7 +57,7 @@ impl Transform {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// # use amethyst::core::transform::Transform;
     /// # use amethyst::core::math::{Isometry3, Translation3, UnitQuaternion, Vector3};
     /// let position = Translation3::new(0.0, 2.0, 4.0);
@@ -97,7 +97,7 @@ impl Transform {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// # use amethyst::core::transform::Transform;
     /// # use amethyst::core::math::{UnitQuaternion, Quaternion, Vector3};
     /// let mut t = Transform::default();

--- a/amethyst_core/src/transform/components/transform.rs
+++ b/amethyst_core/src/transform/components/transform.rs
@@ -58,8 +58,8 @@ impl Transform {
     /// # Examples
     ///
     /// ```rust
-    /// # use amethyst_core::transform::Transform;
-    /// # use amethyst_core::math::{Isometry3, Translation3, UnitQuaternion, Vector3};
+    /// # use amethyst::core::transform::Transform;
+    /// # use amethyst::core::math::{Isometry3, Translation3, UnitQuaternion, Vector3};
     /// let position = Translation3::new(0.0, 2.0, 4.0);
     /// let rotation = UnitQuaternion::from_euler_angles(0.4, 0.2, 0.0);
     /// let scale = Vector3::new(1.0, 1.0, 1.0);
@@ -98,8 +98,8 @@ impl Transform {
     /// # Examples
     ///
     /// ```rust
-    /// # use amethyst_core::transform::Transform;
-    /// # use amethyst_core::math::{UnitQuaternion, Quaternion, Vector3};
+    /// # use amethyst::core::transform::Transform;
+    /// # use amethyst::core::math::{UnitQuaternion, Quaternion, Vector3};
     /// let mut t = Transform::default();
     /// // No rotation by default
     /// assert_eq!(*t.rotation().quaternion(), Quaternion::identity());
@@ -480,7 +480,7 @@ impl Transform {
     /// rotation about the y axis, and 'yaw' will mean rotation about the z axis.
     ///
     /// ```
-    /// # use amethyst_core::transform::Transform;
+    /// # use amethyst::core::transform::Transform;
     /// let mut transform = Transform::default();
     ///
     /// transform.set_rotation_euler(1.0, 0.0, 0.0);
@@ -595,8 +595,8 @@ impl Default for Transform {
 /// Creates a Transform using the `Vector3` as the translation vector.
 ///
 /// ```
-/// # use amethyst_core::{transform::Transform};
-/// # use amethyst_core::math::Vector3;
+/// # use amethyst::core::{transform::Transform};
+/// # use amethyst::core::math::Vector3;
 /// let transform = Transform::from(Vector3::new(100.0, 200.0, 300.0));
 /// assert_eq!(transform.translation().x, 100.0);
 /// ```
@@ -611,8 +611,8 @@ impl From<Vector3<f32>> for Transform {
 /// Creates a Transform using the `Vector3<f64>` as the translation vector.
 /// Provided for convinience when providing constants.
 /// ```
-/// # use amethyst_core::transform::Transform;
-/// # use amethyst_core::math::Vector3;
+/// # use amethyst::core::transform::Transform;
+/// # use amethyst::core::math::Vector3;
 /// let transform = Transform::from(Vector3::new(100.0, 200.0, 300.0));
 /// assert_eq!(transform.translation().x, 100.0);
 impl From<Vector3<f64>> for Transform {

--- a/amethyst_derive/Cargo.toml
+++ b/amethyst_derive/Cargo.toml
@@ -23,6 +23,7 @@ quote = "1.0"
 proc-macro2 = "1.0"
 
 [dev-dependencies]
+amethyst = { path = "../", version = "0.15.3", features = ["renderer"] }
 amethyst_core = { path = "../amethyst_core", version = "0.15.3" }
 amethyst_assets = { path = "../amethyst_assets", version = "0.15.3" }
 amethyst_error = { path = "../amethyst_error", version = "0.15.3" }

--- a/amethyst_error/Cargo.toml
+++ b/amethyst_error/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "amethyst_error"
 version = "0.15.3"
-authors = ["John-John Tedro <udoprog@tedro.se>", "Amethyst Foundation <contact@amethyst.rs>"]
+authors = [
+    "John-John Tedro <udoprog@tedro.se>",
+    "Amethyst Foundation <contact@amethyst.rs>",
+]
 readme = "README.md"
 edition = "2018"
 description = """
@@ -17,3 +20,6 @@ repository = "https://github.com/amethyst/amethyst"
 
 [dependencies]
 backtrace = "0.3.44"
+
+[dev-dependencies]
+amethyst = { path = "../", version = "0.15.3", features = ["renderer"] }

--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -282,8 +282,7 @@ impl<'a> Iterator for Causes<'a> {
 /// Constructs an `Error` using the standard string interpolation syntax.
 ///
 /// ```rust
-/// #[macro_use]
-/// extern crate amethyst_error;
+/// use amethyst_error::format_err;
 ///
 /// fn main() {
 ///     let err = format_err!("number: {}", 42);

--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -113,7 +113,7 @@ impl Error {
     /// through [`ResultExt`](trait.ResultExt.html) using
     /// [`with_context`](trait.ResultExt.html#method.with_context).
     ///
-    /// ```rust
+    /// ```
     /// use std::io;
     ///
     /// use amethyst::error::{Error, ResultExt};
@@ -135,7 +135,7 @@ impl Error {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use amethyst::error::{Error, ResultExt};
     ///
     /// fn failing_function() -> Result<(), Error> {
@@ -216,7 +216,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use amethyst::error::{Error, ResultExt};
     ///
     /// fn failing_function() -> Result<(), Error> {
@@ -281,7 +281,7 @@ impl<'a> Iterator for Causes<'a> {
 
 /// Constructs an `Error` using the standard string interpolation syntax.
 ///
-/// ```rust
+/// ```
 /// use amethyst_error::format_err;
 ///
 /// fn main() {

--- a/amethyst_error/src/lib.rs
+++ b/amethyst_error/src/lib.rs
@@ -116,7 +116,7 @@ impl Error {
     /// ```rust
     /// use std::io;
     ///
-    /// use amethyst_error::{Error, ResultExt};
+    /// use amethyst::error::{Error, ResultExt};
     ///
     /// let e = io::Error::new(io::ErrorKind::Other, "wrapped");
     /// let a = Error::new(e);
@@ -136,7 +136,7 @@ impl Error {
     /// # Examples
     ///
     /// ```rust
-    /// use amethyst_error::{Error, ResultExt};
+    /// use amethyst::error::{Error, ResultExt};
     ///
     /// fn failing_function() -> Result<(), Error> {
     ///     Err(Error::from_string("failing"))
@@ -217,7 +217,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use amethyst_error::{Error, ResultExt};
+    /// use amethyst::error::{Error, ResultExt};
     ///
     /// fn failing_function() -> Result<(), Error> {
     ///     Err(Error::from_string("failing"))

--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -33,5 +33,8 @@ thread_profiler = { version = "0.3", optional = true }
 image = "0.22.2"
 derivative = "2.1.1"
 
+[dev-dependencies]
+amethyst = { path = "../", version = "0.15.3", features = ["renderer"] }
+
 [features]
 profiler = ["thread_profiler/thread_profiler"]

--- a/amethyst_gltf/src/format/material.rs
+++ b/amethyst_gltf/src/format/material.rs
@@ -71,32 +71,36 @@ pub fn load_material(
 
     // Can't use map/and_then because of Result returning from the load_texture function
     prefab.normal = match material.normal_texture() {
-        Some(normal_texture) => Some(
-            load_texture(
-                &normal_texture.texture(),
-                buffers,
-                source.clone(),
-                name,
-                false,
+        Some(normal_texture) => {
+            Some(
+                load_texture(
+                    &normal_texture.texture(),
+                    buffers,
+                    source.clone(),
+                    name,
+                    false,
+                )
+                .map(|data| TexturePrefab::Data(data.into()))?,
             )
-            .map(|data| TexturePrefab::Data(data.into()))?,
-        ),
+        }
 
         None => None,
     };
 
     // Can't use map/and_then because of Result returning from the load_texture function
     prefab.ambient_occlusion = match material.occlusion_texture() {
-        Some(occlusion_texture) => Some(
-            load_texture(
-                &occlusion_texture.texture(),
-                buffers,
-                source.clone(),
-                name,
-                false,
+        Some(occlusion_texture) => {
+            Some(
+                load_texture(
+                    &occlusion_texture.texture(),
+                    buffers,
+                    source.clone(),
+                    name,
+                    false,
+                )
+                .map(|data| TexturePrefab::Data(data.into()))?,
             )
-            .map(|data| TexturePrefab::Data(data.into()))?,
-        ),
+        }
 
         None => None,
     };
@@ -124,19 +128,23 @@ fn load_texture_with_factor(
     srgb: bool,
 ) -> Result<(TextureBuilder<'static>, [f32; 4]), Error> {
     match texture {
-        Some(info) => Ok((
-            load_texture(&info.texture(), buffers, source, name, srgb)?
-                .with_mip_levels(MipLevels::GenerateAuto),
-            factor,
-        )),
-        None => Ok((
-            if srgb {
-                load_from_srgba(Srgba::new(factor[0], factor[1], factor[2], factor[3]))
-            } else {
-                load_from_linear_rgba(LinSrgba::new(factor[0], factor[1], factor[2], factor[3]))
-            },
-            [1.0, 1.0, 1.0, 1.0],
-        )),
+        Some(info) => {
+            Ok((
+                load_texture(&info.texture(), buffers, source, name, srgb)?
+                    .with_mip_levels(MipLevels::GenerateAuto),
+                factor,
+            ))
+        }
+        None => {
+            Ok((
+                if srgb {
+                    load_from_srgba(Srgba::new(factor[0], factor[1], factor[2], factor[3]))
+                } else {
+                    load_from_linear_rgba(LinSrgba::new(factor[0], factor[1], factor[2], factor[3]))
+                },
+                [1.0, 1.0, 1.0, 1.0],
+            ))
+        }
     }
 }
 

--- a/amethyst_input/Cargo.toml
+++ b/amethyst_input/Cargo.toml
@@ -30,6 +30,7 @@ smallvec = { version = "1.2", features = ["serde"] }
 thread_profiler = { version = "0.3", optional = true }
 
 [dev-dependencies]
+amethyst = { path = "../", version = "0.15.3", features = ["renderer"] }
 approx = "0.4"
 
 [features]

--- a/amethyst_locale/Cargo.toml
+++ b/amethyst_locale/Cargo.toml
@@ -30,5 +30,8 @@ type-uuid = "0.1"
 
 thread_profiler = { version = "0.3", optional = true }
 
+[dev-dependencies]
+amethyst = { path = "../", version = "0.15.3", features = ["renderer"] }
+
 [features]
 profiler = ["thread_profiler/thread_profiler"]

--- a/amethyst_network/Cargo.toml
+++ b/amethyst_network/Cargo.toml
@@ -30,3 +30,6 @@ laminar = "0.4"
 log = "0.4"
 thread_profiler = { version = "0.3", optional = true }
 derive-new = "0.5.8"
+
+[dev-dependencies]
+amethyst = { path = "../", version = "0.15.3", features = ["renderer"] }

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -44,8 +44,8 @@ rendy = { version = "0.5", git = "https://github.com/amethyst/rendy", rev = "506
 [target.'cfg(target_os = "linux")'.dependencies]
 rendy = { version = "0.5", git = "https://github.com/amethyst/rendy", rev = "50667887612adc9314accea77438aa7fb925bce0", default-features = false, features = ["vulkan"] }
 
-
 [dev-dependencies]
+amethyst = { path = "../", version = "0.15.3", features = ["renderer"] }
 winit = { version = "0.24", git = "https://github.com/rust-windowing/winit", rev = "38fccebe1fbc4226c75d6180e5317bd93c024951", features = ["serde"] }
 rayon = "1.5"
 more-asserts = "0.2.1"

--- a/amethyst_rendy/src/formats/texture.rs
+++ b/amethyst_rendy/src/formats/texture.rs
@@ -20,33 +20,33 @@ use crate::types::TextureData;
 /// Image format description newtype wrapper for `ImageTextureConfig` from rendy.
 ///
 /// # Example Usage
-/// ```ignore
-/// 
-///    let loader = res.fetch_mut::<DefaultLoader>();
-///    let texture_storage = res.fetch_mut::<AssetStorage<Texture>>();
+/// ```
+/// let loader = res.fetch_mut::<DefaultLoader>();
+/// let texture_storage = res.fetch_mut::<AssetStorage<Texture>>();
 ///
-///    let texture_builder = TextureBuilder::new()
-///        .with_data_width(handle.width)
-///        .with_data_height(handle.height)
-///        .with_kind(image::Kind::D2(handle.width, handle.height, 1, 1))
-///        .with_view_kind(image::ViewKind::D2)
-///        .with_sampler_info(SamplerDesc {
-///        min_filter: Filter::Linear,
-///        mag_filter: Filter::Linear,
-///        mip_filter: Filter::Linear,
-///        wrap_mode: (WrapMode::Clamp, WrapMode::Clamp, WrapMode::Clamp),
-///        lod_bias: Lod(0.0),
-///        lod_range: std::ops::Range {
-///            start: Lod(0.0),
-///            end: Lod(1000.0),
-///        },
-///        comparison: None,
-///        border: PackedColor(0),
-///        anisotropic: Anisotropic::Off,
-///        })
-///        .with_raw_data(handle.pixels, Format::Rgba8Unorm);
+/// let texture_builder = TextureBuilder::new()
+///     .with_data_width(handle.width)
+///     .with_data_height(handle.height)
+///     .with_kind(image::Kind::D2(handle.width, handle.height, 1, 1))
+///     .with_view_kind(image::ViewKind::D2)
+///     .with_sampler_info(SamplerDesc {
+///         min_filter: Filter::Linear,
+///         mag_filter: Filter::Linear,
+///         mip_filter: Filter::Linear,
+///         wrap_mode: (WrapMode::Clamp, WrapMode::Clamp, WrapMode::Clamp),
+///         lod_bias: Lod(0.0),
+///         lod_range: std::ops::Range {
+///             start: Lod(0.0),
+///             end: Lod(1000.0),
+///         },
+///         comparison: None,
+///         border: PackedColor(0),
+///         anisotropic: Anisotropic::Off,
+///     })
+///     .with_raw_data(handle.pixels, Format::Rgba8Unorm);
 ///
-///    let tex: Handle<Texture> = loader.load_from_data(TextureData(texture_builder), (), &texture_storage);
+/// let tex: Handle<Texture> =
+///     loader.load_from_data(TextureData(texture_builder), (), &texture_storage);
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, TypeUuid)]
 #[serde(transparent)]

--- a/amethyst_rendy/src/formats/texture.rs
+++ b/amethyst_rendy/src/formats/texture.rs
@@ -21,14 +21,48 @@ use crate::types::TextureData;
 ///
 /// # Example Usage
 /// ```
-/// let loader = res.fetch_mut::<DefaultLoader>();
-/// let texture_storage = res.fetch_mut::<AssetStorage<Texture>>();
+/// use amethyst::{
+///     assets::{AssetStorage, DefaultLoader, Handle, Loader, ProcessingQueue},
+///     ecs::Resources,
+///     error::Error,
+///     renderer::{
+///         rendy::{
+///             hal::{
+///                 format::Format,
+///                 image::{
+///                     Filter, Kind, Lod, PackedColor, SamplerDesc, Size, ViewKind, WrapMode,
+///                 },
+///             },
+///             texture::{
+///                 image::{load_from_image, ImageTextureConfig, Repr, TextureKind},
+///                 pixel::{AsPixel, Rgba8Srgb},
+///                 TextureBuilder,
+///             },
+///         },
+///         types::TextureData,
+///         Texture,
+///     },
+/// };
+/// # let mut resources = Resources::default();
+/// # let mut loader = DefaultLoader::default();
+/// let texture_storage = resources.get_or_default::<ProcessingQueue<TextureData>>();
+/// struct Image {
+///     pixels: Vec<u8>,
+///     width: u32,
+///     height: u32,
+/// }
+///
+/// let handle = Image {
+///     pixels: vec![],
+///     width: 1,
+///     height: 1,
+/// };
 ///
 /// let texture_builder = TextureBuilder::new()
 ///     .with_data_width(handle.width)
 ///     .with_data_height(handle.height)
-///     .with_kind(image::Kind::D2(handle.width, handle.height, 1, 1))
-///     .with_view_kind(image::ViewKind::D2)
+///     .with_kind(Kind::D2(handle.width, handle.height, 1, 1))
+///     .with_view_kind(ViewKind::D2)
 ///     .with_sampler_info(SamplerDesc {
 ///         min_filter: Filter::Linear,
 ///         mag_filter: Filter::Linear,
@@ -41,7 +75,8 @@ use crate::types::TextureData;
 ///         },
 ///         comparison: None,
 ///         border: PackedColor(0),
-///         anisotropic: Anisotropic::Off,
+///         normalized: true,
+///         anisotropy_clamp: None,
 ///     })
 ///     .with_raw_data(handle.pixels, Format::Rgba8Unorm);
 ///

--- a/amethyst_rendy/src/plugins.rs
+++ b/amethyst_rendy/src/plugins.rs
@@ -65,8 +65,10 @@ mod window {
         /// This function takes linear RGBA. You can convert rgba to linear rgba like so:
         ///
         /// ```
-        /// use amethyst_rendy::{palette::Srgba, rendy::hal::command::ClearColor, RenderToWindow};
-        /// use amethyst_window::DisplayConfig;
+        /// use amethyst::{
+        ///     rendy::{palette::Srgba, rendy::hal::command::ClearColor, RenderToWindow},
+        ///     window::DisplayConfig,
+        /// };
         ///
         /// let your_red: f32 = 255.;
         /// let your_green: f32 = 160.;

--- a/amethyst_rendy/src/plugins.rs
+++ b/amethyst_rendy/src/plugins.rs
@@ -66,7 +66,7 @@ mod window {
         ///
         /// ```
         /// use amethyst::{
-        ///     rendy::{palette::Srgba, rendy::hal::command::ClearColor, RenderToWindow},
+        ///     renderer::{palette::Srgba, rendy::hal::command::ClearColor, RenderToWindow},
         ///     window::DisplayConfig,
         /// };
         ///

--- a/amethyst_rendy/src/pod.rs
+++ b/amethyst_rendy/src/pod.rs
@@ -13,7 +13,7 @@ use rendy::{
 use crate::{mtl, resources::Tint as TintComponent, Sprite};
 
 /// TextureOffset
-/// ```glsl,ignore
+/// ```glsl
 /// struct UvOffset {
 ///    vec2 u_offset;
 ///    vec2 v_offset;
@@ -39,7 +39,7 @@ impl TextureOffset {
 }
 
 /// ViewArgs
-/// ```glsl,ignore
+/// ```glsl
 /// uniform ViewArgs {
 ///    uniform mat4 proj;
 ///    uniform mat4 view;
@@ -58,7 +58,7 @@ pub struct ViewArgs {
 }
 
 /// Tint
-/// ```glsl,ignore
+/// ```glsl
 /// vec4 tint;
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Uniform)]
@@ -74,7 +74,7 @@ impl AsAttribute for Tint {
 }
 
 /// Instance-rate vertex arguments
-/// ```glsl,ignore
+/// ```glsl
 ///  mat4 model;
 ///  vec4 tint;
 /// ```
@@ -111,7 +111,7 @@ impl AsVertex for VertexArgs {
 }
 
 /// Instance-rate joints offset
-/// ```glsl,ignore
+/// ```glsl
 ///  uint joints_offset;
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Uniform)]
@@ -127,7 +127,7 @@ impl AsAttribute for JointsOffset {
 }
 
 /// Skinned Instance-rate vertex arguments.
-/// ```glsl,ignore
+/// ```glsl
 ///  mat4 model;
 ///  vec4 tint;
 ///  uint joints_offset:
@@ -171,7 +171,7 @@ impl SkinnedVertexArgs {
 }
 
 /// point light struct
-/// ```glsl,ignore
+/// ```glsl
 /// struct PointLight {
 ///    vec3 position;
 ///    vec3 color;
@@ -189,7 +189,7 @@ pub struct PointLight {
 }
 
 /// directional light struct
-/// ```glsl,ignore
+/// ```glsl
 /// struct DirectionalLight {
 ///    vec3 color;
 ///    float intensity;
@@ -207,7 +207,7 @@ pub struct DirectionalLight {
 }
 
 /// spot light struct
-/// ```glsl,ignore
+/// ```glsl
 /// struct SpotLight {
 ///    vec3 position;
 ///    vec3 color;
@@ -237,7 +237,7 @@ pub struct SpotLight {
 }
 
 /// Environment Uniform
-/// ```glsl,ignore
+/// ```glsl
 /// uniform Environment {
 ///    vec3 ambient_color;
 ///    vec3 camera_position;
@@ -261,7 +261,7 @@ pub struct Environment {
 }
 
 /// Material Uniform
-/// ```glsl,ignore
+/// ```glsl
 /// uniform Material {
 ///    UvOffset uv_offset;
 ///    float alpha_cutoff;
@@ -287,7 +287,7 @@ impl Material {
 }
 
 /// Sprite Vertex Data
-/// ```glsl,ignore
+/// ```glsl
 /// vec2 dir_x;
 /// vec2 dir_y;
 /// vec2 pos;

--- a/amethyst_rendy/src/sprite/mod.rs
+++ b/amethyst_rendy/src/sprite/mod.rs
@@ -327,9 +327,9 @@ use amethyst_assets::{
 ///
 /// Such a spritesheet description can be loaded using a `Loader` by passing it the handle of the corresponding loaded texture.
 /// ```
-/// # use amethyst::core::ecs::{World};
-/// # use amethyst::assets::{Loader, AssetStorage, DefaultLoader};
-/// # use amethyst::rendy::{sprite::{SpriteSheetFormat, SpriteSheet}, Texture, formats::texture::ImageFormat};
+/// # use amethyst::core::ecs::{World, Resources};
+/// # use amethyst::assets::{Handle, Loader, AssetStorage, DefaultLoader, ProcessingQueue};
+/// # use amethyst::renderer::{sprite::{Sprites, SpriteSheet}, Texture, formats::texture::ImageFormat};
 /// #
 /// # fn load_sprite_sheet(resources: &Resources) {
 /// #   let world = World::default(); // Normally, you would use Amethyst's world
@@ -340,7 +340,8 @@ use amethyst_assets::{
 /// let sprites: Handle<Sprites> = loader.load(
 ///     "my_spritesheet.ron",
 /// );
-/// let spritesheet_handle = loader.load_from_data(SpriteSheet { texture, sprites }, (), &spritesheet_storage)
+/// let spritesheet_storage = resources.get::<ProcessingQueue<SpriteSheet>>().unwrap();
+/// let spritesheet_handle: Handle<SpriteSheet> = loader.load_from_data(SpriteSheet { texture, sprites }, (), &spritesheet_storage);
 /// # }
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, TypeUuid, SerdeImportable)]

--- a/amethyst_rendy/src/sprite/mod.rs
+++ b/amethyst_rendy/src/sprite/mod.rs
@@ -290,7 +290,7 @@ use amethyst_assets::{
 /// This format allows to conveniently load a sprite sheet from a RON file.
 ///
 /// Example:
-/// ```text
+/// ```ron
 /// #![enable(implicit_some)]
 /// {
 /// "04c60333-c790-4586-aa76-086b19167a04":
@@ -326,19 +326,18 @@ use amethyst_assets::{
 /// ```
 ///
 /// Such a spritesheet description can be loaded using a `Loader` by passing it the handle of the corresponding loaded texture.
-/// ```rust, no_run
-/// # use amethyst::core::ecs::{World, WorldExt};
-/// # use amethyst::assets::{Loader, AssetStorage};
+/// ```
+/// # use amethyst::core::ecs::{World};
+/// # use amethyst::assets::{Loader, AssetStorage, DefaultLoader};
 /// # use amethyst::rendy::{sprite::{SpriteSheetFormat, SpriteSheet}, Texture, formats::texture::ImageFormat};
 /// #
-/// # fn load_sprite_sheet() {
+/// # fn load_sprite_sheet(resources: &Resources) {
 /// #   let world = World::default(); // Normally, you would use Amethyst's world
-/// #   let loader = data.resources.get::<DefaultLoader>().unwrap();
-/// #   let spritesheet_storage = world.read_resource::<AssetStorage<SpriteSheet>>();
-/// let texture = loader.load(
+/// #   let loader = resources.get::<DefaultLoader>().unwrap();
+/// let texture: Handle<Texture> = loader.load(
 ///     "my_texture.png",
 /// );
-/// let sprites = loader.load(
+/// let sprites: Handle<Sprites> = loader.load(
 ///     "my_spritesheet.ron",
 /// );
 /// let spritesheet_handle = loader.load_from_data(SpriteSheet { texture, sprites }, (), &spritesheet_storage)

--- a/amethyst_rendy/src/sprite/mod.rs
+++ b/amethyst_rendy/src/sprite/mod.rs
@@ -290,7 +290,7 @@ use amethyst_assets::{
 /// This format allows to conveniently load a sprite sheet from a RON file.
 ///
 /// Example:
-/// ```text,ignore
+/// ```text
 /// #![enable(implicit_some)]
 /// {
 /// "04c60333-c790-4586-aa76-086b19167a04":
@@ -326,7 +326,7 @@ use amethyst_assets::{
 /// ```
 ///
 /// Such a spritesheet description can be loaded using a `Loader` by passing it the handle of the corresponding loaded texture.
-/// ```rust,no_run
+/// ```rust, no_run
 /// # use amethyst::core::ecs::{World, WorldExt};
 /// # use amethyst::assets::{Loader, AssetStorage};
 /// # use amethyst::rendy::{sprite::{SpriteSheetFormat, SpriteSheet}, Texture, formats::texture::ImageFormat};

--- a/amethyst_rendy/src/sprite/mod.rs
+++ b/amethyst_rendy/src/sprite/mod.rs
@@ -327,9 +327,9 @@ use amethyst_assets::{
 ///
 /// Such a spritesheet description can be loaded using a `Loader` by passing it the handle of the corresponding loaded texture.
 /// ```rust,no_run
-/// # use amethyst_core::ecs::{World, WorldExt};
-/// # use amethyst_assets::{Loader, AssetStorage};
-/// # use amethyst_rendy::{sprite::{SpriteSheetFormat, SpriteSheet}, Texture, formats::texture::ImageFormat};
+/// # use amethyst::core::ecs::{World, WorldExt};
+/// # use amethyst::assets::{Loader, AssetStorage};
+/// # use amethyst::rendy::{sprite::{SpriteSheetFormat, SpriteSheet}, Texture, formats::texture::ImageFormat};
 /// #
 /// # fn load_sprite_sheet() {
 /// #   let world = World::default(); // Normally, you would use Amethyst's world

--- a/amethyst_test/Cargo.toml
+++ b/amethyst_test/Cargo.toml
@@ -24,6 +24,7 @@ lazy_static = "1.4"
 log = "0.4"
 
 [dev-dependencies]
+amethyst = { path = "../", version = "0.15.3", features = ["renderer"] }
 serde = "1"
 
 [features]

--- a/amethyst_test/src/amethyst_application.rs
+++ b/amethyst_test/src/amethyst_application.rs
@@ -946,7 +946,7 @@ mod test {
     /// **Note:** If you simply need an audio file to be loaded, just add a `Processor::<Source>` in
     /// the test setup:
     ///
-    /// ```rust
+    /// ```
     /// use amethyst::{assets::Processor, audio::Source};
     ///
     /// AmethystApplication::blank()

--- a/amethyst_test/src/amethyst_application.rs
+++ b/amethyst_test/src/amethyst_application.rs
@@ -946,7 +946,7 @@ mod test {
     /// **Note:** If you simply need an audio file to be loaded, just add a `Processor::<Source>` in
     /// the test setup:
     ///
-    /// ```rust,ignore
+    /// ```rust
     /// use amethyst::{assets::Processor, audio::Source};
     ///
     /// AmethystApplication::blank()

--- a/amethyst_test/src/amethyst_application.rs
+++ b/amethyst_test/src/amethyst_application.rs
@@ -23,8 +23,8 @@ use crate::{
 
 type BundleAddFn = Box<
     dyn FnOnce(
-        GameDataBuilder<'static, 'static>,
-    ) -> Result<GameDataBuilder<'static, 'static>, Error>,
+        DispatcherBuilder<'static, 'static>,
+    ) -> Result<DispatcherBuilder<'static, 'static>, Error>,
 >;
 // Hack: Ideally we want a `SendBoxFnOnce`. However implementing it got too crazy:
 //
@@ -73,14 +73,14 @@ where
 {
     /// Functions to add bundles to the game data.
     ///
-    /// This is necessary because `System`s are not `Send`, and so we cannot send `GameDataBuilder`
+    /// This is necessary because `System`s are not `Send`, and so we cannot send `DispatcherBuilder`
     /// across a thread boundary, necessary to run the `Application` in a sub thread to avoid a
     /// segfault caused by mesa and the software GL renderer.
     #[derivative(Debug = "ignore")]
     bundle_add_fns: Vec<BundleAddFn>,
     /// Functions to add bundles to the game data.
     ///
-    /// This is necessary because `System`s are not `Send`, and so we cannot send `GameDataBuilder`
+    /// This is necessary because `System`s are not `Send`, and so we cannot send `DispatcherBuilder`
     /// across a thread boundary, necessary to run the `Application` in a sub thread to avoid a
     /// segfault caused by mesa and the software GL renderer.
     #[derivative(Debug = "ignore")]
@@ -169,7 +169,7 @@ where
     {
         let mut game_data = bundle_add_fns.into_iter().fold(
             Ok(DispatcherBuilder::default()),
-            |game_data: Result<GameDataBuilder<'_, '_>, Error>, function: BundleAddFn| {
+            |game_data: Result<DispatcherBuilder<'_, '_>, Error>, function: BundleAddFn| {
                 game_data.and_then(function)
             },
         )?;
@@ -189,7 +189,7 @@ where
 
     fn build_application<S>(
         first_state: S,
-        game_data: GameDataBuilder<'static, 'static>,
+        game_data: DispatcherBuilder<'static, 'static>,
         resource_add_fns: Vec<FnResourceAdd>,
         setup_fns: Vec<FnSetup>,
     ) -> Result<CoreApplication<'static, GameData<'static, 'static>, E, R>, Error>
@@ -340,10 +340,9 @@ where
         // `SendBoxFnOnce` is an implementation of this.
         //
         // See <https://users.rust-lang.org/t/move-a-boxed-function-inside-a-closure/18199>
-        self.bundle_add_fns
-            .push(Box::new(|game_data: GameDataBuilder<'static, 'static>| {
-                game_data.with_bundle(bundle)
-            }));
+        self.bundle_add_fns.push(Box::new(
+            |game_data: DispatcherBuilder<'static, 'static>| game_data.with_bundle(bundle),
+        ));
         self
     }
 
@@ -361,7 +360,7 @@ where
         B: SystemBundle<'static, 'static> + 'static,
     {
         self.bundle_add_fns.push(Box::new(
-            move |game_data: GameDataBuilder<'static, 'static>| {
+            move |game_data: DispatcherBuilder<'static, 'static>| {
                 game_data.with_bundle(bundle_function())
             },
         ));
@@ -949,9 +948,8 @@ mod test {
     /// ```
     /// use amethyst::{assets::Processor, audio::Source};
     ///
-    /// AmethystApplication::blank()
-    ///     .with_system(Processor::<Source>::new(), "source_processor", &[])
-    ///     // ...
+    /// AmethystApplication::blank().with_system(Processor::<Source>::new(), "source_processor", &[])
+    /// // ...
     /// ```
     ///
     /// For more details, see <https://github.com/amethyst/amethyst/issues/1595>.

--- a/amethyst_test/src/lib.rs
+++ b/amethyst_test/src/lib.rs
@@ -28,7 +28,7 @@
 //! The following shows a simple example of testing a `State`. More examples are in the
 //! [Examples](#Examples) section.
 //!
-//! ```rust
+//! ```
 //! # use std::marker::PhantomData;
 //! #
 //! # use amethyst_test::prelude::*;
@@ -81,7 +81,7 @@
 //! The Amethyst application is initialized with one of the following functions, each providing a
 //! different set of bundles:
 //!
-//! ```rust, no_run
+//! ```no_run
 //! use amethyst_test::prelude::*;
 //!
 //! #[test]
@@ -117,7 +117,7 @@
 //!
 //! Next, attach the logic you wish to test using the various `.with_*(..)` methods:
 //!
-//! ```rust, no_run
+//! ```no_run
 //! # use amethyst::{
 //! #     core::bundle::SystemBundle,
 //! #     ecs::prelude::*,
@@ -155,7 +155,7 @@
 //! Finally, call `.run()` to run the application. This returns `amethyst::Result<()>`, so you can
 //! wrap it in an `assert!(..);`:
 //!
-//! ```rust, no_run
+//! ```no_run
 //! #[test]
 //! fn test_name() {
 //!     let visibility = false; // Whether the window should be shown
@@ -172,7 +172,7 @@
 //!
 //! Testing a bundle:
 //!
-//! ```rust
+//! ```
 //! # use amethyst_test::prelude::*;
 //! # use amethyst::{
 //! #     core::bundle::SystemBundle,
@@ -219,7 +219,7 @@
 //!
 //! Testing a system:
 //!
-//! ```rust
+//! ```
 //! # use amethyst_test::prelude::*;
 //! # use amethyst::{
 //! #     ecs::prelude::*,
@@ -276,7 +276,7 @@
 //! Testing a System in a custom dispatcher. This is useful when your system must run *after* some
 //! setup has been done:
 //!
-//! ```rust
+//! ```
 //! # use amethyst_test::prelude::*;
 //! # use amethyst::{
 //! #     ecs::prelude::*,

--- a/amethyst_test/src/lib.rs
+++ b/amethyst_test/src/lib.rs
@@ -81,7 +81,7 @@
 //! The Amethyst application is initialized with one of the following functions, each providing a
 //! different set of bundles:
 //!
-//! ```rust,no_run
+//! ```rust, no_run
 //! use amethyst_test::prelude::*;
 //!
 //! #[test]
@@ -117,7 +117,7 @@
 //!
 //! Next, attach the logic you wish to test using the various `.with_*(..)` methods:
 //!
-//! ```rust,no_run
+//! ```rust, no_run
 //! # use amethyst::{
 //! #     core::bundle::SystemBundle,
 //! #     ecs::prelude::*,
@@ -155,7 +155,7 @@
 //! Finally, call `.run()` to run the application. This returns `amethyst::Result<()>`, so you can
 //! wrap it in an `assert!(..);`:
 //!
-//! ```rust,no_run
+//! ```rust, no_run
 //! #[test]
 //! fn test_name() {
 //!     let visibility = false; // Whether the window should be shown

--- a/amethyst_tiles/Cargo.toml
+++ b/amethyst_tiles/Cargo.toml
@@ -38,6 +38,7 @@ glsl-layout = "0.4"
 err-derive = "0.3"
 
 [dev-dependencies]
+amethyst = { path = "../", version = "0.15.3", features = ["renderer"] }
 criterion = "0.3"
 more-asserts = "0.2"
 approx = "0.4"

--- a/amethyst_tiles/src/pod.rs
+++ b/amethyst_tiles/src/pod.rs
@@ -14,7 +14,7 @@ use amethyst_rendy::{
 use glsl_layout::{mat4, uvec3, vec2, vec4, Uniform};
 
 /// `TileMapArgs`
-/// ```glsl,ignore
+/// ```glsl
 /// uniform TileMapArgs {
 ///    uniform mat4 proj;
 ///    uniform mat4 view;
@@ -38,7 +38,7 @@ pub struct TileMapArgs {
 }
 
 /// Tile Vertex Data
-/// ```glsl,ignore
+/// ```glsl
 /// vec2 dir_x;
 /// vec2 dir_y;
 /// vec2 pos;

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -45,5 +45,8 @@ glyph_brush = "0.6"
 thread_profiler = { version = "0.3", optional = true }
 type-uuid = "0.1"
 
+[dev-dependencies]
+amethyst = { path = "../", version = "0.15.3", features = ["renderer"] }
+
 [features]
 profiler = ["thread_profiler/thread_profiler"]

--- a/amethyst_ui/src/config.rs
+++ b/amethyst_ui/src/config.rs
@@ -9,5 +9,5 @@
 pub struct UiConfig {
     #[derivative(Default = "0.5")]
     pub cursor_blink_rate: f32,
-    pub cursor_color: [f32; 4]',
+    pub cursor_color: [f32; 4],
 }

--- a/amethyst_ui/src/image.rs
+++ b/amethyst_ui/src/image.rs
@@ -48,7 +48,7 @@ pub enum UiImage {
     /// This tuple takes linear RGBA. You can convert rgba to linear rgba like so:
     ///
     /// ```
-    /// use amethyst::{rendy::palette::Srgba, ui::UiImage};
+    /// use amethyst::{renderer::palette::Srgba, ui::UiImage};
     ///
     /// let your_red: f32 = 255.;
     /// let your_green: f32 = 160.;

--- a/amethyst_ui/src/image.rs
+++ b/amethyst_ui/src/image.rs
@@ -48,8 +48,7 @@ pub enum UiImage {
     /// This tuple takes linear RGBA. You can convert rgba to linear rgba like so:
     ///
     /// ```
-    /// use amethyst_rendy::palette::Srgba;
-    /// use amethyst_ui::UiImage;
+    /// use amethyst::{rendy::palette::Srgba, ui::UiImage};
     ///
     /// let your_red: f32 = 255.;
     /// let your_green: f32 = 160.;

--- a/amethyst_utils/Cargo.toml
+++ b/amethyst_utils/Cargo.toml
@@ -17,10 +17,8 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.15.3" }
-#amethyst_controls = { path = "../amethyst_controls", version = "0.15.3" }
 amethyst_core = { path = "../amethyst_core", version = "0.15.3" }
 amethyst_error = { path = "../amethyst_error", version = "0.15.3" }
-#amethyst_derive = { path = "../amethyst_derive", version = "0.15.3" }
 amethyst_rendy = { path = "../amethyst_rendy", version = "0.15.3" }
 amethyst_window = { path = "../amethyst_window", version = "0.15.3" }
 derive-new = "0.5.8"

--- a/amethyst_utils/Cargo.toml
+++ b/amethyst_utils/Cargo.toml
@@ -25,9 +25,11 @@ derive-new = "0.5.8"
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
 dunce = "1"
-
 thread_profiler = { version = "0.3", optional = true }
 derivative = "2.1.3"
+
+[dev-dependencies]
+amethyst = { path = "../", version = "0.15.3", features = ["renderer"] }
 
 [features]
 profiler = ["thread_profiler/thread_profiler"]

--- a/amethyst_utils/src/circular_buffer.rs
+++ b/amethyst_utils/src/circular_buffer.rs
@@ -6,7 +6,7 @@ use std::collections::VecDeque;
 /// # Example
 ///
 /// ```rust
-/// # use amethyst_utils::circular_buffer::CircularBuffer;
+/// # use amethyst::utils::circular_buffer::CircularBuffer;
 /// # use std::collections::VecDeque;
 /// let mut buf = CircularBuffer::<u32>::new(2);
 /// assert_eq!(*buf.queue(), VecDeque::<u32>::from(vec![]));

--- a/amethyst_utils/src/circular_buffer.rs
+++ b/amethyst_utils/src/circular_buffer.rs
@@ -5,7 +5,7 @@ use std::collections::VecDeque;
 /// A CircularBuffer that drops the oldest element inserted when full.
 /// # Example
 ///
-/// ```rust
+/// ```
 /// # use amethyst::utils::circular_buffer::CircularBuffer;
 /// # use std::collections::VecDeque;
 /// let mut buf = CircularBuffer::<u32>::new(2);

--- a/amethyst_utils/src/fps_counter.rs
+++ b/amethyst_utils/src/fps_counter.rs
@@ -25,8 +25,8 @@ use crate::circular_buffer::CircularBuffer;
 ///
 /// # Example
 /// ```rust
-/// # use amethyst_utils::fps_counter::FpsCounter;
-/// # use amethyst_core::ecs::{World, Resources};
+/// # use amethyst::utils::fps_counter::FpsCounter;
+/// # use amethyst::core::ecs::{World, Resources};
 /// # let mut world = World::default();
 /// let resources = Resources::default();
 /// let counter = FpsCounter::new(2);

--- a/amethyst_utils/src/fps_counter.rs
+++ b/amethyst_utils/src/fps_counter.rs
@@ -24,11 +24,11 @@ use crate::circular_buffer::CircularBuffer;
 /// framerate by the user.
 ///
 /// # Example
-/// ```rust
+/// ```
 /// # use amethyst::utils::fps_counter::FpsCounter;
 /// # use amethyst::core::ecs::{World, Resources};
 /// # let mut world = World::default();
-/// let resources = Resources::default();
+/// let mut resources = Resources::default();
 /// let counter = FpsCounter::new(2);
 /// resources.insert(counter);
 /// ```

--- a/amethyst_utils/src/ortho_camera.rs
+++ b/amethyst_utils/src/ortho_camera.rs
@@ -69,21 +69,17 @@ impl Default for CameraOrthoWorldCoordinates {
 ///
 /// # Example
 ///
-/// ```rust
-/// # use amethyst::core::ecs::{Builder, World, WorldExt};
+/// ```
+/// # use amethyst::core::ecs::World;
 /// # use amethyst::core::Transform;
-/// # use amethyst::rendy::camera::Camera;
+/// # use amethyst::renderer::camera::Camera;
 /// # use amethyst::utils::ortho_camera::*;
-/// # let mut world = World::new();
-/// # world.register::<Transform>();
-/// # world.register::<Camera>();
-/// # world.register::<CameraOrtho>();
-/// world
-///     .create_entity()
-///     .with(Transform::default())
-///     .with(Camera::standard_2d(1920.0, 1080.0))
-///     .with(CameraOrtho::normalized(CameraNormalizeMode::Contain))
-///     .build();
+/// # let mut world = World::default();
+/// world.push((
+///     Transform::default(),
+///     Camera::standard_2d(1920.0, 1080.0),
+///     CameraOrtho::normalized(CameraNormalizeMode::Contain),
+/// ));
 /// ```
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, new)]
 pub struct CameraOrtho {

--- a/amethyst_utils/src/ortho_camera.rs
+++ b/amethyst_utils/src/ortho_camera.rs
@@ -70,10 +70,10 @@ impl Default for CameraOrthoWorldCoordinates {
 /// # Example
 ///
 /// ```rust
-/// # use amethyst_core::ecs::{Builder, World, WorldExt};
-/// # use amethyst_core::Transform;
-/// # use amethyst_rendy::camera::Camera;
-/// # use amethyst_utils::ortho_camera::*;
+/// # use amethyst::core::ecs::{Builder, World, WorldExt};
+/// # use amethyst::core::Transform;
+/// # use amethyst::rendy::camera::Camera;
+/// # use amethyst::utils::ortho_camera::*;
 /// # let mut world = World::new();
 /// # world.register::<Transform>();
 /// # world.register::<Camera>();

--- a/amethyst_utils/src/removal.rs
+++ b/amethyst_utils/src/removal.rs
@@ -12,8 +12,8 @@ use serde::{Deserialize, Serialize};
 /// # Example
 ///
 /// ```rust
-/// # use amethyst_core::ecs::*;
-/// # use amethyst_utils::removal::*;
+/// # use amethyst::core::ecs::*;
+/// # use amethyst::utils::removal::*;
 /// # let mut world = World::new();
 /// # world.register::<Removal<RemovalId>>();
 ///

--- a/amethyst_utils/src/removal.rs
+++ b/amethyst_utils/src/removal.rs
@@ -11,11 +11,11 @@ use serde::{Deserialize, Serialize};
 ///
 /// # Example
 ///
-/// ```rust
+/// ```
 /// # use amethyst::core::ecs::*;
 /// # use amethyst::utils::removal::*;
-/// # let mut world = World::new();
-/// # world.register::<Removal<RemovalId>>();
+/// let mut world = World::default();
+/// let mut buffer = CommandBuffer::new(&mut world);
 ///
 /// #[derive(Clone, Debug, PartialEq)]
 /// enum RemovalId {
@@ -23,28 +23,19 @@ use serde::{Deserialize, Serialize};
 ///     Something2,
 /// }
 ///
-/// let _entity1 = world
-///     .create_entity()
-///     .with(Removal::new(RemovalId::Something))
-///     .build();
-/// let _entity2 = world
-///     .create_entity()
-///     .with(Removal::new(RemovalId::Something2))
-///     .build();
+/// world.push((Removal::new(RemovalId::Something),));
+/// world.push((Removal::new(RemovalId::Something2),));
 ///
 /// // Remove all entities with the RemovalId value of Something.
-/// exec_removal(
-///     &world.entities(),
-///     &world.read_storage(),
+/// amethyst::utils::removal::exec_removal(
+///     &mut buffer,
+///     &mut (&mut world).into(),
 ///     RemovalId::Something,
 /// );
 ///
 /// // Force the world to be up to date. This is normally called automatically at the end of the
 /// // frame by amethyst.
-/// world.maintain();
-///
-/// // Count entities remaining in the world.
-/// assert_eq!((&*world.entities(),).join().count(), 1);
+/// buffer.flush(&mut world);
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Removal<I>
@@ -65,7 +56,7 @@ where
 }
 
 /// Removes all entities that have the `Removal<I>` component with the specified removal_id.
-pub fn exec_removal<I, D>(commands: &mut CommandBuffer, subworld: &mut SubWorld<'_>, removal_id: I)
+pub fn exec_removal<I>(commands: &mut CommandBuffer, subworld: &mut SubWorld<'_>, removal_id: I)
 where
     I: Debug + Clone + PartialEq + Send + Sync + 'static,
 {

--- a/amethyst_window/Cargo.toml
+++ b/amethyst_window/Cargo.toml
@@ -22,6 +22,9 @@ serde = { version = "1", features = ["derive"] }
 thread_profiler = { version = "0.3", optional = true }
 winit = { version = "0.24", git = "https://github.com/rust-windowing/winit", rev = "38fccebe1fbc4226c75d6180e5317bd93c024951", features = ["serde"] }
 
+[dev-dependencies]
+amethyst = { path = "../", version = "0.15.3", features = ["renderer"] }
+
 [features]
 profiler = ["thread_profiler/thread_profiler"]
 test-support = []

--- a/amethyst_window/src/config.rs
+++ b/amethyst_window/src/config.rs
@@ -63,7 +63,7 @@ pub struct DisplayConfig {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use amethyst::window::{DisplayConfig, Icon};
     ///
     /// // First, create your `DisplayConfig` as usual

--- a/amethyst_window/src/config.rs
+++ b/amethyst_window/src/config.rs
@@ -64,7 +64,7 @@ pub struct DisplayConfig {
     /// # Examples
     ///
     /// ```rust
-    /// use amethyst_window::{DisplayConfig, Icon};
+    /// use amethyst::window::{DisplayConfig, Icon};
     ///
     /// // First, create your `DisplayConfig` as usual
     /// let mut config = DisplayConfig::default(); // or load from file

--- a/amethyst_window/src/config.rs
+++ b/amethyst_window/src/config.rs
@@ -64,7 +64,7 @@ pub struct DisplayConfig {
     /// # Examples
     ///
     /// ```
-    /// use amethyst::window::{DisplayConfig, Icon};
+    /// use amethyst::{window::DisplayConfig, winit::window::Icon};
     ///
     /// // First, create your `DisplayConfig` as usual
     /// let mut config = DisplayConfig::default(); // or load from file
@@ -79,7 +79,7 @@ pub struct DisplayConfig {
     /// // It will now be used as the window icon
     /// config.loaded_icon = Some(Icon::from_rgba(icon, 128, 128).unwrap());
     ///
-    /// // Now, feed this into the `GameDataBuilder` using
+    /// // Now, feed this into the `DispatcherBuilder` using
     /// // `.with_bundle(WindowBundle::from_config(config))`
     /// ```
     #[serde(skip)]

--- a/book/book.toml
+++ b/book/book.toml
@@ -8,9 +8,9 @@ preferred-dark-theme = "coal"
 additional-css = ["style/book.css"]
 additional-js = ["style/book.js"]
 
-#[output.linkcheck]
-#optional = true
-#follow-web-links = true
+[output.linkcheck]
+follow-web-links = true
+warning-policy = "error"
 
-#[output.linkcheck.http-headers]
-#   'crates\.io' = ["Accept: text/html"]
+[output.linkcheck.http-headers]
+'crates\.io' = ["Accept: text/html"]

--- a/book/src/appendices/a_config_files.md
+++ b/book/src/appendices/a_config_files.md
@@ -12,7 +12,7 @@ Luckily, Amethyst uses [RON][ron] configuration files and has infrastructure in 
 
 The existing example uses the following constants:
 
-```rust,ignore
+```rust
 const ARENA_HEIGHT: f32 = 100.0;
 const ARENA_WIDTH: f32 = 100.0;
 const PADDLE_HEIGHT: f32 = 15.0;
@@ -30,7 +30,7 @@ to specify the look of the game. We want to replace this with something more fle
 file. To start, let's create a new file, `config.rs`, to hold our configuration structures. Add the following 
 `use` statements to the top of this file:
 
-```rust,ignore
+```rust
 use std::path::Path;
 
 use amethyst::config::Config;

--- a/book/src/appendices/a_config_files/arena_config.md
+++ b/book/src/appendices/a_config_files/arena_config.md
@@ -2,7 +2,7 @@
 
 To begin with, let's make the `Arena` dimensions configurable. Add this structure to a new file `config.rs`.
 
-```rust,ignore
+```rust
 #[derive(Debug, Deserialize, Serialize)]
 struct ArenaConfig {
     pub height: f32,
@@ -29,13 +29,13 @@ be present. For now though, let's just use the `Default` trait.
 
 Now, in `main.rs`, add the following lines:
 
-```rust,ignore
+```rust
 use crate::config::ArenaConfig;
 ```
 
 We'll need to load the config at startup, so let's add this to the `run` function in `main.rs`
 
-```rust,ignore
+```rust
 let arena_config = ArenaConfig::load(&config)?;
 ```
 

--- a/book/src/appendices/a_config_files/arena_config.md
+++ b/book/src/appendices/a_config_files/arena_config.md
@@ -43,7 +43,7 @@ Now that we have loaded our config, we want to add it to the world so other modu
 it. We do this by adding the config as a resource during `Application` creation:
 
 
-```rust,ignore
+```rust
     .with_resource(arena_config)
     .with_bundle(PongBundle::default())?
 ```
@@ -53,14 +53,14 @@ First, let's change our initialisation steps in `pong.rs`.
 
 Add the following line to the top of `pong.rs`:
 
-```rust,ignore
+```rust
 use crate::config::ArenaConfig;
 ```
 
 Now, in the `initialise_paddles()` function, add the following lines after the initialisation of the
 `left_transform` and `right_transform`.
 
-```rust,ignore
+```rust
 let (arena_height, arena_width) = {
     let config = &world.read_resource::<ArenaConfig>();
     (config.height, config.width)
@@ -76,7 +76,7 @@ It is actually simpler to access a Config file from a system than via the `World
 it in the `System`'s `run()` function, add it to the `SystemData` type. This is what the `BounceSystem` looks
 like when it wants to access the `ArenaConfig`.
 
-```rust,ignore
+```rust
 use crate::config::ArenaConfig;
 ...
 type SystemData = (

--- a/book/src/appendices/a_config_files/ball_config.md
+++ b/book/src/appendices/a_config_files/ball_config.md
@@ -6,7 +6,7 @@ separately.
 
 To prepare for our `BallConfig`, add the following line to the top of `config.rs`:
 
-```rust,ignore
+```rust
 use amethyst::core::math::Vector2;
 ```
 
@@ -16,7 +16,7 @@ a non-trivial data type to a RON file. The `BALL_COLOR` was originally an array,
 handle arrays as tuples, so it will read in a tuple and convert the color values to an array if needed by a
 particular function (e.g., in `pong.rs`).
 
-```rust,ignore
+```rust
 #[derive(Debug, Deserialize, Serialize)]
 pub struct BallConfig {
     pub velocity: Vector2<f32>,
@@ -27,7 +27,7 @@ pub struct BallConfig {
 
 We'll also add the `Default` trait to this config that will match what the full example uses.
 
-```rust,ignore
+```rust
 impl Default for BallConfig {
     fn default() -> Self {
         BallConfig {
@@ -42,7 +42,7 @@ impl Default for BallConfig {
 Still in `config.rs`, add the following structure definition at the very bottom. This structure will be
 backed by the whole `config.ron` file.
 
-```rust,ignore
+```rust
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct PongConfig {
     pub arena: ArenaConfig,
@@ -59,7 +59,7 @@ the `ArenaConfig`.
 
 In `pong.rs`, underneath our loading of the `ArenaConfig`, add the following lines
 
-```rust,ignore
+```rust
 let (velocity_x, velocity_y, radius, color) = {
     let config = world.read_resource::<BallConfig>();
     let c: [f32; 4] = [
@@ -86,19 +86,19 @@ add each resource separately so systems can use only what they want.
 
 First, we need to change what `main.rs` is using. Change
 
-```rust,ignore
+```rust
 use crate::config::ArenaConfig;
 ```
 
 to
 
-```rust,ignore
+```rust
 use crate::config::PongConfig;
 ```
 
 Now, modify the `run()` function, from
 
-```rust,ignore
+```rust
 let arena_config = ArenaConfig::load(&config)?;
 [..]
     .with_bundle(PongBundle::default())?
@@ -108,7 +108,7 @@ let arena_config = ArenaConfig::load(&config)?;
 
 to
 
-```rust,ignore
+```rust
 let pong_config = PongConfig::load(&config)?;
 [..]
     .with_bundle(PongBundle::default())?

--- a/book/src/appendices/a_config_files/paddle_configs.md
+++ b/book/src/appendices/a_config_files/paddle_configs.md
@@ -3,7 +3,7 @@
 We're finally going to add a configuration struct for our Paddles. Because our Pong clone supports two 
 players, we should let them configure each separately. Add the following to the `config.rs` file:
 
-```rust,ignore
+```rust
 #[derive(Debug, Deserialize, Serialize)]
 pub struct PaddleConfig {
     pub height: f32,
@@ -28,7 +28,7 @@ Just like the `BallConfig`, we need to read in the color as a tuple instead of a
 
 Now, to allow us to have two separate `PaddleConfig`s, we will wrap them in a bigger structure as follows:
 
-```rust,ignore
+```rust
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct PaddlesConfig {
     pub left: PaddleConfig,
@@ -38,7 +38,7 @@ pub struct PaddlesConfig {
 
 Now we need to add the `PaddlesConfig` to our `PongConfig` as shown below
 
-```rust,ignore
+```rust
 pub struct PongConfig {
     pub arena: ArenaConfig,
     pub ball: BallConfig,
@@ -48,7 +48,7 @@ pub struct PongConfig {
 
 and modify the `main.rs`'s `run()` function to add our `PaddleConfig`s. 
 
-```rust,ignore
+```rust
     .with_resource(pong_config.arena)
     .with_resource(pong_config.ball)
     .with_resource(pong_config.paddles)
@@ -68,7 +68,7 @@ To avoid issues with the borrow checker, we read the `PaddlesConfig` once and co
 unwrapping them in one big assignment statement.
 In `initialise_paddles()` in `pong.rs`, add this code below reading the `ArenaConfig`.
 
-```rust,ignore
+```rust
 let (
     left_height,
     left_width,
@@ -107,13 +107,13 @@ let (
 
 Now, within this function, replace
 
-```rust,ignore
+```rust
 let y = (arena_height - PADDLE_HEIGHT) / 2.0;
 ```
 
 with 
 
-```rust,ignore
+```rust
 let left_y = (arena_height - left_height) / 2.0;
 let right_y = (arena_height - right_height) / 2.0;
 ```

--- a/book/src/appendices/b_migration_notes/rendy_migration.md
+++ b/book/src/appendices/b_migration_notes/rendy_migration.md
@@ -101,7 +101,7 @@
     ```rust
     use amethyst::renderer::{types::DefaultBackend, RenderingSystem};
 
-    let game_data = GameDataBuilder::default()
+    let game_data = DispatcherBuilder::default()
         .with_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(

--- a/book/src/appendices/b_migration_notes/rendy_migration.md
+++ b/book/src/appendices/b_migration_notes/rendy_migration.md
@@ -18,7 +18,7 @@
 * `Bindings<String, String>` is now `Bindings<StringBindings>`.
 * `Bindings<AX, AC>` is now `Bindings<T>`, where `T` is a new type you must implement:
 
-    ```rust,ignore
+    ```rust
     pub struct ControlBindings;
 
     impl BindingTypes for ControlBindings {
@@ -55,7 +55,7 @@
 * `DisplayConfig`'s `fullscreen` field is now an `Option<MonitorIdent>`. `MonitorIdent` is `MonitorIdent(u16, String)`, indicating the native monitor display ID, and its [name][monID].
 * `WindowBundle` is now separate from `amethyst_renderer`.
 
-    ```rust,ignore
+    ```rust
     use amethyst::window::WindowBundle;
 
     game_data.with_bundle(WindowBundle::from_config_file(display_config_path))?;
@@ -75,7 +75,7 @@
 * `Flipped` component is removed. You can specify `flipped` during sprite loading, or mutating `Transform` at run time.
 * To load a texture in memory, you can't use `[0.; 4].into()` as the `TextureData` anymore. Use:
 
-    ```rust,ignore
+    ```rust
     use amethyst::{
         assets::{AssetStorage, Handle,  DefaultLoader, Loader, Prefab, PrefabLoader},
         ecs::World,
@@ -98,7 +98,7 @@
 
     In `main.rs`:
 
-    ```rust,ignore
+    ```rust
     use amethyst::renderer::{types::DefaultBackend, RenderingSystem};
 
     let game_data = GameDataBuilder::default()
@@ -118,7 +118,7 @@
     ```
 
 * Render passes can be integrated into amethyst by using the newly introduced `RenderPlugin` trait, for example:
-    ```rust,ignore
+    ```rust
     pub struct RenderCustom {
         target: Target,
     }
@@ -157,7 +157,7 @@
     ```
 * `RenderBundle::with_sprite_sheet_processor()` is replaced by:
 
-    ```rust,ignore
+    ```rust
     game_data.with(
         Processor::<SpriteSheet>::new(),
         "sprite_sheet_processor",
@@ -169,7 +169,7 @@
 
 * `RenderBundle::with_sprite_visibility_sorting()` is replaced by:
 
-    ```rust,ignore
+    ```rust
     use amethyst::rendy::sprite_visibility::SpriteVisibilitySortingSystem;
 
     game_data.with(

--- a/book/src/appendices/b_migration_notes/transform_api_changes.md
+++ b/book/src/appendices/b_migration_notes/transform_api_changes.md
@@ -111,7 +111,7 @@ The names of several `Transform` methods have been changed in order to better re
 
 * Set Rotation
 
-    ```rust,ignore
+    ```rust
     transform.set_rotation(UnitQuaternion::identity());
     transform.set_rotation_x_axis(0.4);
     transform.set_rotation_y_axis(2.3);
@@ -123,13 +123,13 @@ The names of several `Transform` methods have been changed in order to better re
 
     - `rotate_2d`, an alias for `prepend_rotation_z_axis`
 
-        ```rust,ignore
+        ```rust
         transform.rotate_2d(5.0);
         ```
 
     - `set_rotation_2d`, an alias for `set_rotation_z_axis`
 
-        ```rust,ignore
+        ```rust
         transform.set_rotation_2d(4.7);
         ```
 
@@ -137,6 +137,6 @@ The names of several `Transform` methods have been changed in order to better re
 
     - Get the Euler angles of a transform's rotation.
 
-        ```rust,ignore
+        ```rust
         let (x, y, z) = transform.euler_angles();
         ```

--- a/book/src/appendices/c_feature_gates.md
+++ b/book/src/appendices/c_feature_gates.md
@@ -9,7 +9,7 @@ To reduce compilation times, you can disable features that are not needed for yo
 
 When compiling, you can use the following Cargo parameters:
 
-```ignore
+```shell,ignore
 cargo (build/test/run) --no-default-features --features feature1,feature2,feature3
 ```
 
@@ -61,7 +61,7 @@ are involved in the test), you need to enable the `test-support` feature.
 
 To enable the profiler, you can use the following feature:
 
-```ignore
+```shell,ignore
 cargo (build/test/run) --features profiler
 ```
 
@@ -72,7 +72,7 @@ You can open this file using the chromium browser (or google chrome) and navigat
 
 When using Amethyst as a dependency of your project, you can use the following to disable default features and enable other ones.
 
-```ignore
+```toml,ignore
 [dependencies.amethyst]
 version = "*"
 default-features = false

--- a/book/src/appendices/c_feature_gates.md
+++ b/book/src/appendices/c_feature_gates.md
@@ -9,7 +9,7 @@ To reduce compilation times, you can disable features that are not needed for yo
 
 When compiling, you can use the following Cargo parameters:
 
-```shell,ignore
+```shell
 cargo (build/test/run) --no-default-features --features feature1,feature2,feature3
 ```
 
@@ -61,7 +61,7 @@ are involved in the test), you need to enable the `test-support` feature.
 
 To enable the profiler, you can use the following feature:
 
-```shell,ignore
+```shell
 cargo (build/test/run) --features profiler
 ```
 
@@ -72,7 +72,7 @@ You can open this file using the chromium browser (or google chrome) and navigat
 
 When using Amethyst as a dependency of your project, you can use the following to disable default features and enable other ones.
 
-```toml,ignore
+```toml
 [dependencies.amethyst]
 version = "*"
 default-features = false

--- a/book/src/assets/how_to_define_custom_assets.md
+++ b/book/src/assets/how_to_define_custom_assets.md
@@ -5,7 +5,6 @@ This guide explains how to define a new asset type to be used in an Amethyst app
 1. Define the type and handle for your asset.
 
     ```rust,edition2018,ignore,noplaypen
-    # extern crate amethyst;
     # extern crate serde_derive;
     #
     use amethyst::{
@@ -58,7 +57,6 @@ This guide explains how to define a new asset type to be used in an Amethyst app
 3. Implement the [`Asset`][doc_asset] trait on the asset type.
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     # extern crate serde_derive;
     #
     # use amethyst::{
@@ -104,7 +102,6 @@ This guide explains how to define a new asset type to be used in an Amethyst app
     The [`Processor<A>` system][doc_processor_system] uses this trait to convert the deserialized asset data into the asset.
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     # extern crate serde_derive;
     #
     # use amethyst::{
@@ -168,7 +165,6 @@ This guide explains how to define a new asset type to be used in an Amethyst app
     If your asset is stored using one of the existing supported formats such as RON or JSON, it can now be used:
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     # extern crate serde_derive;
     #
     # use amethyst::{

--- a/book/src/assets/how_to_define_custom_assets.md
+++ b/book/src/assets/how_to_define_custom_assets.md
@@ -256,7 +256,7 @@ This guide explains how to define a new asset type to be used in an Amethyst app
     #   let app_root = application_root_dir()?;
     #   let assets_dir = app_root.join("assets");
     #
-    #   let game_data = GameDataBuilder::default();
+    #   let game_data = DispatcherBuilder::default();
     #   let mut game = Application::new(
     #       assets_dir,
     #       LoadingState {

--- a/book/src/assets/how_to_define_custom_assets.md
+++ b/book/src/assets/how_to_define_custom_assets.md
@@ -4,7 +4,7 @@ This guide explains how to define a new asset type to be used in an Amethyst app
 
 1. Define the type and handle for your asset.
 
-    ```rust,edition2018,ignore,noplaypen
+    ```rust, edition2018,noplaypen
     # extern crate serde_derive;
     #
     use amethyst::{
@@ -31,14 +31,14 @@ This guide explains how to define a new asset type to be used in an Amethyst app
 
     * The asset type itself, in which case you simply derive `Serialize` and `Deserialize` on the type:
 
-        ```rust,ignore
+        ```rust
         #[derive(Serialize, Deserialize, ..)]
         pub struct EnergyBlast { .. }
         ```
 
     * An enum with different variants &ndash; each for a different data layout:
 
-        ```rust,edition2018,ignore,noplaypen
+        ```rust, edition2018,noplaypen
         # extern crate serde_derive;
         #
         # use serde_derive::{Deserialize, Serialize};
@@ -56,7 +56,7 @@ This guide explains how to define a new asset type to be used in an Amethyst app
 
 3. Implement the [`Asset`][doc_asset] trait on the asset type.
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     # extern crate serde_derive;
     #
     # use amethyst::{
@@ -101,7 +101,7 @@ This guide explains how to define a new asset type to be used in an Amethyst app
 
     The [`Processor<A>` system][doc_processor_system] uses this trait to convert the deserialized asset data into the asset.
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     # extern crate serde_derive;
     #
     # use amethyst::{
@@ -164,7 +164,7 @@ This guide explains how to define a new asset type to be used in an Amethyst app
 
     If your asset is stored using one of the existing supported formats such as RON or JSON, it can now be used:
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     # extern crate serde_derive;
     #
     # use amethyst::{

--- a/book/src/assets/how_to_define_custom_formats.md
+++ b/book/src/assets/how_to_define_custom_formats.md
@@ -165,7 +165,7 @@ If you are defining a new format that may be useful to others, [please send us a
     #     let app_root = application_root_dir()?;
     #     let assets_dir = app_root.join("assets");
     #
-    #     let game_data = GameDataBuilder::default()
+    #     let game_data = DispatcherBuilder::default()
     #         .with(Processor::<EnergyBlast>::new(), "", &[]);
     #     let mut game = Application::new(
     #         assets_dir,

--- a/book/src/assets/how_to_define_custom_formats.md
+++ b/book/src/assets/how_to_define_custom_formats.md
@@ -17,7 +17,7 @@ If you are defining a new format that may be useful to others, [please send us a
 
     In most cases a unit struct is sufficient. When possible, this should implement `Clone` and `Copy` for ergonomic usage.
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     /// Format for loading from `.mylang` files.
     #[derive(Clone, Copy, Debug, Default)]
     pub struct MyLangFormat;
@@ -31,7 +31,7 @@ If you are defining a new format that may be useful to others, [please send us a
 
     In this example the RON deserializer is used, though it is [already a supported format][doc_ron_format].
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     # extern crate ron;
     # extern crate serde;
     #
@@ -66,7 +66,7 @@ If you are defining a new format that may be useful to others, [please send us a
 
     The custom format can now be used:
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     # extern crate ron;
     # extern crate serde;
     # extern crate serde_derive;

--- a/book/src/assets/how_to_define_custom_formats.md
+++ b/book/src/assets/how_to_define_custom_formats.md
@@ -32,7 +32,6 @@ If you are defining a new format that may be useful to others, [please send us a
     In this example the RON deserializer is used, though it is [already a supported format][doc_ron_format].
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     # extern crate ron;
     # extern crate serde;
     #
@@ -68,7 +67,6 @@ If you are defining a new format that may be useful to others, [please send us a
     The custom format can now be used:
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     # extern crate ron;
     # extern crate serde;
     # extern crate serde_derive;

--- a/book/src/assets/how_to_use_assets.md
+++ b/book/src/assets/how_to_use_assets.md
@@ -13,7 +13,6 @@ This guide covers the basic usage of assets into Amethyst for existing supported
 1. Instantiate the Amethyst application with the assets directory.
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     #
     use amethyst::{
         prelude::*,
@@ -53,7 +52,6 @@ This guide covers the basic usage of assets into Amethyst for existing supported
 3. Use the [`Loader`][doc_loader] resource to load the asset.
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     # use amethyst::{
     #     assets::{AssetStorage, Handle,  DefaultLoader, Loader, ProgressCounter},
     #     ecs::{World, WorldExt},
@@ -107,7 +105,6 @@ This guide covers the basic usage of assets into Amethyst for existing supported
     When [`loader.load(..)`][doc_load] is used to load an [`Asset`][doc_asset], the method returns immediately with a handle for the asset. The asset loading is handled asynchronously in the background, so if the handle is used to retrieve the asset, such as with [`world.read_resource::<AssetStorage<Texture>>()`][doc_read_resource][`.get(texture_handle)`][doc_asset_get], it will return `None` until the `Texture` has finished loading.
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     # use amethyst::{
     #     assets::{Handle, ProgressCounter},
     #     prelude::*,
@@ -152,7 +149,6 @@ This guide covers the basic usage of assets into Amethyst for existing supported
    The asset handle can now be used:
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     # use amethyst::{
     #     assets::Handle,
     #     prelude::*,

--- a/book/src/assets/how_to_use_assets.md
+++ b/book/src/assets/how_to_use_assets.md
@@ -31,7 +31,7 @@ This guide covers the basic usage of assets into Amethyst for existing supported
 
         //..
     #   let world = World::new();
-    #   let game_data = GameDataBuilder::default();
+    #   let game_data = DispatcherBuilder::default();
 
         let mut game = Application::new(assets_dir, LoadingState, game_data)?;
     #
@@ -85,7 +85,7 @@ This guide covers the basic usage of assets into Amethyst for existing supported
     #   let app_root = application_root_dir()?;
     #   let assets_dir = app_root.join("assets");
     #
-    #   let game_data = GameDataBuilder::default();
+    #   let game_data = DispatcherBuilder::default();
     #   let mut game = Application::new(
     #       assets_dir,
     #       LoadingState {

--- a/book/src/assets/how_to_use_assets.md
+++ b/book/src/assets/how_to_use_assets.md
@@ -12,7 +12,7 @@ This guide covers the basic usage of assets into Amethyst for existing supported
 
 1. Instantiate the Amethyst application with the assets directory.
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     #
     use amethyst::{
         prelude::*,
@@ -51,7 +51,7 @@ This guide covers the basic usage of assets into Amethyst for existing supported
 
 3. Use the [`Loader`][doc_loader] resource to load the asset.
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     # use amethyst::{
     #     assets::{AssetStorage, Handle,  DefaultLoader, Loader, ProgressCounter},
     #     ecs::{World, WorldExt},
@@ -104,7 +104,7 @@ This guide covers the basic usage of assets into Amethyst for existing supported
 
     When [`loader.load(..)`][doc_load] is used to load an [`Asset`][doc_asset], the method returns immediately with a handle for the asset. The asset loading is handled asynchronously in the background, so if the handle is used to retrieve the asset, such as with [`world.read_resource::<AssetStorage<Texture>>()`][doc_read_resource][`.get(texture_handle)`][doc_asset_get], it will return `None` until the `Texture` has finished loading.
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     # use amethyst::{
     #     assets::{Handle, ProgressCounter},
     #     prelude::*,
@@ -148,7 +148,7 @@ This guide covers the basic usage of assets into Amethyst for existing supported
 
    The asset handle can now be used:
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     # use amethyst::{
     #     assets::Handle,
     #     prelude::*,

--- a/book/src/concepts/entity_and_component.md
+++ b/book/src/concepts/entity_and_component.md
@@ -46,7 +46,6 @@ You will see how these methods are used in later chapters.
 To declare a component, you first declare the relevant underlying data:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::core::math::{Isometry3, Vector3};
 
 /// This `Component` describes the shape of an `Entity`
@@ -67,7 +66,6 @@ pub struct Transform {
 and then you implement the `Component` trait for them:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # struct Shape;
 # struct Transform;
 use amethyst::ecs::{Component, DenseVecStorage, FlaggedStorage};

--- a/book/src/concepts/entity_and_component.md
+++ b/book/src/concepts/entity_and_component.md
@@ -8,7 +8,7 @@ An `Entity` represents a single object in your world. `Component` represents one
 
 In an inheritance design, entity usually contains components. All the data and methods related to an entity are stored within. However, in the ECS design, entity is just a general purpose object. In fact, the implementation of `Entity` in Amethyst is simply:
 
-```rust,ignore
+```rust
 struct Entity(u32, Generation);
 ```
 
@@ -18,9 +18,9 @@ where u32 is the id of the entity and generation is used to check if the entity 
 
 Consider an example where you have three objects: two bottles and a person.
 
-|  object  |   x   |   y   |   shape  |  color  |   name  |
-|:--------:|:-----:|:-----:|:--------:|:-------:|:-------:|
-| Bottle A | 150.0 | 202.1 |  "round" |  "red"  |         |
+|  object  |   x   |   y   |  shape   |  color  |  name   |
+| :------: | :---: | :---: | :------: | :-----: | :-----: |
+| Bottle A | 150.0 | 202.1 | "round"  |  "red"  |         |
 | Bottle B | 570.0 | 122.0 | "square" | "white" |         |
 | Person C | 100.5 | 300.8 |          |         | "Peter" |
 
@@ -45,7 +45,7 @@ You will see how these methods are used in later chapters.
 
 To declare a component, you first declare the relevant underlying data:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::core::math::{Isometry3, Vector3};
 
 /// This `Component` describes the shape of an `Entity`
@@ -65,7 +65,7 @@ pub struct Transform {
 
 and then you implement the `Component` trait for them:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # struct Shape;
 # struct Transform;
 use amethyst::ecs::{Component, DenseVecStorage, FlaggedStorage};

--- a/book/src/concepts/event-channel.md
+++ b/book/src/concepts/event-channel.md
@@ -11,7 +11,6 @@ Typically, `EventChannel`s are inserted as resources in the `World`.
 ### Creating an event channel
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::shrev::EventChannel;
 // In the following examples, `MyEvent` is the event type of the channel.
 #[derive(Debug)]
@@ -28,7 +27,6 @@ let mut channel = EventChannel::<MyEvent>::new();
 Single:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # #[derive(Debug)]
 # pub enum MyEvent {
 #   A,
@@ -43,7 +41,6 @@ Single:
 Multiple:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # #[derive(Debug)]
 # pub enum MyEvent {
 #   A,
@@ -62,7 +59,6 @@ Multiple:
 To subscribe to events, register a reader against the `EventChannel` to receive a `ReaderId`:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # #[derive(Debug)]
 # pub enum MyEvent {
 #   A,
@@ -77,7 +73,6 @@ let mut reader_id = channel.register_reader();
 When reading events, pass the `ReaderId` in:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # #[derive(Debug)]
 # pub enum MyEvent {
 #   A,
@@ -109,7 +104,6 @@ It goes as follow:
 In the **producer** `System`, get a mutable reference to your resource:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::Write;
 # use amethyst::shrev::EventChannel;
 # #[derive(Debug)]
@@ -127,7 +121,6 @@ type SystemData = Write<'a, EventChannel<MyEvent>>;
 In the **receiver** `System`s, you need to store the `ReaderId` somewhere.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::shrev::ReaderId;
 # #[derive(Debug)]
 # pub enum MyEvent {
@@ -143,7 +136,6 @@ struct ReceiverSystem {
 and you also need to get read access:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::Read;
 # use amethyst::shrev::EventChannel;
 # #[derive(Debug)]
@@ -161,7 +153,6 @@ and you also need to get read access:
 Then, in the `System`'s `new` method:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::shrev::{EventChannel, ReaderId};
 # use amethyst::ecs::{System, SystemData, World};
 # #[derive(Debug)]
@@ -188,7 +179,6 @@ impl MySystem {
 Finally, you can read events from your `System`.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::Read;
 # use amethyst::shrev::EventChannel;
 # #[derive(Debug)]

--- a/book/src/concepts/event-channel.md
+++ b/book/src/concepts/event-channel.md
@@ -10,7 +10,7 @@ Typically, `EventChannel`s are inserted as resources in the `World`.
 
 ### Creating an event channel
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::shrev::EventChannel;
 // In the following examples, `MyEvent` is the event type of the channel.
 #[derive(Debug)]
@@ -26,7 +26,7 @@ let mut channel = EventChannel::<MyEvent>::new();
 
 Single:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # #[derive(Debug)]
 # pub enum MyEvent {
 #   A,
@@ -40,7 +40,7 @@ Single:
 
 Multiple:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # #[derive(Debug)]
 # pub enum MyEvent {
 #   A,
@@ -58,7 +58,7 @@ Multiple:
 
 To subscribe to events, register a reader against the `EventChannel` to receive a `ReaderId`:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # #[derive(Debug)]
 # pub enum MyEvent {
 #   A,
@@ -72,7 +72,7 @@ let mut reader_id = channel.register_reader();
 
 When reading events, pass the `ReaderId` in:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # #[derive(Debug)]
 # pub enum MyEvent {
 #   A,
@@ -103,7 +103,7 @@ It goes as follow:
 
 In the **producer** `System`, get a mutable reference to your resource:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::Write;
 # use amethyst::shrev::EventChannel;
 # #[derive(Debug)]
@@ -120,7 +120,7 @@ type SystemData = Write<'a, EventChannel<MyEvent>>;
 
 In the **receiver** `System`s, you need to store the `ReaderId` somewhere.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::shrev::ReaderId;
 # #[derive(Debug)]
 # pub enum MyEvent {
@@ -135,7 +135,7 @@ struct ReceiverSystem {
 
 and you also need to get read access:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::Read;
 # use amethyst::shrev::EventChannel;
 # #[derive(Debug)]
@@ -152,7 +152,7 @@ and you also need to get read access:
 
 Then, in the `System`'s `new` method:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::shrev::{EventChannel, ReaderId};
 # use amethyst::ecs::{System, SystemData, World};
 # #[derive(Debug)]
@@ -178,7 +178,7 @@ impl MySystem {
 
 Finally, you can read events from your `System`.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::Read;
 # use amethyst::shrev::EventChannel;
 # #[derive(Debug)]

--- a/book/src/concepts/resource.md
+++ b/book/src/concepts/resource.md
@@ -11,7 +11,7 @@ Resources are stored in the `World` container.
 
 Adding a resource to a `World` instance is done like this:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 use amethyst::ecs::World;
 
 struct MyResource {
@@ -32,7 +32,7 @@ fn main() {
 ## Fetching a resource (from `World`)
 
 Fetching a resource can be done like this:
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::World;
 # #[derive(Debug, PartialEq)]
 # struct MyResource {
@@ -56,7 +56,7 @@ Fetching a resource can be done like this:
 ```
 
 If you want to get a resource and create it if it doesn't exist:
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::World;
 # struct MyResource;
 # fn main() {
@@ -69,7 +69,7 @@ let fetched = world.entry::<MyResource>().or_insert_with(|| my);
 ```
 
 If you want to change a resource that is already inside of `World`:
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::World;
 # struct MyResource {
 #   pub game_score: i32,

--- a/book/src/concepts/resource.md
+++ b/book/src/concepts/resource.md
@@ -12,7 +12,6 @@ Resources are stored in the `World` container.
 Adding a resource to a `World` instance is done like this:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 use amethyst::ecs::World;
 
 struct MyResource {
@@ -34,7 +33,6 @@ fn main() {
 
 Fetching a resource can be done like this:
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::World;
 # #[derive(Debug, PartialEq)]
 # struct MyResource {
@@ -59,7 +57,6 @@ Fetching a resource can be done like this:
 
 If you want to get a resource and create it if it doesn't exist:
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::World;
 # struct MyResource;
 # fn main() {
@@ -73,7 +70,6 @@ let fetched = world.entry::<MyResource>().or_insert_with(|| my);
 
 If you want to change a resource that is already inside of `World`:
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::World;
 # struct MyResource {
 #   pub game_score: i32,

--- a/book/src/concepts/state.md
+++ b/book/src/concepts/state.md
@@ -92,7 +92,7 @@ For more advanced examples, see the following pong tutorial.
 
 ### Creating a State
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 use amethyst::prelude::*;
 
 struct GameplayState {
@@ -130,7 +130,7 @@ Those are:
 
 Let's use handle_event to go to the `PausedState` and come back by pressing the "Escape" key.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 use amethyst::prelude::*;
 use amethyst::input::{VirtualKeyCode, is_key_down};
 
@@ -177,7 +177,7 @@ But what is this weird `StateEvent` all about?
 Well, it is simply an enum. It regroups multiple types of events that are emitted throughout the engine by default.
 To change the set of events that the state receives, you create a new event enum and derive `EventReader` for that type.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::prelude::*;
 # use amethyst::ui::UiEvent;
 # use amethyst::input::{VirtualKeyCode, is_key_down};

--- a/book/src/concepts/state.md
+++ b/book/src/concepts/state.md
@@ -93,7 +93,6 @@ For more advanced examples, see the following pong tutorial.
 ### Creating a State
 
 ```rust,edition2018,no_run,noplaypen
-extern crate amethyst;
 use amethyst::prelude::*;
 
 struct GameplayState {
@@ -132,7 +131,6 @@ Those are:
 Let's use handle_event to go to the `PausedState` and come back by pressing the "Escape" key.
 
 ```rust,edition2018,no_run,noplaypen
-extern crate amethyst;
 use amethyst::prelude::*;
 use amethyst::input::{VirtualKeyCode, is_key_down};
 
@@ -180,7 +178,6 @@ Well, it is simply an enum. It regroups multiple types of events that are emitte
 To change the set of events that the state receives, you create a new event enum and derive `EventReader` for that type.
 
 ```rust,edition2018,no_run,noplaypen
-# #[macro_use] extern crate amethyst;
 # use amethyst::prelude::*;
 # use amethyst::ui::UiEvent;
 # use amethyst::input::{VirtualKeyCode, is_key_down};

--- a/book/src/concepts/system.md
+++ b/book/src/concepts/system.md
@@ -12,7 +12,7 @@ A system struct is a structure implementing the trait `amethyst::ecs::System`.
 
 Here is a very simple example implementation:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::System;
 struct MyFirstSystem;
 
@@ -40,7 +40,7 @@ The Amethyst engine provides useful system data types to use in order to access 
 
 You can then use one, or multiple of them via a tuple.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{System, Read};
 # use amethyst::core::timing::Time;
 struct MyFirstSystem;
@@ -64,7 +64,7 @@ Once you have access to a storage, you can use them in different ways.
 
 Sometimes, it can be useful to get a component in the storage for a specific entity. This can easily be done using the `get` or, for mutable storages, `get_mut` methods.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{Entity, System, WriteStorage};
 # use amethyst::core::Transform;
 struct WalkPlayerUp {
@@ -99,7 +99,7 @@ Needless to say that you can use it with only one storage to iterate over all en
 
 Keep in mind that **the `join` method is only available by importing `amethyst::ecs::Join`**.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{System, ReadStorage, WriteStorage};
 # use amethyst::core::Transform;
 # struct FallingObject;
@@ -136,7 +136,7 @@ There is a special type of `Storage` in specs called `AntiStorage`.
 The not operator (!) turns a Storage into its AntiStorage counterpart, allowing you to iterate over entities that do NOT have this `Component`.
 It is used like this:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{System, ReadStorage, WriteStorage};
 # use amethyst::core::Transform;
 # struct FallingObject;
@@ -172,7 +172,7 @@ It may sometimes be interesting to manipulate the structure of entities in a sys
 
 Creating an entity while in the context of a system is very similar to the way one would create an entity using the `World` struct. The only difference is that one needs to provide mutable storages of all the components they plan to add to the entity.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{System, WriteStorage, Entities};
 # use amethyst::core::Transform;
 # struct Enemy;
@@ -208,7 +208,7 @@ This system will spawn a new enemy every 200 game loop iterations.
 ### Removing an entity
 
 Deleting an entity is very easy using `Entities<'a>`.
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{System, Entities, Entity};
 # struct MySystem { entity: Entity }
 # impl<'a> System<'a> for MySystem {
@@ -224,7 +224,7 @@ entities.delete(entity);
 
 Sometimes, when you iterate over components, you may want to also know what entity you are working with. To do that, you can use the joining operation with `Entities<'a>`.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{Join, System, Entities, WriteStorage, ReadStorage};
 # use amethyst::core::Transform;
 # struct FallingObject;
@@ -259,7 +259,7 @@ This system does the same thing as the previous `MakeObjectsFall`, but also clea
 You can also insert or remove components from a specific entity.
 To do that, you need to get a mutable storage of the component you want to modify, and simply do:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{System, Entities, Entity, WriteStorage};
 # struct MyComponent;
 # impl amethyst::ecs::Component for MyComponent {
@@ -309,7 +309,7 @@ The following example shows how to keep track of which state we are currently in
 This allows us to do a bit of conditional logic in our systems to determine what to do depending on
 which state is currently active, and manipulating the states by tracking user actions:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 use amethyst::prelude::*;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -394,7 +394,7 @@ Let's say we want the player to be able to press escape to enter the menu.
 We modify our input handler to map the `open_menu` action to `Esc`, and we write the following
 system:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 # enum CurrentState {
@@ -475,7 +475,7 @@ This is rather complicated trait to implement, fortunately Amethyst provides a d
 
 Please note that tuples of structs implementing `SystemData` are themselves `SystemData`. This is very useful when you need to request multiple `SystemData` at once quickly.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # extern crate shred;
 # #[macro_use] extern crate shred_derive;
 #

--- a/book/src/concepts/system.md
+++ b/book/src/concepts/system.md
@@ -13,7 +13,6 @@ A system struct is a structure implementing the trait `amethyst::ecs::System`.
 Here is a very simple example implementation:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::System;
 struct MyFirstSystem;
 
@@ -42,7 +41,6 @@ The Amethyst engine provides useful system data types to use in order to access 
 You can then use one, or multiple of them via a tuple.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{System, Read};
 # use amethyst::core::timing::Time;
 struct MyFirstSystem;
@@ -67,7 +65,6 @@ Once you have access to a storage, you can use them in different ways.
 Sometimes, it can be useful to get a component in the storage for a specific entity. This can easily be done using the `get` or, for mutable storages, `get_mut` methods.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{Entity, System, WriteStorage};
 # use amethyst::core::Transform;
 struct WalkPlayerUp {
@@ -103,7 +100,6 @@ Needless to say that you can use it with only one storage to iterate over all en
 Keep in mind that **the `join` method is only available by importing `amethyst::ecs::Join`**.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{System, ReadStorage, WriteStorage};
 # use amethyst::core::Transform;
 # struct FallingObject;
@@ -141,7 +137,6 @@ The not operator (!) turns a Storage into its AntiStorage counterpart, allowing 
 It is used like this:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{System, ReadStorage, WriteStorage};
 # use amethyst::core::Transform;
 # struct FallingObject;
@@ -178,7 +173,6 @@ It may sometimes be interesting to manipulate the structure of entities in a sys
 Creating an entity while in the context of a system is very similar to the way one would create an entity using the `World` struct. The only difference is that one needs to provide mutable storages of all the components they plan to add to the entity.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{System, WriteStorage, Entities};
 # use amethyst::core::Transform;
 # struct Enemy;
@@ -215,7 +209,6 @@ This system will spawn a new enemy every 200 game loop iterations.
 
 Deleting an entity is very easy using `Entities<'a>`.
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{System, Entities, Entity};
 # struct MySystem { entity: Entity }
 # impl<'a> System<'a> for MySystem {
@@ -232,7 +225,6 @@ entities.delete(entity);
 Sometimes, when you iterate over components, you may want to also know what entity you are working with. To do that, you can use the joining operation with `Entities<'a>`.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{Join, System, Entities, WriteStorage, ReadStorage};
 # use amethyst::core::Transform;
 # struct FallingObject;
@@ -268,7 +260,6 @@ You can also insert or remove components from a specific entity.
 To do that, you need to get a mutable storage of the component you want to modify, and simply do:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{System, Entities, Entity, WriteStorage};
 # struct MyComponent;
 # impl amethyst::ecs::Component for MyComponent {
@@ -319,7 +310,6 @@ This allows us to do a bit of conditional logic in our systems to determine what
 which state is currently active, and manipulating the states by tracking user actions:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 use amethyst::prelude::*;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -405,7 +395,6 @@ We modify our input handler to map the `open_menu` action to `Esc`, and we write
 system:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 # enum CurrentState {
@@ -487,7 +476,6 @@ This is rather complicated trait to implement, fortunately Amethyst provides a d
 Please note that tuples of structs implementing `SystemData` are themselves `SystemData`. This is very useful when you need to request multiple `SystemData` at once quickly.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # extern crate shred;
 # #[macro_use] extern crate shred_derive;
 #

--- a/book/src/concepts/system/implementing_the_system_desc_trait.md
+++ b/book/src/concepts/system/implementing_the_system_desc_trait.md
@@ -4,7 +4,7 @@ If the `SystemDesc` derive is unable to generate a `SystemDesc` trait
 implementation for system initialization, the `SystemDesc` trait can be
 implemented manually:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 use amethyst::{
     audio::output::Output,
@@ -46,7 +46,7 @@ impl<'a, 'b> SystemDesc<'a, 'b, AudioSystem> for AudioSystemDesc {
 
 ## Templates
 
-```rust,ignore
+```rust
 use amethyst_core::SystemDesc;
 
 /// Builds a `SystemName`.
@@ -66,7 +66,7 @@ impl<'a, 'b> SystemDesc<'a, 'b, SystemName> for SystemNameDesc {
 
 With type parameters:
 
-```rust,ignore
+```rust
 use std::marker::PhantomData;
 
 use derivative::Derivative;

--- a/book/src/concepts/system/implementing_the_system_desc_trait.md
+++ b/book/src/concepts/system/implementing_the_system_desc_trait.md
@@ -5,7 +5,6 @@ implementation for system initialization, the `SystemDesc` trait can be
 implemented manually:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 use amethyst::{
     audio::output::Output,

--- a/book/src/concepts/system/implementing_the_system_desc_trait.md
+++ b/book/src/concepts/system/implementing_the_system_desc_trait.md
@@ -38,7 +38,7 @@ impl<'a, 'b> SystemDesc<'a, 'b, AudioSystem> for AudioSystemDesc {
 }
 
 // in `main.rs`:
-// let game_data = GameDataBuilder::default()
+// let game_data = DispatcherBuilder::default()
 //     .with_system_desc(AudioSystemDesc::default(), "", &[]);
 ```
 

--- a/book/src/concepts/system/system_desc_derive.md
+++ b/book/src/concepts/system/system_desc_derive.md
@@ -14,7 +14,6 @@ If your system initialization use case is not covered, please see the
 ## Passing parameters to system constructor
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -44,7 +43,6 @@ impl SystemName {
 <summary>Generated code</summary>
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -94,7 +92,6 @@ impl<'a, 'b> ::amethyst::core::SystemDesc<'a, 'b, SystemName> for SystemNameDesc
 ## Fields to skip -- defaulted by the system constructor
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -125,7 +122,6 @@ impl SystemName {
 <summary>Generated code</summary>
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -175,7 +171,6 @@ impl<'a, 'b> ::amethyst::core::SystemDesc<'a, 'b, SystemName> for SystemNameDesc
 will call  `SystemName::default()`:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -199,7 +194,6 @@ pub struct SystemName {
 <summary>Generated code</summary>
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -240,7 +234,6 @@ impl<'a, 'b> ::amethyst::core::SystemDesc<'a, 'b, SystemName> for SystemNameDesc
 ## Registering a `ReaderId` for an `EventChannel<_>` in the `World`
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -272,7 +265,6 @@ impl SystemName {
 <summary>Generated code</summary>
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -324,7 +316,6 @@ impl<'a, 'b> ::amethyst::core::SystemDesc<'a, 'b, SystemName> for SystemNameDesc
 ## Registering a `ReaderId` to a component's `FlaggedStorage`
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -356,7 +347,6 @@ impl SystemName {
 <summary>Generated code</summary>
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -411,7 +401,6 @@ such as a function call, you must surround that expression in quotes, e.g.
 `#[system_desc(insert("MyResource::default()"))]`.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -434,7 +423,6 @@ impl<'a> System<'a> for SystemName {
 <summary>Generated code</summary>
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     derive::SystemDesc,

--- a/book/src/concepts/system/system_desc_derive.md
+++ b/book/src/concepts/system/system_desc_derive.md
@@ -13,7 +13,7 @@ If your system initialization use case is not covered, please see the
 
 ## Passing parameters to system constructor
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -42,7 +42,7 @@ impl SystemName {
 <details>
 <summary>Generated code</summary>
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -91,7 +91,7 @@ impl<'a, 'b> ::amethyst::core::SystemDesc<'a, 'b, SystemName> for SystemNameDesc
 
 ## Fields to skip -- defaulted by the system constructor
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -121,7 +121,7 @@ impl SystemName {
 <details>
 <summary>Generated code</summary>
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -170,7 +170,7 @@ impl<'a, 'b> ::amethyst::core::SystemDesc<'a, 'b, SystemName> for SystemNameDesc
 **Note:** If there are no field parameters, the `SystemDesc` implementation
 will call  `SystemName::default()`:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -193,7 +193,7 @@ pub struct SystemName {
 <details>
 <summary>Generated code</summary>
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -233,7 +233,7 @@ impl<'a, 'b> ::amethyst::core::SystemDesc<'a, 'b, SystemName> for SystemNameDesc
 
 ## Registering a `ReaderId` for an `EventChannel<_>` in the `World`
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -264,7 +264,7 @@ impl SystemName {
 <details>
 <summary>Generated code</summary>
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -315,7 +315,7 @@ impl<'a, 'b> ::amethyst::core::SystemDesc<'a, 'b, SystemName> for SystemNameDesc
 
 ## Registering a `ReaderId` to a component's `FlaggedStorage`
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -346,7 +346,7 @@ impl SystemName {
 <details>
 <summary>Generated code</summary>
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -400,7 +400,7 @@ impl<'a, 'b> ::amethyst::core::SystemDesc<'a, 'b, SystemName> for SystemNameDesc
 such as a function call, you must surround that expression in quotes, e.g.
 `#[system_desc(insert("MyResource::default()"))]`.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     derive::SystemDesc,
@@ -422,7 +422,7 @@ impl<'a> System<'a> for SystemName {
 <details>
 <summary>Generated code</summary>
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     derive::SystemDesc,

--- a/book/src/concepts/system/system_initialization.md
+++ b/book/src/concepts/system/system_initialization.md
@@ -20,7 +20,6 @@ initialization logic, the `SystemDesc` derive automatically implements the
 `SystemDesc` trait on the system type itself:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 use amethyst::{
     core::SystemDesc,
     derive::SystemDesc,

--- a/book/src/concepts/system/system_initialization.md
+++ b/book/src/concepts/system/system_initialization.md
@@ -19,7 +19,7 @@ logic to instantiate the `System`. For `System`s that do not require special
 initialization logic, the `SystemDesc` derive automatically implements the
 `SystemDesc` trait on the system type itself:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 use amethyst::{
     core::SystemDesc,
     derive::SystemDesc,

--- a/book/src/concepts/world.md
+++ b/book/src/concepts/world.md
@@ -7,7 +7,7 @@ This chapter will showcase those functions and their usage.
 
 ## Adding a resource
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 use amethyst::ecs::{World, WorldExt};
 
 // A simple struct with no data.
@@ -28,7 +28,7 @@ fn main() {
 ## Fetching a resource
 
 Here's how to fetch a read-only resource. Be aware that this method panics if the resource isn't inserted into `Resources`.
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{World, WorldExt};
 # struct MyResource;
 # fn main() {
@@ -38,7 +38,7 @@ Here's how to fetch a read-only resource. Be aware that this method panics if th
 ```
 
 If you are not sure that the resource will be present, use the methods available on `Resources`, as shown in the resource chapter.
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{World, WorldExt};
 # struct MyResource;
 # fn main() {
@@ -49,7 +49,7 @@ If you are not sure that the resource will be present, use the methods available
 
 ## Modifying a resource
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{World, WorldExt};
 # struct MyResource;
 # fn main() {
@@ -65,7 +65,7 @@ Then, you can add components to your entity.
 Finally, you call the build() method on the entity builder to get the actual entity.
 Please note that **in order to use this syntax, you need to import the ``amethyst::prelude::Builder`` trait.**
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{World, WorldExt};
 # struct MyComponent;
 # impl amethyst::ecs::Component for MyComponent {
@@ -83,7 +83,7 @@ Please note that **in order to use this syntax, you need to import the ``amethys
 ```
 
 Shorter version:
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{World, WorldExt};
 # struct MyComponent;
 # impl amethyst::ecs::Component for MyComponent {
@@ -104,7 +104,7 @@ Internally, the `World` interacts with `EntitiesRes`, which is a resource holdin
 
 ## Accessing a `Component`
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{Builder, World, WorldExt};
 # struct MyComponent;
 # impl amethyst::ecs::Component for MyComponent {
@@ -128,7 +128,7 @@ Internally, the `World` interacts with `EntitiesRes`, which is a resource holdin
 
 This is almost the same as accessing a component:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{Builder, World, WorldExt};
 # struct MyComponent;
 # impl amethyst::ecs::Component for MyComponent {
@@ -146,7 +146,7 @@ This is almost the same as accessing a component:
 
 It is pretty rare to use this, but can be useful in some occasions.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{World, WorldExt};
 # fn main() {
 #   let mut world = World::new();
@@ -158,7 +158,7 @@ It is pretty rare to use this, but can be useful in some occasions.
 ## Delete an entity
 
 Single:
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{Builder, World, WorldExt};
 # fn main() {
 #   let mut world = World::new();
@@ -168,7 +168,7 @@ Single:
 ```
 
 Multiple:
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{Builder, World, WorldExt};
 # fn main() {
 #   let mut world = World::new();
@@ -178,7 +178,7 @@ Multiple:
 ```
 
 All:
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{World, WorldExt};
 # fn main() {
 #   let mut world = World::new();
@@ -190,7 +190,7 @@ __Note: Entities are lazily deleted, which means that deletion only happens at t
 
 ## Check if the entity was deleted
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{Builder, World, WorldExt};
 # fn main() {
 #   let mut world = World::new();
@@ -207,7 +207,7 @@ __Note: Entities are lazily deleted, which means that deletion only happens at t
 Sometimes, you will want to create an entity where you need to fetch resources to create the correct components for it.
 There is a function that acts as a shorthand for this:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{ReadExpect, World, WorldExt};
 # struct Dummy;
 # type SomeSystemData<'a> = ReadExpect<'a, Dummy>;

--- a/book/src/concepts/world.md
+++ b/book/src/concepts/world.md
@@ -8,7 +8,6 @@ This chapter will showcase those functions and their usage.
 ## Adding a resource
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 use amethyst::ecs::{World, WorldExt};
 
 // A simple struct with no data.
@@ -30,7 +29,6 @@ fn main() {
 
 Here's how to fetch a read-only resource. Be aware that this method panics if the resource isn't inserted into `Resources`.
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{World, WorldExt};
 # struct MyResource;
 # fn main() {
@@ -41,7 +39,6 @@ Here's how to fetch a read-only resource. Be aware that this method panics if th
 
 If you are not sure that the resource will be present, use the methods available on `Resources`, as shown in the resource chapter.
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{World, WorldExt};
 # struct MyResource;
 # fn main() {
@@ -53,7 +50,6 @@ If you are not sure that the resource will be present, use the methods available
 ## Modifying a resource
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{World, WorldExt};
 # struct MyResource;
 # fn main() {
@@ -70,7 +66,6 @@ Finally, you call the build() method on the entity builder to get the actual ent
 Please note that **in order to use this syntax, you need to import the ``amethyst::prelude::Builder`` trait.**
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{World, WorldExt};
 # struct MyComponent;
 # impl amethyst::ecs::Component for MyComponent {
@@ -89,7 +84,6 @@ Please note that **in order to use this syntax, you need to import the ``amethys
 
 Shorter version:
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{World, WorldExt};
 # struct MyComponent;
 # impl amethyst::ecs::Component for MyComponent {
@@ -111,7 +105,6 @@ Internally, the `World` interacts with `EntitiesRes`, which is a resource holdin
 ## Accessing a `Component`
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{Builder, World, WorldExt};
 # struct MyComponent;
 # impl amethyst::ecs::Component for MyComponent {
@@ -136,7 +129,6 @@ Internally, the `World` interacts with `EntitiesRes`, which is a resource holdin
 This is almost the same as accessing a component:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{Builder, World, WorldExt};
 # struct MyComponent;
 # impl amethyst::ecs::Component for MyComponent {
@@ -155,7 +147,6 @@ This is almost the same as accessing a component:
 It is pretty rare to use this, but can be useful in some occasions.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{World, WorldExt};
 # fn main() {
 #   let mut world = World::new();
@@ -168,7 +159,6 @@ It is pretty rare to use this, but can be useful in some occasions.
 
 Single:
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{Builder, World, WorldExt};
 # fn main() {
 #   let mut world = World::new();
@@ -179,7 +169,6 @@ Single:
 
 Multiple:
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{Builder, World, WorldExt};
 # fn main() {
 #   let mut world = World::new();
@@ -190,7 +179,6 @@ Multiple:
 
 All:
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{World, WorldExt};
 # fn main() {
 #   let mut world = World::new();
@@ -203,7 +191,6 @@ __Note: Entities are lazily deleted, which means that deletion only happens at t
 ## Check if the entity was deleted
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{Builder, World, WorldExt};
 # fn main() {
 #   let mut world = World::new();
@@ -221,7 +208,6 @@ Sometimes, you will want to create an entity where you need to fetch resources t
 There is a function that acts as a shorthand for this:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{ReadExpect, World, WorldExt};
 # struct Dummy;
 # type SomeSystemData<'a> = ReadExpect<'a, Dummy>;

--- a/book/src/controlling_system_execution/custom_game_data.md
+++ b/book/src/controlling_system_execution/custom_game_data.md
@@ -15,7 +15,7 @@ are essential (like rendering, input and UI).
 
 Let's start by creating the `GameData` structure:
 
-```rust,no_run,noplaypen
+```rust, no_run,noplaypen
 # use amethyst::ecs::prelude::Dispatcher;
 #
 pub struct CustomGameData<'a, 'b> {
@@ -26,7 +26,7 @@ pub struct CustomGameData<'a, 'b> {
 
 We also add a utility function for performing dispatch:
 
-```rust,no_run,noplaypen
+```rust, no_run,noplaypen
 # use amethyst::ecs::prelude::{Dispatcher, World};
 #
 # pub struct CustomGameData<'a, 'b> {
@@ -54,7 +54,7 @@ a builder that implements `DataInit`, as well as implement `DataDispose` for our
 `GameData` structure. These are the only requirements placed on the
 `GameData` structure.
 
-```rust,no_run,noplaypen
+```rust, no_run,noplaypen
 #
 # use amethyst::ecs::prelude::{Dispatcher, DispatcherBuilder, System, World, WorldExt};
 # use amethyst::core::SystemBundle;
@@ -136,7 +136,7 @@ impl<'a,'b> DataDispose for CustomGameData<'a,'b> {
 We can now use `CustomGameData` in place of the provided `GameData` when building
 our `Application`, but first we should create some `State`s.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::ecs::prelude::{Dispatcher, World};
 # use amethyst::prelude::{State, StateData, StateEvent, Trans};
@@ -231,7 +231,7 @@ impl<'a, 'b> State<CustomGameData<'a, 'b>, StateEvent> for Main {
 The only thing that remains now is to use our `CustomGameDataBuilder` when building the
 `Application`.
 
-```rust,ignore
+```rust
 #
 # use amethyst::{
 #     core::{transform::TransformBundle, SystemBundle},

--- a/book/src/controlling_system_execution/custom_game_data.md
+++ b/book/src/controlling_system_execution/custom_game_data.md
@@ -67,20 +67,20 @@ a builder that implements `DataInit`, as well as implement `DataDispose` for our
 #
 use amethyst::core::ArcThreadPool;
 
-pub struct CustomGameDataBuilder<'a, 'b> {
+pub struct CustomDispatcherBuilder<'a, 'b> {
     pub core: DispatcherBuilder<'a, 'b>,
     pub running: DispatcherBuilder<'a, 'b>,
 }
 
-impl<'a, 'b> Default for CustomGameDataBuilder<'a, 'b> {
+impl<'a, 'b> Default for CustomDispatcherBuilder<'a, 'b> {
     fn default() -> Self {
-        CustomGameDataBuilder::new()
+        CustomDispatcherBuilder::new()
     }
 }
 
-impl<'a, 'b> CustomGameDataBuilder<'a, 'b> {
+impl<'a, 'b> CustomDispatcherBuilder<'a, 'b> {
     pub fn new() -> Self {
-        CustomGameDataBuilder {
+        CustomDispatcherBuilder {
             core: DispatcherBuilder::new(),
             running: DispatcherBuilder::new(),
         }
@@ -103,7 +103,7 @@ impl<'a, 'b> CustomGameDataBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> DataInit<CustomGameData<'a, 'b>> for CustomGameDataBuilder<'a, 'b> {
+impl<'a, 'b> DataInit<CustomGameData<'a, 'b>> for CustomDispatcherBuilder<'a, 'b> {
     fn build(self, world: &mut World) -> CustomGameData<'a, 'b> {
         // Get a handle to the `ThreadPool`.
         let pool = (*world.read_resource::<ArcThreadPool>()).clone();
@@ -228,7 +228,7 @@ impl<'a, 'b> State<CustomGameData<'a, 'b>, StateEvent> for Main {
 }
 ```
 
-The only thing that remains now is to use our `CustomGameDataBuilder` when building the
+The only thing that remains now is to use our `CustomDispatcherBuilder` when building the
 `Application`.
 
 ```rust
@@ -253,16 +253,16 @@ The only thing that remains now is to use our `CustomGameDataBuilder` when build
 #     running_dispatcher: Option<Dispatcher<'a, 'b>>,
 # }
 #
-# pub struct CustomGameDataBuilder<'a, 'b> {
+# pub struct CustomDispatcherBuilder<'a, 'b> {
 #     pub core: DispatcherBuilder<'a, 'b>,
 #     pub running: DispatcherBuilder<'a, 'b>,
 # }
 #
-# impl<'a, 'b> Default for CustomGameDataBuilder<'a, 'b> {
+# impl<'a, 'b> Default for CustomDispatcherBuilder<'a, 'b> {
 #     fn default() -> Self { unimplemented!() }
 # }
 #
-# impl<'a, 'b> CustomGameDataBuilder<'a, 'b> {
+# impl<'a, 'b> CustomDispatcherBuilder<'a, 'b> {
 #     pub fn new() -> Self { unimplemented!() }
 #     pub fn with_base_bundle<B>(mut self, world: &mut World, bundle: B) -> Result<Self, Error>
 #     where
@@ -279,18 +279,18 @@ The only thing that remains now is to use our `CustomGameDataBuilder` when build
 #     }
 # }
 #
-# impl<'a, 'b> DataInit<CustomGameData<'a, 'b>> for CustomGameDataBuilder<'a, 'b> {
+# impl<'a, 'b> DataInit<CustomGameData<'a, 'b>> for CustomDispatcherBuilder<'a, 'b> {
 #     fn build(self, world: &mut World) -> CustomGameData<'a, 'b> { unimplemented!() }
 # }
 #
-# impl<'a, 'b> DataDispose for CustomGameDataBuilder<'a, 'b> {
+# impl<'a, 'b> DataDispose for CustomDispatcherBuilder<'a, 'b> {
 #     fn dispose(&mut self, world: &mut World) { unimplemented!() }
 # }
 #
 # fn main() -> amethyst::Result<()> {
 #
 let mut app_builder = Application::build(assets_directory, Main)?;
-let game_data = CustomGameDataBuilder::default()
+let game_data = CustomDispatcherBuilder::default()
     .with_running(ExampleSystem, "example_system", &[])
     .with_base_bundle(
         &mut app_builder.world,

--- a/book/src/controlling_system_execution/custom_game_data.md
+++ b/book/src/controlling_system_execution/custom_game_data.md
@@ -16,7 +16,6 @@ are essential (like rendering, input and UI).
 Let's start by creating the `GameData` structure:
 
 ```rust,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::prelude::Dispatcher;
 #
 pub struct CustomGameData<'a, 'b> {
@@ -28,7 +27,6 @@ pub struct CustomGameData<'a, 'b> {
 We also add a utility function for performing dispatch:
 
 ```rust,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::prelude::{Dispatcher, World};
 #
 # pub struct CustomGameData<'a, 'b> {
@@ -57,7 +55,6 @@ a builder that implements `DataInit`, as well as implement `DataDispose` for our
 `GameData` structure.
 
 ```rust,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::ecs::prelude::{Dispatcher, DispatcherBuilder, System, World, WorldExt};
 # use amethyst::core::SystemBundle;
@@ -140,7 +137,6 @@ We can now use `CustomGameData` in place of the provided `GameData` when buildin
 our `Application`, but first we should create some `State`s.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::ecs::prelude::{Dispatcher, World};
 # use amethyst::prelude::{State, StateData, StateEvent, Trans};
@@ -236,7 +232,6 @@ The only thing that remains now is to use our `CustomGameDataBuilder` when build
 `Application`.
 
 ```rust,ignore
-# extern crate amethyst;
 #
 # use amethyst::{
 #     core::{transform::TransformBundle, SystemBundle},

--- a/book/src/controlling_system_execution/pausable_systems.md
+++ b/book/src/controlling_system_execution/pausable_systems.md
@@ -6,7 +6,7 @@ Pausable `System`s can be enabled or disabled depending on the value of a`Resour
 
 Let's get started by creating a new `Resource` that represents the state of our game.
 
-```rust,no_run,noplaypen
+```rust, no_run,noplaypen
 #[derive(PartialEq)]
 pub enum CurrentState {
     Running,
@@ -22,7 +22,7 @@ impl Default for CurrentState {
 
 We'll use this `enum` `Resource` to control whether or not our `System` is running. Next we'll register our `System` and set it as pausable.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     ecs::prelude::*,
@@ -60,7 +60,7 @@ dispatcher.add(
 
 To register the `Resource` or change its value, we can use the following code:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::prelude::*;
 # #[derive(PartialEq)]
 # pub enum CurrentState {

--- a/book/src/controlling_system_execution/pausable_systems.md
+++ b/book/src/controlling_system_execution/pausable_systems.md
@@ -23,7 +23,6 @@ impl Default for CurrentState {
 We'll use this `enum` `Resource` to control whether or not our `System` is running. Next we'll register our `System` and set it as pausable.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     ecs::prelude::*,
@@ -62,7 +61,6 @@ dispatcher.add(
 To register the `Resource` or change its value, we can use the following code:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::prelude::*;
 # #[derive(PartialEq)]
 # pub enum CurrentState {

--- a/book/src/controlling_system_execution/state-specific_dispatcher.md
+++ b/book/src/controlling_system_execution/state-specific_dispatcher.md
@@ -4,7 +4,7 @@ This guide explains how to define a state-specific `Dispatcher` whose `System`s 
 
 First of all we required a `DispatcherBuilder`. The `DispatcherBuilder` handles the actual creation of the `Dispatcher` and the assignment of `System`s to our `Dispatcher`. 
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     ecs::prelude::*,
@@ -16,7 +16,7 @@ let mut dispatcher_builder = DispatcherBuilder::new();
 
 To add `System`s to the `DispatcherBuilder` we use a similar syntax to the one we used to add `System`s to `GameData`.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     ecs::prelude::*,
@@ -34,7 +34,7 @@ dispatcher_builder.add(MovePaddlesSystem, "move_paddles_system", &[]);
 
 Alternatively we can add `Bundle`s of `System`s to our `DispatcherBuilder` directly.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     core::bundle::SystemBundle,
@@ -58,7 +58,7 @@ PongSystemsBundle::default()
 
 The `DispatcherBuilder` can be initialized and populated wherever desired, be it inside the `State` or in an external location. However, the `Dispatcher` needs to modify the `World`s resources in order to initialize the resources used by its `System`s. Therefore, we need to defer building the `Dispatcher` until we can access the `World`. This is commonly done in the `State`s `on_start` method. To showcase how this is done, we'll create a `SimpleState` with a `dispatcher` field and a `on_start` method that builds the `Dispatcher`.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     ecs::prelude::*,
@@ -100,7 +100,7 @@ By default, the dispatcher will create its own pool of worker threads to execute
 
 The `CustomState` requires two annotations (`'a` and `'b`) to satisfy the lifetimes of the `Dispatcher`. Now that we have our `Dispatcher` we need to ensure that it is executed. We do this in the `State`s `update` method.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     ecs::prelude::*,

--- a/book/src/controlling_system_execution/state-specific_dispatcher.md
+++ b/book/src/controlling_system_execution/state-specific_dispatcher.md
@@ -5,7 +5,6 @@ This guide explains how to define a state-specific `Dispatcher` whose `System`s 
 First of all we required a `DispatcherBuilder`. The `DispatcherBuilder` handles the actual creation of the `Dispatcher` and the assignment of `System`s to our `Dispatcher`. 
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     ecs::prelude::*,
@@ -18,7 +17,6 @@ let mut dispatcher_builder = DispatcherBuilder::new();
 To add `System`s to the `DispatcherBuilder` we use a similar syntax to the one we used to add `System`s to `GameData`.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     ecs::prelude::*,
@@ -37,7 +35,6 @@ dispatcher_builder.add(MovePaddlesSystem, "move_paddles_system", &[]);
 Alternatively we can add `Bundle`s of `System`s to our `DispatcherBuilder` directly.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     core::bundle::SystemBundle,
@@ -62,7 +59,6 @@ PongSystemsBundle::default()
 The `DispatcherBuilder` can be initialized and populated wherever desired, be it inside the `State` or in an external location. However, the `Dispatcher` needs to modify the `World`s resources in order to initialize the resources used by its `System`s. Therefore, we need to defer building the `Dispatcher` until we can access the `World`. This is commonly done in the `State`s `on_start` method. To showcase how this is done, we'll create a `SimpleState` with a `dispatcher` field and a `on_start` method that builds the `Dispatcher`.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     ecs::prelude::*,
@@ -105,7 +101,6 @@ By default, the dispatcher will create its own pool of worker threads to execute
 The `CustomState` requires two annotations (`'a` and `'b`) to satisfy the lifetimes of the `Dispatcher`. Now that we have our `Dispatcher` we need to ensure that it is executed. We do this in the `State`s `update` method.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     ecs::prelude::*,

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -61,7 +61,7 @@ Depending on the book version that you choose to read, make sure that the amethy
 
 For the released crates.io version, you should have something like this:
 
-```rust,ignore
+```toml,ignore
 [dependencies]
 amethyst = "LATEST_CRATES.IO_VERSION"
 ```
@@ -69,7 +69,7 @@ The latest crates.io version can be found [here](https://crates.io/crates/amethy
 
 If you want to use the latest unreleased changes, your Cargo.toml file should look like this:
 
-```rust,ignore
+```toml,ignore
 [dependencies]
 amethyst = { git = "https://github.com/amethyst/amethyst", rev = "COMMIT_HASH" }
 ```

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -61,7 +61,7 @@ Depending on the book version that you choose to read, make sure that the amethy
 
 For the released crates.io version, you should have something like this:
 
-```toml,ignore
+```toml
 [dependencies]
 amethyst = "LATEST_CRATES.IO_VERSION"
 ```
@@ -69,7 +69,7 @@ The latest crates.io version can be found [here](https://crates.io/crates/amethy
 
 If you want to use the latest unreleased changes, your Cargo.toml file should look like this:
 
-```toml,ignore
+```toml
 [dependencies]
 amethyst = { git = "https://github.com/amethyst/amethyst", rev = "COMMIT_HASH" }
 ```

--- a/book/src/input/handling_input.md
+++ b/book/src/input/handling_input.md
@@ -4,7 +4,6 @@ Amethyst uses an `InputHandler` to handle user input.
 You initialise this `InputHandler` by creating an `InputBundle` and adding it to the game data.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 use amethyst::{
     prelude::*,
     input::{InputBundle, StringBindings},
@@ -30,7 +29,6 @@ fn main() -> amethyst::Result<()> {
 To use the `InputHandler` inside a `System` you have to add it to the `SystemData`. With this you can check for events from input devices.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 use amethyst::{
     prelude::*,
     input::{InputHandler, ControllerButton, VirtualKeyCode, StringBindings},
@@ -72,7 +70,6 @@ You can find all the methods from `InputHandler` [here][input_ha].
 Now you have to add the `System` to the game data, just like you would do with any other `System`. A `System` that uses an `InputHandler` needs `"input_system"` inside its dependencies.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::{prelude::*, ecs::*, core::SystemDesc, derive::SystemDesc};
 # #[derive(SystemDesc)]
 # struct ExampleSystem; 
@@ -121,7 +118,6 @@ The possible inputs you can specify for axes are listed [here][in_axis]. The pos
 To add these bindings to the `InputBundle` you simply need to call the `with_bindings_from_file` function on the `InputBundle`.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::{prelude::*, input::*, utils::*};
 # fn main() -> amethyst::Result::<()> {
 let root = application_root_dir()?;
@@ -137,7 +133,6 @@ let input_bundle = InputBundle::<StringBindings>::new()
 And now you can get the [axis][axis_val] and [action][is_down] values from the `InputHandler`.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 use amethyst::{
     prelude::*,
     core::{Transform, SystemDesc},

--- a/book/src/input/handling_input.md
+++ b/book/src/input/handling_input.md
@@ -3,7 +3,7 @@
 Amethyst uses an `InputHandler` to handle user input.
 You initialise this `InputHandler` by creating an `InputBundle` and adding it to the game data.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 use amethyst::{
     prelude::*,
     input::{InputBundle, StringBindings},
@@ -28,7 +28,7 @@ fn main() -> amethyst::Result<()> {
 
 To use the `InputHandler` inside a `System` you have to add it to the `SystemData`. With this you can check for events from input devices.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 use amethyst::{
     prelude::*,
     input::{InputHandler, ControllerButton, VirtualKeyCode, StringBindings},
@@ -69,7 +69,7 @@ You can find all the methods from `InputHandler` [here][input_ha].
 
 Now you have to add the `System` to the game data, just like you would do with any other `System`. A `System` that uses an `InputHandler` needs `"input_system"` inside its dependencies.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::{prelude::*, ecs::*, core::SystemDesc, derive::SystemDesc};
 # #[derive(SystemDesc)]
 # struct ExampleSystem; 
@@ -88,7 +88,7 @@ let game_data = GameDataBuilder::default()
 
 Instead of hard coding in all the key bindings, you can store all the bindings in a config file. A config file for key bindings with the RON format looks something like this:
 
-```ron,ignore
+```ron
 (
     axes: {
         "vertical": Emulated(pos: Key(W), neg: Key(S)),
@@ -117,7 +117,7 @@ The possible inputs you can specify for axes are listed [here][in_axis]. The pos
 
 To add these bindings to the `InputBundle` you simply need to call the `with_bindings_from_file` function on the `InputBundle`.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::{prelude::*, input::*, utils::*};
 # fn main() -> amethyst::Result::<()> {
 let root = application_root_dir()?;
@@ -132,7 +132,7 @@ let input_bundle = InputBundle::<StringBindings>::new()
 
 And now you can get the [axis][axis_val] and [action][is_down] values from the `InputHandler`.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 use amethyst::{
     prelude::*,
     core::{Transform, SystemDesc},

--- a/book/src/input/handling_input.md
+++ b/book/src/input/handling_input.md
@@ -16,7 +16,7 @@ fn main() -> amethyst::Result<()> {
     let input_bundle = InputBundle::<StringBindings>::new();
 
     let mut world = World::new();
-    let game_data = GameDataBuilder::default()
+    let game_data = DispatcherBuilder::default()
     //..
     .with_bundle(input_bundle)?
     //..
@@ -75,7 +75,7 @@ Now you have to add the `System` to the game data, just like you would do with a
 # struct ExampleSystem; 
 # impl<'a> System<'a> for ExampleSystem { type SystemData = (); fn run(&mut self, _: ()) {}}
 #
-let game_data = GameDataBuilder::default()
+let game_data = DispatcherBuilder::default()
     //..
     .with(ExampleSystem, "example_system", &["input_system"])
     //..

--- a/book/src/input/how_to_define_custom_control_bindings.md
+++ b/book/src/input/how_to_define_custom_control_bindings.md
@@ -12,7 +12,7 @@ Using a custom type to handle input instead of using `String` has many advantage
 
 Defining a custom type for the `InputBundle` is done by implementing the `BindingTypes` trait. This trait contains two types, an `Axis` type and an `Action` type. These types are usually defined as enums.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # extern crate serde;
 use std::fmt::{self, Display};
 
@@ -55,13 +55,13 @@ The `Axis` and `Action` type both need to derive all the traits listed above, th
 
 For serializing and deserializing you need to add [serde] to the dependencies like this:
 
-```toml,ignore
+```toml
 serde = { version = "1", features = ["derive"] }
 ```
 
 If you want to add additional information you can add it to the enum or change the `Axis` and `Action` types to a struct. For example:
 
-```rust,ignore
+```rust
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 enum AxisBinding {
     Horizontal(usize),
@@ -80,7 +80,7 @@ We can now use this custom type in our `InputBundle` and create a RON config fil
 
 The config file might look something like this:
 
-```ron,ignore
+```ron
 (
     axes: {
         Vertical(0): Emulated(pos: Key(W), neg: Key(S)),
@@ -99,7 +99,7 @@ Here the number after the binding type could be the ID of the player, but you ca
 
 With the config file we can create an `InputBundle` like in the previous section.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::input::StringBindings as MovementBindingTypes;
 use amethyst::input::InputBundle;
 
@@ -117,7 +117,7 @@ let input_bundle =
 
 And add the `InputBundle` to the game data just like before.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::prelude::*;
 # use amethyst::input::{InputBundle, StringBindings};
 #
@@ -139,7 +139,7 @@ let game_data = GameDataBuilder::default()
 
 Now that we have added an `InputBundle` with a custom `BindingTypes`, we can use the `InputHandler` just like with `StringBindings`, but instead of using `String`s we use our custom enums.
 
-```rust,edition2018,no_run,noplaypen,ignore
+```rust, edition2018,no_run,noplaypen
 use amethyst::{
     core::{Transform, SystemDesc},
     derive::SystemDesc,
@@ -197,7 +197,7 @@ impl<'s> System<'s> for MovementSystem {
 
 And don't forget to add the `MovementSystem` to the game data.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::prelude::*;
 # use amethyst::ecs::*;
 # use amethyst::core::SystemDesc;

--- a/book/src/input/how_to_define_custom_control_bindings.md
+++ b/book/src/input/how_to_define_custom_control_bindings.md
@@ -125,7 +125,7 @@ And add the `InputBundle` to the game data just like before.
 # let input_bundle = InputBundle::<StringBindings>::default();
 #
 let mut world = World::new();
-let game_data = GameDataBuilder::default()
+let game_data = DispatcherBuilder::default()
     //..
     .with_bundle(input_bundle)?
     //..
@@ -205,7 +205,7 @@ And don't forget to add the `MovementSystem` to the game data.
 # #[derive(SystemDesc)]
 # struct MovementSystem;
 # impl<'a> System<'a> for MovementSystem {type SystemData=(); fn run(&mut self, _: ()) {}}
-let game_data = GameDataBuilder::default()
+let game_data = DispatcherBuilder::default()
 //..
     .with(MovementSystem, "movement_system", &["input_system"])
 //..

--- a/book/src/input/how_to_define_custom_control_bindings.md
+++ b/book/src/input/how_to_define_custom_control_bindings.md
@@ -13,7 +13,6 @@ Using a custom type to handle input instead of using `String` has many advantage
 Defining a custom type for the `InputBundle` is done by implementing the `BindingTypes` trait. This trait contains two types, an `Axis` type and an `Action` type. These types are usually defined as enums.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # extern crate serde;
 use std::fmt::{self, Display};
 
@@ -101,7 +100,6 @@ Here the number after the binding type could be the ID of the player, but you ca
 With the config file we can create an `InputBundle` like in the previous section.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::input::StringBindings as MovementBindingTypes;
 use amethyst::input::InputBundle;
 
@@ -120,7 +118,6 @@ let input_bundle =
 And add the `InputBundle` to the game data just like before.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::prelude::*;
 # use amethyst::input::{InputBundle, StringBindings};
 #
@@ -143,7 +140,6 @@ let game_data = GameDataBuilder::default()
 Now that we have added an `InputBundle` with a custom `BindingTypes`, we can use the `InputHandler` just like with `StringBindings`, but instead of using `String`s we use our custom enums.
 
 ```rust,edition2018,no_run,noplaypen,ignore
-# extern crate amethyst;
 use amethyst::{
     core::{Transform, SystemDesc},
     derive::SystemDesc,
@@ -202,7 +198,6 @@ impl<'s> System<'s> for MovementSystem {
 And don't forget to add the `MovementSystem` to the game data.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::prelude::*;
 # use amethyst::ecs::*;
 # use amethyst::core::SystemDesc;

--- a/book/src/pong-tutorial/pong-tutorial-01.md
+++ b/book/src/pong-tutorial/pong-tutorial-01.md
@@ -34,7 +34,7 @@ features = ["metal"]
 We can start with editing the `main.rs` file inside `src` directory.
 You can delete everything in that file, then add these imports:
 
-```rust,ignore
+```rust
 //! Pong Tutorial 1
 
 use amethyst::{
@@ -59,14 +59,14 @@ working on defining our game code.
 
 Now we create our core game struct:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 pub struct Pong;
 ```
 
 We'll be implementing the [`SimpleState`][simplestate] trait on this struct, which is
 used by Amethyst's state machine to start, stop, and update the game.
 
-```rust,ignore
+```rust
 impl SimpleState for Pong {}
 ```
 
@@ -79,7 +79,7 @@ started! We'll start with our `main()` function, and we'll have it return a
 `Result` so that we can use `?`. This will allow us to automatically exit
 if any errors occur during setup.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::prelude::*;
 fn main() -> amethyst::Result<()> {
 
@@ -100,7 +100,7 @@ fn main() -> amethyst::Result<()> {
 Inside `main()` we first start the amethyst logger with a default `LoggerConfig`
 so we can see errors, warnings and debug messages while the program is running.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # fn main() {
 amethyst::start_logger(Default::default());
@@ -129,7 +129,7 @@ project manually, go ahead and create it now.
 In either case, open `display.ron` and change its contents to the
 following:
 
-```rust,ignore
+```rust
 (
     title: "Pong!",
     dimensions: Some((500, 500)),
@@ -147,7 +147,7 @@ say "Pong!" instead of the sad, lowercase default of "pong".
 In `main()` in `main.rs`, we will prepare the path to a file containing
 the display configuration:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     utils::application_root_dir,
@@ -165,7 +165,7 @@ let display_config_path = app_root.join("config").join("display.ron");
 
 In `main()` in `main.rs` we are going to add the basic application setup:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::{
 #     prelude::*,
 #     utils::application_root_dir,
@@ -210,7 +210,7 @@ to do by adding a renderer!
 After preparing the display config and application scaffolding, it's time to actually use it.
 Last time we left our `GameDataBuilder` instance empty, now we'll add some systems to it.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::{
 #     prelude::*,
 #     renderer::{

--- a/book/src/pong-tutorial/pong-tutorial-01.md
+++ b/book/src/pong-tutorial/pong-tutorial-01.md
@@ -80,7 +80,6 @@ started! We'll start with our `main()` function, and we'll have it return a
 if any errors occur during setup.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::prelude::*;
 fn main() -> amethyst::Result<()> {
 
@@ -102,7 +101,6 @@ Inside `main()` we first start the amethyst logger with a default `LoggerConfig`
 so we can see errors, warnings and debug messages while the program is running.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # fn main() {
 amethyst::start_logger(Default::default());
@@ -150,7 +148,6 @@ In `main()` in `main.rs`, we will prepare the path to a file containing
 the display configuration:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     utils::application_root_dir,
@@ -169,7 +166,6 @@ let display_config_path = app_root.join("config").join("display.ron");
 In `main()` in `main.rs` we are going to add the basic application setup:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::{
 #     prelude::*,
 #     utils::application_root_dir,
@@ -215,7 +211,6 @@ After preparing the display config and application scaffolding, it's time to act
 Last time we left our `GameDataBuilder` instance empty, now we'll add some systems to it.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::{
 #     prelude::*,
 #     renderer::{

--- a/book/src/pong-tutorial/pong-tutorial-01.md
+++ b/book/src/pong-tutorial/pong-tutorial-01.md
@@ -172,7 +172,7 @@ In `main()` in `main.rs` we are going to add the basic application setup:
 # };
 # fn main() -> Result<(), amethyst::Error> {
 # struct Pong; impl SimpleState for Pong {}
-let game_data = GameDataBuilder::default();
+let game_data = DispatcherBuilder::default();
 
 # let app_root = application_root_dir()?;
 let assets_dir = app_root.join("assets");
@@ -182,7 +182,7 @@ game.run();
 # }
 ```
 
-Here we're creating a new instance of `GameDataBuilder`, a central repository
+Here we're creating a new instance of `DispatcherBuilder`, a central repository
 of all the game logic that runs periodically during the game runtime. Right now it's empty,
 but soon we will start adding all sorts of systems and bundles to it - which will run our game code.
 
@@ -208,7 +208,7 @@ to do by adding a renderer!
 ## Setting up basic rendering
 
 After preparing the display config and application scaffolding, it's time to actually use it.
-Last time we left our `GameDataBuilder` instance empty, now we'll add some systems to it.
+Last time we left our `DispatcherBuilder` instance empty, now we'll add some systems to it.
 
 ```rust, edition2018,no_run,noplaypen
 # use amethyst::{
@@ -225,7 +225,7 @@ let app_root = application_root_dir()?;
 
 let display_config_path = app_root.join("config").join("display.ron");
 
-let game_data = GameDataBuilder::default()
+let game_data = DispatcherBuilder::default()
     .with_bundle(
         RenderingBundle::<DefaultBackend>::new()
             // The RenderToWindow plugin provides all the scaffolding for opening a window and drawing on it

--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -25,7 +25,7 @@ initialization code from the Pong code.
 1. In the `src` directory, create a new file called `pong.rs` and add the
    following `use` statements. These are needed to make it through this chapter:
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     #
     use amethyst::{
         assets::{AssetStorage,  DefaultLoader, Loader, Handle},
@@ -41,7 +41,7 @@ initialization code from the Pong code.
 
 3. In `main.rs` declare `pong` as a module and import the `Pong` state:
 
-    ```rust,ignore
+    ```rust
     mod pong;
 
     use crate::pong::Pong;
@@ -52,7 +52,7 @@ initialization code from the Pong code.
 First, in `pong.rs`, let's add a new method to our `State` implementation: `on_start`.
 This method is called when the State starts. We will leave it empty for now.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::prelude::*;
 # struct Pong;
 impl SimpleState for Pong {
@@ -76,7 +76,7 @@ will.
 
 1. Define the size of the playable area at the top of `pong.rs`.
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     pub const ARENA_HEIGHT: f32 = 100.0;
     pub const ARENA_WIDTH: f32 = 100.0;
     ```
@@ -87,7 +87,7 @@ will.
 
     In pong, we want the camera to cover the entire arena. Let's do it in a new function `initialise_camera`:
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     #
     # const ARENA_HEIGHT: f32 = 100.0;
     # const ARENA_WIDTH: f32 = 100.0;
@@ -134,7 +134,7 @@ will.
 3. To finish setting up the camera, we need to call `initialise_camera` from the
    Pong state's `on_start` method:
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     # use amethyst::prelude::*;
     # use amethyst::ecs::World;
     # fn initialise_camera(world: &mut World) { }
@@ -156,14 +156,14 @@ Now, we will create the `Paddle` component, all in `pong.rs`.
 
 1. Define constants for the paddle width and height.
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     pub const PADDLE_HEIGHT: f32 = 16.0;
     pub const PADDLE_WIDTH: f32 = 4.0;
     ```
 
 2. Define the `Side` enum and `Paddle` struct:
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     # pub const PADDLE_HEIGHT: f32 = 16.0;
     # pub const PADDLE_WIDTH: f32 = 4.0;
     #
@@ -196,7 +196,7 @@ Now, we will create the `Paddle` component, all in `pong.rs`.
 
 3. Implement the `Component` trait for `Paddle`:
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     #
     # use amethyst::ecs::{Component, DenseVecStorage};
     #
@@ -222,7 +222,7 @@ include that component and add them to our `World`.
 
 First let's look at our imports:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 use amethyst::core::transform::Transform;
 ```
 
@@ -239,7 +239,7 @@ Keep in mind that the anchor point of our entities will be in the middle of the
 image we will want to render on top of them. This is a good rule to follow in
 general, as it makes operations like rotation easier.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::prelude::*;
 # use amethyst::core::Transform;
 # use amethyst::ecs::World;
@@ -290,7 +290,7 @@ virtual world, but we'll need to do some more work to actually *draw* them.
 As a sanity check, let's make sure the code for initialising the paddles
 compiles. Update the `on_start` method to the following:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::prelude::*;
 # use amethyst::ecs::World;
 # fn initialise_paddles(world: &mut World) { }
@@ -308,7 +308,7 @@ fn on_start(&mut self, data: StateData<'_, GameData>) {
 
 Let's run our blank screen game!
 
-```text,ignore
+```text
 Tried to fetch resource of type `MaskedStorage<Paddle>`[^1] from the `World`, but the resource does not exist.
 
 You may ensure the resource exists through one of the following methods:
@@ -328,7 +328,7 @@ set up in the `World`. The error message above means we have registered the
 this by adding the following line before `initialise_paddles(world)` in the
 `on_start` method:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{World, WorldExt};
 # struct Paddle;
 # impl amethyst::ecs::Component for Paddle {
@@ -360,7 +360,7 @@ similarly to how you would register a system. We already have `RenderBundle` in 
 registering another one will look similar. You have to first import
 `TransformBundle`, then register it as follows:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 use amethyst::core::transform::TransformBundle;
 #
@@ -407,7 +407,7 @@ function in `pong.rs` called `load_sprite_sheet`.
 
 First, let's declare the function and load the sprite sheet's image data.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     assets::{AssetStorage,  DefaultLoader, Loader, Handle},
@@ -465,7 +465,7 @@ Alongside our sprite sheet texture, we need a file describing where the sprites
 are on the sheet. Let's create, right next to it, a file called
 `pong_spritesheet.ron`. It will contain the following sprite sheet definition:
 
-```text,ignore
+```text
 List((
     texture_width: 8,
     texture_height: 16,
@@ -494,7 +494,7 @@ List((
 
 Finally, we load the file containing the position of each sprite on the sheet.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     assets::{AssetStorage, Handle,  DefaultLoader, Loader},
@@ -549,7 +549,7 @@ So far, so good. We have a sprite sheet loaded, now we need to link the sprites
 to the paddles. We update the `initialise_paddles` function by changing its
 signature to:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::World;
 # use amethyst::{assets::Handle, renderer::sprite::SpriteSheet};
 fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>)
@@ -560,7 +560,7 @@ Inside `initialise_paddles`, we construct a `SpriteRender` for a paddle. We
 only need one here, since the only difference between the two paddles is that
 the right one is flipped horizontally.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::World;
 # use amethyst::{assets::Handle, renderer::{SpriteRender, SpriteSheet}};
 # fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>) {
@@ -575,7 +575,7 @@ sprite in the sprite sheet, we use `0` for the `sprite_number`.
 
 Next we simply add the components to the paddle entities:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::World;
 # use amethyst::assets::Handle;
 # use amethyst::renderer::sprite::{SpriteSheet, SpriteRender};
@@ -601,7 +601,7 @@ world
 We're nearly there, we just have to wire up the sprite to the paddles. We put it
 all together in the `on_start()` method:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::assets::Handle;
 # use amethyst::prelude::*;
 # use amethyst::renderer::{sprite::SpriteSheet, Texture};

--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -26,7 +26,6 @@ initialization code from the Pong code.
    following `use` statements. These are needed to make it through this chapter:
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     #
     use amethyst::{
         assets::{AssetStorage,  DefaultLoader, Loader, Handle},
@@ -54,7 +53,6 @@ First, in `pong.rs`, let's add a new method to our `State` implementation: `on_s
 This method is called when the State starts. We will leave it empty for now.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::prelude::*;
 # struct Pong;
 impl SimpleState for Pong {
@@ -90,7 +88,6 @@ will.
     In pong, we want the camera to cover the entire arena. Let's do it in a new function `initialise_camera`:
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     #
     # const ARENA_HEIGHT: f32 = 100.0;
     # const ARENA_WIDTH: f32 = 100.0;
@@ -138,7 +135,6 @@ will.
    Pong state's `on_start` method:
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     # use amethyst::prelude::*;
     # use amethyst::ecs::World;
     # fn initialise_camera(world: &mut World) { }
@@ -201,7 +197,6 @@ Now, we will create the `Paddle` component, all in `pong.rs`.
 3. Implement the `Component` trait for `Paddle`:
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     #
     # use amethyst::ecs::{Component, DenseVecStorage};
     #
@@ -228,7 +223,6 @@ include that component and add them to our `World`.
 First let's look at our imports:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 use amethyst::core::transform::Transform;
 ```
 
@@ -246,7 +240,6 @@ image we will want to render on top of them. This is a good rule to follow in
 general, as it makes operations like rotation easier.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::prelude::*;
 # use amethyst::core::Transform;
 # use amethyst::ecs::World;
@@ -298,7 +291,6 @@ As a sanity check, let's make sure the code for initialising the paddles
 compiles. Update the `on_start` method to the following:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::prelude::*;
 # use amethyst::ecs::World;
 # fn initialise_paddles(world: &mut World) { }
@@ -337,7 +329,6 @@ this by adding the following line before `initialise_paddles(world)` in the
 `on_start` method:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{World, WorldExt};
 # struct Paddle;
 # impl amethyst::ecs::Component for Paddle {
@@ -370,7 +361,6 @@ registering another one will look similar. You have to first import
 `TransformBundle`, then register it as follows:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 use amethyst::core::transform::TransformBundle;
 #
@@ -418,7 +408,6 @@ function in `pong.rs` called `load_sprite_sheet`.
 First, let's declare the function and load the sprite sheet's image data.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     assets::{AssetStorage,  DefaultLoader, Loader, Handle},
@@ -506,7 +495,6 @@ List((
 Finally, we load the file containing the position of each sprite on the sheet.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     assets::{AssetStorage, Handle,  DefaultLoader, Loader},
@@ -562,7 +550,6 @@ to the paddles. We update the `initialise_paddles` function by changing its
 signature to:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::World;
 # use amethyst::{assets::Handle, renderer::sprite::SpriteSheet};
 fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>)
@@ -574,7 +561,6 @@ only need one here, since the only difference between the two paddles is that
 the right one is flipped horizontally.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::World;
 # use amethyst::{assets::Handle, renderer::{SpriteRender, SpriteSheet}};
 # fn initialise_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>) {
@@ -590,7 +576,6 @@ sprite in the sprite sheet, we use `0` for the `sprite_number`.
 Next we simply add the components to the paddle entities:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::World;
 # use amethyst::assets::Handle;
 # use amethyst::renderer::sprite::{SpriteSheet, SpriteRender};
@@ -617,7 +602,6 @@ We're nearly there, we just have to wire up the sprite to the paddles. We put it
 all together in the `on_start()` method:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::assets::Handle;
 # use amethyst::prelude::*;
 # use amethyst::renderer::{sprite::SpriteSheet, Texture};

--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -380,7 +380,7 @@ fn main() -> amethyst::Result<()> {
 #       app_root.join("config/display.ron");
 #
     // ...
-    let game_data = GameDataBuilder::default()
+    let game_data = DispatcherBuilder::default()
         // ...
 
         // Add the transform bundle which handles tracking entity positions

--- a/book/src/pong-tutorial/pong-tutorial-03.md
+++ b/book/src/pong-tutorial/pong-tutorial-03.md
@@ -26,7 +26,7 @@ Let's start by creating a config file under the `config` directory of our
 project, called `bindings.ron`, which will contain a RON representation
 of the [amethyst_input::Bindings][doc_bindings] struct:
 
-```ron,ignore
+```ron
 (
   axes: {
     "left_paddle": Emulated(pos: Key(W), neg: Key(S)),
@@ -50,7 +50,7 @@ Next, we'll add an `InputBundle` to the game's `Application` object, that
 contains an `InputHandler` system which captures inputs, and maps them to the
 axes we defined. Let's make the following changes to `main.rs`.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::prelude::*;
 # use amethyst::core::transform::TransformBundle;
 # use amethyst_utils::application_root_dir;
@@ -91,7 +91,7 @@ directory called `systems` under `src` to hold all our systems. We'll use a
 module to collect and export each of our systems to the rest of the
 application. Here's our `mod.rs` for `src/systems`:
 
-```rust,ignore
+```rust
 pub use self::paddle::PaddleSystem;
 
 mod paddle;
@@ -99,7 +99,7 @@ mod paddle;
 
 We're finally ready to implement the `PaddleSystem` in `systems/paddle.rs`:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # mod pong {
 #     use amethyst::ecs::prelude::*;
@@ -199,11 +199,11 @@ immutable for the `Paddle` and mutable for the `Transform`.
 
 Let's add this system to our `GameDataBuilder` in `main.rs`:
 
-```rust,ignore
+```rust
 mod systems; // Import the module
 ```
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::prelude::*;
 # use amethyst::core::transform::TransformBundle;
 # use amethyst::input::StringBindings;
@@ -255,7 +255,7 @@ If we run the game now, we'll see the console print our keypresses.
 Let's make it update the position of the paddle. To do this, we'll modify the y
 component of the transform's translation.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::core::Transform;
 # use amethyst::core::SystemDesc;
 # use amethyst::derive::SystemDesc;
@@ -313,7 +313,7 @@ to `PADDLE_HEIGHT * 0.5` (the bottom of the arena plus the offset).
 
 Our run function should now look something like this:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::core::Transform;
 # use amethyst::core::SystemDesc;
 # use amethyst::derive::SystemDesc;
@@ -370,7 +370,7 @@ Now that we have a system in place that uses the `Paddle` component,
 we no longer need to manually register it with the `world`: the system
 will take care of that for us, as well as set up the storage.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::assets::Handle;
 # use amethyst::ecs::World;
 # use amethyst::prelude::*;

--- a/book/src/pong-tutorial/pong-tutorial-03.md
+++ b/book/src/pong-tutorial/pong-tutorial-03.md
@@ -51,7 +51,6 @@ contains an `InputHandler` system which captures inputs, and maps them to the
 axes we defined. Let's make the following changes to `main.rs`.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::prelude::*;
 # use amethyst::core::transform::TransformBundle;
 # use amethyst_utils::application_root_dir;
@@ -101,7 +100,6 @@ mod paddle;
 We're finally ready to implement the `PaddleSystem` in `systems/paddle.rs`:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # mod pong {
 #     use amethyst::ecs::prelude::*;
@@ -206,7 +204,6 @@ mod systems; // Import the module
 ```
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::prelude::*;
 # use amethyst::core::transform::TransformBundle;
 # use amethyst::input::StringBindings;
@@ -259,7 +256,6 @@ Let's make it update the position of the paddle. To do this, we'll modify the y
 component of the transform's translation.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::core::Transform;
 # use amethyst::core::SystemDesc;
 # use amethyst::derive::SystemDesc;
@@ -318,7 +314,6 @@ to `PADDLE_HEIGHT * 0.5` (the bottom of the arena plus the offset).
 Our run function should now look something like this:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::core::Transform;
 # use amethyst::core::SystemDesc;
 # use amethyst::derive::SystemDesc;
@@ -376,7 +371,6 @@ we no longer need to manually register it with the `world`: the system
 will take care of that for us, as well as set up the storage.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::assets::Handle;
 # use amethyst::ecs::World;
 # use amethyst::prelude::*;

--- a/book/src/pong-tutorial/pong-tutorial-03.md
+++ b/book/src/pong-tutorial/pong-tutorial-03.md
@@ -70,7 +70,7 @@ let input_bundle = InputBundle::<StringBindings>::new()
 # let assets_dir = "assets";
 # struct Pong;
 # impl SimpleState for Pong { }
-let game_data = GameDataBuilder::default()
+let game_data = DispatcherBuilder::default()
     .with_bundle(TransformBundle::new())?
     .with_bundle(input_bundle)?
     // ..
@@ -197,7 +197,7 @@ immutable for the `Paddle` and mutable for the `Transform`.
 > by using `par_join` instead of `join`, but here the overhead introduced is not
 > worth the gain offered by parallelism.
 
-Let's add this system to our `GameDataBuilder` in `main.rs`:
+Let's add this system to our `DispatcherBuilder` in `main.rs`:
 
 ```rust
 mod systems; // Import the module
@@ -228,7 +228,7 @@ fn main() -> amethyst::Result<()> {
 # }
 # }
 # let input_bundle = amethyst::input::InputBundle::<StringBindings>::new();
-let game_data = GameDataBuilder::default()
+let game_data = DispatcherBuilder::default()
     // ...
     .with_bundle(TransformBundle::new())?
     .with_bundle(input_bundle)?

--- a/book/src/pong-tutorial/pong-tutorial-04.md
+++ b/book/src/pong-tutorial/pong-tutorial-04.md
@@ -23,7 +23,6 @@ keeping it simple.
 In `pong.rs`, let's create the `Ball` Component.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{Component, DenseVecStorage};
 pub struct Ball {
     pub velocity: [f32; 2],
@@ -41,7 +40,6 @@ Then let's add an `initialise_ball` function the same way we wrote the
 `initialise_paddles` function.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::prelude::*;
 # use amethyst::assets::{Loader, AssetStorage, Handle};
 # use amethyst::renderer::{Texture, SpriteRender, Sprite, SpriteSheet};
@@ -91,7 +89,6 @@ second one, whose index is `1`.
 Finally, let's make sure the code is working as intended by updating the `on_start` method:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::prelude::*;
 # use amethyst::assets::Handle;
 # use amethyst::renderer::{Texture, SpriteSheet};
@@ -136,7 +133,6 @@ in the center. In the next section, we're going to make this ball actually move!
 We're now ready to implement the `MoveBallsSystem` in `systems/move_balls.rs`:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{Component, DenseVecStorage};
 #
 # mod pong {
@@ -203,7 +199,6 @@ If a collision is detected, the ball bounces off. This is done
 by negating the velocity of the `Ball` component on the `x` or `y` axis.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{Component, DenseVecStorage};
 #
 # mod pong {
@@ -315,7 +310,6 @@ Also, don't forget to add `mod move_balls` and `mod bounce` in `systems/mod.rs`
 as well as adding our new systems to the game data:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::prelude::*;
 # use amethyst::core::transform::TransformBundle;
 # use amethyst::window::DisplayConfig;
@@ -390,7 +384,6 @@ First, let's add a new method to our state: `update`.
 Let's add that `update` method just below `on_start`:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::prelude::*;
 # struct MyState;
 # impl SimpleState for MyState {
@@ -411,7 +404,6 @@ as a local variable inside `on_start`. For that reason, we have to make it a par
 Let's add some fields to our `Pong` struct:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst; use amethyst::renderer::SpriteSheet;
 # use amethyst::assets::Handle;
 #[derive(Default)]
 pub struct Pong {
@@ -428,7 +420,6 @@ We've also added `#[derive(Default)]`, which will automatically implement `Defau
 default empty state. Now let's use that inside our `Application` creation code in `main.rs`:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::{
 #     ecs::{World, WorldExt},
 #     prelude::*,
@@ -450,7 +441,6 @@ Now let's finish our timer and ball spawning code. We have to do two things:
 - then we have to `initialise_ball` once after the time has passed inside `update`:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::{assets::Handle, renderer::SpriteSheet};
 # use amethyst::prelude::*;
 use amethyst::core::timing::Time;

--- a/book/src/pong-tutorial/pong-tutorial-04.md
+++ b/book/src/pong-tutorial/pong-tutorial-04.md
@@ -8,7 +8,7 @@ and bounces around!
 
 First, let's define some other useful constants for this chapter in `pong.rs`:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 pub const BALL_VELOCITY_X: f32 = 75.0;
 pub const BALL_VELOCITY_Y: f32 = 50.0;
 pub const BALL_RADIUS: f32 = 2.0;
@@ -22,7 +22,7 @@ keeping it simple.
 
 In `pong.rs`, let's create the `Ball` Component.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{Component, DenseVecStorage};
 pub struct Ball {
     pub velocity: [f32; 2],
@@ -39,7 +39,7 @@ A ball has a velocity and a radius, so we store that information in the componen
 Then let's add an `initialise_ball` function the same way we wrote the
 `initialise_paddles` function.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::prelude::*;
 # use amethyst::assets::{Loader, AssetStorage, Handle};
 # use amethyst::renderer::{Texture, SpriteRender, Sprite, SpriteSheet};
@@ -88,7 +88,7 @@ second one, whose index is `1`.
 
 Finally, let's make sure the code is working as intended by updating the `on_start` method:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::prelude::*;
 # use amethyst::assets::Handle;
 # use amethyst::renderer::{Texture, SpriteSheet};
@@ -132,7 +132,7 @@ in the center. In the next section, we're going to make this ball actually move!
 
 We're now ready to implement the `MoveBallsSystem` in `systems/move_balls.rs`:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{Component, DenseVecStorage};
 #
 # mod pong {
@@ -198,7 +198,7 @@ paddles, as well as balls and the top and bottom edges of the arena.
 If a collision is detected, the ball bounces off. This is done
 by negating the velocity of the `Ball` component on the `x` or `y` axis.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{Component, DenseVecStorage};
 #
 # mod pong {
@@ -309,7 +309,7 @@ The following image illustrates how collisions with paddles are checked.
 Also, don't forget to add `mod move_balls` and `mod bounce` in `systems/mod.rs`
 as well as adding our new systems to the game data:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::prelude::*;
 # use amethyst::core::transform::TransformBundle;
 # use amethyst::window::DisplayConfig;
@@ -383,7 +383,7 @@ struct to actually hold some data.
 First, let's add a new method to our state: `update`.
 Let's add that `update` method just below `on_start`:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::prelude::*;
 # struct MyState;
 # impl SimpleState for MyState {
@@ -403,7 +403,7 @@ as a local variable inside `on_start`. For that reason, we have to make it a par
 
 Let's add some fields to our `Pong` struct:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::assets::Handle;
 #[derive(Default)]
 pub struct Pong {
@@ -419,7 +419,7 @@ It will be created inside the `on_start` method instead.
 We've also added `#[derive(Default)]`, which will automatically implement `Default` trait for us, which allows to create
 default empty state. Now let's use that inside our `Application` creation code in `main.rs`:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::{
 #     ecs::{World, WorldExt},
 #     prelude::*,
@@ -440,7 +440,7 @@ Now let's finish our timer and ball spawning code. We have to do two things:
 - First, we have to initialize our state and remove `initialise_ball` from `on_start`,
 - then we have to `initialise_ball` once after the time has passed inside `update`:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::{assets::Handle, renderer::SpriteSheet};
 # use amethyst::prelude::*;
 use amethyst::core::timing::Time;

--- a/book/src/pong-tutorial/pong-tutorial-04.md
+++ b/book/src/pong-tutorial/pong-tutorial-04.md
@@ -342,7 +342,7 @@ as well as adding our new systems to the game data:
 # }
 # }
 # let input_bundle = amethyst::input::InputBundle::<StringBindings>::new();
-let game_data = GameDataBuilder::default()
+let game_data = DispatcherBuilder::default()
 #    .with_bundle(TransformBundle::new())?
 #    .with_bundle(input_bundle)?
 #    .with(systems::PaddleSystem, "paddle_system", &["input_system"])
@@ -428,7 +428,7 @@ default empty state. Now let's use that inside our `Application` creation code i
 # #[derive(Default)] struct Pong;
 # impl SimpleState for Pong { }
 # fn main() -> amethyst::Result<()> {
-#   let game_data = GameDataBuilder::default();
+#   let game_data = DispatcherBuilder::default();
 #   let assets_dir = "/";
 #   let world = World::new();
 let mut game = Application::new(assets_dir, Pong::default(), game_data)?;

--- a/book/src/pong-tutorial/pong-tutorial-05.md
+++ b/book/src/pong-tutorial/pong-tutorial-05.md
@@ -358,7 +358,7 @@ game window. You'll notice that the scores don't update yet when the ball makes
 it to either side, so we'll add that next!
 
 
-[font-download]: https://github.com/amethyst/amethyst/raw/master/examples/pong_tutorial_05/assets/font/square.ttf
+[font-download]: https://github.com/amethyst/amethyst/blob/main/examples/pong_tutorial_05/assets/font/square.ttf?raw=true
 [input-handler]: https://docs.amethyst.rs/master/amethyst_input/struct.InputHandler.html
 [ui-bundle]: https://docs.amethyst.rs/master/amethyst_ui/struct.UiBundle.html
 

--- a/book/src/pong-tutorial/pong-tutorial-05.md
+++ b/book/src/pong-tutorial/pong-tutorial-05.md
@@ -16,7 +16,7 @@ reached either edge of the arena and reset its position and velocity. We'll also
 make a note of who got the point for the round.
 
 First, we'll add a new module to `systems/mod.rs`
-```rust,ignore
+```rust
 pub use self::winner::WinnerSystem;
 
 mod winner;
@@ -24,7 +24,7 @@ mod winner;
 
 Then, we'll create `systems/winner.rs`:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # mod pong {
 #     use amethyst::ecs::prelude::*;
@@ -95,7 +95,7 @@ its direction and put it back in the middle of the screen.
 Now, we just need to add our new system to `main.rs`, and we should be able to
 keep playing after someone scores and log who got the point.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #    core::transform::TransformBundle,
@@ -175,13 +175,13 @@ to display our players' scores.
 
 First, let's add the UI rendering in `main.rs`. Add the following imports:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 use amethyst::ui::{RenderUi, UiBundle};
 ```
 
 Then, add a `RenderUi` plugin to your `RenderBundle` like so:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::{
 #     ecs::{World, WorldExt},
 #     prelude::*,
@@ -202,7 +202,7 @@ Then, add a `RenderUi` plugin to your `RenderBundle` like so:
 
 Finally, add the `UiBundle` after the `InputBundle`:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::{
 #     ecs::{World, WorldExt},
 #     input::StringBindings,
@@ -234,7 +234,7 @@ and `axes`. So just know that your `UiBundle` type should match your
 Now we have everything set up so we can start rendering a scoreboard in our
 game. We'll start by creating some structures in `pong.rs`:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 use amethyst::{
     // --snip--
     ecs::{Component, DenseVecStorage, Entity},
@@ -261,7 +261,7 @@ gone ahead and marked it as public (same with `ScoreText`). `ScoreText` is also
 a container, but this one holds handles to the UI `Entity`s that will be
 rendered to the screen. We'll create those next:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 use amethyst::{
 #     assets::{AssetStorage,  DefaultLoader, Loader},
@@ -370,7 +370,7 @@ point. You'll see just how easy this is with our `ECS` design. All we have to do
 is modify our `WinnerSystem` to access the players' scores and update them
 accordingly:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # mod pong {
 #     use amethyst::ecs::prelude::*;

--- a/book/src/pong-tutorial/pong-tutorial-05.md
+++ b/book/src/pong-tutorial/pong-tutorial-05.md
@@ -25,7 +25,6 @@ mod winner;
 Then, we'll create `systems/winner.rs`:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # mod pong {
 #     use amethyst::ecs::prelude::*;
@@ -97,7 +96,6 @@ Now, we just need to add our new system to `main.rs`, and we should be able to
 keep playing after someone scores and log who got the point.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #    core::transform::TransformBundle,
@@ -178,14 +176,12 @@ to display our players' scores.
 First, let's add the UI rendering in `main.rs`. Add the following imports:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 use amethyst::ui::{RenderUi, UiBundle};
 ```
 
 Then, add a `RenderUi` plugin to your `RenderBundle` like so:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::{
 #     ecs::{World, WorldExt},
 #     prelude::*,
@@ -207,7 +203,6 @@ Then, add a `RenderUi` plugin to your `RenderBundle` like so:
 Finally, add the `UiBundle` after the `InputBundle`:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::{
 #     ecs::{World, WorldExt},
 #     input::StringBindings,
@@ -240,7 +235,6 @@ Now we have everything set up so we can start rendering a scoreboard in our
 game. We'll start by creating some structures in `pong.rs`:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 use amethyst::{
     // --snip--
     ecs::{Component, DenseVecStorage, Entity},
@@ -268,7 +262,6 @@ a container, but this one holds handles to the UI `Entity`s that will be
 rendered to the screen. We'll create those next:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 use amethyst::{
 #     assets::{AssetStorage,  DefaultLoader, Loader},
@@ -378,7 +371,6 @@ is modify our `WinnerSystem` to access the players' scores and update them
 accordingly:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # mod pong {
 #     use amethyst::ecs::prelude::*;

--- a/book/src/pong-tutorial/pong-tutorial-05.md
+++ b/book/src/pong-tutorial/pong-tutorial-05.md
@@ -143,7 +143,7 @@ keep playing after someone scores and log who got the point.
 # let config = DisplayConfig::load(&path)?;
 # let input_bundle = amethyst::input::InputBundle::<StringBindings>::new();
 #
-let game_data = GameDataBuilder::default()
+let game_data = DispatcherBuilder::default()
 #    .with_bundle(TransformBundle::new())?
 #    .with_bundle(input_bundle)?
 #    .with(systems::PaddleSystem, "paddle_system", &["input_system"])
@@ -192,7 +192,7 @@ Then, add a `RenderUi` plugin to your `RenderBundle` like so:
 #     ui::RenderUi,
 # };
 # fn main() -> Result<(), amethyst::Error>{
-# let game_data = GameDataBuilder::default()
+# let game_data = DispatcherBuilder::default()
     .with_bundle(RenderingBundle::<DefaultBackend>::new()
         // ...
             .with_plugin(RenderUi::default()),
@@ -212,7 +212,7 @@ Finally, add the `UiBundle` after the `InputBundle`:
 # fn main() -> Result<(), amethyst::Error>{
 # let display_config_path = "";
 # struct Pong;
-# let game_data = GameDataBuilder::default()
+# let game_data = DispatcherBuilder::default()
 .with_bundle(UiBundle::<StringBindings>::new())?
 # ;
 #

--- a/book/src/pong-tutorial/pong-tutorial-06.md
+++ b/book/src/pong-tutorial/pong-tutorial-06.md
@@ -15,7 +15,6 @@ mod audio;
 Create a file called `audio.rs`:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 use amethyst::{
     assets::Loader,
@@ -74,7 +73,6 @@ impl SimpleState for Pong {
 Finally, we'll need our game to include the Audio Bundle. In `main.rs`:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::GameDataBuilder;
 use amethyst::audio::AudioBundle;
@@ -98,7 +96,6 @@ fn main() -> amethyst::Result<()> {
 Let's start by creating a function to play the bounce sound. In `audio.rs`, add:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 use amethyst::{
     assets::AssetStorage,
@@ -183,7 +180,6 @@ Now try running your game (`cargo run`). Don't forget to turn up your volume!
 Just as we did for the bounce sound, let's create a function to play the score sound. Update `audio.rs`:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use amethyst::{
 #     audio::{output::Output, Source, SourceHandle},
@@ -281,7 +277,6 @@ const MUSIC_TRACKS: &[&str] = &[
 Then, create a Music Resource:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 use std::{iter::Cycle, vec::IntoIter};
 #
@@ -297,7 +292,6 @@ Since we only have two music tracks, we use a `Cycle` to infinitely alternate be
 Next, we need to add the Music Resource to our World. Update `initialise_audio`:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 # use std::{iter::Cycle, vec::IntoIter};
 #

--- a/book/src/pong-tutorial/pong-tutorial-06.md
+++ b/book/src/pong-tutorial/pong-tutorial-06.md
@@ -8,13 +8,13 @@ Let's get started by creating an `audio` subdirectory under `assets`. Then downl
 
 Next, we'll create a Resource to store our sound effects in. In `main.rs`, add:
 
-```rust,ignore
+```rust
 mod audio;
 ```
 
 Create a file called `audio.rs`:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 use amethyst::{
     assets::Loader,
@@ -58,7 +58,7 @@ pub fn initialise_audio(world: &mut World) {
 
 Then, we'll need to add the Sounds Resource to our World. Update `pong.rs`:
 
-```rust,ignore
+```rust
 use crate::audio::initialise_audio;
 
 impl SimpleState for Pong {
@@ -72,7 +72,7 @@ impl SimpleState for Pong {
 
 Finally, we'll need our game to include the Audio Bundle. In `main.rs`:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::GameDataBuilder;
 use amethyst::audio::AudioBundle;
@@ -95,7 +95,7 @@ fn main() -> amethyst::Result<()> {
 
 Let's start by creating a function to play the bounce sound. In `audio.rs`, add:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 use amethyst::{
     assets::AssetStorage,
@@ -118,7 +118,7 @@ pub fn play_bounce_sound(sounds: &Sounds, storage: &AssetStorage<Source>, output
 
 Then, we'll update the Bounce System to play the sound whenever the ball bounces. Update `systems/bounce.rs`:
 
-```rust,ignore
+```rust
 
 use amethyst::{
     assets::AssetStorage,
@@ -179,7 +179,7 @@ Now try running your game (`cargo run`). Don't forget to turn up your volume!
 
 Just as we did for the bounce sound, let's create a function to play the score sound. Update `audio.rs`:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::{
 #     audio::{output::Output, Source, SourceHandle},
@@ -202,7 +202,7 @@ pub fn play_score_sound(sounds: &Sounds, storage: &AssetStorage<Source>, output:
 
 Then, we'll update our Winner System to play the score sound whenever a player scores. Update `systems/winner.rs`:
 
-```rust,ignore
+```rust
 use amethyst::{
     assets::AssetStorage,
     audio::{output::Output, Source},
@@ -264,7 +264,7 @@ Let's start by downloading [Albatross][albatross] and [Where's My Jetpack?][wher
 
 In `audio.rs`, add the paths to the music tracks below the paths to the sound effects:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 const BOUNCE_SOUND: &str = "audio/bounce.ogg";
 const SCORE_SOUND: &str = "audio/score.ogg";
 
@@ -276,7 +276,7 @@ const MUSIC_TRACKS: &[&str] = &[
 
 Then, create a Music Resource:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 use std::{iter::Cycle, vec::IntoIter};
 #
@@ -291,7 +291,7 @@ Since we only have two music tracks, we use a `Cycle` to infinitely alternate be
 
 Next, we need to add the Music Resource to our World. Update `initialise_audio`:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use std::{iter::Cycle, vec::IntoIter};
 #
@@ -354,7 +354,7 @@ pub fn initialise_audio(world: &mut World) {
 
 Finally, let's add a DJ System to our game to play the music. In `main.rs`:
 
-```rust,ignore
+```rust
 use amethyst::audio::DjSystemDesc;
 use crate::audio::Music;
 

--- a/book/src/pong-tutorial/pong-tutorial-06.md
+++ b/book/src/pong-tutorial/pong-tutorial-06.md
@@ -74,13 +74,13 @@ Finally, we'll need our game to include the Audio Bundle. In `main.rs`:
 
 ```rust, edition2018,no_run,noplaypen
 #
-# use amethyst::GameDataBuilder;
+# use amethyst::DispatcherBuilder;
 use amethyst::audio::AudioBundle;
 
 fn main() -> amethyst::Result<()> {
     // --snip--
 
-    let game_data = GameDataBuilder::default()
+    let game_data = DispatcherBuilder::default()
         // ... other bundles
         .with_bundle(AudioBundle::default())?
         // ... systems
@@ -361,7 +361,7 @@ use crate::audio::Music;
 fn main() -> amethyst::Result<()> {
     // --snip--
 
-    let game_data = GameDataBuilder::default()
+    let game_data = DispatcherBuilder::default()
         // ... bundles
         .with_system_desc(
             DjSystemDesc::new(|music: &mut Music| music.music.next()),

--- a/book/src/prefabs.md
+++ b/book/src/prefabs.md
@@ -12,7 +12,7 @@ It is certainly possible to define the values for each monster in code. However,
 
 In data-oriented design, instantiating monsters is logic and is part of the executable, but the values to use for the components is data. The executable can instantiate any monster using the data for the monsters read from a *prefab* file like the following:
 
-```ron,ignore
+```ron
 // monster_weak.ron
 //
 // This is simply an example of what a prefab can look like.

--- a/book/src/prefabs.md
+++ b/book/src/prefabs.md
@@ -12,7 +12,7 @@ It is certainly possible to define the values for each monster in code. However,
 
 In data-oriented design, instantiating monsters is logic and is part of the executable, but the values to use for the components is data. The executable can instantiate any monster using the data for the monsters read from a *prefab* file like the following:
 
-```rust,ignore
+```ron,ignore
 // monster_weak.ron
 //
 // This is simply an example of what a prefab can look like.

--- a/book/src/prefabs/how_to_define_prefabs_adapter.md
+++ b/book/src/prefabs/how_to_define_prefabs_adapter.md
@@ -2,7 +2,7 @@
 
 This guide explains how to define a [`PrefabData`] for a [`Component`] using an intermediate type called an adapter. This pattern is used when there are multiple ways to serialize / construct the [`Component`]:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # extern crate serde;
 #
 # use amethyst::ecs::{storage::DenseVecStorage, Component};
@@ -40,7 +40,7 @@ If you are attempting to adapt a more complex type, please choose the appropriat
 
     Create a (de)serializable enum type with a variant for each representation. The following is an example of an adapter type for the `Position` component, which allows either `i32` or `f32` values to be specified in the prefab:
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     # extern crate serde;
     #
     use amethyst::{
@@ -62,7 +62,7 @@ If you are attempting to adapt a more complex type, please choose the appropriat
 
     **Note:** You may already have a type that captures the multiple representations. For example, for the [`Camera`] component, the [`CameraPrefab`] enum captures the different representations:
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     # extern crate serde;
     #
     # use serde::{Deserialize, Serialize};
@@ -87,7 +87,7 @@ If you are attempting to adapt a more complex type, please choose the appropriat
 
 3. Implement the [`PrefabData`] trait for the adapter type.
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     # extern crate serde;
     #
     # use amethyst::{
@@ -147,7 +147,7 @@ If you are attempting to adapt a more complex type, please choose the appropriat
 
 4. Now the adapter type can be used in a prefab to attach the component to the entity.
 
-    ```rust,ignore
+    ```rust
     #![enable(implicit_some)]
     Prefab(
         entities: [

--- a/book/src/prefabs/how_to_define_prefabs_adapter.md
+++ b/book/src/prefabs/how_to_define_prefabs_adapter.md
@@ -3,7 +3,6 @@
 This guide explains how to define a [`PrefabData`] for a [`Component`] using an intermediate type called an adapter. This pattern is used when there are multiple ways to serialize / construct the [`Component`]:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # extern crate serde;
 #
 # use amethyst::ecs::{storage::DenseVecStorage, Component};
@@ -42,7 +41,6 @@ If you are attempting to adapt a more complex type, please choose the appropriat
     Create a (de)serializable enum type with a variant for each representation. The following is an example of an adapter type for the `Position` component, which allows either `i32` or `f32` values to be specified in the prefab:
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     # extern crate serde;
     #
     use amethyst::{
@@ -65,7 +63,6 @@ If you are attempting to adapt a more complex type, please choose the appropriat
     **Note:** You may already have a type that captures the multiple representations. For example, for the [`Camera`] component, the [`CameraPrefab`] enum captures the different representations:
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     # extern crate serde;
     #
     # use serde::{Deserialize, Serialize};
@@ -91,7 +88,6 @@ If you are attempting to adapt a more complex type, please choose the appropriat
 3. Implement the [`PrefabData`] trait for the adapter type.
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     # extern crate serde;
     #
     # use amethyst::{

--- a/book/src/prefabs/how_to_define_prefabs_aggregate.md
+++ b/book/src/prefabs/how_to_define_prefabs_aggregate.md
@@ -31,7 +31,6 @@ If you intend to include a [`Component`] that has not yet got a corresponding [`
     In these examples, `Named`, `Position`, and `Weapon` all derive [`PrefabData`].
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     # extern crate serde;
     # use amethyst::{
     #     assets::{PrefabData, ProgressCounter},
@@ -64,7 +63,6 @@ If you intend to include a [`Component`] that has not yet got a corresponding [`
     If you want to mix different types of entities within a single prefab then you must define an enum that implements `PrefabData`. Each variant is treated in the same way as `PrefabData` structs.
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     # extern crate serde;
     # use amethyst::{
     #     assets::{PrefabData, ProgressCounter},
@@ -113,7 +111,6 @@ If you intend to include a [`Component`] that has not yet got a corresponding [`
     **Note:** There is an important limitation when building `PrefabData`s, particularly enum `PrefabData`s. No two fields in the `PrefabData` or in any nested `PrefabData`s under it can access the same `Component` unless all accesses are reads. This is still true even if the fields appear in different variants of an enum. This means that the following `PrefabData` will fail at runtime when loaded:
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     # extern crate serde;
     # use amethyst::{
     #     assets::{PrefabData, ProgressCounter},
@@ -151,7 +148,6 @@ If you intend to include a [`Component`] that has not yet got a corresponding [`
     The problem is that both the `SpriteScenePrefab`s need to write to `Transform` and several other common `Components`. Because Amythest's underlyng ECS system determines what resources are accessed based on static types it can't determine that only one of the `SpriteScenePrefab`s will be accessed at a time and it attempts a double mutable borrow which fails. The solution is to define the `PrefabData` hierarchically so each component only appears once:
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     # extern crate serde;
     # use amethyst::{
     #     assets::{PrefabData, ProgressCounter},

--- a/book/src/prefabs/how_to_define_prefabs_aggregate.md
+++ b/book/src/prefabs/how_to_define_prefabs_aggregate.md
@@ -16,7 +16,7 @@ If you intend to include a [`Component`] that has not yet got a corresponding [`
 
 2. Import the following items:
 
-    ```rust,ignore
+    ```rust
     use amethyst::{
         assets::{PrefabData, ProgressCounter},
         derive::PrefabData,
@@ -30,7 +30,7 @@ If you intend to include a [`Component`] that has not yet got a corresponding [`
 
     In these examples, `Named`, `Position`, and `Weapon` all derive [`PrefabData`].
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     # extern crate serde;
     # use amethyst::{
     #     assets::{PrefabData, ProgressCounter},
@@ -62,7 +62,7 @@ If you intend to include a [`Component`] that has not yet got a corresponding [`
 
     If you want to mix different types of entities within a single prefab then you must define an enum that implements `PrefabData`. Each variant is treated in the same way as `PrefabData` structs.
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     # extern crate serde;
     # use amethyst::{
     #     assets::{PrefabData, ProgressCounter},
@@ -110,7 +110,7 @@ If you intend to include a [`Component`] that has not yet got a corresponding [`
     ```
     **Note:** There is an important limitation when building `PrefabData`s, particularly enum `PrefabData`s. No two fields in the `PrefabData` or in any nested `PrefabData`s under it can access the same `Component` unless all accesses are reads. This is still true even if the fields appear in different variants of an enum. This means that the following `PrefabData` will fail at runtime when loaded:
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     # extern crate serde;
     # use amethyst::{
     #     assets::{PrefabData, ProgressCounter},
@@ -147,7 +147,7 @@ If you intend to include a [`Component`] that has not yet got a corresponding [`
 
     The problem is that both the `SpriteScenePrefab`s need to write to `Transform` and several other common `Components`. Because Amythest's underlyng ECS system determines what resources are accessed based on static types it can't determine that only one of the `SpriteScenePrefab`s will be accessed at a time and it attempts a double mutable borrow which fails. The solution is to define the `PrefabData` hierarchically so each component only appears once:
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     # extern crate serde;
     # use amethyst::{
     #     assets::{PrefabData, ProgressCounter},
@@ -196,7 +196,7 @@ If you intend to include a [`Component`] that has not yet got a corresponding [`
 4. Now the type can be used in a prefab.
     * `struct` prefab data:
 
-        ```rust,ignore
+        ```rust
         #![enable(implicit_some)]
         Prefab(
             entities: [
@@ -212,7 +212,7 @@ If you intend to include a [`Component`] that has not yet got a corresponding [`
 
     * `enum` prefab data:
 
-        ```rust,ignore
+        ```rust
         #![enable(implicit_some)]
         Prefab(
             entities: [

--- a/book/src/prefabs/how_to_define_prefabs_prelude.md
+++ b/book/src/prefabs/how_to_define_prefabs_prelude.md
@@ -21,7 +21,6 @@ Component     | Serialized representation             | Example(s)            | 
     This is where the `Component` type itself is completely serializable &ndash; the data is self-contained.
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     # extern crate serde;
     #
     # use amethyst::ecs::{storage::DenseVecStorage, Component};
@@ -38,7 +37,6 @@ Component     | Serialized representation             | Example(s)            | 
     This is where are multiple ways to construct the component, and a user should be able to choose which one to use.
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     # extern crate serde;
     #
     # use amethyst::ecs::{storage::DenseVecStorage, Component};
@@ -75,8 +73,6 @@ Component     | Serialized representation             | Example(s)            | 
     This is where most of the component is serializable, but there is also data that is only accessible at runtime, such as a device ID or an asset handle.
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst_audio;
-    # extern crate amethyst_core;
     #
     # use amethyst_audio::output::Output;
     # use amethyst_core::{
@@ -112,7 +108,6 @@ Component     | Serialized representation             | Example(s)            | 
     This is where the `Component` itself stores `Handle<_>`s.
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     #
     # use amethyst::{
     #     assets::Handle,

--- a/book/src/prefabs/how_to_define_prefabs_prelude.md
+++ b/book/src/prefabs/how_to_define_prefabs_prelude.md
@@ -6,13 +6,13 @@ If you are looking for a guide for how to define prefab data that combines the c
 
 If you are looking for a guide to define prefab data for a `Component`, first we need to figure out its type based on its serialized representation. The following table summarizes the types, and links to the relevant guide. For additional detail, refer to the code snippets below the table.
 
-Component     | Serialized representation             | Example(s)            | Prefab Data        | Guide
-------------- | ------------------------------------- | --------------------- | ------------------ | ---
-`YourType`    | `Self` &ndash; `YourType`             | `Position`            | `Position`         | [Simple]
-`YourType`    | Multiple &ndash; `V1(..)`, `V2(..)`   | [`Camera`]            | [`CameraPrefab`]   | [Adapter]
-`YourType`    | Subset of `YourType`                  | [`AudioListener`]     | [`AudioPrefab`]    | [Asset]
-`Handle<A>`   | Loaded from `A::Data`                 | [`Mesh`], [`Texture`] | [`MeshData`], [`TexturePrefab`] | [Asset]
-`ManyHandles` | Data that component stores handles of | [`Material`]          | [`MaterialPrefab`] | [Multi-Handle]
+| Component     | Serialized representation             | Example(s)            | Prefab Data                     | Guide          |
+| ------------- | ------------------------------------- | --------------------- | ------------------------------- | -------------- |
+| `YourType`    | `Self` &ndash; `YourType`             | `Position`            | `Position`                      | [Simple]       |
+| `YourType`    | Multiple &ndash; `V1(..)`, `V2(..)`   | [`Camera`]            | [`CameraPrefab`]                | [Adapter]      |
+| `YourType`    | Subset of `YourType`                  | [`AudioListener`]     | [`AudioPrefab`]                 | [Asset]        |
+| `Handle<A>`   | Loaded from `A::Data`                 | [`Mesh`], [`Texture`] | [`MeshData`], [`TexturePrefab`] | [Asset]        |
+| `ManyHandles` | Data that component stores handles of | [`Material`]          | [`MaterialPrefab`]              | [Multi-Handle] |
 
 ### Serialized Representation
 
@@ -20,7 +20,7 @@ Component     | Serialized representation             | Example(s)            | 
 
     This is where the `Component` type itself is completely serializable &ndash; the data is self-contained.
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     # extern crate serde;
     #
     # use amethyst::ecs::{storage::DenseVecStorage, Component};
@@ -36,7 +36,7 @@ Component     | Serialized representation             | Example(s)            | 
 
     This is where are multiple ways to construct the component, and a user should be able to choose which one to use.
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     # extern crate serde;
     #
     # use amethyst::ecs::{storage::DenseVecStorage, Component};
@@ -72,7 +72,7 @@ Component     | Serialized representation             | Example(s)            | 
 
     This is where most of the component is serializable, but there is also data that is only accessible at runtime, such as a device ID or an asset handle.
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     #
     # use amethyst_audio::output::Output;
     # use amethyst_core::{
@@ -107,7 +107,7 @@ Component     | Serialized representation             | Example(s)            | 
 
     This is where the `Component` itself stores `Handle<_>`s.
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     #
     # use amethyst::{
     #     assets::Handle,

--- a/book/src/prefabs/how_to_define_prefabs_simple.md
+++ b/book/src/prefabs/how_to_define_prefabs_simple.md
@@ -2,7 +2,7 @@
 
 This guide explains how to enable a [`Component`] to be used in a [`Prefab`]. This can be applied where the [`Component`] type itself is completely serializable &ndash; the data is self-contained:
 
-```rust,no_run,noplaypen
+```rust, no_run,noplaypen
 # extern crate serde;
 #
 # use amethyst::ecs::{storage::DenseVecStorage, Component};
@@ -26,7 +26,7 @@ If you are attempting to adapt a more complex type, please choose the appropriat
 
 2. Import the following items:
 
-    ```rust,ignore
+    ```rust
     use amethyst::{
         assets::{PrefabData, ProgressCounter},
         derive::PrefabData,
@@ -38,7 +38,7 @@ If you are attempting to adapt a more complex type, please choose the appropriat
 
 3. Add the following attributes on your type:
 
-    ```rust,ignore
+    ```rust
     #[derive(Deserialize, Serialize, PrefabData)]
     #[prefab(Component)]
     #[serde(default)] // <--- optional
@@ -47,7 +47,7 @@ If you are attempting to adapt a more complex type, please choose the appropriat
 
     Example:
 
-    ```rust,edition2018,no_run,noplaypen
+    ```rust, edition2018,no_run,noplaypen
     # extern crate derivative;
     # extern crate serde;
     #
@@ -78,7 +78,7 @@ If you are attempting to adapt a more complex type, please choose the appropriat
 
 4. Now the type can be used in a prefab:
 
-    ```rust,ignore
+    ```rust
     #![enable(implicit_some)]
     Prefab(
         entities: [

--- a/book/src/prefabs/how_to_define_prefabs_simple.md
+++ b/book/src/prefabs/how_to_define_prefabs_simple.md
@@ -3,7 +3,6 @@
 This guide explains how to enable a [`Component`] to be used in a [`Prefab`]. This can be applied where the [`Component`] type itself is completely serializable &ndash; the data is self-contained:
 
 ```rust,no_run,noplaypen
-# extern crate amethyst;
 # extern crate serde;
 #
 # use amethyst::ecs::{storage::DenseVecStorage, Component};
@@ -49,7 +48,6 @@ If you are attempting to adapt a more complex type, please choose the appropriat
     Example:
 
     ```rust,edition2018,no_run,noplaypen
-    # extern crate amethyst;
     # extern crate derivative;
     # extern crate serde;
     #

--- a/book/src/prefabs/how_to_define_prefabs_simple.md
+++ b/book/src/prefabs/how_to_define_prefabs_simple.md
@@ -89,10 +89,10 @@ If you are attempting to adapt a more complex type, please choose the appropriat
     )
     ```
 
-To see this in a complete example, run the [`prefab_basic` example] from the Amethyst repository:
+To see this in a complete example, run the [`prefab` example] from the Amethyst repository:
 
 ```bash
-cargo run -p prefab_basic
+cargo run -p prefab
 ```
 
 [`Component`]: https://docs.rs/specs/~0.16/specs/trait.Component.html
@@ -101,5 +101,5 @@ cargo run -p prefab_basic
 [api_pf_derive]: https://docs.amethyst.rs/master/amethyst_derive/derive.PrefabData.html
 [ser_def]: https://serde.rs/container-attrs.html#default
 [ser_unk]: https://serde.rs/container-attrs.html#deny_unknown_fields
-[`prefab_basic` example]: https://github.com/amethyst/amethyst/tree/master/examples/prefab_basic
+[`prefab` example]: https://github.com/amethyst/amethyst/tree/master/examples/prefab
 [bk_prefab_prelude]: ./how_to_define_prefabs_prelude.html

--- a/book/src/prefabs/prefabs_in_amethyst.md
+++ b/book/src/prefabs/prefabs_in_amethyst.md
@@ -20,7 +20,6 @@ The remainder of this page explains these at a conceptual level; subsequent page
 In its stored form, a prefab is a serialized list of entities and their components that should be instantiated together. To begin, we will look at a simple prefab that attaches a simple component to a single entity. We will use the following `Position` component:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # extern crate derivative;
 # extern crate serde;
 #
@@ -96,7 +95,6 @@ cargo run -p prefab_basic
 If there are multiple components to be attached to the entity, then we need a type that aggregates the [`Component`]s:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # extern crate derivative;
 # extern crate serde;
 #
@@ -189,7 +187,6 @@ Prefab(
 Could be implemented using an enum like this:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # extern crate derivative;
 # extern crate serde;
 #

--- a/book/src/prefabs/prefabs_in_amethyst.md
+++ b/book/src/prefabs/prefabs_in_amethyst.md
@@ -84,10 +84,10 @@ In the background, the [`PrefabLoaderSystem`] will run, and attach the `Position
 | ------------------------ | --------------------------- | ----------------------- |
 | Entity(0, Generation(1)) | Handle { id: 0 }            | Position(1.0, 2.0, 3.0) |
 
-This can be seen by running the `prefab_basic` example from the Amethyst repository:
+This can be seen by running the `prefab` example from the Amethyst repository:
 
 ```bash
-cargo run -p prefab_basic
+cargo run -p prefab
 ```
 
 ### Multiple Components

--- a/book/src/prefabs/prefabs_in_amethyst.md
+++ b/book/src/prefabs/prefabs_in_amethyst.md
@@ -19,7 +19,7 @@ The remainder of this page explains these at a conceptual level; subsequent page
 
 In its stored form, a prefab is a serialized list of entities and their components that should be instantiated together. To begin, we will look at a simple prefab that attaches a simple component to a single entity. We will use the following `Position` component:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # extern crate derivative;
 # extern crate serde;
 #
@@ -46,7 +46,7 @@ The important derives are the [`Component`] and [`PrefabData`] &ndash; [`Compone
 
 Here is an example `.ron` file of a prefab with an entity with a `Position`:
 
-```rust,ignore
+```rust
 #![enable(implicit_some)]
 Prefab(
     entities: [
@@ -68,21 +68,21 @@ The top level type is a [`Prefab`], and holds a list of `entities`. These are no
 
 When we load this prefab, the prefab entity is read as:
 
-```rust,ignore
+```rust
 PrefabEntity { parent: None, data: Some(Position(1.0, 2.0, 3.0)) }
 ```
 
 Next, we create an entity with the prefab handle, `Handle<Prefab<Position>>`:
 
 | Entity                   | Handle<Prefab&lt;Position>> |
-| ------------------------ | ------------------------ |
-| Entity(0, Generation(1)) | Handle { id: 0 }         |
+| ------------------------ | --------------------------- |
+| Entity(0, Generation(1)) | Handle { id: 0 }            |
 
 In the background, the [`PrefabLoaderSystem`] will run, and attach the `Position` component:
 
 | Entity                   | Handle<Prefab&lt;Position>> | Position                |
-| ------------------------ | ------------------------ | ----------------------- |
-| Entity(0, Generation(1)) | Handle { id: 0 }         | Position(1.0, 2.0, 3.0) |
+| ------------------------ | --------------------------- | ----------------------- |
+| Entity(0, Generation(1)) | Handle { id: 0 }            | Position(1.0, 2.0, 3.0) |
 
 This can be seen by running the `prefab_basic` example from the Amethyst repository:
 
@@ -94,7 +94,7 @@ cargo run -p prefab_basic
 
 If there are multiple components to be attached to the entity, then we need a type that aggregates the [`Component`]s:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # extern crate derivative;
 # extern crate serde;
 #
@@ -129,7 +129,7 @@ Here, the `Player` type is **not** a [`Component`], but it does implement [`Pref
 
 The corresponding prefab file is written as follows:
 
-```rust,ignore
+```rust
 #![enable(implicit_some)]
 Prefab(
     entities: [
@@ -148,8 +148,8 @@ When an entity is created with this prefab, Amethyst will recurse into each of t
 Now, when we create an entity with the prefab handle, both components will be attached:
 
 | Handle<Prefab&lt;Player>> | Position                | Player                 |
-| ---------------------- | ----------------------- | ---------------------- |
-| Handle { id: 0 }       | Position(1.0, 2.0, 3.0) | Named { name: "Zero" } |
+| ------------------------- | ----------------------- | ---------------------- |
+| Handle { id: 0 }          | Position(1.0, 2.0, 3.0) | Named { name: "Zero" } |
 
 This can be seen by running the `prefab_multi` example from the Amethyst repository:
 
@@ -161,7 +161,7 @@ cargo run -p prefab_multi
 
 The next level is to instantiate multiple entities, each with their own set of [`Component`]s. The current implementation of [`Prefab`] requires the `data` field to be the same type for *every* [`PrefabEntity`] in the list. This means that to have different types of entity in the same prefab they must be variants of an enum. For instance, a prefab like this:
 
-```rust,ignore
+```rust
 #![enable(implicit_some)]
 Prefab(
     entities: [
@@ -186,7 +186,7 @@ Prefab(
 
 Could be implemented using an enum like this:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # extern crate derivative;
 # extern crate serde;
 #
@@ -238,15 +238,15 @@ pub enum CustomPrefabData {
 When we run this, we start off by creating one entity:
 
 | Entity                   | Handle<Prefab&lt;CustomPrefabData>>> |
-| ------------------------ | --------------------------------- |
-| Entity(0, Generation(1)) | Handle { id: 0 }                  |
+| ------------------------ | ------------------------------------ |
+| Entity(0, Generation(1)) | Handle { id: 0 }                     |
 
 When the [`PrefabLoaderSystem`] runs, this becomes the following:
 
 | Entity                   | Handle<Prefab&lt;CustomPrefabData>>> | Parent                   | Position                | Player                 | Weapon |
-| ------------------------ | --------------------------------- | ------------------------ | ----------------------- | ---------------------- | ------ |
-| Entity(0, Generation(1)) | Handle { id: 0 }                  | None                     | Position(1.0, 2.0, 3.0) | Named { name: "Zero" } | None   |
-| Entity(1, Generation(1)) | None                              | Entity(0, Generation(1)) | Position(4.0, 5.0, 6.0) | None                   | Sword  |
+| ------------------------ | ------------------------------------ | ------------------------ | ----------------------- | ---------------------- | ------ |
+| Entity(0, Generation(1)) | Handle { id: 0 }                     | None                     | Position(1.0, 2.0, 3.0) | Named { name: "Zero" } | None   |
+| Entity(1, Generation(1)) | None                                 | Entity(0, Generation(1)) | Position(4.0, 5.0, 6.0) | None                   | Sword  |
 
 * The entity that the `Handle<Prefab<T>>` is attached will be augmented with [`Component`]s from the first [`PrefabEntity`].
 * A new entity is created for subsequent [`PrefabEntity`] entries in the `entities` list.
@@ -254,18 +254,18 @@ When the [`PrefabLoaderSystem`] runs, this becomes the following:
 Note that the `Weapon` has a parent with index `0`. Let's see what happens when multiple entities are created with this prefab. First, two entities are created with the prefab handle:
 
 | Entity                   | Handle<Prefab&lt;CustomPrefabData>>> |
-| ------------------------ | --------------------------------- |
-| Entity(0, Generation(1)) | Handle { id: 0 }                  |
-| Entity(1, Generation(1)) | Handle { id: 0 }                  |
+| ------------------------ | ------------------------------------ |
+| Entity(0, Generation(1)) | Handle { id: 0 }                     |
+| Entity(1, Generation(1)) | Handle { id: 0 }                     |
 
 Next, the [`PrefabLoaderSystem`] runs and creates and augments the entities:
 
 | Entity                   | Handle<Prefab&lt;CustomPrefabData>>> | Parent                   | Position                | Player                 | Weapon |
-| ------------------------ | --------------------------------- | ------------------------ | ----------------------- | ---------------------- | ------ |
-| Entity(0, Generation(1)) | Handle { id: 0 }                  | None                     | Position(1.0, 2.0, 3.0) | Named { name: "Zero" } | None   |
-| Entity(1, Generation(1)) | Handle { id: 0 }                  | None                     | Position(1.0, 2.0, 3.0) | Named { name: "Zero" } | None   |
-| Entity(2, Generation(1)) | None                              | Entity(0, Generation(1)) | Position(4.0, 5.0, 6.0) | None                   | Sword  |
-| Entity(3, Generation(1)) | None                              | Entity(1, Generation(1)) | Position(4.0, 5.0, 6.0) | None                   | Sword  |
+| ------------------------ | ------------------------------------ | ------------------------ | ----------------------- | ---------------------- | ------ |
+| Entity(0, Generation(1)) | Handle { id: 0 }                     | None                     | Position(1.0, 2.0, 3.0) | Named { name: "Zero" } | None   |
+| Entity(1, Generation(1)) | Handle { id: 0 }                     | None                     | Position(1.0, 2.0, 3.0) | Named { name: "Zero" } | None   |
+| Entity(2, Generation(1)) | None                                 | Entity(0, Generation(1)) | Position(4.0, 5.0, 6.0) | None                   | Sword  |
+| Entity(3, Generation(1)) | None                                 | Entity(1, Generation(1)) | Position(4.0, 5.0, 6.0) | None                   | Sword  |
 
 The sword entity `2` has player entity `0` as its parent, and sword entity `3` has player entity `1` as its parent.
 

--- a/book/src/prefabs/prefabs_technical_explanation.md
+++ b/book/src/prefabs/prefabs_technical_explanation.md
@@ -61,7 +61,7 @@ Ok, so what would a simple implementation of `PrefabData` look like?
 
 Let's take a look at the implementation for `Transform`, which is a core concept in Amethyst:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::assets::PrefabData;
 # use amethyst::ecs::{WriteStorage, Entity, Component, NullStorage};
 # use amethyst::Error;
@@ -108,7 +108,7 @@ are no secondary assets to load from `Source` here.
 Let's look at a slightly more complex implementation, the `AssetPrefab`. This `PrefabData` is used to
 load extra `Asset`s as part of a `Prefab`:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # #[macro_use] extern crate serde_derive;
 # use amethyst::assets::{Asset, AssetStorage,  DefaultLoader, Loader, Format, Handle, ProgressCounter};
 # use amethyst::assets::PrefabData;
@@ -210,7 +210,7 @@ In addition, deriving a `Prefab` requires that `amethyst::Error`, `amethyst::ecs
 
 An example of a single `Component` derive:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # #[macro_use] extern crate serde_derive;
 # use amethyst::{
 #     assets::{
@@ -238,7 +238,7 @@ This will derive a `PrefabData` implementation that inserts `SomeComponent` on a
 
 Lets look at an example of an aggregate struct:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # #[macro_use] extern crate serde_derive;
 # use amethyst::assets::{Asset, AssetStorage,  DefaultLoader, Loader, Format, Handle, ProgressCounter, PrefabData, AssetPrefab};
 # use amethyst::core::Transform;
@@ -257,7 +257,7 @@ This can now be used to create `Prefab`s with `Transform` and `Mesh` on entities
 
 One last example that also adds a custom pure data `Component` into the aggregate `PrefabData`:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # #[macro_use] extern crate serde_derive;
 # use amethyst::assets::{Asset, AssetStorage,  DefaultLoader, Loader, Format, Handle, ProgressCounter, PrefabData, AssetPrefab};
 # use amethyst::core::Transform;
@@ -315,7 +315,7 @@ There are a few provided formats that create `Prefab`s, some with very specific 
 For an example of a `Prefab` in `ron` format, look at `examples/assets/prefab/example.ron`. The
 `PrefabData` for this is:
 
-```rust,ignore
+```rust
 (
     Option<GraphicsPrefab<ObjFormat, TextureFormat>>,
     Option<Transform>,

--- a/book/src/prefabs/prefabs_technical_explanation.md
+++ b/book/src/prefabs/prefabs_technical_explanation.md
@@ -62,7 +62,6 @@ Ok, so what would a simple implementation of `PrefabData` look like?
 Let's take a look at the implementation for `Transform`, which is a core concept in Amethyst:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::assets::PrefabData;
 # use amethyst::ecs::{WriteStorage, Entity, Component, NullStorage};
 # use amethyst::Error;
@@ -110,7 +109,6 @@ Let's look at a slightly more complex implementation, the `AssetPrefab`. This `P
 load extra `Asset`s as part of a `Prefab`:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # #[macro_use] extern crate serde_derive;
 # use amethyst::assets::{Asset, AssetStorage,  DefaultLoader, Loader, Format, Handle, ProgressCounter};
 # use amethyst::assets::PrefabData;
@@ -213,7 +211,6 @@ In addition, deriving a `Prefab` requires that `amethyst::Error`, `amethyst::ecs
 An example of a single `Component` derive:
 
 ```rust,edition2018,no_run,noplaypen
-# #[macro_use] extern crate amethyst;
 # #[macro_use] extern crate serde_derive;
 # use amethyst::{
 #     assets::{
@@ -242,7 +239,6 @@ This will derive a `PrefabData` implementation that inserts `SomeComponent` on a
 Lets look at an example of an aggregate struct:
 
 ```rust,edition2018,no_run,noplaypen
-# #[macro_use] extern crate amethyst;
 # #[macro_use] extern crate serde_derive;
 # use amethyst::assets::{Asset, AssetStorage,  DefaultLoader, Loader, Format, Handle, ProgressCounter, PrefabData, AssetPrefab};
 # use amethyst::core::Transform;
@@ -262,7 +258,6 @@ This can now be used to create `Prefab`s with `Transform` and `Mesh` on entities
 One last example that also adds a custom pure data `Component` into the aggregate `PrefabData`:
 
 ```rust,edition2018,no_run,noplaypen
-# #[macro_use] extern crate amethyst;
 # #[macro_use] extern crate serde_derive;
 # use amethyst::assets::{Asset, AssetStorage,  DefaultLoader, Loader, Format, Handle, ProgressCounter, PrefabData, AssetPrefab};
 # use amethyst::core::Transform;

--- a/book/src/sprites/define_the_sprite_sheet.md
+++ b/book/src/sprites/define_the_sprite_sheet.md
@@ -61,7 +61,6 @@ For more information about list and grid based sprite sheets, including the type
 Once you have ron file ready, you can load it using the texture handle of the sheet's image you loaded earlier:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::assets::{Loader, AssetStorage, Handle};
 # use amethyst::ecs::{World, WorldExt};
 # use amethyst::renderer::{SpriteSheetFormat, SpriteSheet, Texture};
@@ -105,7 +104,6 @@ In Amethyst, pixel dimensions and texture coordinates are stored in the `Sprite`
 The following snippet shows you how to naively define a `SpriteSheet`. In a real application, you would typically use the sprite sheet from file feature, which is much more convenient.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 use amethyst::assets::Handle;
 use amethyst::renderer::{sprite::TextureCoordinates, Sprite, SpriteSheet, Texture};
 

--- a/book/src/sprites/define_the_sprite_sheet.md
+++ b/book/src/sprites/define_the_sprite_sheet.md
@@ -8,7 +8,7 @@ There are two ways to load a sprite sheet definition: from a file or from code.
 The easiest way to load your sprites is to use a sprite sheet definition ron file.
 Here is an example of such a definition file using a list of sprites:
 
-```text,ignore
+```text
 List((
     // Width of the texture used by the sprite sheet
     texture_width: 48,
@@ -41,7 +41,7 @@ List((
 
 Or you can use a grid based definition, for example:
 
-```text,ignore
+```text
 Grid((
     // Width of the texture used by the sprite sheet
     texture_width: 48,
@@ -60,7 +60,7 @@ For more information about list and grid based sprite sheets, including the type
 
 Once you have ron file ready, you can load it using the texture handle of the sheet's image you loaded earlier:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::assets::{Loader, AssetStorage, Handle};
 # use amethyst::ecs::{World, WorldExt};
 # use amethyst::renderer::{SpriteSheetFormat, SpriteSheet, Texture};
@@ -93,17 +93,17 @@ Importantly, **we use pixel coordinates as well as texture coordinates** to defi
 
 The following table lists the differences between the coordinate systems:
 
-| Pixel coordinates                     | Texture coordinates                       |
-| ------------------------------------- | ----------------------------------------- |
-| Begin at the top left of the image    | Begin at the bottom left of the image     |
-| Increase to the right and down        | Increase to the right and up              |
-| Range from 0 to (width or height - 1) | Range from 0.0 to 1.0                     |
+| Pixel coordinates                     | Texture coordinates                   |
+| ------------------------------------- | ------------------------------------- |
+| Begin at the top left of the image    | Begin at the bottom left of the image |
+| Increase to the right and down        | Increase to the right and up          |
+| Range from 0 to (width or height - 1) | Range from 0.0 to 1.0                 |
 
 In Amethyst, pixel dimensions and texture coordinates are stored in the `Sprite` struct. Since texture coordinates can be derived from pixel coordinates, Amethyst provides the `Sprite::from_pixel_values` function to create a `Sprite`.
 
 The following snippet shows you how to naively define a `SpriteSheet`. In a real application, you would typically use the sprite sheet from file feature, which is much more convenient.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 use amethyst::assets::Handle;
 use amethyst::renderer::{sprite::TextureCoordinates, Sprite, SpriteSheet, Texture};
 

--- a/book/src/sprites/load_the_texture.md
+++ b/book/src/sprites/load_the_texture.md
@@ -4,7 +4,7 @@ The first part of loading sprites into Amethyst is to read the image into memory
 
 The following snippet shows how to load a PNG / JPEG / GIF / ICO image:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 use amethyst::assets::{AssetStorage, Handle,  DefaultLoader, Loader};
 use amethyst::prelude::*;
 use amethyst::renderer::{formats::texture::ImageFormat, Texture};
@@ -45,7 +45,7 @@ The loaded texture will use nearest filtering, i.e. the pixels won't be interpol
 If you want to tweak the sampling, you can change `ImageFormat::default()` to
 `ImageFormat(my_config)`, and create your own `my_config` like this:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 use amethyst::renderer::rendy::hal::image::{Filter, SamplerInfo, WrapMode};
 use amethyst::renderer::rendy::texture::image::{ImageTextureConfig, Repr, TextureKind};
 

--- a/book/src/sprites/load_the_texture.md
+++ b/book/src/sprites/load_the_texture.md
@@ -5,7 +5,6 @@ The first part of loading sprites into Amethyst is to read the image into memory
 The following snippet shows how to load a PNG / JPEG / GIF / ICO image:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 use amethyst::assets::{AssetStorage, Handle,  DefaultLoader, Loader};
 use amethyst::prelude::*;
 use amethyst::renderer::{formats::texture::ImageFormat, Texture};
@@ -47,7 +46,6 @@ If you want to tweak the sampling, you can change `ImageFormat::default()` to
 `ImageFormat(my_config)`, and create your own `my_config` like this:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 use amethyst::renderer::rendy::hal::image::{Filter, SamplerInfo, WrapMode};
 use amethyst::renderer::rendy::texture::image::{ImageTextureConfig, Repr, TextureKind};
 

--- a/book/src/sprites/modify_the_texture.md
+++ b/book/src/sprites/modify_the_texture.md
@@ -13,7 +13,6 @@ own values, so a [`Tint`][doc_tint] with a white color will have no
 effect on the sprite.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::assets::{AssetStorage,  DefaultLoader, Loader, Handle};
 use amethyst::core::transform::Transform;
 # use amethyst::prelude::*;

--- a/book/src/sprites/modify_the_texture.md
+++ b/book/src/sprites/modify_the_texture.md
@@ -12,7 +12,7 @@ To use [`Tint`][doc_tint], register [`Tint`][doc_tint] as a new
 own values, so a [`Tint`][doc_tint] with a white color will have no
 effect on the sprite.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::assets::{AssetStorage,  DefaultLoader, Loader, Handle};
 use amethyst::core::transform::Transform;
 # use amethyst::prelude::*;

--- a/book/src/sprites/orthographic_camera.md
+++ b/book/src/sprites/orthographic_camera.md
@@ -4,7 +4,7 @@ Finally, you need to tell Amethyst to draw in 2D space. This is done by creating
 
 The following snippet demonstrates how to set up a `Camera` that sees entities within screen bounds, where the entities' Z position is between -10.0 and 10.0:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 use amethyst::{
     core::{math::Orthographic3, transform::Transform},
     prelude::*,

--- a/book/src/sprites/orthographic_camera.md
+++ b/book/src/sprites/orthographic_camera.md
@@ -5,7 +5,6 @@ Finally, you need to tell Amethyst to draw in 2D space. This is done by creating
 The following snippet demonstrates how to set up a `Camera` that sees entities within screen bounds, where the entities' Z position is between -10.0 and 10.0:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 use amethyst::{
     core::{math::Orthographic3, transform::Transform},
     prelude::*,

--- a/book/src/sprites/set_up_the_render_pass.md
+++ b/book/src/sprites/set_up_the_render_pass.md
@@ -16,7 +16,7 @@ use amethyst::{
 };
 # fn main() -> Result<(), amethyst::Error> {
 #
-# let game_data = GameDataBuilder::default()
+# let game_data = DispatcherBuilder::default()
 #     .with_bundle(
 #
 // inside your rendering bundle setup

--- a/book/src/sprites/set_up_the_render_pass.md
+++ b/book/src/sprites/set_up_the_render_pass.md
@@ -4,7 +4,6 @@ Amethyst supports drawing sprites using the `RenderFlat2D` render plugin.
 To enable this you have to do the following:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 use amethyst::{
     ecs::{World, WorldExt},

--- a/book/src/sprites/set_up_the_render_pass.md
+++ b/book/src/sprites/set_up_the_render_pass.md
@@ -3,7 +3,7 @@
 Amethyst supports drawing sprites using the `RenderFlat2D` render plugin.
 To enable this you have to do the following:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 use amethyst::{
     ecs::{World, WorldExt},

--- a/book/src/sprites/sprite_render_component.md
+++ b/book/src/sprites/sprite_render_component.md
@@ -2,7 +2,10 @@
 
 After loading the `SpriteSheet`, you need to attach it to an entity using the `SpriteRender` component and indicate which sprite to draw. The `SpriteRender` component looks like this:
 
-```rust,ignore
+```rust ,edition2018
+use amethyst::assets::{Handle};
+use amethyst::renderer::{SpriteSheet};
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct SpriteRender {
     /// Handle to the sprite sheet of the sprite
@@ -16,9 +19,9 @@ The sprite number is the index of the sprite loaded in the sprite sheet. What's 
 
 In the previous section you wrote a function that returns a `SpriteSheet`. This can be turned into a `Handle<SpriteSheet>` using the `Loader` resource as follows:
 
-```rust,edition2018,no_run,noplaypen
-use amethyst::assets::{AssetStorage,  DefaultLoader, Loader, Handle};
-# use amethyst::prelude::*;
+```rust ,edition2018
+use amethyst::assets::{AssetStorage, ProcessingQueue, DefaultLoader, Loader, Handle};
+use amethyst::prelude::*;
 use amethyst::renderer::{SpriteSheet, Texture};
 
 # pub fn load_texture<N>(name: N, world: &World) -> Handle<Texture>
@@ -31,6 +34,7 @@ use amethyst::renderer::{SpriteSheet, Texture};
 # pub fn load_sprite_sheet(texture: Handle<Texture>) -> SpriteSheet {
 #     unimplemented!();
 # }
+
 #[derive(Debug)]
 struct ExampleState;
 
@@ -40,12 +44,12 @@ impl SimpleState for ExampleState {
         // ...
 
         let sprite_sheet = load_sprite_sheet(texture_handle);
-        let sprite_sheet_handle = {
-            let loader = data.world.read_resource::<DefaultLoader>();
+        let sprite_sheet_handle: Handle<SpriteSheet> = {
+            let loader = data.resources.get::<DefaultLoader>().unwrap();
             loader.load_from_data(
                 sprite_sheet,
                 (),
-                &data.world.read_resource::<AssetStorage<SpriteSheet>>(),
+                &data.resources.get::<ProcessingQueue<SpriteSheet>>().unwrap(),
             )
         };
     }
@@ -56,10 +60,10 @@ impl SimpleState for ExampleState {
 
 Cool, finally we have all the parts, let's build a `SpriteRender` and attach it to an entity:
 
-```rust,edition2018,no_run,noplaypen
-# use amethyst::assets::{AssetStorage,  DefaultLoader, Loader, Handle};
+```rust ,edition2018,no_run,noplaypen
+use amethyst::assets::{AssetStorage, ProcessingQueue, DefaultLoader, Loader, Handle};
 use amethyst::core::transform::Transform;
-# use amethyst::prelude::*;
+use amethyst::prelude::*;
 use amethyst::renderer::{
     SpriteRender, SpriteSheet,
     Texture, Transparent
@@ -76,6 +80,7 @@ use amethyst::window::ScreenDimensions;
 # pub fn load_sprite_sheet(texture: Handle<Texture>) -> SpriteSheet {
 #     unimplemented!();
 # }
+
 #[derive(Debug)]
 struct ExampleState;
 
@@ -85,16 +90,16 @@ impl SimpleState for ExampleState {
 #
 #         let sprite_sheet = load_sprite_sheet(texture_handle);
 #         let sprite_sheet_handle = {
-#             let loader = data.world.read_resource::<DefaultLoader>();
+#             let loader = data.resources.get::<DefaultLoader>().unwrap();
 #             loader.load_from_data(
 #                 sprite_sheet,
 #                 (),
-#                 &data.world.read_resource::<AssetStorage<SpriteSheet>>(),
+#                 &data.resources.get::<ProcessingQueue<SpriteSheet>>().unwrap(),
 #             )
 #         };
         // ...
 
-        self.initialize_sprite(&mut data.world, sprite_sheet_handle);
+        self.initialize_sprite(&mut data.world, &data.resources, sprite_sheet_handle);
     }
 }
 
@@ -102,10 +107,11 @@ impl ExampleState {
     fn initialize_sprite(
         &mut self,
         world: &mut World,
+        resources: &Resources,
         sprite_sheet_handle: Handle<SpriteSheet>,
     ) {
         let (width, height) = {
-            let dim = world.read_resource::<ScreenDimensions>();
+            let dim = resources.get::<ScreenDimensions>().unwrap();
             (dim.width(), dim.height())
         };
 
@@ -116,12 +122,7 @@ impl ExampleState {
         // 0 indicates the first sprite in the sheet.
         let sprite_render = SpriteRender::new(sprite_sheet_handle, 0);  // First sprite
 
-        world
-            .create_entity()
-            .with(sprite_render)
-            .with(sprite_transform)
-            .with(Transparent) // If your sprite is transparent
-            .build();
+        world.push((sprite_render, sprite_transform, Transparent));
     }
 }
 #

--- a/book/src/sprites/sprite_render_component.md
+++ b/book/src/sprites/sprite_render_component.md
@@ -17,7 +17,6 @@ The sprite number is the index of the sprite loaded in the sprite sheet. What's 
 In the previous section you wrote a function that returns a `SpriteSheet`. This can be turned into a `Handle<SpriteSheet>` using the `Loader` resource as follows:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 use amethyst::assets::{AssetStorage,  DefaultLoader, Loader, Handle};
 # use amethyst::prelude::*;
 use amethyst::renderer::{SpriteSheet, Texture};
@@ -58,7 +57,6 @@ impl SimpleState for ExampleState {
 Cool, finally we have all the parts, let's build a `SpriteRender` and attach it to an entity:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::assets::{AssetStorage,  DefaultLoader, Loader, Handle};
 use amethyst::core::transform::Transform;
 # use amethyst::prelude::*;

--- a/book/src/testing.md
+++ b/book/src/testing.md
@@ -9,8 +9,6 @@ The `amethyst_test` crate provides support to write tests ergonomically and expr
 The following shows a simple example of testing a `State`. More examples are in following pages.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
-# extern crate amethyst_test;
 #
 # use std::marker::PhantomData;
 #
@@ -61,8 +59,6 @@ fn loading_state_adds_load_resource() -> Result<(), Error> {
 The Amethyst application is initialized with one of the following functions, each providing a different set of bundles:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
-# extern crate amethyst_test;
 #
 use amethyst_test::prelude::*;
 
@@ -123,8 +119,6 @@ fn test_name() {
 Finally, call `.run()` to run the application. This returns `amethyst::Result<()>`, so we return that as part of the function:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
-# extern crate amethyst_test;
 #
 # use amethyst::Error;
 # use amethyst_test::prelude::*;

--- a/book/src/testing.md
+++ b/book/src/testing.md
@@ -8,7 +8,7 @@ The `amethyst_test` crate provides support to write tests ergonomically and expr
 
 The following shows a simple example of testing a `State`. More examples are in following pages.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use std::marker::PhantomData;
 #
@@ -58,7 +58,7 @@ fn loading_state_adds_load_resource() -> Result<(), Error> {
 
 The Amethyst application is initialized with one of the following functions, each providing a different set of bundles:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 use amethyst_test::prelude::*;
 
@@ -95,7 +95,7 @@ fn test_name() {
 
 Next, attach the logic for your test using the various `.with_*(..)` methods:
 
-```rust,ignore
+```rust
 #[test]
 fn test_name() {
     let visibility = false; // Whether the window should be shown
@@ -118,7 +118,7 @@ fn test_name() {
 
 Finally, call `.run()` to run the application. This returns `amethyst::Result<()>`, so we return that as part of the function:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 # use amethyst::Error;
 # use amethyst_test::prelude::*;

--- a/book/src/testing/test_examples.md
+++ b/book/src/testing/test_examples.md
@@ -2,7 +2,7 @@
 
 ## Testing a `Bundle`
 
-```rust,edition2018
+```rust, edition2018
 #
 # use amethyst_test::prelude::*;
 # use amethyst::{
@@ -56,7 +56,7 @@ fn bundle_registers_system_with_resource() -> Result<(), Error> {
 
 ## Testing a `System`
 
-```rust,edition2018
+```rust, edition2018
 #
 # use amethyst_test::prelude::*;
 # use amethyst::{
@@ -115,7 +115,7 @@ fn system_increases_component_value_by_one() -> Result<(), Error> {
 
 This is useful when your system must run *after* some setup has been done, for example adding a resource:
 
-```rust,edition2018
+```rust, edition2018
 #
 # use amethyst_test::prelude::*;
 # use amethyst::{

--- a/book/src/testing/test_examples.md
+++ b/book/src/testing/test_examples.md
@@ -3,8 +3,6 @@
 ## Testing a `Bundle`
 
 ```rust,edition2018
-# extern crate amethyst;
-# extern crate amethyst_test;
 #
 # use amethyst_test::prelude::*;
 # use amethyst::{
@@ -59,8 +57,6 @@ fn bundle_registers_system_with_resource() -> Result<(), Error> {
 ## Testing a `System`
 
 ```rust,edition2018
-# extern crate amethyst;
-# extern crate amethyst_test;
 #
 # use amethyst_test::prelude::*;
 # use amethyst::{
@@ -120,8 +116,6 @@ fn system_increases_component_value_by_one() -> Result<(), Error> {
 This is useful when your system must run *after* some setup has been done, for example adding a resource:
 
 ```rust,edition2018
-# extern crate amethyst;
-# extern crate amethyst_test;
 #
 # use amethyst_test::prelude::*;
 # use amethyst::{

--- a/book/src/tiles/create_a_tile_map.md
+++ b/book/src/tiles/create_a_tile_map.md
@@ -3,7 +3,6 @@
 With the `tiles` feature installed and our `RenderTiles2D` render pass setup, we can create a `TileMap` component and add it an entity. We need to have a sprite sheet loaded before the creation so this example assume a handle to a sprite sheet exists.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 use amethyst::{
     core::{
         math::{Point3, Vector3},

--- a/book/src/tiles/create_a_tile_map.md
+++ b/book/src/tiles/create_a_tile_map.md
@@ -2,7 +2,7 @@
 
 With the `tiles` feature installed and our `RenderTiles2D` render pass setup, we can create a `TileMap` component and add it an entity. We need to have a sprite sheet loaded before the creation so this example assume a handle to a sprite sheet exists.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 use amethyst::{
     core::{
         math::{Point3, Vector3},

--- a/book/src/tiles/setup.md
+++ b/book/src/tiles/setup.md
@@ -36,7 +36,7 @@ impl Tile for SimpleTile {
 
 # fn main() -> Result<(), amethyst::Error> {
 #
-# let game_data = GameDataBuilder::default()
+# let game_data = DispatcherBuilder::default()
 #     .with_bundle(
 #
 // inside your rendering bundle setup

--- a/book/src/tiles/setup.md
+++ b/book/src/tiles/setup.md
@@ -3,7 +3,7 @@
 
 In order to use the tiles package you need add the `tiles` feature to your `Cargo.toml`:
 
-```rust,ignore
+```rust
 [dependencies]
 amethyst = { version = "LATEST_CRATES.IO_VERSION", features = ["tiles"] }
 ```
@@ -12,7 +12,7 @@ amethyst = { version = "LATEST_CRATES.IO_VERSION", features = ["tiles"] }
 
 Now you can add the render pass to your application:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 #
 use amethyst::{
     core::math::Point3,

--- a/book/src/tiles/setup.md
+++ b/book/src/tiles/setup.md
@@ -13,7 +13,6 @@ amethyst = { version = "LATEST_CRATES.IO_VERSION", features = ["tiles"] }
 Now you can add the render pass to your application:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 #
 use amethyst::{
     core::math::Point3,

--- a/book/src/ui/interacting.md
+++ b/book/src/ui/interacting.md
@@ -9,7 +9,6 @@ and the latter interaction through `handle_event` method of your active state.
 Let's start of with some boilerplate code: 
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::System;
 
 pub struct SimpleButtonSystem;
@@ -35,7 +34,6 @@ since the `ReaderId` actually pulls (reads) information  from the `EventChannel`
 Adding it up, it should look like this: 
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{System, Read};
 # use amethyst::shrev::{EventChannel, ReaderId};
 # use amethyst::ui::UiEvent;
@@ -56,7 +54,6 @@ impl<'s> System<'s> for SimpleButtonSystem {
 We also need a constructor for our system:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{System, Read};
 # use amethyst::shrev::{EventChannel, ReaderId};
 # use amethyst::ui::UiEvent;
@@ -84,7 +81,6 @@ impl SimpleButtonSystem {
 To add the system to our game data we actually need a `SystemDesc` implementation for our system:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{System, World, Read, Write, SystemData};
 # use amethyst::core::SystemDesc;
 # use amethyst::shrev::{EventChannel, ReaderId};
@@ -123,7 +119,6 @@ Now that this is done we can start reading our events!
 In our systems `run` method we are going to loop through all the events:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{System, World, Read};
 # use amethyst::core::SystemDesc;
 # use amethyst::shrev::{EventChannel, ReaderId};
@@ -149,7 +144,6 @@ Firstly we need to fetch two more components that
 we used for our entity - `UiTransform` and `UiText`.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{System, World, Read, ReadStorage, WriteStorage};
 # use amethyst::core::SystemDesc;
 # use amethyst::shrev::{EventChannel, ReaderId};
@@ -173,7 +167,6 @@ Usage of `WriteStorage<'s, UiText>` is needed since we will be changing
 the color that is the property of the `UiText` component.
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::{System, World, Read, ReadStorage, WriteStorage};
 # use amethyst::core::SystemDesc;
 # use amethyst::shrev::{EventChannel, ReaderId};

--- a/book/src/ui/interacting.md
+++ b/book/src/ui/interacting.md
@@ -8,7 +8,7 @@ and the latter interaction through `handle_event` method of your active state.
 
 Let's start of with some boilerplate code: 
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::System;
 
 pub struct SimpleButtonSystem;
@@ -33,7 +33,7 @@ since the `ReaderId` actually pulls (reads) information  from the `EventChannel`
 
 Adding it up, it should look like this: 
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{System, Read};
 # use amethyst::shrev::{EventChannel, ReaderId};
 # use amethyst::ui::UiEvent;
@@ -53,7 +53,7 @@ impl<'s> System<'s> for SimpleButtonSystem {
 
 We also need a constructor for our system:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{System, Read};
 # use amethyst::shrev::{EventChannel, ReaderId};
 # use amethyst::ui::UiEvent;
@@ -80,7 +80,7 @@ impl SimpleButtonSystem {
 
 To add the system to our game data we actually need a `SystemDesc` implementation for our system:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{System, World, Read, Write, SystemData};
 # use amethyst::core::SystemDesc;
 # use amethyst::shrev::{EventChannel, ReaderId};
@@ -118,7 +118,7 @@ Now that this is done we can start reading our events!
 
 In our systems `run` method we are going to loop through all the events:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{System, World, Read};
 # use amethyst::core::SystemDesc;
 # use amethyst::shrev::{EventChannel, ReaderId};
@@ -143,7 +143,7 @@ Let's try and change the text color when the button receives a hovered event!
 Firstly we need to fetch two more components that 
 we used for our entity - `UiTransform` and `UiText`.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{System, World, Read, ReadStorage, WriteStorage};
 # use amethyst::core::SystemDesc;
 # use amethyst::shrev::{EventChannel, ReaderId};
@@ -166,7 +166,7 @@ type SystemData = Read<'s, EventChannel<UiEvent>>;
 Usage of `WriteStorage<'s, UiText>` is needed since we will be changing 
 the color that is the property of the `UiText` component.
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::{System, World, Read, ReadStorage, WriteStorage};
 # use amethyst::core::SystemDesc;
 # use amethyst::shrev::{EventChannel, ReaderId};

--- a/book/src/ui/introduction.md
+++ b/book/src/ui/introduction.md
@@ -24,7 +24,7 @@ to draw these widgets.
 
 A minimalistic game data would now look like this:  
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::{
 #     GameDataBuilder,
 #     core::transform::TransformBundle,

--- a/book/src/ui/introduction.md
+++ b/book/src/ui/introduction.md
@@ -25,7 +25,6 @@ to draw these widgets.
 A minimalistic game data would now look like this:  
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::{
 #     GameDataBuilder,
 #     core::transform::TransformBundle,

--- a/book/src/ui/introduction.md
+++ b/book/src/ui/introduction.md
@@ -26,7 +26,7 @@ A minimalistic game data would now look like this:
 
 ```rust, edition2018,no_run,noplaypen
 # use amethyst::{
-#     GameDataBuilder,
+#     DispatcherBuilder,
 #     core::transform::TransformBundle,
 #     input::{InputBundle, StringBindings},
 #     renderer::{types::DefaultBackend, RenderingBundle, RenderToWindow},
@@ -35,7 +35,7 @@ A minimalistic game data would now look like this:
 # };
 # 
 # pub fn main() -> Result<()> {
-    let game_data = GameDataBuilder::default()
+    let game_data = DispatcherBuilder::default()
         .with_bundle(TransformBundle::new())?
         .with_bundle(InputBundle::<StringBindings>::new())?
         .with_bundle(UiBundle::<StringBindings>::new())?

--- a/book/src/ui/simple_button.md
+++ b/book/src/ui/simple_button.md
@@ -23,7 +23,6 @@ You don't have to use all three at the same time of course but variations of two
 One way of defining a `UiTransform` is like so:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ui::{Anchor, UiTransform};
 
 let ui_transform = UiTransform::new(
@@ -55,7 +54,6 @@ to set the area big enough for the text to fit in!
 ### Creating the `UiText`
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::assets::{AssetStorage,  DefaultLoader, Loader};
 # use amethyst::ui::{Anchor, FontAsset, get_default_font, LineMode, UiText};
 # use amethyst::prelude::{World, WorldExt};
@@ -84,7 +82,6 @@ You also need to load a specific font handle and provide it for the text.
 If you had some state implemented you can create the button on its `on_start` method:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::assets::{AssetStorage,  DefaultLoader, Loader};
 # use amethyst::ui::{
 #     Anchor, FontAsset, get_default_font, LineMode, UiText, UiTransform,
@@ -158,7 +155,6 @@ have a `UiTransform` component!
 The code snippet would look like this now:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::assets::{AssetStorage,  DefaultLoader, Loader};
 # use amethyst::ui::{
 #     Anchor, FontAsset, get_default_font, LineMode, UiText, UiTransform, Interactable,

--- a/book/src/ui/simple_button.md
+++ b/book/src/ui/simple_button.md
@@ -22,7 +22,7 @@ You don't have to use all three at the same time of course but variations of two
 
 One way of defining a `UiTransform` is like so:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ui::{Anchor, UiTransform};
 
 let ui_transform = UiTransform::new(
@@ -53,7 +53,7 @@ to set the area big enough for the text to fit in!
 
 ### Creating the `UiText`
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::assets::{AssetStorage,  DefaultLoader, Loader};
 # use amethyst::ui::{Anchor, FontAsset, get_default_font, LineMode, UiText};
 # use amethyst::prelude::{World, WorldExt};
@@ -81,7 +81,7 @@ You also need to load a specific font handle and provide it for the text.
 
 If you had some state implemented you can create the button on its `on_start` method:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::assets::{AssetStorage,  DefaultLoader, Loader};
 # use amethyst::ui::{
 #     Anchor, FontAsset, get_default_font, LineMode, UiText, UiTransform,
@@ -154,7 +154,7 @@ have a `UiTransform` component!
 
 The code snippet would look like this now:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::assets::{AssetStorage,  DefaultLoader, Loader};
 # use amethyst::ui::{
 #     Anchor, FontAsset, get_default_font, LineMode, UiText, UiTransform, Interactable,

--- a/book/src/ui/state_interaction.md
+++ b/book/src/ui/state_interaction.md
@@ -3,7 +3,6 @@
 Let's declare our state, and call it `MenuState`:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::ecs::Entity;
 #
 #[derive(Default)]
@@ -23,7 +22,6 @@ In our `on_start` method of this state we can create the button as shown in
 previous chapters, but here we will save the entity in our struct:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::{
 #  assets::{AssetStorage,  DefaultLoader, Loader},
 # 	ecs::{Entity, World, WorldExt},
@@ -88,7 +86,6 @@ All the input received will be handled in the [handle_event](https://docs.amethy
 method of our state:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::{
 #   assets::{AssetStorage,  DefaultLoader, Loader},
 #   ecs::{Entity, World, WorldExt},
@@ -190,7 +187,6 @@ The way we do that is by adding a [Hidden](https://docs.amethyst.rs/master/ameth
 component to our button:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::{
 #   assets::{AssetStorage,  DefaultLoader, Loader},
 #   core::Hidden,
@@ -284,7 +280,6 @@ impl SimpleState for MenuState {
 The same goes for `on_resume` if we actually want to redisplay the button:
 
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
 # use amethyst::{
 #   assets::{AssetStorage,  DefaultLoader, Loader},
 #   core::Hidden,

--- a/book/src/ui/state_interaction.md
+++ b/book/src/ui/state_interaction.md
@@ -2,7 +2,7 @@
 
 Let's declare our state, and call it `MenuState`:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::ecs::Entity;
 #
 #[derive(Default)]
@@ -21,7 +21,7 @@ It will also serve to hold our ui entity.
 In our `on_start` method of this state we can create the button as shown in
 previous chapters, but here we will save the entity in our struct:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::{
 #  assets::{AssetStorage,  DefaultLoader, Loader},
 # 	ecs::{Entity, World, WorldExt},
@@ -85,7 +85,7 @@ impl SimpleState for MenuState {
 All the input received will be handled in the [handle_event](https://docs.amethyst.rs/master/amethyst/trait.State.html#method.handle_event)
 method of our state:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::{
 #   assets::{AssetStorage,  DefaultLoader, Loader},
 #   ecs::{Entity, World, WorldExt},
@@ -186,7 +186,7 @@ Upon pushing another state the `on_pause` method will run - here we can hide our
 The way we do that is by adding a [Hidden](https://docs.amethyst.rs/master/amethyst_core/struct.Hidden.html)
 component to our button:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::{
 #   assets::{AssetStorage,  DefaultLoader, Loader},
 #   core::Hidden,
@@ -279,7 +279,7 @@ impl SimpleState for MenuState {
 
 The same goes for `on_resume` if we actually want to redisplay the button:
 
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 # use amethyst::{
 #   assets::{AssetStorage,  DefaultLoader, Loader},
 #   core::Hidden,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -58,7 +58,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 ### Added
 
 - New `optional_graphics` example demonstrating running an app with and without graphics ([#2282])
-- Return a standalone `Dispatcher` from `GameDataBuilder::build_dispatcher`
+- Return a standalone `Dispatcher` from `DispatcherBuilder::build_dispatcher`
   instead of using `DataInit` to build a `GameData` ([#2294])
 - Added _User Interface_ chapter to The Book ([#2311], [#2346], [#2347], [#2368], [#2373])
 - Support text alignment in `UiButton` and `UiLabel` ([#2316])
@@ -423,7 +423,7 @@ The format is based on [Keep a Changelog][kc], and this project adheres to
 - Splitted the `/resources` directory of amethyst projects into `/assets` and `/config`. ([#1806])
 - Rename FPSCounter, FPSCounterBundle, FPSCounterSystem to FpsCounter, FpsCounterBundle, FpsCounterSystem. ([#1719])
 - Add Tint component support for sprites. ([#1756])
-- Remove remaining <N: RealField> type parameter on GameDataBuilder, add Debug derive to LoggerConfig ([#1758])
+- Remove remaining <N: RealField> type parameter on DispatcherBuilder, add Debug derive to LoggerConfig ([#1758])
 - Inverted mouse wheel scroll direction event. Now using winit's standard. ([#1767])
 - Add `load_from_data_async` to Asset Loader. ([#1753])
 - Add `SerializableFormat` marker trait which is now needed to be implemented for all the formats that are supposed to be serialized. ([#1720])

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -65,7 +65,7 @@ done the following things first:
    * `rustup update stable nightly`
    * `cargo +nightly fmt --all`
    * `cargo +nightly clippy --workspace --all-targets --all-features -Z unstable-options`
-   * `cargo test --all-targets --workspace --all-features`
+   * `cargo test --workspace --all-features`
    * `cargo run -p $YOUR_EXAMPLE`
    
     You can copy `script/pre-commit` to `.git/hooks/pre-commit` for a prompt to remind you of these requirements and automatically lint and fix some of them for you when committing.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -240,8 +240,7 @@ Code snippets in markdown files should be surrounded by triple backticks with th
 
 ````
 ```rust,edition2018,no_run,noplaypen
-# extern crate amethyst;
-use amethyst::ecs::{World, WorldExt};
+use amethyst::ecs::{World};
 
 // A simple struct with no data.
 struct MyResource;

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -239,7 +239,7 @@ page, we can do this inline.
 Code snippets in markdown files should be surrounded by triple backticks with the modifier `rust,edition2018,no_run,noplaypen`. Use `#` to hide lines that are necessary to compile in doctests but aren't relevant to the example, use `//` for in-code comments.  For example: 
 
 ````
-```rust,edition2018,no_run,noplaypen
+```rust, edition2018,no_run,noplaypen
 use amethyst::ecs::{World};
 
 // A simple struct with no data.

--- a/script/pre-commit
+++ b/script/pre-commit
@@ -9,10 +9,10 @@ read -r -p "Would you like to lint your code before committing? [y/N]" response
 response=${response,,} # tolower
 if [[ $response =~ ^(yes|y|Y) ]]; then
     echo "Linting..."
-    cargo +nightly check -q --workspace --all-targets --features empty,optional ||
-    echo -e "${RED}Lint Errors Found, Try this command: ${GREEN}cargo +nightly fix --workspace --features empty,optional --allow-dirty --allow-staged${NC}" && exit 1
+    cargo +nightly check -q --workspace --all-targets --all-features ||
+    echo -e "${RED}Lint Errors Found, Try this command: ${GREEN}cargo +nightly fix --workspace --all-features --allow-dirty --allow-staged${NC}" && exit 1
     sleep 1 # fixes possibly newer errors
-    cargo +nightly clippy -q -Z unstable-options --workspace --features empty,optional ||
-    echo -e "${RED}Lint Errors Found, Try this command: ${GREEN}cargo +nightly clippy -Z unstable-options --workspace --features empty,optional --fix --allow-dirty --allow-staged${NC}" && exit 1
+    cargo +nightly clippy -q -Z unstable-options --workspace --all-targets --all-features ||
+    echo -e "${RED}Lint Errors Found, Try this command: ${GREEN}cargo +nightly clippy -Z unstable-options --workspace --all-targets --all-features --fix --allow-dirty --allow-staged${NC}" && exit 1
     cargo +nightly fmt --all
 fi

--- a/src/app.rs
+++ b/src/app.rs
@@ -107,6 +107,7 @@ where
 ///     core::transform::{Parent, Transform},
 ///     prelude::*,
 /// };
+/// use env_logger;
 ///
 /// struct NullState;
 /// impl EmptyState for NullState {}
@@ -173,7 +174,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// use amethyst::prelude::*;
     ///
     /// struct NullState;
@@ -457,7 +458,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```no_run
     /// use amethyst::{
     ///     core::transform::{Parent, Transform},
     ///     prelude::*,
@@ -594,17 +595,15 @@ where
     ///
     /// struct Score {
     ///     score: u32,
-    ///     user: String
+    ///     user: String,
     /// }
     ///
     /// # fn main() -> amethyst::Result<()> {
     /// let score_board = HighScores(Vec::new());
     /// let assets_dir = "assets/";
-    /// let game = Application::build(assets_dir, NullState)?
-    ///     .with_resource(score_board);
+    /// let game = Application::build(assets_dir, NullState)?.with_resource(score_board);
     /// #     Ok(())
     /// # }
-    ///
     /// ```
     pub fn with_resource<R: Resource>(mut self, resource: R) -> Self {
         self.resources.insert(resource);
@@ -634,10 +633,12 @@ where
     ///
     /// # Examples
     ///
-    /// ```
-    /// use amethyst::prelude::*;
-    /// use amethyst::assets::{Directory,  DefaultLoader, Loader, Handle};
-    /// use amethyst::renderer::{Mesh, formats::mesh::ObjFormat};
+    /// ```ignore
+    /// use amethyst::{
+    ///     assets::{DefaultLoader, Directory, Handle, Loader},
+    ///     prelude::*,
+    ///     renderer::{formats::mesh::ObjFormat, Mesh},
+    /// };
     ///
     /// # fn main() -> amethyst::Result<()> {
     /// let assets_dir = "assets/";
@@ -653,11 +654,8 @@ where
     /// impl SimpleState for LoadingState {
     ///     fn on_start(&mut self, data: StateData<'_, GameData>) {
     ///         let loader = data.resources.get::<DefaultLoader>().unwrap();
-    ///         let storage = data.resources.get().unwrap();
-    ///
     ///         // Load a teapot mesh from the directory that registered above.
-    ///         let mesh: Handle<Mesh> =
-    ///             loader.load_from("teapot", ObjFormat, "custom_directory", (), &storage);
+    ///         let mesh: Handle<Mesh> = loader.load("teapot.obj");
     ///     }
     /// }
     /// ```
@@ -690,28 +688,32 @@ where
     ///
     /// # Examples
     ///
-    /// ```
-    /// use amethyst::prelude::*;
-    /// use amethyst::assets::{Directory,  DefaultLoader, Loader, Handle};
-    /// use amethyst::renderer::{Mesh, formats::mesh::ObjFormat};
+    /// ```no_run
+    /// use amethyst::{
+    ///     assets::{DefaultLoader, Directory, Handle, Loader, LoaderBundle},
+    ///     prelude::*,
+    ///     renderer::Mesh,
+    /// };
     ///
     /// # fn main() -> amethyst::Result<()> {
+    /// #      amethyst::start_logger(Default::default());
+    /// let mut dispatcher = DispatcherBuilder::default();
+    /// dispatcher.add_bundle(LoaderBundle);
     /// let assets_dir = "assets/";
     /// let game = Application::build(assets_dir, LoadingState)?
     ///     // Register the directory "custom_directory" as default source for the loader.
     ///     .with_default_source(Directory::new("custom_directory"))
-    ///     .build(DispatcherBuilder::default())?
+    ///     .build(dispatcher)?
     ///     .run();
-    /// #     Ok(())
+    /// # Ok(())
     /// # }
     ///
     /// struct LoadingState;
     /// impl SimpleState for LoadingState {
     ///     fn on_start(&mut self, data: StateData<'_, GameData>) {
     ///         let loader = data.resources.get::<DefaultLoader>().unwrap();
-    ///         let storage = data.resources.get().unwrap();
     ///         // Load a teapot mesh from the directory that registered above.
-    ///         let mesh: Handle<Mesh> = loader.load("teapot", ObjFormat, (), &storage);
+    ///         let mesh: Handle<Mesh> = loader.load("teapot.obj");
     ///     }
     /// }
     /// ```
@@ -720,7 +722,7 @@ where
         O: Source,
     {
         {
-            let _loader = self.resources.get_mut::<DefaultLoader>().unwrap();
+            // let _loader = self.resources.get_mut::<DefaultLoader>().unwrap();
             // FIXME Update the location on the loader
             // loader.set_default_source(store);
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -173,7 +173,7 @@ where
     ///
     /// # Examples
     ///
-    /// ~~~no_run
+    /// ```
     /// use amethyst::prelude::*;
     ///
     /// struct NullState;
@@ -187,7 +187,7 @@ where
     ///
     /// #  Ok(())
     /// # }
-    /// ~~~
+    /// ```
     pub fn new<P, S, I>(path: P, initial_state: S, init: I) -> Result<Self, Error>
     where
         P: AsRef<Path>,
@@ -457,9 +457,11 @@ where
     ///
     /// # Examples
     ///
-    /// ~~~no_run
-    /// use amethyst::prelude::*;
-    /// use amethyst::core::transform::{Parent, Transform};
+    /// ```rust
+    /// use amethyst::{
+    ///     core::transform::{Parent, Transform},
+    ///     prelude::*,
+    /// };
     ///
     /// struct NullState;
     /// impl EmptyState for NullState {}
@@ -472,8 +474,8 @@ where
     /// // returning a new object with the modified configuration.
     /// let assets_dir = "assets/";
     /// let game = Application::build(assets_dir, NullState)?
-    /// // lastly we can build the Application object
-    /// // the `build` function takes the user defined game data initializer as input
+    ///     // lastly we can build the Application object
+    ///     // the `build` function takes the user defined game data initializer as input
     ///     .build(())?;
     ///
     /// // the game instance can now be run, this exits only when the game is done
@@ -481,7 +483,7 @@ where
     ///
     /// # Ok(())
     /// # }
-    /// ~~~
+    /// ```
     pub fn new<P: AsRef<Path>>(path: P, initial_state: S) -> Result<Self, Error> {
         if !log_enabled!(Level::Error) {
             eprintln!(
@@ -580,7 +582,7 @@ where
     ///
     /// # Examples
     ///
-    /// ~~~no_run
+    /// ```
     /// use amethyst::prelude::*;
     ///
     /// struct NullState;
@@ -603,7 +605,7 @@ where
     /// #     Ok(())
     /// # }
     ///
-    /// ~~~
+    /// ```
     pub fn with_resource<R: Resource>(mut self, resource: R) -> Self {
         self.resources.insert(resource);
         self
@@ -632,7 +634,7 @@ where
     ///
     /// # Examples
     ///
-    /// ~~~no_run
+    /// ```
     /// use amethyst::prelude::*;
     /// use amethyst::assets::{Directory,  DefaultLoader, Loader, Handle};
     /// use amethyst::renderer::{Mesh, formats::mesh::ObjFormat};
@@ -658,7 +660,7 @@ where
     ///             loader.load_from("teapot", ObjFormat, "custom_directory", (), &storage);
     ///     }
     /// }
-    /// ~~~
+    /// ```
     pub fn with_source<I, O>(self, _name: I, _store: O) -> Self
     where
         I: Into<String>,
@@ -688,7 +690,7 @@ where
     ///
     /// # Examples
     ///
-    /// ~~~no_run
+    /// ```
     /// use amethyst::prelude::*;
     /// use amethyst::assets::{Directory,  DefaultLoader, Loader, Handle};
     /// use amethyst::renderer::{Mesh, formats::mesh::ObjFormat};
@@ -712,7 +714,7 @@ where
     ///         let mesh: Handle<Mesh> = loader.load("teapot", ObjFormat, (), &storage);
     ///     }
     /// }
-    /// ~~~
+    /// ```
     pub fn with_default_source<O>(self, _store: O) -> Self
     where
         O: Source,

--- a/src/app.rs
+++ b/src/app.rs
@@ -633,7 +633,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```no_run
     /// use amethyst::{
     ///     assets::{DefaultLoader, Directory, Handle, Loader},
     ///     prelude::*,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! # Example
 //!
-//! ```rust, no_run
+//! ```no_run
 //! use amethyst::prelude::*;
 //! use amethyst::winit::event::{Event, KeyboardInput, VirtualKeyCode, WindowEvent};
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,10 @@
 //! # Example
 //!
 //! ```no_run
-//! use amethyst::prelude::*;
-//! use amethyst::winit::event::{Event, KeyboardInput, VirtualKeyCode, WindowEvent};
+//! use amethyst::{
+//!     prelude::*,
+//!     winit::event::{Event, KeyboardInput, VirtualKeyCode, WindowEvent},
+//! };
 //!
 //! struct GameState;
 //!
@@ -25,13 +27,20 @@
 //!     fn handle_event(&mut self, _: StateData<'_, GameData>, event: StateEvent) -> SimpleTrans {
 //!         if let StateEvent::Window(event) = &event {
 //!             match event {
-//!                  Event::WindowEvent { event, .. } => match event {
-//!                     WindowEvent::KeyboardInput {
-//!                         input: KeyboardInput { virtual_keycode: Some(VirtualKeyCode::Escape), .. }, ..
-//!                     } |
-//!                     WindowEvent::CloseRequested => Trans::Quit,
-//!                     _ => Trans::None,
-//!                 },
+//!                 Event::WindowEvent { event, .. } => {
+//!                     match event {
+//!                         WindowEvent::KeyboardInput {
+//!                             input:
+//!                                 KeyboardInput {
+//!                                     virtual_keycode: Some(VirtualKeyCode::Escape),
+//!                                     ..
+//!                                 },
+//!                             ..
+//!                         }
+//!                         | WindowEvent::CloseRequested => Trans::Quit,
+//!                         _ => Trans::None,
+//!                     }
+//!                 }
 //!                 _ => Trans::None,
 //!             }
 //!         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,9 @@
 //!
 //! # Example
 //!
-//! ```rust,no_run
+//! ```rust, no_run
 //! use amethyst::prelude::*;
-//! use amethyst::winit::{Event, KeyboardInput, VirtualKeyCode, WindowEvent};
+//! use amethyst::winit::event::{Event, KeyboardInput, VirtualKeyCode, WindowEvent};
 //!
 //! struct GameState;
 //!

--- a/src/state.rs
+++ b/src/state.rs
@@ -93,7 +93,7 @@ impl<T, E> Debug for Trans<T, E> {
 /// Event queue to trigger state `Trans` from other places than a `State`'s methods.
 /// FIXME: needs example
 /// # Example:
-/// ```rust, ignore
+/// ```ignore
 /// resources.get_mut::<EventChannel<TransEvent<MyGameData, StateEvent>>>().single_write(Box::new(|| Trans::Quit));
 /// ```
 ///
@@ -678,12 +678,12 @@ impl<'a, T, E: Send + Sync + 'static> StateMachine<'a, T, E> {
                 });
             }
 
-            //push the new states
+            // push the new states
             let state_count = states.len();
             for (count, state) in states.into_iter().enumerate() {
                 self.state_stack.push(state);
 
-                //State was just pushed, thus pop will always succeed
+                // State was just pushed, thus pop will always succeed
                 let new_state = self.state_stack.last_mut().unwrap();
                 new_state.on_start(StateData {
                     world,
@@ -691,7 +691,7 @@ impl<'a, T, E: Send + Sync + 'static> StateMachine<'a, T, E> {
                     data,
                 });
                 if count != state_count - 1 {
-                    //pause on each state but the last
+                    // pause on each state but the last
                     new_state.on_pause(StateData {
                         world,
                         resources,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
<!--- Separate Additions, Removals and Modifications -->
inline docs are passing with this pr, this will enable `cargo test --doc` in CI and enable mdbook and linkcheck as well.

fixes docs highlighting in vscode as well and formats inline examples.

takes a first stab at updating some of the book copy as well, but that will be a page-by-page endeavor.

have a working local method of testing book, but checking how CI runs with this PR.  may disable the mdbook check if failing and do separate PR for it.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->



## Screenshots (if appropriate):



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] My code follows the code style of this project.
- [ ] If my change required a change to the documentation I have updated the documentation accordingly.
- [ ] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [ ] My code is used in an example.
