### PR TITLE
Fix "panic message is not a string literal"

### DIFF
--- a/amethyst_core/src/transform/transform_system.rs
+++ b/amethyst_core/src/transform/transform_system.rs
@@ -33,10 +33,8 @@ impl System for TransformSystem {
                             transform.global_matrix = transform.matrix();
                             debug_assert!(
                                 transform.is_finite(),
-                                format!(
-                                    "Entity {:?} had a non-finite `Transform` {:?}",
-                                    entity, transform
-                                )
+                                "Entity {:?} had a non-finite `Transform` {:?}",
+                                entity, transform
                             );
                         }
 
@@ -75,10 +73,8 @@ impl System for TransformSystem {
                             transform.global_matrix = transform.parent_matrix * transform.matrix();
                             debug_assert!(
                                 transform.is_finite(),
-                                format!(
-                                    "Entity {:?} had a non-finite `Transform` {:?}",
-                                    entity, transform
-                                )
+                                "Entity {:?} had a non-finite `Transform` {:?}",
+                                entity, transform
                             );
                         }
                     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
cargo build was warning "this is no longer accepted in Rust 2021" on the format! used within the debug_assert!

<!--- Separate Additions, Removals and Modifications -->
modified lines to use a format string and arguments,without needing to use format!


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
this very minor pull request prevents 2 warnings on build. it was the most obvious way that I could try and be involved.
<!--- If it fixes an open issue, please link to the issue here. -->



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
cargo build before the change output 2 warnings
cargo build after the change does not output any warnings.



## Screenshots (if appropriate):



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [ ] If my change required a change to the documentation I have updated the documentation accordingly.
- [ ] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [ ] My code is used in an example.
