### PR TITLE
Add missing extern crate statements to book.

### DIFF
--- a/amethyst_core/src/named.rs
+++ b/amethyst_core/src/named.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 /// can generally treat the `name` field as a [`&str`][str] without needing to know whether the
 /// name is actually an owned or borrowed string.
 ///
-/// [`Entity`]: https://docs.rs/specs/*/specs/struct.Entity.html
+/// `Entity`
 /// [`Cow<'static, str>`]: https://doc.rust-lang.org/std/borrow/enum.Cow.html
 /// [`String`]: https://doc.rust-lang.org/std/string/struct.String.html
 /// [str]: https://doc.rust-lang.org/std/primitive.str.html

--- a/book/book.toml
+++ b/book/book.toml
@@ -2,6 +2,9 @@
 title = "Amethyst Documentation"
 author = "Eyal Kalderon, Jojolepro (Joël Lupien), Moxinilian (Théo Degioanni), Kylejlin (Kyle Lin)"
 
+[rust]
+edition = "2018"
+
 [output.html]
 default-theme = "light"
 preferred-dark-theme = "coal"

--- a/book/src/appendices/a_config_files.md
+++ b/book/src/appendices/a_config_files.md
@@ -31,6 +31,7 @@ file. To start, let's create a new file, `config.rs`, to hold our configuration 
 `use` statements to the top of this file:
 
 ```rust
+# extern crate amethyst;
 use std::path::Path;
 
 use amethyst::config::Config;

--- a/book/src/appendices/a_config_files/arena_config.md
+++ b/book/src/appendices/a_config_files/arena_config.md
@@ -3,6 +3,8 @@
 To begin with, let's make the `Arena` dimensions configurable. Add this structure to a new file `config.rs`.
 
 ```rust
+# extern crate amethyst;
+# extern crate serde;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -34,6 +36,8 @@ be present. For now though, let's use the `Default` trait.
 We'll need to load the config at startup, so let's add this to the `main` function in `main.rs`
 
 ```rust
+# extern crate amethyst;
+# extern crate serde;
 # mod config {
 #   use serde::{Deserialize, Serialize};
 # 
@@ -64,6 +68,8 @@ Now that we have loaded our config, we want to add it to the world so other modu
 it. We do this by adding the config as a resource during `Application` creation:
 
 ```rust
