### PR TITLE
fix: Add legion_prefab as dep for ui for macro

### DIFF
--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -44,6 +44,7 @@ lazy_static = "1.4"
 glyph_brush = "0.6"
 thread_profiler = { version = "0.3", optional = true }
 type-uuid = "0.1"
+legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
 
 [dev-dependencies]
 amethyst = { path = "../", version = "0.15.3", features = ["renderer"] }


### PR DESCRIPTION
## Description
Without Legion prefab, used macros doesn't seem to work in amethyst_UI. 

## Motivation and Context
I needed this to make work ui examples / build ui 


## How Has This Been Tested?
By successfully launching the ui_from_code example

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [X] My code follows the code style of this project.
- [] If my change required a change to the documentation I have updated the documentation accordingly.
- [ ] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [X] My code is used in an example.
