### PR TITLE
Make system macro usable

### DIFF
--- a/amethyst_animation/src/skinning/systems.rs
+++ b/amethyst_animation/src/skinning/systems.rs
@@ -19,7 +19,7 @@ use super::resources::*;
 pub struct VertexSkinningSystem;
 
 impl System<'_> for VertexSkinningSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         let mut updated = HashSet::new();
         let mut updated_skins = HashSet::new();
 

--- a/amethyst_animation/src/systems/control.rs
+++ b/amethyst_animation/src/systems/control.rs
@@ -42,7 +42,7 @@ where
     I: std::fmt::Debug + PartialEq + Eq + Hash + Copy + Send + Sync + 'static,
     T: AnimationSampling + Clone + std::fmt::Debug,
 {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(mut self) -> Box<dyn ParallelRunnable> {
         self.next_id = 1;
         let mut remove_sets = Vec::default();
         let mut remove_ids = Vec::default();

--- a/amethyst_animation/src/systems/sampling.rs
+++ b/amethyst_animation/src/systems/sampling.rs
@@ -38,7 +38,7 @@ impl<T> System<'_> for SamplerInterpolationSystem<T>
 where
     T: AnimationSampling + std::fmt::Debug,
 {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         let mut inner = Vec::default();
         let mut channels = Vec::default();
 

--- a/amethyst_assets/src/prefab/processor.rs
+++ b/amethyst_assets/src/prefab/processor.rs
@@ -68,7 +68,7 @@ impl Prefab {
 struct PrefabProcessorSystem;
 
 impl System<'static> for PrefabProcessorSystem {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("PrefabProcessorSystem")
                 .read_resource::<ComponentRegistry>()

--- a/amethyst_assets/src/processor.rs
+++ b/amethyst_assets/src/processor.rs
@@ -37,7 +37,7 @@ impl<A> System<'_> for AssetProcessorSystem<A>
 where
     A: Asset + ProcessableAsset,
 {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new(format!("Asset Processor: {}", A::name()))
                 .write_resource::<ProcessingQueue<A::Data>>()

--- a/amethyst_assets/src/reload.rs
+++ b/amethyst_assets/src/reload.rs
@@ -139,7 +139,7 @@ enum HotReloadStrategyInner {
 pub struct HotReloadSystem;
 
 impl System<'_> for HotReloadSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("HotReloadSystem")
                 .write_resource::<HotReloadStrategy>()

--- a/amethyst_audio/src/systems/audio.rs
+++ b/amethyst_audio/src/systems/audio.rs
@@ -29,7 +29,7 @@ pub struct AudioSystem;
 pub struct SelectedListener(pub Option<Entity>);
 
 impl System<'_> for AudioSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("AudioSystem")
                 .read_resource::<OutputWrapper>()

--- a/amethyst_audio/src/systems/dj.rs
+++ b/amethyst_audio/src/systems/dj.rs
@@ -70,10 +70,10 @@ where
 
 impl<F, R> System<'static> for DjSystem<F, R>
 where
-    F: FnMut(&mut R) -> Option<SourceHandle> + Send + Sync,
-    R: Send + Sync,
+    F: FnMut(&mut R) -> Option<SourceHandle> + Send + Sync + 'static,
+    R: Send + Sync + 'static,
 {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(mut self) -> Box<dyn ParallelRunnable + 'static> {
         Box::new(
             SystemBuilder::new("DjSystem")
                 .read_resource::<AssetStorage<Source>>()

--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -31,7 +31,7 @@ pub struct FlyMovementSystem {
 }
 
 impl System<'static> for FlyMovementSystem {
-    fn build(&'static mut self) -> Box<dyn systems::ParallelRunnable> {
+    fn build(self) -> Box<dyn systems::ParallelRunnable> {
         Box::new(
             SystemBuilder::new("FlyMovementSystem")
                 .read_resource::<Time>()
@@ -66,7 +66,7 @@ impl System<'static> for FlyMovementSystem {
 pub struct ArcBallRotationSystem;
 
 impl System<'_> for ArcBallRotationSystem {
-    fn build(&mut self) -> Box<dyn systems::ParallelRunnable> {
+    fn build(self) -> Box<dyn systems::ParallelRunnable> {
         Box::new(
             SystemBuilder::new("ArcBallRotationSystem")
                 .with_query(<&ArcBallControl>::query())
@@ -122,7 +122,7 @@ pub struct FreeRotationSystem {
 }
 
 impl System<'static> for FreeRotationSystem {
-    fn build(&'static mut self) -> Box<dyn systems::ParallelRunnable> {
+    fn build(mut self) -> Box<dyn systems::ParallelRunnable> {
         Box::new(
             SystemBuilder::new("FreeRotationSystem")
                 .read_resource::<EventChannel<Event<'static, ()>>>()
@@ -166,7 +166,7 @@ pub struct MouseFocusUpdateSystem {
 }
 
 impl System<'static> for MouseFocusUpdateSystem {
-    fn build(&'static mut self) -> Box<dyn systems::ParallelRunnable> {
+    fn build(mut self) -> Box<dyn systems::ParallelRunnable> {
         Box::new(
             SystemBuilder::new("MouseFocusUpdateSystem")
                 .read_resource::<EventChannel<Event<'static, ()>>>()
@@ -194,7 +194,7 @@ impl System<'static> for MouseFocusUpdateSystem {
 pub struct CursorHideSystem;
 
 impl ThreadLocalSystem<'_> for CursorHideSystem {
-    fn build(&mut self) -> Box<dyn systems::Runnable> {
+    fn build(self) -> Box<dyn systems::Runnable> {
         let mut is_hidden = false;
 
         Box::new(

--- a/amethyst_core/src/dispatcher.rs
+++ b/amethyst_core/src/dispatcher.rs
@@ -26,13 +26,13 @@ pub trait SystemBundle {
 /// A System builds a ParallelRunnable for the Dispatcher
 pub trait System<'a> {
     /// builds the Runnable part of System
-    fn build(&'a mut self) -> Box<dyn ParallelRunnable + 'static>;
+    fn build(self) -> Box<dyn ParallelRunnable + 'static>;
 }
 
 /// A System builds a Runnable for the Dispatcher
 pub trait ThreadLocalSystem<'a> {
     /// builds the Runnable part of System
-    fn build(&'a mut self) -> Box<dyn Runnable + 'static>;
+    fn build(self) -> Box<dyn Runnable + 'static>;
 }
 
 /// This structure is an intermediate step for building [Dispatcher]. When [DispatcherBuilder::build] is called,
@@ -70,7 +70,7 @@ pub struct DispatcherBuilder {
 impl<'a> DispatcherBuilder {
     /// Adds a system to the schedule.
     pub fn add_system<S: System<'a> + 'a>(&mut self, system: Box<S>) -> &mut Self {
-        let s: &'a mut S = Box::leak(system);
+        let s = *system;
         log::debug!("Building system");
         self.items.push(DispatcherItem::System(s.build()));
         self
@@ -78,7 +78,7 @@ impl<'a> DispatcherBuilder {
 
     /// Adds a thread local system to the schedule. This system will be executed on the main thread.
     pub fn add_thread_local<T: ThreadLocalSystem<'a> + 'a>(&mut self, system: Box<T>) -> &mut Self {
-        let s: &'a mut T = Box::leak(system);
+        let s = *system;
         self.items
             .push(DispatcherItem::ThreadLocalSystem(s.build()));
         self
@@ -213,7 +213,7 @@ pub mod tests {
     struct MySystem;
 
     impl System<'_> for MySystem {
-        fn build(&mut self) -> Box<dyn ParallelRunnable> {
+        fn build(self) -> Box<dyn ParallelRunnable> {
             Box::new(
                 SystemBuilder::new("test")
                     .write_resource::<MyResource>()

--- a/amethyst_core/src/dispatcher.rs
+++ b/amethyst_core/src/dispatcher.rs
@@ -29,10 +29,30 @@ pub trait System<'a> {
     fn build(self) -> Box<dyn ParallelRunnable + 'static>;
 }
 
+impl<'a, T, R> System<'a> for T
+where
+    T: FnOnce() -> R,
+    R: ParallelRunnable + 'static,
+{
+    fn build(self) -> Box<dyn ParallelRunnable + 'static> {
+        Box::new(self())
+    }
+}
+
 /// A System builds a Runnable for the Dispatcher
 pub trait ThreadLocalSystem<'a> {
     /// builds the Runnable part of System
     fn build(self) -> Box<dyn Runnable + 'static>;
+}
+
+impl<'a, T, R> ThreadLocalSystem<'a> for T
+where
+    T: FnOnce() -> R,
+    R: Runnable + 'static,
+{
+    fn build(self) -> Box<dyn Runnable + 'static> {
+        Box::new(self())
+    }
 }
 
 /// This structure is an intermediate step for building [Dispatcher]. When [DispatcherBuilder::build] is called,

--- a/amethyst_core/src/hide_hierarchy_system.rs
+++ b/amethyst_core/src/hide_hierarchy_system.rs
@@ -16,7 +16,7 @@ use crate::{
 pub struct HideHierarchySystem;
 
 impl System<'_> for HideHierarchySystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("HideHierarchySystem")
                 .with_query(<(&Children, Option<&HiddenPropagate>)>::query())

--- a/amethyst_core/src/system_ext.rs
+++ b/amethyst_core/src/system_ext.rs
@@ -42,7 +42,7 @@ use legion::{
 /// struct TestSystem;
 ///
 /// impl System<'_> for TestSystem {
-///     fn build(&mut self) -> Box<dyn ParallelRunnable> {
+///     fn build(self) -> Box<dyn ParallelRunnable> {
 ///         Box::new(pausable(
 ///             SystemBuilder::new("TestSystem")
 ///                 .write_resource::<u32>()

--- a/amethyst_core/src/system_ext.rs
+++ b/amethyst_core/src/system_ext.rs
@@ -165,7 +165,7 @@ mod test {
     struct TestSystem;
 
     impl System<'_> for TestSystem {
-        fn build(&mut self) -> Box<dyn ParallelRunnable> {
+        fn build(self) -> Box<dyn ParallelRunnable> {
             Box::new(pausable(
                 SystemBuilder::new("TestSystem")
                     .write_resource::<u32>()

--- a/amethyst_core/src/transform/missing_previous_parent_system.rs
+++ b/amethyst_core/src/transform/missing_previous_parent_system.rs
@@ -8,7 +8,7 @@ use crate::ecs::*;
 pub struct MissingPreviousParentSystem;
 
 impl System<'_> for MissingPreviousParentSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("MissingPreviousParentSystem")
                 // Entities with missing `PreviousParent`

--- a/amethyst_core/src/transform/parent_update_system.rs
+++ b/amethyst_core/src/transform/parent_update_system.rs
@@ -12,7 +12,7 @@ use crate::ecs::*;
 pub struct ParentUpdateSystem;
 
 impl System<'_> for ParentUpdateSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("ParentUpdateSystem")
                 // Entities with a removed `Parent`

--- a/amethyst_core/src/transform/transform_system.rs
+++ b/amethyst_core/src/transform/transform_system.rs
@@ -8,7 +8,7 @@ use crate::ecs::*;
 pub struct TransformSystem;
 
 impl System<'_> for TransformSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("TransformSystem")
                 // Entities at the hierarchy root (no parent component)

--- a/amethyst_input/src/system.rs
+++ b/amethyst_input/src/system.rs
@@ -18,7 +18,7 @@ pub struct InputSystem {
 }
 
 impl System<'static> for InputSystem {
-    fn build(&'static mut self) -> Box<dyn systems::ParallelRunnable> {
+    fn build(mut self) -> Box<dyn systems::ParallelRunnable> {
         Box::new(
             SystemBuilder::new("InputSystem")
                 .read_resource::<EventChannel<Event<'static, ()>>>()

--- a/amethyst_network/src/simulation/timing.rs
+++ b/amethyst_network/src/simulation/timing.rs
@@ -12,7 +12,7 @@ const DEFAULT_SIM_FRAME_RATE: u32 = 30;
 pub struct NetworkSimulationTimeSystem;
 
 impl System<'_> for NetworkSimulationTimeSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("NetworkSimulationTimeSystem")
                 .write_resource::<NetworkSimulationTime>()

--- a/amethyst_network/src/simulation/transport/laminar.rs
+++ b/amethyst_network/src/simulation/transport/laminar.rs
@@ -50,7 +50,7 @@ impl SystemBundle for LaminarNetworkBundle {
 pub struct LaminarNetworkSendSystem;
 
 impl System<'_> for LaminarNetworkSendSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("LaminarNetworkSendSystem")
                 .write_resource::<TransportResource>()
@@ -130,7 +130,7 @@ impl System<'_> for LaminarNetworkSendSystem {
 pub struct LaminarNetworkPollSystem;
 
 impl System<'_> for LaminarNetworkPollSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("LaminarNetworkPollSystem")
                 .write_resource::<LaminarSocketResource>()
@@ -147,7 +147,7 @@ impl System<'_> for LaminarNetworkPollSystem {
 pub struct LaminarNetworkRecvSystem;
 
 impl System<'_> for LaminarNetworkRecvSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("LaminarNetworkRecvSystem")
                 .write_resource::<LaminarSocketResource>()

--- a/amethyst_network/src/simulation/transport/tcp.rs
+++ b/amethyst_network/src/simulation/transport/tcp.rs
@@ -68,7 +68,7 @@ pub struct TcpStreamManagementSystem;
 
 #[allow(clippy::map_entry)]
 impl System<'_> for TcpStreamManagementSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("TcpStreamManagementSystem")
                 .write_resource::<TcpNetworkResource>()
@@ -115,7 +115,7 @@ impl System<'_> for TcpStreamManagementSystem {
 pub struct TcpConnectionListenerSystem;
 
 impl System<'_> for TcpConnectionListenerSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("TcpConnectionListenerSystem")
                 .write_resource::<TcpNetworkResource>()
@@ -155,7 +155,7 @@ impl System<'_> for TcpConnectionListenerSystem {
 pub struct TcpNetworkSendSystem;
 
 impl System<'_> for TcpNetworkSendSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("TcpNetworkSendSystem")
                 .write_resource::<TransportResource>()
@@ -206,7 +206,7 @@ fn write_message(
 pub struct TcpNetworkRecvSystem;
 
 impl System<'_> for TcpNetworkRecvSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("TcpNetworkRecvSystem")
                 .write_resource::<TcpNetworkResource>()

--- a/amethyst_network/src/simulation/transport/udp.rs
+++ b/amethyst_network/src/simulation/transport/udp.rs
@@ -45,7 +45,7 @@ impl SystemBundle for UdpNetworkBundle {
 pub struct UdpNetworkSendSystem;
 
 impl System<'_> for UdpNetworkSendSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("UdpNetworkSendSystem")
                 .write_resource::<TransportResource>()
@@ -88,7 +88,7 @@ impl System<'_> for UdpNetworkSendSystem {
 pub struct UdpNetworkReceiveSystem;
 
 impl System<'_> for UdpNetworkReceiveSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("UdpNetworkReceiveSystem")
                 .write_resource::<UdpSocketResource>()

--- a/amethyst_rendy/src/sprite_visibility.rs
+++ b/amethyst_rendy/src/sprite_visibility.rs
@@ -46,7 +46,7 @@ struct Internals {
 pub struct SpriteVisibilitySortingSystem;
 
 impl System<'_> for SpriteVisibilitySortingSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         let mut transparent_centroids: Vec<Internals> = Vec::default();
 
         Box::new(

--- a/amethyst_rendy/src/system.rs
+++ b/amethyst_rendy/src/system.rs
@@ -141,7 +141,7 @@ pub struct MeshProcessorSystem<B: Backend> {
 }
 
 impl<B: Backend> System<'_> for MeshProcessorSystem<B> {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("MeshProcessorSystem")
                 .write_resource::<ProcessingQueue<MeshData>>()
@@ -187,7 +187,7 @@ pub struct TextureProcessorSystem<B> {
 }
 
 impl<B: Backend> System<'_> for TextureProcessorSystem<B> {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("TextureProcessorSystem")
                 .write_resource::<ProcessingQueue<TextureData>>()

--- a/amethyst_rendy/src/visibility.rs
+++ b/amethyst_rendy/src/visibility.rs
@@ -80,7 +80,7 @@ pub struct VisibilitySortingSystem {
 }
 
 impl System<'static> for VisibilitySortingSystem {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(mut self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("VisibilitySortingSystem")
                 .read_resource::<ActiveCamera>()

--- a/amethyst_ui/src/blink.rs
+++ b/amethyst_ui/src/blink.rs
@@ -28,7 +28,7 @@ pub struct Blink {
 pub struct BlinkSystem;
 
 impl System<'_> for BlinkSystem {
-    fn build(&'_ mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("BlinkSystem")
                 .read_resource::<Time>()

--- a/amethyst_ui/src/button/system.rs
+++ b/amethyst_ui/src/button/system.rs
@@ -77,7 +77,7 @@ impl UiButtonSystem {
 }
 
 impl System<'static> for UiButtonSystem {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(mut self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("UiButtonSystem")
                 .write_resource::<EventChannel<UiButtonAction>>()

--- a/amethyst_ui/src/drag.rs
+++ b/amethyst_ui/src/drag.rs
@@ -44,7 +44,7 @@ impl DragWidgetSystem {
 }
 
 impl System<'static> for DragWidgetSystem {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(mut self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("DragWidgetSystem")
                 .write_resource::<EventChannel<UiEvent>>()

--- a/amethyst_ui/src/event.rs
+++ b/amethyst_ui/src/event.rs
@@ -104,7 +104,7 @@ impl UiMouseSystem {
 }
 
 impl System<'static> for UiMouseSystem {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(mut self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("UiMouseSystem")
                 .write_resource::<EventChannel<UiEvent>>()

--- a/amethyst_ui/src/event_retrigger.rs
+++ b/amethyst_ui/src/event_retrigger.rs
@@ -67,7 +67,7 @@ where
 }
 
 impl<T: EventRetrigger + 'static> System<'static> for EventRetriggerSystem<T> {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(mut self) -> Box<dyn ParallelRunnable> {
         let system_name = format!("{}System", std::any::type_name::<T>());
         Box::new(
             SystemBuilder::new(system_name)

--- a/amethyst_ui/src/glyphs.rs
+++ b/amethyst_ui/src/glyphs.rs
@@ -137,7 +137,7 @@ pub(crate) struct GlyphTextureProcessorSystem<B> {
 }
 
 impl<B: Backend> System<'static> for GlyphTextureProcessorSystem<B> {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         use hal::format::{Component as C, Swizzle};
 
         Box::new(
@@ -182,7 +182,7 @@ impl<B: Backend> System<'static> for GlyphTextureProcessorSystem<B> {
 }
 
 impl<B: Backend> System<'static> for UiGlyphsSystem<B> {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(mut self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("UiGlyphsSystem")
                 .write_resource::<Factory<B>>()

--- a/amethyst_ui/src/layout.rs
+++ b/amethyst_ui/src/layout.rs
@@ -149,7 +149,7 @@ impl UiTransformSystem {
 }
 
 impl System<'static> for UiTransformSystem {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(mut self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("UiTransformSystem")
                 .read_resource::<ScreenDimensions>()

--- a/amethyst_ui/src/resize.rs
+++ b/amethyst_ui/src/resize.rs
@@ -45,7 +45,7 @@ impl ResizeSystem {
 }
 
 impl System<'static> for ResizeSystem {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(mut self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("ResizeSystem")
                 .read_resource::<ScreenDimensions>()

--- a/amethyst_ui/src/selection.rs
+++ b/amethyst_ui/src/selection.rs
@@ -70,7 +70,7 @@ impl<G> System<'static> for SelectionKeyboardSystem<G>
 where
     G: Send + Sync + 'static + PartialEq,
 {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(mut self) -> Box<dyn ParallelRunnable> {
         Box::new(SystemBuilder::new("SelectionKeyboardSystem")
             .read_resource::<EventChannel<Event<'static, ()>    >>()
             .read_resource::<CachedSelectionOrderResource>()
@@ -181,7 +181,7 @@ impl<G> System<'static> for SelectionMouseSystem<G>
 where
     G: Send + Sync + 'static + PartialEq,
 {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(mut self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("SelectionMouseSystem")
                 .read_resource::<CachedSelectionOrderResource>()

--- a/amethyst_ui/src/selection_order_cache.rs
+++ b/amethyst_ui/src/selection_order_cache.rs
@@ -60,7 +60,7 @@ impl<G> System<'_> for CacheSelectionSystem<G>
 where
     G: Send + Sync + 'static + PartialEq,
 {
-    fn build(&'_ mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("CacheSelectionOrderSystem")
                 .write_resource::<CachedSelectionOrderResource>()

--- a/amethyst_ui/src/sound.rs
+++ b/amethyst_ui/src/sound.rs
@@ -79,7 +79,7 @@ impl UiSoundSystem {
 }
 
 impl System<'static> for UiSoundSystem {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(mut self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("UiSoundSystem")
                 .write_resource::<EventChannel<UiPlaySoundAction>>()

--- a/amethyst_ui/src/text.rs
+++ b/amethyst_ui/src/text.rs
@@ -169,7 +169,7 @@ impl TextEditingMouseSystem {
 }
 
 impl System<'static> for TextEditingMouseSystem {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(mut self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("TextEditingMouseSystem")
                 .read_resource::<Time>()

--- a/amethyst_ui/src/text_editing.rs
+++ b/amethyst_ui/src/text_editing.rs
@@ -31,7 +31,7 @@ impl TextEditingInputSystem {
 }
 
 impl System<'static> for TextEditingInputSystem {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(mut self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("TextEditingInputSystem")
                 .read_resource::<EventChannel<Event<'static, ()>>>()

--- a/amethyst_utils/src/auto_fov.rs
+++ b/amethyst_utils/src/auto_fov.rs
@@ -56,7 +56,7 @@ impl Default for AutoFov {
 pub struct AutoFovSystem;
 
 impl System<'_> for AutoFovSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         let mut last_dimensions = ScreenDimensions::new(0, 0);
 
         Box::new(

--- a/amethyst_utils/src/fps_counter.rs
+++ b/amethyst_utils/src/fps_counter.rs
@@ -83,7 +83,7 @@ impl FpsCounter {
 struct FpsCounterSystem;
 
 impl System<'_> for FpsCounterSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("fps_counter_system")
                 .read_resource::<Time>()

--- a/amethyst_window/src/system.rs
+++ b/amethyst_window/src/system.rs
@@ -19,7 +19,7 @@ pub struct WindowSystem;
 
 /// Builds window system that updates `ScreenDimensions` resource from a provided `Window`.
 impl System<'_> for WindowSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("WindowSystem")
                 .write_resource::<ScreenDimensions>()
@@ -58,7 +58,7 @@ pub struct EventLoopSystem {
 }
 
 impl ThreadLocalSystem<'static> for EventLoopSystem {
-    fn build(&'static mut self) -> Box<dyn Runnable> {
+    fn build(mut self) -> Box<dyn Runnable> {
         let mut events = Vec::with_capacity(128);
 
         Box::new(

--- a/examples/auto_fov/main.rs
+++ b/examples/auto_fov/main.rs
@@ -248,7 +248,7 @@ impl SimpleState for Example {
 struct ShowFovSystem;
 
 impl System<'_> for ShowFovSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("ShowFovSystem")
                 .read_resource::<ScreenDimensions>()

--- a/examples/debug_lines/main.rs
+++ b/examples/debug_lines/main.rs
@@ -29,7 +29,7 @@ use amethyst::{
 struct ExampleLinesSystem;
 
 impl System<'_> for ExampleLinesSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("ExampleLinesSystem")
                 .read_resource::<Time>()

--- a/examples/debug_lines_ortho/main.rs
+++ b/examples/debug_lines_ortho/main.rs
@@ -23,7 +23,7 @@ use amethyst::{
 struct ExampleLinesSystem;
 
 impl System<'_> for ExampleLinesSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("ExampleLinesSystem")
                 .read_resource::<ScreenDimensions>()

--- a/examples/events/main.rs
+++ b/examples/events/main.rs
@@ -49,7 +49,7 @@ struct GameplayState;
 struct SpammingSystem;
 
 impl System<'_> for SpammingSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("SpamSystem")
                 .write_resource::<EventChannel<MyEvent>>()
@@ -70,7 +70,7 @@ struct SpamReceiverSystem {
 }
 
 impl System<'static> for SpamReceiverSystem {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(mut self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("SpamSystem")
                 .read_resource::<EventChannel<MyEvent>>()

--- a/examples/events_custom_state_event/system.rs
+++ b/examples/events_custom_state_event/system.rs
@@ -28,7 +28,7 @@ impl<'a, 'b> SystemBundle for MyBundle {
 struct DifficultySystem;
 
 impl System<'_> for DifficultySystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("DifficultySystem")
                 .write_resource::<EventChannel<GameEvent>>()

--- a/examples/mouse_raycast/main.rs
+++ b/examples/mouse_raycast/main.rs
@@ -32,7 +32,7 @@ use amethyst::{
 struct MouseRaycastSystem;
 
 impl System<'_> for MouseRaycastSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("MouseRaycastSystem")
                 .with_query(<(&Camera, &Transform)>::query())

--- a/examples/net_client/main.rs
+++ b/examples/net_client/main.rs
@@ -67,7 +67,7 @@ struct SpamSystem {
 }
 
 impl System<'static> for SpamSystem {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(mut self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("TransformSystem")
                 .read_resource::<NetworkSimulationTime>()

--- a/examples/net_server/main.rs
+++ b/examples/net_server/main.rs
@@ -72,7 +72,7 @@ struct SpamReceiveSystem {
 }
 
 impl System<'static> for SpamReceiveSystem {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(mut self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("SpamReceiveSystem")
                 .read_resource::<EventChannel<NetworkSimulationEvent>>()

--- a/examples/pong_tutorial_03/systems/paddle.rs
+++ b/examples/pong_tutorial_03/systems/paddle.rs
@@ -10,7 +10,7 @@ use crate::pong::{Paddle, Side, ARENA_HEIGHT, PADDLE_HEIGHT};
 pub struct PaddleSystem;
 
 impl System<'_> for PaddleSystem {
-    fn build(&'_ mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("PaddleSystem")
                 .with_query(<(&Paddle, &mut Transform)>::query())

--- a/examples/pong_tutorial_04/systems/bounce.rs
+++ b/examples/pong_tutorial_04/systems/bounce.rs
@@ -5,7 +5,7 @@ use crate::pong::{Ball, Paddle, Side, ARENA_HEIGHT};
 pub struct BounceSystem;
 
 impl System<'_> for BounceSystem {
-    fn build(&'_ mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("BounceSystem")
                 .with_query(<(&mut Ball, &Transform)>::query())

--- a/examples/pong_tutorial_04/systems/move_balls.rs
+++ b/examples/pong_tutorial_04/systems/move_balls.rs
@@ -9,7 +9,7 @@ use crate::pong::Ball;
 pub struct BallSystem;
 
 impl System<'_> for BallSystem {
-    fn build(&'_ mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("MoveBallsSystem")
                 .with_query(<(&Ball, &mut Transform)>::query())

--- a/examples/pong_tutorial_04/systems/paddle.rs
+++ b/examples/pong_tutorial_04/systems/paddle.rs
@@ -10,7 +10,7 @@ use crate::pong::{Paddle, Side, ARENA_HEIGHT, PADDLE_HEIGHT};
 pub struct PaddleSystem;
 
 impl System<'_> for PaddleSystem {
-    fn build(&'_ mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("PaddleSystem")
                 .with_query(<(&mut Paddle, &mut Transform)>::query())

--- a/examples/pong_tutorial_05/systems/bounce.rs
+++ b/examples/pong_tutorial_05/systems/bounce.rs
@@ -5,7 +5,7 @@ use crate::pong::{Ball, Paddle, Side, ARENA_HEIGHT};
 pub struct BounceSystem;
 
 impl System<'_> for BounceSystem {
-    fn build(&'_ mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("BounceSystem")
                 .with_query(<(&mut Ball, &Transform)>::query())

--- a/examples/pong_tutorial_05/systems/move_balls.rs
+++ b/examples/pong_tutorial_05/systems/move_balls.rs
@@ -9,7 +9,7 @@ use crate::pong::Ball;
 pub struct BallSystem;
 
 impl System<'_> for BallSystem {
-    fn build(&'_ mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("MoveBallsSystem")
                 .with_query(<(&Ball, &mut Transform)>::query())

--- a/examples/pong_tutorial_05/systems/paddle.rs
+++ b/examples/pong_tutorial_05/systems/paddle.rs
@@ -10,7 +10,7 @@ use crate::pong::{Paddle, Side, ARENA_HEIGHT, PADDLE_HEIGHT};
 pub struct PaddleSystem;
 
 impl System<'_> for PaddleSystem {
-    fn build(&'_ mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("PaddleSystem")
                 .with_query(<(&mut Paddle, &mut Transform)>::query())

--- a/examples/pong_tutorial_05/systems/winner.rs
+++ b/examples/pong_tutorial_05/systems/winner.rs
@@ -12,7 +12,7 @@ use crate::pong::{Ball, ScoreBoard, ScoreText, ARENA_WIDTH};
 pub struct WinnerSystem;
 
 impl System<'_> for WinnerSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("WinnerSystem")
                 .with_query(<(&mut Ball, &mut Transform)>::query())

--- a/examples/pong_tutorial_06/systems/bounce.rs
+++ b/examples/pong_tutorial_06/systems/bounce.rs
@@ -14,7 +14,7 @@ use crate::{
 pub struct BounceSystem;
 
 impl System<'_> for BounceSystem {
-    fn build(&'_ mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("BounceSystem")
                 .read_resource::<Sounds>()

--- a/examples/pong_tutorial_06/systems/move_balls.rs
+++ b/examples/pong_tutorial_06/systems/move_balls.rs
@@ -9,7 +9,7 @@ use crate::pong::Ball;
 pub struct BallSystem;
 
 impl System<'_> for BallSystem {
-    fn build(&'_ mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("MoveBallsSystem")
                 .with_query(<(&Ball, &mut Transform)>::query())

--- a/examples/pong_tutorial_06/systems/paddle.rs
+++ b/examples/pong_tutorial_06/systems/paddle.rs
@@ -10,7 +10,7 @@ use crate::pong::{Paddle, Side, ARENA_HEIGHT, PADDLE_HEIGHT};
 pub struct PaddleSystem;
 
 impl System<'_> for PaddleSystem {
-    fn build(&'_ mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("PaddleSystem")
                 .with_query(<(&mut Paddle, &mut Transform)>::query())

--- a/examples/pong_tutorial_06/systems/winner.rs
+++ b/examples/pong_tutorial_06/systems/winner.rs
@@ -12,7 +12,7 @@ use crate::pong::{Ball, ScoreBoard, ScoreText, ARENA_WIDTH};
 pub struct WinnerSystem;
 
 impl System<'_> for WinnerSystem {
-    fn build(&mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("WinnerSystem")
                 .with_query(<(&mut Ball, &mut Transform)>::query())

--- a/examples/sprite_camera_follow/main.rs
+++ b/examples/sprite_camera_follow/main.rs
@@ -22,7 +22,7 @@ struct Player;
 struct MovementSystem;
 
 impl<'s> System<'s> for MovementSystem {
-    fn build(&'s mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("MovementSystem")
                 .read_resource::<InputHandler>()

--- a/examples/tiles/systems/camera_movement.rs
+++ b/examples/tiles/systems/camera_movement.rs
@@ -8,7 +8,7 @@ use amethyst::{
 pub(crate) struct CameraMovementSystem;
 
 impl System<'static> for CameraMovementSystem {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("CameraMovementSystem")
                 .read_resource::<ActiveCamera>()

--- a/examples/tiles/systems/camera_switch.rs
+++ b/examples/tiles/systems/camera_switch.rs
@@ -23,7 +23,7 @@ impl Default for CameraSwitchSystem {
     }
 }
 impl System<'static> for CameraSwitchSystem {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(mut self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("CameraSwitchSystem")
                 .write_resource::<ActiveCamera>()

--- a/examples/tiles/systems/draw_selection.rs
+++ b/examples/tiles/systems/draw_selection.rs
@@ -14,7 +14,7 @@ pub struct DrawSelectionSystem {
 }
 
 impl System<'static> for DrawSelectionSystem {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(mut self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("DrawSelectionSystem")
                 .write_resource::<ActiveCamera>()

--- a/examples/tiles/systems/map_movement.rs
+++ b/examples/tiles/systems/map_movement.rs
@@ -22,7 +22,7 @@ impl Default for MapMovementSystem {
     }
 }
 impl System<'static> for MapMovementSystem {
-    fn build(&'static mut self) -> Box<dyn ParallelRunnable> {
+    fn build(mut self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("MapMovementSystem")
                 .read_resource::<Time>()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
<!--- Separate Additions, Removals and Modifications -->
Make `System::build` and `ThreadLocalSystem::build` consume self.

Add two blanket impls so that `FnOnce` closures implement `Runnable` and `ParallelRunnable`.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When using the `system` macro:
```rust
#[system]
fn camera_move(
    world: &mut SubWorld,
    #[state] readerid: &mut ReaderId<GameInputEvent>,
) { /*...*/ }
```
You can't add the resulting `Runnable` to the dispatcher because the return type of camera_move_system implements neither `System` nor `ThreadLocalSystem`.

This pull request makes the following code compile:
```rust
pub struct ControlsBundle;
impl SystemBundle for ControlsBundle {
    fn load(
        &mut self,
        world: &mut legion::World,
        resources: &mut legion::Resources,
        builder: &mut amethyst::ecs::DispatcherBuilder,
    ) -> Result<(), amethyst::Error> {
        let readerid = resources
            .get_mut::<EventChannel<GameInputEvent>>()
            .unwrap()
            .register_reader();

        builder.add_thread_local(Box::new(|| camera_move_system(readerid)));
        Ok(())
    }
}
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
```bash
cargo test --workspace --all-features
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [ ] If my change required a change to the documentation I have updated the documentation accordingly.
- [ ] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [ ] My code is used in an example.