+# extern crate amethyst;
+# extern crate serde;
 use amethyst::{
     assets::LoaderBundle,
     config::Config,
@@ -111,6 +117,8 @@ First, let's change our initialization steps in `pong.rs`.
 Add the following line to the top of `pong.rs`:
 
 ```rust ,ignore
+# extern crate amethyst;
+# extern crate serde;
 use crate::config::ArenaConfig;
 ```
 
@@ -118,6 +126,8 @@ Now, in the `initialize_paddles()` function, add the following lines after the i
 `left_transform` and `right_transform`.
 
 ```rust
+# extern crate amethyst;
+# extern crate serde;
 # mod config {
 #   use serde::{Deserialize, Serialize};
 # 
@@ -161,6 +171,8 @@ It is actually simpler to access a Config file from a system than via the `Resou
 it in the `System`'s closure, add `.read_resource::<ArenaConfig>()` to the `SystemBuilder`.
 
 ```rust
+# extern crate amethyst;
+# extern crate serde;
 # mod config {
 #   use serde::{Deserialize, Serialize};
 # 

--- a/book/src/appendices/a_config_files/ball_config.md
+++ b/book/src/appendices/a_config_files/ball_config.md
@@ -7,6 +7,8 @@ separately.
 To prepare for our `BallConfig`, add the following line to the top of `config.rs`:
 
 ```rust
+# extern crate amethyst;
+# extern crate serde;
 use amethyst::core::math::Vector2;
 ```
 
@@ -17,6 +19,8 @@ handle arrays as tuples, so it will read in a tuple and convert the color values
 particular function (e.g., in `pong.rs`).
 
 ```rust
+# extern crate amethyst;
+# extern crate serde;
 use amethyst::core::math::Vector2;
 use serde::{Deserialize, Serialize};
 
@@ -31,6 +35,8 @@ pub struct BallConfig {
 We'll also add the `Default` trait to this config that will match what the full example uses.
 
 ```rust
+# extern crate amethyst;
+# extern crate serde;
 # use amethyst::core::math::Vector2;
 # use serde::{Deserialize, Serialize};
 # 
@@ -56,6 +62,8 @@ Still in `config.rs`, add the following structure definition at the bottom. This
 backed by the whole `config.ron` file.
 
 ```rust
+# extern crate amethyst;
+# extern crate serde;
 # use amethyst::core::math::Vector2;
 # use serde::{Deserialize, Serialize};
 # 
@@ -108,6 +116,8 @@ the `ArenaConfig`.
 In `pong.rs`, underneath our loading of the `ArenaConfig`, add the following lines
 
 ```rust
+# extern crate amethyst;
+# extern crate serde;
 # use amethyst::core::math::Vector2;
 # use amethyst::ecs::Resources;
 # use serde::{Deserialize, Serialize};
@@ -161,18 +171,24 @@ add each resource separately so systems can use only what they want.
 First, we need to change what `main.rs` is using. Change
 
 ```rust ,ignore
+# extern crate amethyst;
+# extern crate serde;
 use crate::config::ArenaConfig;
 ```
 
 to
 
 ```rust ,ignore
+# extern crate amethyst;
+# extern crate serde;
 use crate::config::PongConfig;
 ```
 
 Now, modify the `main` function, from
 
 ```rust
+# extern crate amethyst;
+# extern crate serde;
 # use amethyst::{
 #   assets::LoaderBundle,
 #   config::Config,
@@ -217,6 +233,8 @@ Now, modify the `main` function, from
 to
 
 ```rust
+# extern crate amethyst;
+# extern crate serde;
 # use amethyst::{
 #   assets::LoaderBundle,
 #   config::Config,

--- a/book/src/appendices/a_config_files/paddle_configs.md
+++ b/book/src/appendices/a_config_files/paddle_configs.md
@@ -4,6 +4,7 @@ Finally, we're going to add a configuration struct for our Paddles. Because our 
 players, we should let them configure each separately. Add the following to the `config.rs` file:
 
 ```rust
+# extern crate serde;
 # use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -31,6 +32,7 @@ Just like the `BallConfig`, we need to read in the color as a tuple instead of a
 Now, to allow us to have two separate `PaddleConfig`s, we will wrap them in a bigger structure as follows:
 
 ```rust
+# extern crate serde;
 # use serde::{Deserialize, Serialize};
 # 
 # #[derive(Debug, Deserialize, Serialize)]
@@ -62,6 +64,8 @@ pub struct PaddlesConfig {
 Now we need to add the `PaddlesConfig` to our `PongConfig` as shown below
 
 ```rust
+# extern crate amethyst;
+# extern crate serde;
 # use amethyst::core::math::Vector2;
 # use serde::{Deserialize, Serialize};
 # 
@@ -134,6 +138,8 @@ pub struct PongConfig {
 and modify the `main.rs`'s `run()` function to add our `PaddleConfig`s.
 
 ```rust
+# extern crate amethyst;
+# extern crate serde;
 # use amethyst::{
 #   assets::LoaderBundle,
 #   config::Config,
@@ -236,6 +242,8 @@ unwrapping them in one big assignment statement.
 In `initialize_paddles()` in `pong.rs`, add this code below reading the `ArenaConfig`.
 
 ```rust
+# extern crate amethyst;
+# extern crate serde;
 # use amethyst::ecs::Resources;
 # use serde::{Deserialize, Serialize};
 # 

--- a/book/src/assets/how_to_define_custom_assets.md
+++ b/book/src/assets/how_to_define_custom_assets.md
@@ -20,6 +20,8 @@ This guide explains how to define a new asset type to use in an Amethyst applica
    - The asset type itself, in which case you derive `Serialize`, `Deserialize` and `TypeUuid` on the type:
 
      ```rust
+     # extern crate type_uuid;
+     # extern crate serde;
      use serde::{Deserialize, Serialize};
      use type_uuid::TypeUuid;
 
@@ -34,6 +36,7 @@ This guide explains how to define a new asset type to use in an Amethyst applica
    - An enum with different variants – each for a different data layout:
 
      ```rust
+     # extern crate serde;
      # use serde::{Deserialize, Serialize};
 
      /// Separate serializable type to support different versions
@@ -50,6 +53,8 @@ This guide explains how to define a new asset type to use in an Amethyst applica
 1. Implement the [`Asset`][doc_asset] trait on the asset type.
 
    ```rust
+   # extern crate amethyst;
+   # extern crate serde;
    # use amethyst::assets::{Asset, Handle};
    # use serde::{Deserialize, Serialize};
    # use type_uuid::TypeUuid;
@@ -86,6 +91,9 @@ This guide explains how to define a new asset type to use in an Amethyst applica
    The [`AssetProcessorSystem<A>` system][doc_processor_system] uses this trait to convert the deserialized asset data into the asset.
 
    ```rust
+   # extern crate amethyst;
+   # extern crate serde;
+   # extern crate type_uuid;
    # use amethyst::assets::{Asset, Handle};
    # use serde::{Deserialize, Serialize};
    # use type_uuid::TypeUuid;
@@ -145,6 +153,9 @@ This guide explains how to define a new asset type to use in an Amethyst applica
    If your asset is stored using one of the existing supported formats such as RON or JSON, it can now be used:
 
    ```rust
+   # extern crate amethyst;
+   # extern crate serde;
+   # extern crate type_uuid;
    # use amethyst::assets::{Asset, Handle};
    # use serde::{Deserialize, Serialize};
    # use type_uuid::TypeUuid;

--- a/book/src/assets/how_to_define_custom_formats.md
+++ b/book/src/assets/how_to_define_custom_formats.md
@@ -15,6 +15,8 @@ If you are defining a new format that may be useful to others, [please send us a
    derive `Serialize`, `Deserialize` and `TypeUuid` for use in prefabs.
 
    ```rust
+   # extern crate type_uuid;
+   # extern crate serde;
    use serde::{Deserialize, Serialize};
    use type_uuid::TypeUuid;
 
@@ -33,6 +35,9 @@ If you are defining a new format that may be useful to others, [please send us a
    In this example the RON deserializer is used, though it is [already a supported format][doc_ron_format].
 
    ```rust
+   # extern crate amethyst;
+   # extern crate serde;
+   # extern crate type_uuid;
    # use amethyst::assets::{Asset, Handle};
    # use serde::{Deserialize, Serialize};
    # use type_uuid::TypeUuid;
@@ -118,6 +123,10 @@ If you are defining a new format that may be useful to others, [please send us a
    The custom format can now be used:
 
    ```rust
+   # extern crate amethyst;
+   # extern crate serde;
+   # extern crate type_uuid;
+   # extern crate ron;
    # use amethyst::assets::{Asset, AssetStorage, Format, Handle, ProcessingState, ProgressCounter};
    # use ron::de::Deserializer;
    # use serde::{Deserialize, Serialize};

--- a/book/src/assets/how_to_use_assets.md
+++ b/book/src/assets/how_to_use_assets.md
@@ -13,6 +13,7 @@ This guide covers the basic usage of assets into Amethyst for existing supported
 1. Instantiate the Amethyst application with the assets directory.
 
    ```rust
+   # extern crate amethyst;
    use amethyst::prelude::*;
    use amethyst::utils::application_root_dir;
 
@@ -44,6 +45,7 @@ This guide covers the basic usage of assets into Amethyst for existing supported
 1. Use the [`Loader`][doc_loader] resource to load the asset.
 
    ```rust
+   # extern crate amethyst;
    # use amethyst::prelude::*;
    # use amethyst::utils::application_root_dir;
    # use amethyst::{
@@ -87,6 +89,7 @@ This guide covers the basic usage of assets into Amethyst for existing supported
    When [`loader.load(..)`][doc_load] is used to load an [`Asset`][doc_asset], the method returns immediately with a handle for the asset. The asset loading is handled asynchronously in the background, so if the handle is used to retrieve the asset, such as with [`resources.get::<AssetStorage<Texture>>()`][doc_read_resource][`.get(texture_handle)`][doc_asset_get], it will return `None` until the `Texture` has finished loading.
 
    ```rust
+   # extern crate amethyst;
    # use amethyst::prelude::*;
    # use amethyst::utils::application_root_dir;
    # use amethyst::{
@@ -150,6 +153,7 @@ This guide covers the basic usage of assets into Amethyst for existing supported
    The asset handle can now be used:
 
    ```rust
+   # extern crate amethyst;
    # use amethyst::prelude::*;
    # use amethyst::utils::application_root_dir;
    # use amethyst::{

--- a/book/src/concepts/entity_and_component.md
+++ b/book/src/concepts/entity_and_component.md
@@ -38,6 +38,7 @@ Querying is covered in the systems chapter.
 To declare a component, you declare the relevant underlying data.  Legion ECS will create archetypes that correspond to the different combinations of this data.:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{
 #   core::{
 #       math::{Isometry3, Vector3},

--- a/book/src/concepts/event-channel.md
+++ b/book/src/concepts/event-channel.md
@@ -11,6 +11,7 @@ Typically, `EventChannel`s are inserted as resources in the `World`.
 ### Creating an event channel
 
 ```rust
+# extern crate amethyst;
 # use amethyst::shrev::EventChannel;
 // In the following examples, `MyEvent` is the event type of the channel.
 #[derive(Debug)]
@@ -27,6 +28,7 @@ let mut channel = EventChannel::<MyEvent>::new();
 Single:
 
 ```rust
+# extern crate amethyst;
 # #[derive(Debug)]
 # pub enum MyEvent {
 #   A,
@@ -42,6 +44,7 @@ Single:
 Multiple:
 
 ```rust
+# extern crate amethyst;
 # #[derive(Debug)]
 # pub enum MyEvent {
 #   A,
@@ -61,6 +64,7 @@ Multiple:
 To subscribe to events, register a reader against the `EventChannel` to receive a `ReaderId`:
 
 ```rust
+# extern crate amethyst;
 # #[derive(Debug)]
 # pub enum MyEvent {
 #   A,
@@ -76,6 +80,7 @@ To subscribe to events, register a reader against the `EventChannel` to receive 
 When reading events, pass the `ReaderId` in:
 
 ```rust
+# extern crate amethyst;
 # #[derive(Debug)]
 # pub enum MyEvent {
 #   A,
@@ -108,6 +113,7 @@ It goes as follow:
 In the **producer** `System`, get a mutable reference to your resource:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::shrev::EventChannel;
 # 
 # #[derive(Debug)]
@@ -127,6 +133,7 @@ In the **producer** `System`, get a mutable reference to your resource:
 In the **receiver** `System`s, you need to store the `ReaderId` somewhere.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::shrev::ReaderId;
 # 
 # #[derive(Debug)]
@@ -144,6 +151,7 @@ struct ReceiverSystem {
 and you also need to get read access:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{shrev::EventChannel};
 # 
 # #[derive(Debug)]
@@ -163,6 +171,7 @@ and you also need to get read access:
 Then, in the `System`'s `new` method:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{
 #   ecs::{System, World},
 #   shrev::{EventChannel, ReaderId},
@@ -194,6 +203,7 @@ impl MySystem {
 Finally, you can read events from your `System`.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{shrev::EventChannel};
 # 
 # #[derive(Debug)]

--- a/book/src/concepts/resource.md
+++ b/book/src/concepts/resource.md
@@ -12,6 +12,7 @@ Resources are stored in the `Resources` container.
 Adding a resource to a `Resources` instance is done like this:
 
 ```rust
+# extern crate amethyst;
 use amethyst::ecs::Resources;
 
 struct MyResource {
@@ -32,6 +33,7 @@ fn main() {
 Fetching a resource can be done like this:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::Resources;
 # #[derive(Debug, PartialEq)]
 # struct MyResource {
@@ -54,6 +56,7 @@ Fetching a resource can be done like this:
 If you want to get a resource and create it if it doesn't exist:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::Resources;
 # struct MyResource;
 # fn main() {
@@ -69,6 +72,7 @@ If you want to get a resource and create it if it doesn't exist:
 If you want to change a resource that is already inside of `Resources`:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::Resources;
 # struct MyResource {
 #   pub game_score: i32,
@@ -94,6 +98,7 @@ Other ways of fetching a resource will be covered in the system section of the b
 ## Deleting a resource
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::Resources;
 # struct MyResource {
 #   pub game_score: i32,

--- a/book/src/concepts/state.md
+++ b/book/src/concepts/state.md
@@ -97,6 +97,7 @@ For more advanced examples, see the following pong tutorial.
 ### Creating a State
 
 ```rust
+# extern crate amethyst;
 use amethyst::prelude::*;
 
 struct GameplayState {
@@ -137,6 +138,7 @@ Those are:
 Let's use `handle_event` to go to the `PausedState` and come back by pressing the "Escape" key.
 
 ```rust
+# extern crate amethyst;
 use amethyst::{
     input::{is_key_down, VirtualKeyCode},
     prelude::*,
@@ -187,6 +189,7 @@ Well, it is simply an enum. It regroups multiple types of events that are emitte
 To change the set of events that the state receives, you create a new event enum and derive `EventReader` for that type.
 
 ```rust
+# extern crate amethyst;
 // These imports are required for the #[derive(EventReader)] code to build
 use amethyst::{
     core::{

--- a/book/src/concepts/system.md
+++ b/book/src/concepts/system.md
@@ -13,6 +13,7 @@ A system struct is a structure implementing the trait `amethyst::ecs::System`.
 Here is a simple example implementation:
 
 ```rust
+# extern crate amethyst;
 use amethyst::ecs::{ParallelRunnable, System};
 
 struct MyFirstSystem;
@@ -31,6 +32,7 @@ This system will, on every iteration of the game loop, print "Hello!" in the con
 Using `SystemBuilder` requires you to specify the resource and component access requirements of the system using `read_resource`, `write_resource`, `read_component` and `write_component` (you can also use `with_query` but we'll get to that later.)  Refer to the [Legion SystemBuilder docs][sb] for more information.  A system may also have local data stored in its own struct.
 
 ```rust
+# extern crate amethyst;
 use amethyst::core::timing::Time;
 use amethyst::ecs::{ParallelRunnable, System};
 
@@ -60,6 +62,7 @@ Once you have access to a storage, you can use them in different ways.
 Sometimes, it can be useful to get a component in the storage for a specific entity. This can easily be done using the `get` or, for mutable storages, `get_mut` methods.
 
 ```rust
+# extern crate amethyst;
 use amethyst::core::Transform;
 use amethyst::ecs::{Entity, System};
 

--- a/book/src/concepts/system/implementing_the_system_desc_trait.md
+++ b/book/src/concepts/system/implementing_the_system_desc_trait.md
@@ -5,6 +5,7 @@ implementation for system initialization, the `SystemDesc` trait can be
 implemented manually:
 
 ```rust
+# extern crate amethyst;
 use amethyst::{
     audio::output::Output,
     ecs::{System, World},
@@ -40,6 +41,7 @@ impl SystemDesc<'a, 'b, AudioSystem> for AudioSystemDesc {
 ## Templates
 
 ```rust
+# extern crate amethyst;
 /// Builds a `SystemName`.
 #[derive(Default, Debug)]
 pub struct SystemNameDesc;
@@ -56,6 +58,8 @@ impl SystemDesc<'a, 'b, SystemName> for SystemNameDesc {
 With type parameters:
 
 ```rust
+# extern crate amethyst;
+# extern crate derivative;
 use std::marker::PhantomData;
 
 use derivative::Derivative;

--- a/book/src/concepts/system/system_desc_derive.md
+++ b/book/src/concepts/system/system_desc_derive.md
@@ -14,6 +14,7 @@ If your system initialization use case is not covered, please see the
 ## Passing parameters to system constructor
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::System;
 pub struct SystemName {
     field_0: u32,
@@ -31,6 +32,7 @@ impl SystemName {
 <summary>Generated code</summary>
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::System;
 # 
 # pub struct SystemName {
@@ -69,6 +71,7 @@ impl<'a, 'b> ::amethyst::core::SystemDesc<'a, 'b, SystemName> for SystemNameDesc
 ## Fields to skip -- defaulted by the system constructor
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::System;
 # 
 pub struct SystemName {
@@ -91,6 +94,7 @@ impl SystemName {
 <summary>Generated code</summary>
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::System;
 # 
 # pub struct SystemName {
@@ -134,6 +138,7 @@ impl<'a, 'b> ::amethyst::core::SystemDesc<'a, 'b, SystemName> for SystemNameDesc
 will call  `SystemName::default()`:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::System;
 # 
 #[derive(Default)]
@@ -147,6 +152,7 @@ pub struct SystemName {
 <summary>Generated code</summary>
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::System;
 # 
 # #[derive(Default)]
@@ -178,6 +184,7 @@ impl<'a, 'b> ::amethyst::core::SystemDesc<'a, 'b, SystemName> for SystemNameDesc
 ## Registering a `ReaderId` for an `EventChannel<_>` in the `World`
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{
 #   ecs::System,
 #   shrev::{EventChannel, ReaderId},
@@ -200,6 +207,7 @@ impl SystemName {
 <summary>Generated code</summary>
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{
 #   ecs::System,
 #   shrev::{EventChannel, ReaderId},
@@ -242,6 +250,7 @@ impl<'a, 'b> ::amethyst::core::SystemDesc<'a, 'b, SystemName> for SystemNameDesc
 ## Registering a `ReaderId` to a component's `FlaggedStorage`
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{
 #   ecs::System,
 #   shrev::{EventChannel, ReaderId},
@@ -264,6 +273,7 @@ impl SystemName {
 <summary>Generated code</summary>
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{
 #   ecs::System,
 #   shrev::{EventChannel, ReaderId},
@@ -306,6 +316,7 @@ impl<'a, 'b> ::amethyst::core::SystemDesc<'a, 'b, SystemName> for SystemNameDesc
 ## Inserting a resource into the `World`
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::System;
 # 
 pub struct NonDefault;
@@ -322,6 +333,7 @@ impl System for SystemName {
 <summary>Generated code</summary>
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::System;
 # 
 # pub struct NonDefault;

--- a/book/src/concepts/system/system_initialization.md
+++ b/book/src/concepts/system/system_initialization.md
@@ -20,6 +20,7 @@ initialization logic, the `SystemDesc` derive automatically implements the
 `SystemDesc` trait on the system type itself:
 
 ```rust
+# extern crate amethyst;
 use amethyst::ecs::{System, World};
 
 struct SystemName;

--- a/book/src/concepts/world.md
+++ b/book/src/concepts/world.md
@@ -9,6 +9,7 @@ are singletons available across all systems.  See [Resources][res] for more abou
 ## Creating entities
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::{World};
 
 #[derive(Default)]
@@ -25,6 +26,7 @@ struct MyComponent {
 ## Accessing a `Component`
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::{World};
 # #[derive(Default)]
 # struct MyComponent {
@@ -47,6 +49,7 @@ struct MyComponent {
 This is almost the same as accessing a component:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::{ World};
 # #[derive(Default)]
 # struct MyComponent {
@@ -67,6 +70,7 @@ This is almost the same as accessing a component:
 Single:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::World;
 # fn main() {
     let mut world = World::default();
@@ -78,6 +82,7 @@ Single:
 All:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::World;
 # fn main() {
 #   let mut world = World::default();
@@ -90,6 +95,7 @@ __Note: Entities are lazily deleted, which means that deletion only happens at t
 ## Check if the entity was deleted
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::World;
 # fn main() {
 #   let mut world = World::default();

--- a/book/src/controlling_system_execution/custom_game_data.md
+++ b/book/src/controlling_system_execution/custom_game_data.md
@@ -16,6 +16,7 @@ are essential (like rendering, input and UI).
 Let's start by creating the `GameData` structure:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::Dispatcher;
 # 
 pub struct CustomGameData<'a, 'b> {
@@ -27,6 +28,7 @@ pub struct CustomGameData<'a, 'b> {
 We also add a utility function for performing dispatch:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::{Dispatcher, World};
 # 
 # pub struct CustomGameData<'a, 'b> {
@@ -55,6 +57,7 @@ a builder that implements `DataInit`, as well as implement `DataDispose` for our
 `GameData` structure.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::core::SystemBundle;
 # use amethyst::ecs::{Dispatcher, DispatcherBuilder, System, World};
 # use amethyst::{DataDispose, DataInit, Error};
@@ -139,6 +142,7 @@ We can now use `CustomGameData` in place of the provided `GameData` when buildin
 our `Application`, but first we should create some `State`s.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::{Dispatcher, World};
 # use amethyst::input::{is_close_requested, is_key_down, VirtualKeyCode};
 # use amethyst::prelude::*;
@@ -239,6 +243,7 @@ The only thing that remains now is to use our `CustomDispatcherBuilder` when bui
 `Application`.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{
 #   core::{transform::TransformBundle, SystemBundle},
 #   ecs::{Dispatcher, DispatcherBuilder, World},

--- a/book/src/controlling_system_execution/pausable_systems.md
+++ b/book/src/controlling_system_execution/pausable_systems.md
@@ -23,6 +23,7 @@ impl Default for CurrentState {
 We'll use this `enum` `Resource` to control whether or not our `System` is running. Next we'll register our `System` and set it as pausable.
 
 ```rust
+# extern crate amethyst;
 #
 # use amethyst::{
 #     ecs::*,
@@ -60,6 +61,7 @@ dispatcher.add(
 To register the `Resource` or change its value, we can use the following code:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::prelude::*;
 # #[derive(PartialEq)]
 # pub enum CurrentState {

--- a/book/src/controlling_system_execution/state-specific_dispatcher.md
+++ b/book/src/controlling_system_execution/state-specific_dispatcher.md
@@ -5,6 +5,7 @@ This guide explains how to define a state-specific `Dispatcher` whose `System`s 
 First of all we required a `DispatcherBuilder`. The `DispatcherBuilder` handles the actual creation of the `Dispatcher` and the assignment of `System`s to our `Dispatcher`.
 
 ```rust
+# extern crate amethyst;
 #
 # use amethyst::{
 #     ecs::*,
@@ -17,6 +18,7 @@ let mut dispatcher_builder = DispatcherBuilder::new();
 To add `System`s to the `DispatcherBuilder` we use a similar syntax to the one we used to add `System`s to `GameData`.
 
 ```rust
+# extern crate amethyst;
 #
 # use amethyst::{
 #     ecs::*,
@@ -35,6 +37,7 @@ dispatcher_builder.add(MovePaddlesSystem, "move_paddles_system", &[]);
 Alternatively we can add `Bundle`s of `System`s to our `DispatcherBuilder` directly.
 
 ```rust
+# extern crate amethyst;
 #
 # use amethyst::{
 #     core::bundle::SystemBundle,
@@ -59,6 +62,7 @@ PongSystemsBundle::default()
 The `DispatcherBuilder` can be initialized and populated wherever desired, be it inside the `State` or in an external location. However, the `Dispatcher` needs to modify the `World`s resources in order to initialize the resources used by its `System`s. Therefore, we need to defer building the `Dispatcher` until we can access the `World`. This is commonly done in the `State`s `on_start` method. To showcase how this is done, we'll create a `SimpleState` with a `dispatcher` field and a `on_start` method that builds the `Dispatcher`.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{core::ArcThreadPool, ecs::*, prelude::*};
 # 
 # struct MoveBallsSystem;
@@ -101,6 +105,7 @@ By default, the dispatcher will create its own pool of worker threads to execute
 The `CustomState` requires two annotations (`'a` and `'b`) to satisfy the lifetimes of the `Dispatcher`. Now that we have our `Dispatcher` we need to ensure that it is executed. We do this in the `State`s `update` method.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{ecs::*, prelude::*};
 # 
 # #[derive(Default)]

--- a/book/src/input/handling_input.md
+++ b/book/src/input/handling_input.md
@@ -4,6 +4,7 @@ Amethyst uses an `InputHandler` to handle user input.
 You initialize this `InputHandler` by creating an `InputBundle` and adding it to the game data.
 
 ```rust
+# extern crate amethyst;
 use amethyst::{input::InputBundle, prelude::*};
 
 # struct Example;
@@ -24,6 +25,7 @@ use amethyst::{input::InputBundle, prelude::*};
 To use the `InputHandler` inside a `System` you have to add it to the `SystemData`. With this you can check for events from input devices.
 
 ```rust
+# extern crate amethyst;
 use amethyst::{
     ecs::{System, World},
     input::{ControllerButton, InputHandler, VirtualKeyCode},
@@ -61,6 +63,7 @@ You can find all the methods from `InputHandler` [here][input_ha].
 Now you have to add the `System` to the game data, like you would do with any other `System`. A `System` that uses an `InputHandler` needs `"input_system"` inside its dependencies.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{ecs::*, prelude::*};
 # struct ExampleSystem;
 # impl System for ExampleSystem {
@@ -108,6 +111,7 @@ The possible inputs you can specify for axes are listed [here][in_axis]. The pos
 To add these bindings to the `InputBundle` you simply need to call the `with_bindings_from_file` function on the `InputBundle`.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{input::*, prelude::*, utils::*};
 # fn main() -> amethyst::Result<()> {
     let root = application_root_dir()?;
@@ -123,6 +127,7 @@ To add these bindings to the `InputBundle` you simply need to call the `with_bin
 And now you can get the [axis][axis_val] and [action][is_down] values from the `InputHandler`.
 
 ```rust
+# extern crate amethyst;
 use amethyst::{
     core::{Transform},
     ecs::{System, World},

--- a/book/src/pong-tutorial/pong-tutorial-01.md
+++ b/book/src/pong-tutorial/pong-tutorial-01.md
@@ -35,6 +35,7 @@ We can start with editing the `main.rs` file inside `src` directory.
 You can delete everything in that file, then add these imports:
 
 ```rust
+# extern crate amethyst;
 //! Pong Tutorial 1
 
 use amethyst::{
@@ -67,6 +68,7 @@ We'll be implementing the [`SimpleState`][simplestate] trait on this struct, whi
 used by Amethyst's state machine to start, stop, and update the game.
 
 ```rust
+# extern crate amethyst;
 impl SimpleState for Pong {}
 ```
 
@@ -80,6 +82,7 @@ started! We'll start with our `main()` function, and we'll have it return a
 if any errors occur during setup.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::prelude::*;
 fn main() -> amethyst::Result<()> {
     // We'll put the rest of the code here.
@@ -100,6 +103,7 @@ Inside `main()` we first start the amethyst logger with a default `LoggerConfig`
 so we can see errors, warnings and debug messages while the program is running.
 
 ```rust
+# extern crate amethyst;
 # fn main() {
     amethyst::start_logger(Default::default());
 # }
@@ -146,6 +150,7 @@ In `main()` in `main.rs`, we will prepare the path to a file containing
 the display configuration:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{utils::application_root_dir, Error};
 # 
 # fn main() -> Result<(), Error> {
@@ -160,6 +165,7 @@ the display configuration:
 In `main()` in `main.rs` we are going to add the basic application setup:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{prelude::*, utils::application_root_dir};
 # fn main() -> Result<(), amethyst::Error> {
 #   struct Pong;
@@ -203,6 +209,7 @@ After preparing the display config and application scaffolding, it's time to act
 Last time we left our `DispatcherBuilder` instance empty, now we'll add some systems to it.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{
 #   prelude::*,
 #   renderer::{

--- a/book/src/pong-tutorial/pong-tutorial-02.md
+++ b/book/src/pong-tutorial/pong-tutorial-02.md
@@ -26,6 +26,7 @@ initialization code from the Pong code.
    following `use` statements. These are needed to make it through this chapter:
 
    ```rust
+   # extern crate amethyst;
    use amethyst::{
        assets::{AssetStorage, DefaultLoader, Handle, Loader},
        core::transform::Transform,
@@ -52,6 +53,7 @@ First, in `pong.rs`, let's add a new method to our `State` implementation: `on_s
 This method is called when the State starts. We will leave it empty for now.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::prelude::*;
 # struct Pong;
 impl SimpleState for Pong {
@@ -85,6 +87,7 @@ will.
    In pong, we want the camera to cover the entire arena. Let's do it in a new function `initialize_camera`:
 
    ```rust
+   # extern crate amethyst;
    # const ARENA_HEIGHT: f32 = 100.0;
    # const ARENA_WIDTH: f32 = 100.0;
    # use amethyst::core::Transform;
@@ -128,6 +131,7 @@ will.
    Pong state's `on_start` method:
 
    ```rust
+   # extern crate amethyst;
    # use amethyst::ecs::World;
    # use amethyst::prelude::*;
    # fn initialize_camera(world: &mut World) {}
@@ -195,6 +199,7 @@ include that component and add them to our `World`.
 First let's look at our imports:
 
 ```rust
+# extern crate amethyst;
 use amethyst::core::transform::Transform;
 ```
 
@@ -212,6 +217,7 @@ image we will want to render on top of them. This is a good rule to follow in
 general, as it makes operations like rotation easier.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::core::Transform;
 # use amethyst::ecs::World;
 # use amethyst::prelude::*;
@@ -254,6 +260,7 @@ As a sanity check, let's make sure the code for initializing the paddles
 compiles. Update the `on_start` method to the following:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::World;
 # use amethyst::prelude::*;
 # fn initialize_paddles(world: &mut World) {}
@@ -292,6 +299,7 @@ this by adding the following line before `initialize_paddles(world)` in the
 `on_start` method:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::World;
 # struct Paddle;
 # fn register() {
@@ -321,6 +329,7 @@ registering another one will look similar. You have to first import
 `TransformBundle`, then register it as follows:
 
 ```rust
+# extern crate amethyst;
 use amethyst::core::transform::TransformBundle;
 # use amethyst::{prelude::*, utils::application_root_dir};
 # 
@@ -361,6 +370,7 @@ function in `pong.rs` called `load_sprite_sheet`.
 First, let's declare the function and load the sprite sheet's image data.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{
 #   assets::{AssetStorage, DefaultLoader, Handle, Loader},
 #   core::transform::Transform,
@@ -443,6 +453,7 @@ List((
 Finally, we load the file containing the position of each sprite on the sheet.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{
 #   assets::{AssetStorage, DefaultLoader, Handle, Loader},
 #   core::transform::Transform,
@@ -492,6 +503,7 @@ to the paddles. We update the `initialize_paddles` function by changing its
 signature to:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::World;
 # use amethyst::{assets::Handle, renderer::sprite::SpriteSheet};
 fn initialize_paddles(world: &mut World, sprite_sheet_handle: Handle<SpriteSheet>)
@@ -504,6 +516,7 @@ only need one here, since the only difference between the two paddles is that
 the right one is flipped horizontally.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::World;
 # use amethyst::{
 #   assets::Handle,
@@ -522,6 +535,7 @@ sprite in the sprite sheet, we use `0` for the `sprite_number`.
 Next we simply add the components to the paddle entities:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::assets::Handle;
 # use amethyst::ecs::World;
 # use amethyst::prelude::*;
@@ -541,6 +555,7 @@ We're nearly there, we have to wire up the sprite to the paddles. We put it
 all together in the `on_start()` method:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::assets::Handle;
 # use amethyst::ecs::World;
 # use amethyst::prelude::*;

--- a/book/src/pong-tutorial/pong-tutorial-03.md
+++ b/book/src/pong-tutorial/pong-tutorial-03.md
@@ -51,6 +51,7 @@ contains an `InputHandler` system which captures inputs, and maps them to the
 axes we defined. Let's make the following changes to `main.rs`.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::core::transform::TransformBundle;
 # use amethyst::prelude::*;
 # use amethyst::window::DisplayConfig;
@@ -103,6 +104,7 @@ mod paddle;
 We're finally ready to implement the `PaddleSystem` in `systems/paddle.rs`:
 
 ```rust
+# extern crate amethyst;
 # mod pong {
 #   pub enum Side {
 #       Left,
@@ -197,6 +199,7 @@ mod systems; // Import the module
 ```
 
 ```rust
+# extern crate amethyst;
 # use amethyst::core::transform::TransformBundle;
 # use amethyst::input::StringBindings;
 # use amethyst::prelude::*;
@@ -244,6 +247,7 @@ Let's make it update the position of the paddle. To do this, we'll modify the y
 component of the transform's translation.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::core::Transform;
 # use amethyst::ecs::{System, World};
 # use amethyst::input::InputHandler;
@@ -297,6 +301,7 @@ to `PADDLE_HEIGHT * 0.5` (the bottom of the arena plus the offset).
 Our run function should now look something like this:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::core::Transform;
 # use amethyst::ecs::{System, World};
 # use amethyst::input::InputHandler;
@@ -349,6 +354,7 @@ we no longer need to manually register it with the `world`: the system
 will take care of that for us, as well as set up the storage.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::assets::Handle;
 # use amethyst::ecs::World;
 # use amethyst::prelude::*;

--- a/book/src/pong-tutorial/pong-tutorial-04.md
+++ b/book/src/pong-tutorial/pong-tutorial-04.md
@@ -35,6 +35,7 @@ Then let's add an `initialize_ball` function the same way we wrote the
 `initialize_paddles` function.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::assets::{AssetStorage, Handle, Loader};
 # use amethyst::core::transform::Transform;
 # use amethyst::ecs::World;
@@ -77,6 +78,7 @@ second one, whose index is `1`.
 Finally, let's make sure the code is working as intended by updating the `on_start` method:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::assets::Handle;
 # use amethyst::ecs::World;
 # use amethyst::prelude::*;
@@ -117,6 +119,7 @@ in the center. In the next section, we're going to make this ball actually move!
 We're now ready to implement the `MoveBallsSystem` in `systems/move_balls.rs`:
 
 ```rust
+# extern crate amethyst;
 # mod pong {
 #   pub struct Ball {
 #       pub velocity: [f32; 2],
@@ -172,6 +175,7 @@ If a collision is detected, the ball bounces off. This is done
 by negating the velocity of the `Ball` component on the `x` or `y` axis.
 
 ```rust
+# extern crate amethyst;
 # mod pong {
 #   pub struct Ball {
 #       pub velocity: [f32; 2],
@@ -269,6 +273,7 @@ The following image illustrates how collisions with paddles are checked.
 We will need to add `mod move_balls` and `mod bounce` as well as `MoveBallsSystem` and
 `BounceSystem` to our `systems/mod.rs`:
 ```rust
+# extern crate amethyst;
 pub use self::paddle::PaddleSystem;
 pub use self::move_balls::MoveBallsSystem;
 pub use self::bounce::BounceSystem;
@@ -280,6 +285,7 @@ mod paddle;
 
 Also, don't forget to add our new systems to the game data:
 ```rust
+# extern crate amethyst;
 # use amethyst::core::transform::TransformBundle;
 # use amethyst::input::StringBindings;
 # use amethyst::prelude::*;
@@ -345,6 +351,7 @@ First, let's add a new method to our state: `update`.
 Let's add that `update` method just below `on_start`:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::prelude::*;
 # struct MyState;
 # impl SimpleState for MyState {
@@ -365,6 +372,7 @@ as a local variable inside `on_start`. For that reason, we have to make it a par
 Let's add some fields to our `Pong` struct:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::assets::Handle;
 #[derive(Default)]
 pub struct Pong {
@@ -381,6 +389,7 @@ We've also added `#[derive(Default)]`, which will automatically implement `Defau
 default empty state. Now let's use that inside our `Application` creation code in `main.rs`:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{ecs::World, prelude::*};
 # 
 # #[derive(Default)]
@@ -401,6 +410,7 @@ Now let's finish our timer and ball spawning code. We have to do two things:
 - then we have to `initialize_ball` once after the time has passed inside `update`:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::prelude::*;
 # use amethyst::{assets::Handle, renderer::SpriteSheet};
 use amethyst::core::timing::Time;

--- a/book/src/pong-tutorial/pong-tutorial-05.md
+++ b/book/src/pong-tutorial/pong-tutorial-05.md
@@ -25,6 +25,7 @@ mod winner;
 Then, we'll create `systems/winner.rs`:
 
 ```rust
+# extern crate amethyst;
 # mod pong {
 #   pub struct Ball {
 #       pub radius: f32,
@@ -83,6 +84,7 @@ Now, we need to add our new system to `main.rs`, and we should be able to
 keep playing after someone scores and log who got the point.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{
 #   core::transform::TransformBundle, ecs::World, input::StringBindings, prelude::*,
 #   window::DisplayConfig,
@@ -145,12 +147,14 @@ to display our players' scores.
 First, let's add the UI rendering in `main.rs`. Add the following imports:
 
 ```rust
+# extern crate amethyst;
 use amethyst::ui::{RenderUi, UiBundle};
 ```
 
 Then, add a `RenderUi` plugin to your `RenderBundle` like so:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{
 #   ecs::World,
 #   prelude::*,
@@ -171,6 +175,7 @@ Then, add a `RenderUi` plugin to your `RenderBundle` like so:
 Finally, add the `UiBundle` after the `InputBundle`:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ui::UiBundle;
 # use amethyst::{ecs::World, input::StringBindings, prelude::*};
 # fn main() -> Result<(), amethyst::Error> {
@@ -199,6 +204,7 @@ Now we have everything set up so we can start rendering a scoreboard in our
 game. We'll start by creating some structures in `pong.rs`:
 
 ```rust
+# extern crate amethyst;
 /// ScoreBoard contains the actual score data
 #[derive(Default)]
 pub struct ScoreBoard {
@@ -222,6 +228,7 @@ a container, but this one holds handles to the UI `Entity`s that will be
 rendered to the screen. We'll create those next:
 
 ```rust
+# extern crate amethyst;
 use amethyst::ui::{Anchor, LineMode, TtfFormat, UiText, UiTransform};
 
 # pub struct Pong;
@@ -327,6 +334,7 @@ is modify our `WinnerSystem` to access the players' scores and update them
 accordingly:
 
 ```rust
+# extern crate amethyst;
 # mod pong {
 #   pub struct Ball {
 #       pub radius: f32,

--- a/book/src/pong-tutorial/pong-tutorial-06.md
+++ b/book/src/pong-tutorial/pong-tutorial-06.md
@@ -15,6 +15,7 @@ mod audio;
 Create a file called `audio.rs`:
 
 ```rust
+# extern crate amethyst;
 use amethyst::{
     assets::Loader,
     audio::{OggFormat, SourceHandle},
@@ -58,6 +59,7 @@ pub fn initialize_audio(world: &mut World) {
 Then, we'll need to add the Sounds Resource to our World. Update `pong.rs`:
 
 ```rust
+# extern crate amethyst;
 use crate::audio::initialize_audio;
 
 impl SimpleState for Pong {
@@ -72,6 +74,7 @@ impl SimpleState for Pong {
 Finally, we'll need our game to include the Audio Bundle. In `main.rs`:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::DispatcherBuilder;
 use amethyst::audio::AudioBundle;
 
@@ -94,6 +97,7 @@ fn main() -> amethyst::Result<()> {
 Let's start by creating a function to play the bounce sound. In `audio.rs`, add:
 
 ```rust
+# extern crate amethyst;
 use amethyst::{
     assets::AssetStorage,
     audio::{output::Output, Source, SourceHandle},
@@ -115,6 +119,7 @@ pub fn play_bounce_sound(sounds: &Sounds, storage: &AssetStorage<Source>, output
 Then, we'll update the Bounce System to play the sound whenever the ball bounces. Update `systems/bounce.rs`:
 
 ```rust
+# extern crate amethyst;
 use amethyst::{
     assets::AssetStorage,
     audio::{output::Output, Source},
@@ -174,6 +179,7 @@ Now try running your game (`cargo run`). Don't forget to turn up your volume!
 Just as we did for the bounce sound, let's create a function to play the score sound. Update `audio.rs`:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{
 #   assets::AssetStorage,
 #   audio::{output::Output, Source, SourceHandle},
@@ -196,6 +202,7 @@ pub fn play_score_sound(sounds: &Sounds, storage: &AssetStorage<Source>, output:
 Then, we'll update our Winner System to play the score sound whenever a player scores. Update `systems/winner.rs`:
 
 ```rust
+# extern crate amethyst;
 use crate::audio::{play_score_sound, Sounds};
 use amethyst::{
     assets::AssetStorage,
@@ -259,6 +266,7 @@ Let's start by downloading [Albatross] and [Where's My Jetpack?][wheres-my-jetpa
 In `audio.rs`, add the paths to the music tracks below the paths to the sound effects:
 
 ```rust
+# extern crate amethyst;
 const BOUNCE_SOUND: &str = "audio/bounce.ogg";
 const SCORE_SOUND: &str = "audio/score.ogg";
 
@@ -271,6 +279,7 @@ const MUSIC_TRACKS: &[&str] = &[
 Then, create a Music Resource:
 
 ```rust
+# extern crate amethyst;
 use std::{iter::Cycle, vec::IntoIter};
 # use amethyst::audio::SourceHandle;
 
@@ -284,6 +293,7 @@ Since we only have two music tracks, we use a `Cycle` to infinitely alternate be
 Next, we need to add the Music Resource to our World. Update `initialize_audio`:
 
 ```rust
+# extern crate amethyst;
 # use std::{iter::Cycle, vec::IntoIter};
 # 
 use amethyst::{
@@ -345,6 +355,7 @@ pub fn initialize_audio(world: &mut World) {
 Finally, let's add a DJ System to our game to play the music. In `main.rs`:
 
 ```rust
+# extern crate amethyst;
 use crate::audio::Music;
 use amethyst::audio::DjSystemDesc;
 

--- a/book/src/prefabs/how_to_define_prefabs_aggregate.md
+++ b/book/src/prefabs/how_to_define_prefabs_aggregate.md
@@ -17,6 +17,7 @@ If you intend to include a [`Component`] that has not yet got a corresponding [`
 1. Import the following items:
 
    ```rust
+   # extern crate amethyst;
    use amethyst::{
        assets::{PrefabData, ProgressCounter},
        derive::PrefabData,
@@ -60,6 +61,7 @@ If you intend to include a [`Component`] that has not yet got a corresponding [`
    If you want to mix different types of entities within a single prefab then you must define an enum that implements `PrefabData`. Each variant is treated in the same way as `PrefabData` structs.
 
    ```rust
+   # extern crate amethyst;
    # extern crate serde;
    # use amethyst::{
    #   assets::{PrefabData, ProgressCounter},
@@ -104,6 +106,7 @@ If you intend to include a [`Component`] that has not yet got a corresponding [`
    **Note:** There is an important limitation when building `PrefabData`s, particularly enum `PrefabData`s. No two fields in the `PrefabData` or in any nested `PrefabData`s under it can access the same `Component` unless all accesses are reads. This is still true even if the fields appear in different variants of an enum. This means that the following `PrefabData` will fail at runtime when loaded:
 
    ```rust
+   # extern crate amethyst;
    # extern crate serde;
    # use amethyst::{
    #   assets::{PrefabData, ProgressCounter},
@@ -137,6 +140,7 @@ If you intend to include a [`Component`] that has not yet got a corresponding [`
    The problem is that both the `SpriteScenePrefab`s need to write to `Transform` and several other common `Components`. Because Amythest's underlyng ECS system determines what resources are accessed based on static types it can't determine that only one of the `SpriteScenePrefab`s will be accessed at a time and it attempts a double mutable borrow which fails. The solution is to define the `PrefabData` hierarchically so each component only appears once:
 
    ```rust
+   # extern crate amethyst;
    # extern crate serde;
    # use amethyst::{
    #   assets::{PrefabData, ProgressCounter},

--- a/book/src/prefabs/how_to_define_prefabs_prelude.md
+++ b/book/src/prefabs/how_to_define_prefabs_prelude.md
@@ -21,6 +21,7 @@ If you are looking for a guide to define prefab data for a `Component`, first we
   This is where the `Component` type itself is completely serializable – the data is self-contained.
 
   ```rust
+  # extern crate amethyst;
   # extern crate serde;
   # 
   # use serde::{Deserialize, Serialize};
@@ -36,6 +37,7 @@ If you are looking for a guide to define prefab data for a `Component`, first we
   This is where are multiple ways to construct the component, and a user should be able to choose which one to use.
 
   ```rust
+  # extern crate amethyst;
   # extern crate serde;
   #
   # use serde::{Deserialize, Serialize};
@@ -71,6 +73,7 @@ If you are looking for a guide to define prefab data for a `Component`, first we
   This is where most of the component is serializable, but there is also data that is only accessible at runtime, such as a device ID or an asset handle.
 
   ```rust
+  # extern crate amethyst;
   # use amethyst_audio::output::Output;
   # use amethyst_core::{
   #   ecs::{storage::HashMapStorage, Component},
@@ -105,6 +108,7 @@ If you are looking for a guide to define prefab data for a `Component`, first we
   This is where the `Component` itself stores `Handle<_>`s.
 
   ```rust
+  # extern crate amethyst;
   # use amethyst::{assets::Handle, renderer::Texture};
   # 
   /// Material struct.

--- a/book/src/prefabs/how_to_define_prefabs_simple.md
+++ b/book/src/prefabs/how_to_define_prefabs_simple.md
@@ -26,6 +26,8 @@ If you are attempting to adapt a more complex type, please choose the appropriat
 1. Import the following items:
 
    ```rust
+   # extern crate amethyst;
+   # extern crate serde;
    use amethyst::{
        assets::{PrefabData, ProgressCounter},
        derive::PrefabData,
@@ -38,6 +40,8 @@ If you are attempting to adapt a more complex type, please choose the appropriat
 1. Add the following attributes on your type:
 
    ```rust
+   # extern crate amethyst;
+   # extern crate serde;
    #[derive(Deserialize, Serialize, PrefabData)]
    #[prefab(Component)]
    #[serde(default)] // <--- optional

--- a/book/src/prefabs/prefabs_in_amethyst.md
+++ b/book/src/prefabs/prefabs_in_amethyst.md
@@ -20,6 +20,7 @@ The remainder of this page explains these at a conceptual level; subsequent page
 In its stored form, a prefab is a serialized list of entities and their components that should be instantiated together. To begin, we will look at a simple prefab that attaches a simple component to a single entity. We will use the following `Position` component:
 
 ```rust
+# extern crate amethyst;
 # extern crate derivative;
 # extern crate serde;
 # 
@@ -92,6 +93,7 @@ cargo run -p prefab
 If there are multiple components to be attached to the entity, then we need a type that aggregates the [`Component`]s:
 
 ```rust
+# extern crate amethyst;
 # extern crate derivative;
 # extern crate serde;
 # 
@@ -181,6 +183,7 @@ Prefab(
 Could be implemented using an enum like this:
 
 ```rust
+# extern crate amethyst;
 # extern crate derivative;
 # extern crate serde;
 # 

--- a/book/src/prefabs/prefabs_technical_explanation.md
+++ b/book/src/prefabs/prefabs_technical_explanation.md
@@ -62,6 +62,7 @@ Ok, so what would a simple implementation of `PrefabData` look like?
 Let's take a look at the implementation for `Transform`, which is a core concept in Amethyst:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::assets::PrefabData;
 # use amethyst::ecs::{Entity};
 # use amethyst::Error;
@@ -109,6 +110,7 @@ Let's look at a slightly more complex implementation, the `AssetPrefab`. This `P
 load extra `Asset`s as part of a `Prefab`:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::assets::PrefabData;
 # use amethyst::assets::{
 #   Asset, AssetStorage, DefaultLoader, Format, Handle, Loader, ProgressCounter,
@@ -211,6 +213,7 @@ and visible in the current scope. This is due to how Rust macros work.
 An example of a single `Component` derive:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{
 #   assets::{Asset, AssetStorage, Format, Handle, Loader, PrefabData, ProgressCounter},
 #   derive::PrefabData,
@@ -230,6 +233,7 @@ This will derive a `PrefabData` implementation that inserts `SomeComponent` on a
 Lets look at an example of an aggregate struct:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::assets::{
 #   Asset, AssetPrefab, AssetStorage, DefaultLoader, Format, Handle, Loader, PrefabData,
 #   ProgressCounter,
@@ -251,6 +255,7 @@ This can now be used to create `Prefab`s with `Transform` and `Mesh` on entities
 One last example that also adds a custom pure data `Component` into the aggregate `PrefabData`:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::assets::{
 #   Asset, AssetPrefab, AssetStorage, DefaultLoader, Format, Handle, Loader, PrefabData,
 #   ProgressCounter,

--- a/book/src/sprites/define_the_sprite_sheet.md
+++ b/book/src/sprites/define_the_sprite_sheet.md
@@ -61,6 +61,7 @@ For more information about list and grid based sprite sheets, including the type
 Once you have ron file ready, you can load it using the texture handle of the sheet's image you loaded earlier:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::assets::{AssetStorage, Handle, Loader};
 # use amethyst::ecs::World;
 # use amethyst::renderer::{SpriteSheet, SpriteSheetFormat, Texture};
@@ -104,6 +105,7 @@ In Amethyst, pixel dimensions and texture coordinates are stored in the `Sprite`
 The following snippet shows you how to naively define a `SpriteSheet`. In a real application, you would typically use the sprite sheet from file feature, which is much more convenient.
 
 ```rust
+# extern crate amethyst;
 use amethyst::assets::Handle;
 use amethyst::renderer::{sprite::TextureCoordinates, Sprite, SpriteSheet, Texture};
 

--- a/book/src/sprites/load_the_texture.md
+++ b/book/src/sprites/load_the_texture.md
@@ -5,6 +5,7 @@ The first part of loading sprites into Amethyst is to read the image into memory
 The following snippet shows how to load a PNG / JPEG / GIF / ICO image:
 
 ```rust
+# extern crate amethyst;
 use amethyst::assets::{AssetStorage, DefaultLoader, Handle, Loader};
 use amethyst::prelude::*;
 use amethyst::renderer::{formats::texture::ImageFormat, Texture};
@@ -42,6 +43,7 @@ If you want to tweak the sampling, you can change `ImageFormat::default()` to
 `ImageFormat(my_config)`, and create your own `my_config` like this:
 
 ```rust
+# extern crate amethyst;
 use amethyst::renderer::rendy::hal::image::{Filter, SamplerInfo, WrapMode};
 use amethyst::renderer::rendy::texture::image::{ImageTextureConfig, Repr, TextureKind};
 

--- a/book/src/sprites/modify_the_texture.md
+++ b/book/src/sprites/modify_the_texture.md
@@ -13,6 +13,7 @@ own values, so a [`Tint`][doc_tint] with a white color will have no
 effect on the sprite.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::assets::{AssetStorage, DefaultLoader, Handle, Loader};
 use amethyst::core::transform::Transform;
 # use amethyst::prelude::*;

--- a/book/src/sprites/orthographic_camera.md
+++ b/book/src/sprites/orthographic_camera.md
@@ -5,6 +5,7 @@ Finally, you need to tell Amethyst to draw in 2D space. This is done by creating
 The following snippet demonstrates how to set up a `Camera` that sees entities within screen bounds, where the entities' Z position is between -10.0 and 10.0:
 
 ```rust
+# extern crate amethyst;
 use amethyst::{
     core::{math::Orthographic3, transform::Transform},
     prelude::*,

--- a/book/src/sprites/set_up_the_render_pass.md
+++ b/book/src/sprites/set_up_the_render_pass.md
@@ -4,6 +4,7 @@ Amethyst supports drawing sprites using the `RenderFlat2D` render plugin.
 To enable this you have to do the following:
 
 ```rust
+# extern crate amethyst;
 use amethyst::{
     ecs::World,
     prelude::*,

--- a/book/src/sprites/sprite_render_component.md
+++ b/book/src/sprites/sprite_render_component.md
@@ -3,6 +3,7 @@
 After loading the `SpriteSheet`, you need to attach it to an entity using the `SpriteRender` component and indicate which sprite to draw. The `SpriteRender` component looks like this:
 
 ```rust
+# extern crate amethyst;
 use amethyst::assets::Handle;
 use amethyst::renderer::SpriteSheet;
 
@@ -20,6 +21,7 @@ The sprite number is the index of the sprite loaded in the sprite sheet. What's 
 In the previous section you wrote a function that returns a `SpriteSheet`. This can be turned into a `Handle<SpriteSheet>` using the `Loader` resource as follows:
 
 ```rust
+# extern crate amethyst;
 use amethyst::assets::{AssetStorage, DefaultLoader, Handle, Loader, ProcessingQueue};
 use amethyst::prelude::*;
 use amethyst::renderer::{SpriteSheet, Texture};
@@ -63,6 +65,7 @@ impl SimpleState for ExampleState {
 Cool, finally we have all the parts, let's build a `SpriteRender` and attach it to an entity:
 
 ```rust
+# extern crate amethyst;
 use amethyst::assets::{AssetStorage, DefaultLoader, Handle, Loader, ProcessingQueue};
 use amethyst::core::transform::Transform;
 use amethyst::prelude::*;

--- a/book/src/testing.md
+++ b/book/src/testing.md
@@ -9,6 +9,7 @@ The `amethyst_test` crate provides support to write tests ergonomically and expr
 The following shows a simple example of testing a `State`. More examples are in following pages.
 
 ```rust
+# extern crate amethyst;
 # use std::marker::PhantomData;
 # 
 # use amethyst::prelude::*;
@@ -55,6 +56,7 @@ fn loading_state_adds_load_resource() -> Result<(), Error> {
 The Amethyst application is initialized with one of the following functions, each providing a different set of bundles:
 
 ````rust
+# extern crate amethyst_test;
 use amethyst_test::prelude::*;
 
 #[test]
@@ -89,6 +91,7 @@ fn test_name() {
 Next, attach the logic for your test using the various `.with_*(..)` methods:
 
 ```rust
+# extern crate amethyst_test;
 #[test]
 fn test_name() {
     let visibility = false; // Whether the window should be shown
@@ -111,6 +114,8 @@ fn test_name() {
 Finally, call `.run()` to run the application. This returns `amethyst::Result<()>`, so we return that as part of the function:
 
 ```rust
+# extern crate amethyst;
+# extern crate amethyst_test;
 # use amethyst::Error;
 # use amethyst_test::prelude::*;
 # 

--- a/book/src/testing/test_examples.md
+++ b/book/src/testing/test_examples.md
@@ -3,6 +3,7 @@
 ## Testing a `Bundle`
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{core::bundle::SystemBundle, prelude::*, Error};
 # use amethyst_test::prelude::*;
 # 
@@ -47,6 +48,7 @@ fn bundle_registers_system_with_resource() -> Result<(), Error> {
 ## Testing a `System`
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{prelude::*, Error};
 # use amethyst_test::prelude::*;
 # 
@@ -94,6 +96,7 @@ fn system_increases_component_value_by_one() -> Result<(), Error> {
 This is useful when your system must run *after* some setup has been done, for example adding a resource:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{prelude::*, Error};
 # use amethyst_test::prelude::*;
 # 

--- a/book/src/tiles/create_a_tile_map.md
+++ b/book/src/tiles/create_a_tile_map.md
@@ -3,6 +3,7 @@
 With the `tiles` feature installed and our `RenderTiles2D` render pass setup, we can create a `TileMap` component and add it an entity. We need to have a sprite sheet loaded before the creation so this example assume a handle to a sprite sheet exists.
 
 ```rust
+# extern crate amethyst;
 use amethyst::{
     core::{
         math::{Point3, Vector3},

--- a/book/src/tiles/setup.md
+++ b/book/src/tiles/setup.md
@@ -4,7 +4,7 @@
 
 In order to use the tiles package you need add the `tiles` feature to your `Cargo.toml`:
 
-```rust
+```text
 [dependencies]
 amethyst = { version = "LATEST_CRATES.IO_VERSION", features = ["tiles"] }
 ```
@@ -14,6 +14,7 @@ amethyst = { version = "LATEST_CRATES.IO_VERSION", features = ["tiles"] }
 Now you can add the render pass to your application:
 
 ```rust
+# extern crate amethyst;
 use amethyst::{
     core::math::Point3,
     ecs::World,

--- a/book/src/ui/interacting.md
+++ b/book/src/ui/interacting.md
@@ -9,6 +9,7 @@ and the latter interaction through `handle_event` method of your active state.
 Let's start of with some boilerplate code:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::System;
 
 pub struct SimpleButtonSystem;
@@ -30,6 +31,7 @@ since the `ReaderId` actually pulls (reads) information  from the `EventChannel`
 Adding it up, it should look like this:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::{System};
 # use amethyst::shrev::{EventChannel, ReaderId};
 # use amethyst::ui::UiEvent;
@@ -48,6 +50,7 @@ impl System for SimpleButtonSystem {
 We also need a constructor for our system:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::{System};
 # use amethyst::shrev::{EventChannel, ReaderId};
 # use amethyst::ui::UiEvent;
@@ -71,6 +74,7 @@ impl SimpleButtonSystem {
 To add the system to our game data we actually need a `SystemDesc` implementation for our system:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::{System, World};
 # use amethyst::shrev::{EventChannel, ReaderId};
 # use amethyst::ui::UiEvent;
@@ -105,6 +109,7 @@ Now that this is done we can start reading our events!
 In our systems `run` method we are going to loop through all the events:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::{System, World};
 # use amethyst::shrev::{EventChannel, ReaderId};
 # use amethyst::ui::UiEvent;
@@ -129,6 +134,7 @@ Firstly we need to fetch two more components that
 we used for our entity - `UiTransform` and `UiText`.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::{System, World};
 # use amethyst::shrev::{EventChannel, ReaderId};
 # use amethyst::ui::{UiEvent, UiText, UiTransform};
@@ -150,6 +156,7 @@ Usage of `.write_component::<UiText>` is needed since we will be changing
 the color that is the property of the `UiText` component.
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::{System, World};
 # use amethyst::shrev::{EventChannel, ReaderId};
 # use amethyst::ui::{UiEvent, UiEventType, UiText, UiTransform};

--- a/book/src/ui/introduction.md
+++ b/book/src/ui/introduction.md
@@ -25,6 +25,7 @@ to draw these widgets.
 A minimalistic game data would now look like this:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{
 #   core::transform::TransformBundle,
 #   input::InputBundle,

--- a/book/src/ui/simple_button.md
+++ b/book/src/ui/simple_button.md
@@ -22,6 +22,7 @@ You don't have to use all three at the same time of course but variations of two
 One way of defining a `UiTransform` is like so:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ui::{Anchor, UiTransform};
 
 let ui_transform = UiTransform::new(
@@ -52,6 +53,7 @@ to set the area big enough for the text to fit in!
 ### Creating the `UiText`
 
 ```rust
+# extern crate amethyst;
 # use amethyst::assets::{AssetStorage, DefaultLoader, Loader};
 # use amethyst::prelude::World;
 # use amethyst::ui::{get_default_font, Anchor, FontAsset, LineMode, UiText};
@@ -81,6 +83,7 @@ You also need to load a specific font handle and provide it for the text.
 If you had some state implemented you can create the button on its `on_start` method:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::assets::{AssetStorage, DefaultLoader, Loader};
 # use amethyst::prelude::*;
 # use amethyst::ui::{get_default_font, Anchor, FontAsset, LineMode, UiText, UiTransform};
@@ -146,6 +149,7 @@ have a `UiTransform` component!
 The code snippet would look like this now:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::assets::{AssetStorage, DefaultLoader, Loader};
 # use amethyst::ecs::World;
 # use amethyst::prelude::*;

--- a/book/src/ui/state_interaction.md
+++ b/book/src/ui/state_interaction.md
@@ -3,6 +3,7 @@
 Let's declare our state, and call it `MenuState`:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::ecs::Entity;
 # 
 #[derive(Default)]
@@ -22,6 +23,7 @@ In our `on_start` method of this state we can create the button as shown in
 previous chapters, but here we will save the entity in our struct:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{
 #  assets::{AssetStorage,  DefaultLoader, Loader},
 # 	ecs::{Entity, World},
@@ -82,6 +84,7 @@ All the input received will be handled in the [handle\_event](https://docs.ameth
 method of our state:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{
 #   assets::{AssetStorage,  DefaultLoader, Loader},
 #   ecs::{Entity, World},
@@ -175,6 +178,7 @@ The way we do that is by adding a [Hidden](https://docs.amethyst.rs/master/ameth
 component to our button:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{
 #   assets::{AssetStorage,  DefaultLoader, Loader},
 #   core::Hidden,
@@ -265,6 +269,7 @@ impl SimpleState for MenuState {
 The same goes for `on_resume` if we actually want to redisplay the button:
 
 ```rust
+# extern crate amethyst;
 # use amethyst::{
 #   assets::{AssetStorage,  DefaultLoader, Loader},
 #   core::Hidden,

--- a/src/app.rs
+++ b/src/app.rs
@@ -160,12 +160,6 @@ where
     /// - `S`: A type that implements the `State` trait. e.g. Your initial
     ///        game logic.
     ///
-    /// # Lifetimes
-    ///
-    /// - `a`: The lifetime of the `State` objects.
-    /// - `b`: This lifetime is inherited from `specs` and `shred`, it is
-    ///        the minimum lifetime of the systems used by `CoreApplication`
-    ///
     /// # Errors
     ///
     /// Application will return an error if the internal thread pool fails
@@ -430,12 +424,6 @@ where
     ///
     /// - `S`: A type that implements the `State` trait. e.g. Your initial
     ///        game logic.
-    ///
-    /// # Lifetimes
-    ///
-    /// - `a`: The lifetime of the `State` objects.
-    /// - `b`: This lifetime is inherited from `specs` and `shred`, it is
-    ///        the minimum lifetime of the systems used by `CoreApplication`
     ///
     /// # Errors
     ///


### PR DESCRIPTION
Yes, the book is broken. This is the first step towards fixing it: it makes it so running the tests say something else than "unresolved crate: amethyst" and actually tries to compile the tests.