### PR TITLE
Remove box in system `DispatcherBuilder::add_system` and `DispatcherBuilder::add_system`

### DIFF
--- a/amethyst_animation/src/bundle.rs
+++ b/amethyst_animation/src/bundle.rs
@@ -28,7 +28,7 @@ impl SystemBundle for VertexSkinningBundle {
         _resources: &mut Resources,
         builder: &mut DispatcherBuilder,
     ) -> Result<(), Error> {
-        builder.add_system(Box::new(VertexSkinningSystem::default()));
+        builder.add_system(VertexSkinningSystem::default());
         Ok(())
     }
 }
@@ -56,9 +56,7 @@ where
         _resources: &mut Resources,
         builder: &mut DispatcherBuilder,
     ) -> Result<(), Error> {
-        builder.add_system(Box::new(
-            crate::systems::sampling::SamplerInterpolationSystem::<T>::default(),
-        ));
+        builder.add_system(crate::systems::sampling::SamplerInterpolationSystem::<T>::default());
 
         Ok(())
     }
@@ -94,10 +92,7 @@ where
         builder: &mut DispatcherBuilder,
     ) -> Result<(), Error> {
         builder.add_bundle(SamplingBundle::<T> { m: PhantomData });
-        builder.add_system(Box::new(crate::systems::control::AnimationControlSystem::<
-            I,
-            T,
-        >::default()));
+        builder.add_system(crate::systems::control::AnimationControlSystem::<I, T>::default());
 
         Ok(())
     }

--- a/amethyst_assets/src/loader.rs
+++ b/amethyst_assets/src/loader.rs
@@ -482,7 +482,7 @@ where
             res.get_or_insert_with(ProcessingQueue::<Intermediate>::default);
         },
         register_system: |builder| {
-            builder.add_system(Box::new(ProcessorSystem::default()));
+            builder.add_system(ProcessorSystem::default());
         },
         with_storage: |res, func| {
             func(&mut (

--- a/amethyst_assets/src/processor.rs
+++ b/amethyst_assets/src/processor.rs
@@ -44,7 +44,7 @@ where
                 .write_resource::<AssetStorage<A>>()
                 .build(|_, _, (queue, storage), _| {
                     // drain the changed queue
-                    while let Some(_) = queue.changed.pop() {}
+                    while queue.changed.pop().is_some() {}
                     queue.process(storage, ProcessableAsset::process);
                     storage.process_custom_drop(|_| {});
                 }),

--- a/amethyst_audio/src/bundle.rs
+++ b/amethyst_audio/src/bundle.rs
@@ -24,7 +24,7 @@ impl SystemBundle for AudioBundle {
         resources.get_or_default::<OutputWrapper>();
         resources.get_or_default::<SelectedListener>();
 
-        builder.add_system(Box::new(AudioSystem));
+        builder.add_system(AudioSystem);
         Ok(())
     }
 }

--- a/amethyst_audio/src/systems/dj.rs
+++ b/amethyst_audio/src/systems/dj.rs
@@ -49,10 +49,12 @@ where
         builder: &mut DispatcherBuilder,
     ) -> Result<(), Error> {
         init_output(resources);
-        builder.add_system(Box::new(DjSystem {
-            f: self.f,
-            _phantom: PhantomData,
-        }));
+        builder.add_system(
+            DjSystem {
+                f: self.f,
+                _phantom: PhantomData,
+            },
+        );
         Ok(())
     }
 }

--- a/amethyst_audio/src/systems/dj.rs
+++ b/amethyst_audio/src/systems/dj.rs
@@ -49,12 +49,10 @@ where
         builder: &mut DispatcherBuilder,
     ) -> Result<(), Error> {
         init_output(resources);
-        builder.add_system(
-            DjSystem {
-                f: self.f,
-                _phantom: PhantomData,
-            },
-        );
+        builder.add_system(DjSystem {
+            f: self.f,
+            _phantom: PhantomData,
+        });
         Ok(())
     }
 }

