### PR TITLE
Fix a path in the tiles example

### DIFF
--- a/examples/tiles/main.rs
+++ b/examples/tiles/main.rs
@@ -156,7 +156,7 @@ fn main() -> amethyst::Result<()> {
     dispatcher.add_bundle(LoaderBundle);
     dispatcher.add_bundle(TransformBundle);
     dispatcher
-        .add_bundle(InputBundle::new().with_bindings_from_file("examples/tiles/config/input.ron")?);
+        .add_bundle(InputBundle::new().with_bindings_from_file("config/input.ron")?);
 
     dispatcher.add_system(systems::MapMovementSystem::default());
     dispatcher.add_system(systems::CameraSwitchSystem::default());


### PR DESCRIPTION
Signed-off-by: Michael X. Grey <grey@openrobotics.org>

<!--- Provide a general summary of your changes in the Title above -->
## Description

This simply fixes a hardcoded file path in the `tiles` example. It seems the path is a hold over from when examples were compiled and run as part of the overall `amethyst` crate whereas now they seem to be treated independently.



## Motivation and Context

Without this change, the path is wrong and the program panics.


## How Has This Been Tested?

`cargo run` inside of the `examples/tiles` directory.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [ ] ~~If my change required a change to the documentation I have updated the documentation accordingly.~~
- [ ] ~~I have updated the content of the book if this PR would make the book outdated.~~
- [ ] ~~I have added tests to cover my changes.~~
- [ ] ~~My code is used in an example.~~
