### PR TITLE
Implement "spin-sleep" strategy for the frame rate limiter sleep

### DIFF
--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -36,6 +36,7 @@ rayon = "1.5"
 shrev = "1.1.1"
 simba = { version = "0.3" }
 smallvec = "1.4"
+spin_sleep = "1.0.0"
 thread_profiler = { version = "0.3", optional = true }
 serde-diff = "0.4"
 


### PR DESCRIPTION
## Description

Replace the thread::sleep() invocation with the `spin-sleep` crate API, which, on Windows, yields very good accuracy at virtually no cost.

This is though, a complex subject, so, for more information, see the references added to the documentation.

Adds the [`spin-sleep`](https://github.com/alexheretic/spin-sleep) dependency.

## Motivation and Context

The current frame limiter sleep strategy is inaccurate, while the yield one is excessively resource-intensive.

Closes #2083.

## How Has This Been Tested?

Tested by running the `fly_camera` example, although, for the experimental data, the new strategy has been tested on multiple O/Ss and projects. See the referenced issue.

## Checklist:

- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project. Hopefully!
- [x] ~If my change required a change to the documentation I have updated the documentation accordingly.~ Doesn't apply
- [x] ~I have updated the content of the book if this PR would make the book outdated.~ Doesn't apply.
- [ ] I have added tests to cover my changes. **This point requires review** - I'm not aware of any realistic test strategy that can distinguish the change from the original strategy; also note that the frame limiter does not have a test suite.
- [x] ~My code is used in an example.~ Doesn't apply.

## Further considerations

I've done the change at the best of my capacity, however, this area as a whole should be at the very least tested on other machines, in order to be considered solid (IMO).  
In particular, I've tested multiple projects on Linux, and the performance on such O/S was terrible. With my setup only, I can't prove whether Amethyst just performs poorly on Linux, or if it's a problem with my setup.  
Additionally, the setup I've used for experimentation may not be representative of the typical one (see referenced issue).

Having said that, the PR has been very carefully researched an thought out. I only think that this area (the frame limiter) should receive attention to be very solid.

In particular, the new strategy makes the Yield and SleepYield strategy likely obsolete (but again, I can't prove this using my setup only).

Coffee for the masses! S.