### PR TITLE
Fixed missed line in Book, beginner pong example forgot to include a 'pub use'

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-04.md
+++ b/book/src/pong-tutorial/pong-tutorial-04.md
@@ -266,8 +266,18 @@ The following image illustrates how collisions with paddles are checked.
 
 ![Collision explanotary drawing](../images/pong_tutorial/pong_paddle_collision.png)
 
-Also, don't forget to add `mod move_balls` and `mod bounce` in `systems/mod.rs`
-as well as adding our new systems to the game data:
+We will need to add `mod move_balls` and `mod bounce` as well as `MoveBallsSystem` and
+`BounceSystem` to our `systems/mod.rs`:
+```rust
+pub use self::paddle::PaddleSystem;
+pub use self::move_balls::MoveBallsSystem;
+pub use self::bounce::BounceSystem;
+
+mod move_balls;
+mod bounce;
+mod paddle;
+```
+Also, don't forget to add our new systems to the game data:
 
 ```rust
 # use amethyst::core::transform::TransformBundle;

--- a/book/src/pong-tutorial/pong-tutorial-04.md
+++ b/book/src/pong-tutorial/pong-tutorial-04.md
@@ -277,8 +277,8 @@ mod move_balls;
 mod bounce;
 mod paddle;
 ```
-Also, don't forget to add our new systems to the game data:
 
+Also, don't forget to add our new systems to the game data:
 ```rust
 # use amethyst::core::transform::TransformBundle;
 # use amethyst::input::StringBindings;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

In the "pong tutorial" section of the Amethyst Book, there is a part where two systems are added to project, but the book forgets to mention to expose these systems with a `pub use` inside the mod.rs

<!--- Describe your changes in detail -->

I expanded on the section that says to include `mod move_balls` and `mod bounce` and included the use statements of the two systems.  I expanded it to be a code snippet in an effort to make it readable, now that it includes adding several things.  

<!--- Separate Additions, Removals and Modifications -->

Removing two lines that stated to add the mod statements.

Added a similar line but including a code snippet of the new mod.rs file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Fixing small documentation inconsistencies.  If these lines I added to the book are not 
added to the pong project, the code won't compile.


<!--- If it fixes an open issue, please link to the issue here. -->



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

I have tested the code that the book now recommends, it runs the pong game as it should to that point.
(cargo run)


## Screenshots (if appropriate):



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x ] My code follows the code style of this project.
- [ ] If my change required a change to the documentation I have updated the documentation accordingly.
- [ ] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [ ] My code is used in an example.