--- a/amethyst_controls/src/bundles.rs
+++ b/amethyst_controls/src/bundles.rs
@@ -75,27 +75,23 @@ impl SystemBundle for FlyControlBundle {
         resources: &mut Resources,
         builder: &mut DispatcherBuilder,
     ) -> Result<(), Error> {
-        builder.add_system(
-            FlyMovementSystem {
-                speed: self.speed,
-                horizontal_axis: self.horizontal_axis.clone(),
-                vertical_axis: self.vertical_axis.clone(),
-                longitudinal_axis: self.longitudinal_axis.clone(),
-            },
-        );
+        builder.add_system(FlyMovementSystem {
+            speed: self.speed,
+            horizontal_axis: self.horizontal_axis.clone(),
+            vertical_axis: self.vertical_axis.clone(),
+            longitudinal_axis: self.longitudinal_axis.clone(),
+        });
 
         let reader = resources
             .get_mut::<EventChannel<Event<'static, ()>>>()
             .expect("Window event channel not found in resources")
             .register_reader();
 
-        builder.add_system(
-            FreeRotationSystem {
-                sensitivity_x: self.sensitivity_x,
-                sensitivity_y: self.sensitivity_y,
-                reader,
-            },
-        );
+        builder.add_system(FreeRotationSystem {
+            sensitivity_x: self.sensitivity_x,
+            sensitivity_y: self.sensitivity_y,
+            reader,
+        });
 
         resources.insert(WindowFocus::new());
 
@@ -161,13 +157,11 @@ impl SystemBundle for ArcBallControlBundle {
             .expect("Window event channel not found in resources")
             .register_reader();
 
-        builder.add_system(
-            FreeRotationSystem {
-                sensitivity_x: self.sensitivity_x,
-                sensitivity_y: self.sensitivity_y,
-                reader,
-            },
-        );
+        builder.add_system(FreeRotationSystem {
+            sensitivity_x: self.sensitivity_x,
+            sensitivity_y: self.sensitivity_y,
+            reader,
+        });
 
         builder.add_system(ArcBallRotationSystem);
 

--- a/amethyst_controls/src/bundles.rs
+++ b/amethyst_controls/src/bundles.rs
@@ -75,23 +75,27 @@ impl SystemBundle for FlyControlBundle {
         resources: &mut Resources,
         builder: &mut DispatcherBuilder,
     ) -> Result<(), Error> {
-        builder.add_system(Box::new(FlyMovementSystem {
-            speed: self.speed,
-            horizontal_axis: self.horizontal_axis.clone(),
-            vertical_axis: self.vertical_axis.clone(),
-            longitudinal_axis: self.longitudinal_axis.clone(),
-        }));
+        builder.add_system(
+            FlyMovementSystem {
+                speed: self.speed,
+                horizontal_axis: self.horizontal_axis.clone(),
+                vertical_axis: self.vertical_axis.clone(),
+                longitudinal_axis: self.longitudinal_axis.clone(),
+            },
+        );
 
         let reader = resources
             .get_mut::<EventChannel<Event<'static, ()>>>()
             .expect("Window event channel not found in resources")
             .register_reader();
 
-        builder.add_system(Box::new(FreeRotationSystem {
-            sensitivity_x: self.sensitivity_x,
-            sensitivity_y: self.sensitivity_y,
-            reader,
-        }));
+        builder.add_system(
+            FreeRotationSystem {
+                sensitivity_x: self.sensitivity_x,
+                sensitivity_y: self.sensitivity_y,
+                reader,
+            },
+        );
 
         resources.insert(WindowFocus::new());
 
@@ -100,10 +104,10 @@ impl SystemBundle for FlyControlBundle {
             .expect("Window event channel not found in resources")
             .register_reader();
 
-        builder.add_system(Box::new(MouseFocusUpdateSystem { reader }));
+        builder.add_system(MouseFocusUpdateSystem { reader });
 
         resources.insert(HideCursor::default());
-        builder.add_thread_local(Box::new(CursorHideSystem));
+        builder.add_thread_local(CursorHideSystem);
 
         Ok(())
     }
@@ -157,13 +161,15 @@ impl SystemBundle for ArcBallControlBundle {
             .expect("Window event channel not found in resources")
             .register_reader();
 
-        builder.add_system(Box::new(FreeRotationSystem {
-            sensitivity_x: self.sensitivity_x,
-            sensitivity_y: self.sensitivity_y,
-            reader,
-        }));
+        builder.add_system(
+            FreeRotationSystem {
+                sensitivity_x: self.sensitivity_x,
+                sensitivity_y: self.sensitivity_y,
+                reader,
+            },
+        );
 
-        builder.add_system(Box::new(ArcBallRotationSystem));
+        builder.add_system(ArcBallRotationSystem);
 
         resources.insert(WindowFocus::new());
 
@@ -172,10 +178,10 @@ impl SystemBundle for ArcBallControlBundle {
             .expect("Window event channel not found in resources")
             .register_reader();
 
-        builder.add_system(Box::new(MouseFocusUpdateSystem { reader }));
+        builder.add_system(MouseFocusUpdateSystem { reader });
 
         resources.insert(HideCursor::default());
-        builder.add_thread_local(Box::new(CursorHideSystem));
+        builder.add_thread_local(CursorHideSystem);
 
         Ok(())
     }

--- a/amethyst_core/src/dispatcher.rs
+++ b/amethyst_core/src/dispatcher.rs
@@ -89,18 +89,16 @@ pub struct DispatcherBuilder {
 
 impl<'a> DispatcherBuilder {
     /// Adds a system to the schedule.
-    pub fn add_system<S: System<'a> + 'a>(&mut self, system: Box<S>) -> &mut Self {
-        let s = *system;
+    pub fn add_system<S: System<'a> + 'a>(&mut self, system: S) -> &mut Self {
         log::debug!("Building system");
-        self.items.push(DispatcherItem::System(s.build()));
+        self.items.push(DispatcherItem::System(system.build()));
         self
     }
 
     /// Adds a thread local system to the schedule. This system will be executed on the main thread.
-    pub fn add_thread_local<T: ThreadLocalSystem<'a> + 'a>(&mut self, system: Box<T>) -> &mut Self {
-        let s = *system;
+    pub fn add_thread_local<T: ThreadLocalSystem<'a> + 'a>(&mut self, system: T) -> &mut Self {
         self.items
-            .push(DispatcherItem::ThreadLocalSystem(s.build()));
+            .push(DispatcherItem::ThreadLocalSystem(system.build()));
         self
     }
 
@@ -296,7 +294,7 @@ pub mod tests {
         resources.insert(MyResource(false));
 
         let mut dispatcher = DispatcherBuilder::default()
-            .add_system(Box::new(MySystem))
+            .add_system(MySystem)
             .build(&mut world, &mut resources)
             .unwrap();
 

--- a/amethyst_core/src/system_ext.rs
+++ b/amethyst_core/src/system_ext.rs
@@ -58,7 +58,7 @@ use legion::{
 /// let mut resources = Resources::default();
 ///
 /// let mut dispatcher = DispatcherBuilder::default()
-///     .add_system(Box::new(TestSystem))
+///     .add_system(TestSystem)
 ///     .build(&mut world, &mut resources)
 ///     .unwrap();
 ///
@@ -185,7 +185,7 @@ mod test {
         resources.insert(CurrentState::Enabled);
 
         let mut dispatcher = DispatcherBuilder::default()
-            .add_system(Box::new(TestSystem))
+            .add_system(TestSystem)
             .build(&mut world, &mut resources)
             .unwrap();
 
@@ -204,7 +204,7 @@ mod test {
         resources.insert(CurrentState::Enabled);
 
         let mut dispatcher = DispatcherBuilder::default()
-            .add_system(Box::new(TestSystem))
+            .add_system(TestSystem)
             .build(&mut world, &mut resources)
             .unwrap();
 

--- a/amethyst_core/src/transform/bundle.rs
+++ b/amethyst_core/src/transform/bundle.rs
@@ -17,9 +17,9 @@ impl SystemBundle for TransformBundle {
         builder: &mut DispatcherBuilder,
     ) -> Result<(), Error> {
         builder
-            .add_system(Box::new(MissingPreviousParentSystem))
-            .add_system(Box::new(ParentUpdateSystem))
-            .add_system(Box::new(TransformSystem));
+            .add_system(MissingPreviousParentSystem)
+            .add_system(ParentUpdateSystem)
+            .add_system(TransformSystem);
 
         Ok(())
     }

--- a/amethyst_input/src/bundle.rs
+++ b/amethyst_input/src/bundle.rs
@@ -110,7 +110,7 @@ impl SystemBundle for InputBundle {
 
         resources.insert(handler);
 
-        builder.add_system(Box::new(InputSystem { reader }));
+        builder.add_system(InputSystem { reader });
 
         Ok(())
     }

--- a/amethyst_network/src/simulation/transport/laminar.rs
+++ b/amethyst_network/src/simulation/transport/laminar.rs
@@ -37,10 +37,10 @@ impl SystemBundle for LaminarNetworkBundle {
         resources.insert(LaminarSocketResource::new(self.socket.take()));
 
         builder
-            .add_system(Box::new(NetworkSimulationTimeSystem))
-            .add_system(Box::new(LaminarNetworkSendSystem))
-            .add_system(Box::new(LaminarNetworkPollSystem))
-            .add_system(Box::new(LaminarNetworkRecvSystem));
+            .add_system(NetworkSimulationTimeSystem)
+            .add_system(LaminarNetworkSendSystem)
+            .add_system(LaminarNetworkPollSystem)
+            .add_system(LaminarNetworkRecvSystem);
 
         Ok(())
     }

--- a/amethyst_network/src/simulation/transport/tcp.rs
+++ b/amethyst_network/src/simulation/transport/tcp.rs
@@ -51,11 +51,11 @@ impl SystemBundle for TcpNetworkBundle {
         // followed by TcpConnectionListenerSystem and TcpStreamManagementSystem
         // then TcpNetworkSendSystem and TcpNetworkRecvSystem
         builder
-            .add_system(Box::new(NetworkSimulationTimeSystem))
-            .add_system(Box::new(TcpConnectionListenerSystem))
-            .add_system(Box::new(TcpStreamManagementSystem))
-            .add_system(Box::new(TcpNetworkSendSystem))
-            .add_system(Box::new(TcpNetworkRecvSystem));
+            .add_system(NetworkSimulationTimeSystem)
+            .add_system(TcpConnectionListenerSystem)
+            .add_system(TcpStreamManagementSystem)
+            .add_system(TcpNetworkSendSystem)
+            .add_system(TcpNetworkRecvSystem);
 
         Ok(())
     }

--- a/amethyst_network/src/simulation/transport/udp.rs
+++ b/amethyst_network/src/simulation/transport/udp.rs
@@ -33,9 +33,9 @@ impl SystemBundle for UdpNetworkBundle {
         ));
 
         builder
-            .add_system(Box::new(NetworkSimulationTimeSystem))
-            .add_system(Box::new(UdpNetworkReceiveSystem))
-            .add_system(Box::new(UdpNetworkSendSystem));
+            .add_system(NetworkSimulationTimeSystem)
+            .add_system(UdpNetworkReceiveSystem)
+            .add_system(UdpNetworkSendSystem);
 
         Ok(())
     }

--- a/amethyst_rendy/src/plugins.rs
+++ b/amethyst_rendy/src/plugins.rs
@@ -205,7 +205,7 @@ impl<B: Backend, D: Base3DPassDef> RenderPlugin<B> for RenderBase3D<D> {
         builder: &mut DispatcherBuilder,
     ) -> Result<(), Error> {
         resources.insert(Visibility::default());
-        builder.add_system(Box::new(VisibilitySortingSystem::default()));
+        builder.add_system(VisibilitySortingSystem::default());
         Ok(())
     }
 
@@ -259,7 +259,7 @@ impl<B: Backend> RenderPlugin<B> for RenderFlat2D {
         builder: &mut DispatcherBuilder,
     ) -> Result<(), Error> {
         resources.insert(SpriteVisibility::default());
-        builder.add_system(Box::new(SpriteVisibilitySortingSystem));
+        builder.add_system(SpriteVisibilitySortingSystem);
         Ok(())
     }
 

--- a/amethyst_ui/src/bundle.rs
+++ b/amethyst_ui/src/bundle.rs
@@ -97,7 +97,9 @@ where
             .add_system(UiTransformSystem::new())
             .add_system(UiMouseSystem::new())
             .add_system(UiButtonSystem::new(ui_btn_reader))
-            .add_system(ui_button_action_retrigger_event_system(ui_btn_action_retrigger_reader))
+            .add_system(ui_button_action_retrigger_event_system(
+                ui_btn_action_retrigger_reader,
+            ))
             .add_system(CacheSelectionSystem::<G>::new())
             .add_system(TextEditingMouseSystem::new(text_editing_mouse_reader))
             .add_system(SelectionMouseSystem::<G>::new(selection_mouse_reader))
@@ -135,22 +137,18 @@ impl SystemBundle for AudioUiBundle {
         resources.insert(EventChannel::<UiPlaySoundAction>::new());
 
         builder
-            .add_system(
-                UiSoundSystem::new(
-                    resources
-                        .get_mut::<EventChannel<UiPlaySoundAction>>()
-                        .unwrap()
-                        .register_reader(),
-                ),
-            )
-            .add_system(
-                ui_sound_event_retrigger_system(
-                    resources
-                        .get_mut::<EventChannel<UiEvent>>()
-                        .unwrap()
-                        .register_reader(),
-                ),
-            );
+            .add_system(UiSoundSystem::new(
+                resources
+                    .get_mut::<EventChannel<UiPlaySoundAction>>()
+                    .unwrap()
+                    .register_reader(),
+            ))
+            .add_system(ui_sound_event_retrigger_system(
+                resources
+                    .get_mut::<EventChannel<UiEvent>>()
+                    .unwrap()
+                    .register_reader(),
+            ));
         Ok(())
     }
 

--- a/amethyst_ui/src/bundle.rs
+++ b/amethyst_ui/src/bundle.rs
@@ -56,9 +56,7 @@ where
         resources.insert(CachedSelectionOrderResource::default());
 
         resources.insert(ProcessingQueue::<GlyphTextureData>::default());
-        builder.add_system(Box::new(
-            GlyphTextureProcessorSystem::<DefaultBackend>::default(),
-        ));
+        builder.add_system(GlyphTextureProcessorSystem::<DefaultBackend>::default());
 
         log::debug!("Creating UI EventChannel Readers");
         let ui_btn_reader = resources
@@ -96,28 +94,18 @@ where
 
         log::debug!("Adding UI Systems to Dispatcher");
         builder
-            .add_system(Box::new(UiTransformSystem::new()))
-            .add_system(Box::new(UiMouseSystem::new()))
-            .add_system(Box::new(UiButtonSystem::new(ui_btn_reader)))
-            .add_system(Box::new(ui_button_action_retrigger_event_system(
-                ui_btn_action_retrigger_reader,
-            )))
-            .add_system(Box::new(CacheSelectionSystem::<G>::new()))
-            .add_system(Box::new(TextEditingMouseSystem::new(
-                text_editing_mouse_reader,
-            )))
-            .add_system(Box::new(SelectionMouseSystem::<G>::new(
-                selection_mouse_reader,
-            )))
-            .add_system(Box::new(SelectionKeyboardSystem::<G>::new(
-                selection_keyboard_reader,
-            )))
-            .add_system(Box::new(TextEditingInputSystem::new(
-                text_editing_input_reader,
-            )))
-            .add_system(Box::new(ResizeSystem::new()))
-            .add_system(Box::new(DragWidgetSystem::new(drag_widget_reader)))
-            .add_system(Box::new(BlinkSystem));
+            .add_system(UiTransformSystem::new())
+            .add_system(UiMouseSystem::new())
+            .add_system(UiButtonSystem::new(ui_btn_reader))
+            .add_system(ui_button_action_retrigger_event_system(ui_btn_action_retrigger_reader))
+            .add_system(CacheSelectionSystem::<G>::new())
+            .add_system(TextEditingMouseSystem::new(text_editing_mouse_reader))
+            .add_system(SelectionMouseSystem::<G>::new(selection_mouse_reader))
+            .add_system(SelectionKeyboardSystem::<G>::new(selection_keyboard_reader))
+            .add_system(TextEditingInputSystem::new(text_editing_input_reader))
+            .add_system(ResizeSystem::new())
+            .add_system(DragWidgetSystem::new(drag_widget_reader))
+            .add_system(BlinkSystem);
 
         Ok(())
     }
@@ -147,18 +135,22 @@ impl SystemBundle for AudioUiBundle {
         resources.insert(EventChannel::<UiPlaySoundAction>::new());
 
         builder
-            .add_system(Box::new(UiSoundSystem::new(
-                resources
-                    .get_mut::<EventChannel<UiPlaySoundAction>>()
-                    .unwrap()
-                    .register_reader(),
-            )))
-            .add_system(Box::new(ui_sound_event_retrigger_system(
-                resources
-                    .get_mut::<EventChannel<UiEvent>>()
-                    .unwrap()
-                    .register_reader(),
-            )));
+            .add_system(
+                UiSoundSystem::new(
+                    resources
+                        .get_mut::<EventChannel<UiPlaySoundAction>>()
+                        .unwrap()
+                        .register_reader(),
+                ),
+            )
+            .add_system(
+                ui_sound_event_retrigger_system(
+                    resources
+                        .get_mut::<EventChannel<UiEvent>>()
+                        .unwrap()
+                        .register_reader(),
+                ),
+            );
         Ok(())
     }
 

--- a/amethyst_ui/src/pass.rs
+++ b/amethyst_ui/src/pass.rs
@@ -67,7 +67,7 @@ impl<B: Backend> RenderPlugin<B> for RenderUi {
     ) -> Result<(), Error> {
         resources.insert(UiGlyphsResource::new(resources));
 
-        builder.add_system(Box::new(crate::glyphs::UiGlyphsSystem::<B>::default()));
+        builder.add_system(crate::glyphs::UiGlyphsSystem::<B>::default());
         Ok(())
     }
 

--- a/amethyst_utils/src/fps_counter.rs
+++ b/amethyst_utils/src/fps_counter.rs
@@ -115,7 +115,7 @@ impl SystemBundle for FpsCounterBundle {
         _resources: &mut Resources,
         builder: &mut DispatcherBuilder,
     ) -> Result<(), Error> {
-        builder.add_system(Box::new(FpsCounterSystem));
+        builder.add_system(FpsCounterSystem);
         Ok(())
     }
 }

--- a/amethyst_window/src/bundle.rs
+++ b/amethyst_window/src/bundle.rs
@@ -74,8 +74,8 @@ impl SystemBundle for WindowBundle {
         resources.insert(window);
 
         builder
-            .add_system(Box::new(WindowSystem))
-            .add_thread_local(Box::new(EventLoopSystem { event_loop }));
+            .add_system(WindowSystem)
+            .add_thread_local(EventLoopSystem { event_loop });
 
         Ok(())
     }

--- a/amethyst_window/src/config.rs
+++ b/amethyst_window/src/config.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-
 use serde::{Deserialize, Serialize};
 #[cfg(target_os = "windows")]
 use winit::platform::windows::{IconExtWindows, WindowBuilderExtWindows};

--- a/amethyst_window/src/config.rs
+++ b/amethyst_window/src/config.rs
@@ -1,11 +1,14 @@
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
-#[cfg(target_os = "windows")]
-use winit::platform::windows::{IconExtWindows, WindowBuilderExtWindows};
 use winit::{
     dpi::Size,
     window::{Fullscreen, Icon, WindowAttributes, WindowBuilder},
+};
+#[cfg(target_os = "windows")]
+use {
+    log::error,
+    winit::platform::windows::{IconExtWindows, WindowBuilderExtWindows},
 };
 
 use crate::monitor::{MonitorIdent, MonitorsAccess};

--- a/amethyst_window/src/config.rs
+++ b/amethyst_window/src/config.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use log::error;
+
 use serde::{Deserialize, Serialize};
 #[cfg(target_os = "windows")]
 use winit::platform::windows::{IconExtWindows, WindowBuilderExtWindows};

--- a/examples/auto_fov/main.rs
+++ b/examples/auto_fov/main.rs
@@ -60,8 +60,8 @@ fn main() -> Result<(), Error> {
     game_data
         .add_bundle(LoaderBundle)
         .add_bundle(TransformBundle)
-        .add_system(Box::new(AutoFovSystem))
-        .add_system(Box::new(ShowFovSystem))
+        .add_system(AutoFovSystem)
+        .add_system(ShowFovSystem)
         .add_bundle(InputBundle::new())
         .add_bundle(UiBundle::<u32>::new())
         .add_bundle(

--- a/examples/debug_lines/main.rs
+++ b/examples/debug_lines/main.rs
@@ -184,7 +184,7 @@ fn main() -> amethyst::Result<()> {
     game_data
         .add_bundle(LoaderBundle)
         .add_bundle(InputBundle::new().with_bindings_from_file(&key_bindings_path)?)
-        .add_system(Box::new(ExampleLinesSystem))
+        .add_system(ExampleLinesSystem)
         .add_bundle(
             FlyControlBundle::new(
                 Some("move_x".into()),

--- a/examples/debug_lines_ortho/main.rs
+++ b/examples/debug_lines_ortho/main.rs
@@ -108,7 +108,7 @@ fn main() -> amethyst::Result<()> {
 
     let mut game_data = DispatcherBuilder::default();
     game_data
-        .add_system(Box::new(ExampleLinesSystem))
+        .add_system(ExampleLinesSystem)
         .add_bundle(TransformBundle::default())
         .add_bundle(LoaderBundle)
         .add_bundle(

--- a/examples/events/main.rs
+++ b/examples/events/main.rs
@@ -26,8 +26,8 @@ impl<'a, 'b> SystemBundle for MyBundle {
         let reader = chan.register_reader();
         resources.insert(chan);
 
-        builder.add_system(Box::new(SpammingSystem));
-        builder.add_system(Box::new(SpamReceiverSystem { reader }));
+        builder.add_system(SpammingSystem);
+        builder.add_system(SpamReceiverSystem { reader });
         Ok(())
     }
 }

--- a/examples/events_custom_state_event/system.rs
+++ b/examples/events_custom_state_event/system.rs
@@ -19,7 +19,7 @@ impl<'a, 'b> SystemBundle for MyBundle {
         let chan = EventChannel::<GameEvent>::default();
         resources.insert(chan);
 
-        builder.add_system(Box::new(DifficultySystem));
+        builder.add_system(DifficultySystem);
         Ok(())
     }
 }

--- a/examples/mouse_raycast/main.rs
+++ b/examples/mouse_raycast/main.rs
@@ -302,7 +302,7 @@ fn main() -> amethyst::Result<()> {
                 .with_plugin(RenderUi::default())
                 .with_plugin(RenderFlat2D::default()),
         )
-        .add_system(Box::new(MouseRaycastSystem));
+        .add_system(MouseRaycastSystem);
 
     let game = Application::build(assets_dir, Example::default())?.build(game_data)?;
     game.run();

--- a/examples/net_client/main.rs
+++ b/examples/net_client/main.rs
@@ -54,7 +54,7 @@ impl SystemBundle for SpamBundle {
         resources.insert(TransportResource::default());
         resources.insert(NetworkSimulationTime::default());
 
-        builder.add_system(Box::new(SpamSystem { reader }));
+        builder.add_system(SpamSystem { reader });
 
         Ok(())
     }

--- a/examples/net_server/main.rs
+++ b/examples/net_server/main.rs
@@ -60,7 +60,7 @@ impl SystemBundle for SpamReceiveBundle {
         resources.insert(TransportResource::default());
         resources.insert(NetworkSimulationTime::default());
 
-        builder.add_system(Box::new(SpamReceiveSystem { reader }));
+        builder.add_system(SpamReceiveSystem { reader });
         Ok(())
     }
 }

--- a/examples/pong_tutorial_03/main.rs
+++ b/examples/pong_tutorial_03/main.rs
@@ -38,7 +38,7 @@ fn main() -> amethyst::Result<()> {
             InputBundle::new().with_bindings_from_file(app_root.join("config/bindings.ron"))?,
         )
         // We have now added our own system, the PaddleSystem, defined in systems/paddle.rs
-        .add_system(Box::new(PaddleSystem))
+        .add_system(PaddleSystem)
         .add_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 // The RenderToWindow plugin provides all the scaffolding for opening a window and

--- a/examples/pong_tutorial_04/main.rs
+++ b/examples/pong_tutorial_04/main.rs
@@ -39,9 +39,9 @@ fn main() -> amethyst::Result<()> {
             InputBundle::new().with_bindings_from_file(app_root.join("config/bindings.ron"))?,
         )
         // We have now added our own systems, defined in the systems module
-        .add_system(Box::new(PaddleSystem))
-        .add_system(Box::new(BallSystem))
-        .add_system(Box::new(BounceSystem))
+        .add_system(PaddleSystem)
+        .add_system(BallSystem)
+        .add_system(BounceSystem)
         .add_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 // The RenderToWindow plugin provides all the scaffolding for opening a window and

--- a/examples/pong_tutorial_05/main.rs
+++ b/examples/pong_tutorial_05/main.rs
@@ -44,10 +44,10 @@ fn main() -> amethyst::Result<()> {
             InputBundle::new().with_bindings_from_file(app_root.join("config/bindings.ron"))?,
         )
         // We have now added our own systems, defined in the systems module
-        .add_system(Box::new(PaddleSystem))
-        .add_system(Box::new(BallSystem))
-        .add_system(Box::new(BounceSystem))
-        .add_system(Box::new(WinnerSystem))
+        .add_system(PaddleSystem)
+        .add_system(BallSystem)
+        .add_system(BounceSystem)
+        .add_system(WinnerSystem)
         .add_bundle(UiBundle::<u32>::default())
         .add_bundle(
             RenderingBundle::<DefaultBackend>::new()

--- a/examples/pong_tutorial_06/bundle.rs
+++ b/examples/pong_tutorial_06/bundle.rs
@@ -20,11 +20,11 @@ impl SystemBundle for PongBundle {
         builder: &mut DispatcherBuilder,
     ) -> Result<(), Error> {
         builder
-            .add_system(Box::new(PaddleSystem))
-            .add_system(Box::new(BallSystem))
+            .add_system(PaddleSystem)
+            .add_system(BallSystem)
             .flush()
-            .add_system(Box::new(BounceSystem))
-            .add_system(Box::new(WinnerSystem));
+            .add_system(BounceSystem)
+            .add_system(WinnerSystem);
         Ok(())
     }
 }

--- a/examples/sprite_camera_follow/main.rs
+++ b/examples/sprite_camera_follow/main.rs
@@ -167,7 +167,7 @@ fn main() -> amethyst::Result<()> {
         .add_bundle(LoaderBundle)
         .add_bundle(TransformBundle)
         .add_bundle(InputBundle::new().with_bindings_from_file(app_root.join("config/input.ron"))?)
-        .add_system(Box::new(MovementSystem))
+        .add_system(MovementSystem)
         .add_bundle(
             RenderingBundle::<DefaultBackend>::new()
                 .with_plugin(

--- a/examples/tiles/main.rs
+++ b/examples/tiles/main.rs
@@ -158,10 +158,10 @@ fn main() -> amethyst::Result<()> {
     dispatcher
         .add_bundle(InputBundle::new().with_bindings_from_file("examples/tiles/config/input.ron")?);
 
-    dispatcher.add_system(Box::new(systems::MapMovementSystem::default()));
-    dispatcher.add_system(Box::new(systems::CameraSwitchSystem::default()));
-    dispatcher.add_system(Box::new(systems::CameraMovementSystem));
-    dispatcher.add_system(Box::new(systems::DrawSelectionSystem::default()));
+    dispatcher.add_system(systems::MapMovementSystem::default());
+    dispatcher.add_system(systems::CameraSwitchSystem::default());
+    dispatcher.add_system(systems::CameraMovementSystem);
+    dispatcher.add_system(systems::DrawSelectionSystem::default());
     dispatcher.add_bundle(
         RenderingBundle::<DefaultBackend>::new()
             .with_plugin(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
<!--- Separate Additions, Removals and Modifications -->
Remove boxes from the `system` argument in `DispatcherBuilder::add_system` and `DispatcherBuilder::add_system` and update all calls to these functions.

Also fix a bunch of clippy warnings.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It seems boxes here are redundant and everything works without them. This change also simplifies system addition to the `DispatcherBuilder` because users don't have to box systems.

Never mind if there were plans to do trait object stuff with systems (not legion ones, they are still boxed). Going to close this PR in this case.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
```
cargo test --workspace --all-features
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [ ] If my change required a change to the documentation I have updated the documentation accordingly.
- [ ] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [ ] My code is used in an example.
