### PR TITLE
Remove unused import in config.rs

### DIFF
--- a/amethyst_window/src/config.rs
+++ b/amethyst_window/src/config.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use image::{self, DynamicImage};
 use serde::{Deserialize, Serialize};
 #[cfg(target_os = "windows")]
-use winit::platform::windows::{IconExtWindows, WindowBuilderExtWindows};
+use winit::platform::windows::WindowBuilderExtWindows;
 use winit::{
     dpi::Size,
     window::{Fullscreen, Icon, WindowAttributes, WindowBuilder},


### PR DESCRIPTION
## Description
This pull request removes unused `winit::platform::IconExtWindows` use in `amethyst_window/src/config.rs`

## Checklist:
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
