### PR TITLE
Update legion dependency to 0.4

### DIFF
--- a/amethyst_animation/Cargo.toml
+++ b/amethyst_animation/Cargo.toml
@@ -31,7 +31,7 @@ thread_profiler = { version = "0.3", optional = true }
 alga = "0.9.3"
 type-uuid = "0.1.2"
 uuid = "0.8.2"
-legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "8565883493aaf6044e210ffe2e72eec519d46369" }
 
 [dev-dependencies]
 amethyst = { path = "../", version = "0.16.0", features = ["renderer"] }

--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -51,8 +51,8 @@ uuid = { version = "0.8", features = ["v4"] }
 bincode = "1.3"
 type-uuid = "0.1"
 futures-executor = { version = "0.3", default-features = false }
-legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "8565883493aaf6044e210ffe2e72eec519d46369" }
+prefab-format = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "8565883493aaf6044e210ffe2e72eec519d46369" }
 encoding_rs_io = "0.1"
 serde-diff = "0.4"
 structopt = { version = "0.3", default-features = false, optional = true }

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -26,12 +26,12 @@ serde = { version = "1", features = ["derive"] }
 approx = "0.5"
 derive-new = "0.5"
 getset = "0.1.1"
-legion = { version = "0.3.1", default-features = false, features = [
+legion = { version = "0.4", default-features = false, features = [
     "serialize",
     "crossbeam-events",
     "codegen",
 ] }
-legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "8565883493aaf6044e210ffe2e72eec519d46369" }
 nalgebra = { version = "0.25", default-features = false, features = ["serde-serialize"] }
 rayon = "1.5"
 shrev = "1.1.1"

--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -24,7 +24,7 @@ err-derive = "0.3.0"
 base64 = "0.13"
 fnv = "1"
 gltf = { version = "0.16", features = ["KHR_lights_punctual"] }
-legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "8565883493aaf6044e210ffe2e72eec519d46369" }
 hibitset = { version = "0.6.3", features = ["parallel"] }
 log = "0.4"
 mikktspace = "0.2.0"

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -34,7 +34,7 @@ indexmap = { version = "1.7", features = ["rayon"] }
 type-uuid = "0.1"
 thread_profiler = { version = "0.3", optional = true }
 approx = "0.5"
-legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "8565883493aaf6044e210ffe2e72eec519d46369" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 rendy = { version = "0.5", git = "https://github.com/amethyst/rendy", rev = "50667887612adc9314accea77438aa7fb925bce0", default-features = false, features = ["metal"] }

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -44,7 +44,7 @@ lazy_static = "1.4"
 glyph_brush = "0.6"
 thread_profiler = { version = "0.3", optional = true }
 type-uuid = "0.1"
-legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "8565883493aaf6044e210ffe2e72eec519d46369" }
 
 [dev-dependencies]
 amethyst = { path = "../", version = "0.16.0", features = ["renderer"] }


### PR DESCRIPTION
Update legion dependency version from 0.3.1 to 0.4

## Description
Remove dependency to legion 0.3.1 in crates 
- amethyst_core

Add dependency to legion 0.4 in crates 
- amethyst_core

Remove dependency to legion-prefab 7c30249f106e6177549e223ca2823eec8ab6c70b in crates 
- amethyst_animation
- amethyst_assets
- amethyst_core
- amethyst_gltf
- amethyst_rendy
- amethyst_ui

Add dependency to legion-prefab 8565883493aaf6044e210ffe2e72eec519d46369 in crates 
- amethyst_animation
- amethyst_assets
- amethyst_core
- amethyst_gltf
- amethyst_rendy
- amethyst_ui

## Motivation and Context
The main motivation is to include the fix of an issue with world spliting not behaving as said in the docs  (components read was exclusive instead of shared)
- See https://github.com/amethyst/legion/pull/235 for more details
It also improve consistency between the main crate (legion 0.4) and sub crates (legion 0.3.1)

## How Has This Been Tested?
I use it in my main project and nothing is broken (quite the opposite in fact)

## Checklist:
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [ ] If my change required a change to the documentation I have updated the documentation accordingly.
- [ ] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [ ] My code is used in an example.

This is my first PR here, don't hesitate to give constructive feedback ^^
