### PR TITLE
Send `ValueChange` UI event when text is deleted

### DIFF
--- a/amethyst_ui/src/text_editing.rs
+++ b/amethyst_ui/src/text_editing.rs
@@ -124,7 +124,7 @@ impl<'a> System<'a> for TextEditingInputSystem {
                             focused_edit.cursor_blink_timer = 0.0;
                         }
                         VirtualKeyCode::Back => {
-                            let updated = delete_highlighted(focused_edit, focused_text);
+                            let mut updated = delete_highlighted(focused_edit, focused_text);
                             if !updated && focused_edit.cursor_position > 0 {
                                 if let Some((byte, len)) = focused_text
                                     .text
@@ -143,7 +143,7 @@ impl<'a> System<'a> for TextEditingInputSystem {
                             }
                         }
                         VirtualKeyCode::Delete => {
-                            let updated = delete_highlighted(focused_edit, focused_text);
+                            let mut updated = delete_highlighted(focused_edit, focused_text);
                             if !updated {
                                 if let Some((start_byte, start_glyph_len)) = focused_text
                                     .text

--- a/amethyst_ui/src/text_editing.rs
+++ b/amethyst_ui/src/text_editing.rs
@@ -124,9 +124,8 @@ impl<'a> System<'a> for TextEditingInputSystem {
                             focused_edit.cursor_blink_timer = 0.0;
                         }
                         VirtualKeyCode::Back => {
-                            if !delete_highlighted(focused_edit, focused_text)
-                                && focused_edit.cursor_position > 0
-                            {
+                            let updated = delete_highlighted(focused_edit, focused_text);
+                            if !updated && focused_edit.cursor_position > 0 {
                                 if let Some((byte, len)) = focused_text
                                     .text
                                     .grapheme_indices(true)
@@ -135,11 +134,17 @@ impl<'a> System<'a> for TextEditingInputSystem {
                                 {
                                     focused_text.text.drain(byte..(byte + len));
                                     focused_edit.cursor_position -= 1;
+                                    updated = true;
                                 }
+                            }
+                            if updated {
+                                edit_events
+                                    .single_write(UiEvent::new(UiEventType::ValueChange, entity));
                             }
                         }
                         VirtualKeyCode::Delete => {
-                            if !delete_highlighted(focused_edit, focused_text) {
+                            let updated = delete_highlighted(focused_edit, focused_text);
+                            if !updated {
                                 if let Some((start_byte, start_glyph_len)) = focused_text
                                     .text
                                     .grapheme_indices(true)
@@ -150,7 +155,12 @@ impl<'a> System<'a> for TextEditingInputSystem {
                                     focused_text
                                         .text
                                         .drain(start_byte..(start_byte + start_glyph_len));
+                                    updated = true;
                                 }
+                            }
+                            if updated {
+                                edit_events
+                                    .single_write(UiEvent::new(UiEventType::ValueChange, entity));
                             }
                         }
                         VirtualKeyCode::Left => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
<!--- Separate Additions, Removals and Modifications -->
This PR adds functionality for firing UI events with the type `ValueChange` whenever text is modified by deletion of pressing keys Back or Delete.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I found that the editable text lacks this functionality, since deletion of text should also be considered a change in value.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I have tested the event firing against a private project, to see that the event is fired when text is deleted. I am not sure if there is more extensible testing needed in this regard, since I couldn't find any prior tests for this kind of functionality.


## Screenshots (if appropriate):
N/A


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [x] If my change required a change to the documentation I have updated the documentation accordingly.
- [x] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [ ] My code is used in an example.
