### PR TITLE
Port SamplerInterpolationSystem to legion macros (0.4) syntax

### DIFF
--- a/amethyst_animation/Cargo.toml
+++ b/amethyst_animation/Cargo.toml
@@ -32,6 +32,7 @@ alga = "0.9.3"
 type-uuid = "0.1.2"
 uuid = "0.8.2"
 legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "8565883493aaf6044e210ffe2e72eec519d46369" }
+legion = "0.4"
 
 [dev-dependencies]
 amethyst = { path = "../", version = "0.16.0", features = ["renderer"] }

--- a/amethyst_animation/src/bundle.rs
+++ b/amethyst_animation/src/bundle.rs
@@ -4,7 +4,10 @@ use amethyst_core::ecs::{DispatcherBuilder, Resources, SystemBundle, World};
 use derivative::Derivative;
 use marker::PhantomData;
 
-use crate::{bundle, resources::AnimationSampling, skinning::VertexSkinningSystem};
+use crate::{
+    bundle, resources::AnimationSampling, skinning::VertexSkinningSystem,
+    systems::sampling::sampler_interpolation_system,
+};
 
 /// Bundle for vertex skinning
 ///
@@ -56,7 +59,7 @@ where
         _resources: &mut Resources,
         builder: &mut DispatcherBuilder,
     ) -> amethyst_core::Result<()> {
-        builder.add_system(crate::systems::sampling::SamplerInterpolationSystem::<T>::default());
+        builder.add_system(|| sampler_interpolation_system::<T>(Vec::new(), Vec::new()));
 
         Ok(())
     }

--- a/examples/animation/main.rs
+++ b/examples/animation/main.rs
@@ -154,7 +154,9 @@ impl SimpleState for Example {
     }
 
     fn handle_event(&mut self, data: StateData<'_, GameData>, event: StateEvent) -> SimpleTrans {
-        let StateData { world, .. } = data;
+        let StateData {
+            world, resources, ..
+        } = data;
         let mut buffer = CommandBuffer::new(world);
 
         if let StateEvent::Window(event) = &event {
@@ -165,6 +167,7 @@ impl SimpleState for Example {
                 Some((VirtualKeyCode::Space, ElementState::Pressed)) => {
                     add_animation(
                         world,
+                        resources,
                         self.sphere.unwrap(),
                         self.current_animation,
                         self.rate,
@@ -176,6 +179,7 @@ impl SimpleState for Example {
                 Some((VirtualKeyCode::D, ElementState::Pressed)) => {
                     add_animation(
                         world,
+                        resources,
                         self.sphere.unwrap(),
                         AnimationId::Translate,
                         self.rate,
@@ -184,6 +188,7 @@ impl SimpleState for Example {
                     );
                     add_animation(
                         world,
+                        resources,
                         self.sphere.unwrap(),
                         AnimationId::Rotate,
                         self.rate,
@@ -192,6 +197,7 @@ impl SimpleState for Example {
                     );
                     add_animation(
                         world,
+                        resources,
                         self.sphere.unwrap(),
                         AnimationId::Scale,
                         self.rate,
@@ -207,7 +213,7 @@ impl SimpleState for Example {
                         self.sphere.unwrap(),
                     )
                     .unwrap()
-                    .step(self.current_animation, StepDirection::Backward);
+                    .step(&self.current_animation, StepDirection::Backward);
                 }
 
                 Some((VirtualKeyCode::Right, ElementState::Pressed)) => {
@@ -217,7 +223,7 @@ impl SimpleState for Example {
                         self.sphere.unwrap(),
                     )
                     .unwrap()
-                    .step(self.current_animation, StepDirection::Forward);
+                    .step(&self.current_animation, StepDirection::Forward);
                 }
 
                 Some((VirtualKeyCode::F, ElementState::Pressed)) => {
@@ -228,7 +234,7 @@ impl SimpleState for Example {
                         self.sphere.unwrap(),
                     )
                     .unwrap()
-                    .set_rate(self.current_animation, self.rate);
+                    .set_rate(&self.current_animation, self.rate);
                 }
 
                 Some((VirtualKeyCode::V, ElementState::Pressed)) => {
@@ -239,7 +245,7 @@ impl SimpleState for Example {
                         self.sphere.unwrap(),
                     )
                     .unwrap()
-                    .set_rate(self.current_animation, self.rate);
+                    .set_rate(&self.current_animation, self.rate);
                 }
 
                 Some((VirtualKeyCode::H, ElementState::Pressed)) => {
@@ -250,7 +256,7 @@ impl SimpleState for Example {
                         self.sphere.unwrap(),
                     )
                     .unwrap()
-                    .set_rate(self.current_animation, self.rate);
+                    .set_rate(&self.current_animation, self.rate);
                 }
 
                 Some((VirtualKeyCode::R, ElementState::Pressed)) => {
@@ -268,7 +274,7 @@ impl SimpleState for Example {
                 _ => {}
             };
         }
-        buffer.flush(world);
+        buffer.flush(world, resources);
 
         Trans::None
     }
@@ -301,7 +307,7 @@ impl SimpleState for Example {
                 }
             }
         }
-        buffer.flush(data.world);
+        buffer.flush(data.world, data.resources);
 
         Trans::None
     }
@@ -339,6 +345,7 @@ fn main() -> amethyst::Result<()> {
 
 fn add_animation(
     world: &mut World,
+    resources: &mut Resources,
     entity: Entity,
     id: AnimationId,
     rate: f32,
@@ -362,8 +369,8 @@ fn add_animation(
 
         match defer {
             None => {
-                if toggle_if_exists && control_set.has_animation(id) {
-                    control_set.toggle(id);
+                if toggle_if_exists && control_set.has_animation(&id) {
+                    control_set.toggle(&id);
                 } else {
                     control_set.add_animation(
                         id,
@@ -388,6 +395,6 @@ fn add_animation(
             }
         }
 
-        buffer.flush(world);
+        buffer.flush(world, resources);
     }
 }


### PR DESCRIPTION
## Description
Modifications:
- SamplerInterpolationSystem now uses legion macros (0.4) syntax.
  - The `#[state]` is used to keep what looked like a previous optimization of re-using the same `Vec`s to avoid re-allocating every frame. Alternative ways to conserve this optimization without using `#[state]` could be better.
- Fixed compile errors in `animation` example.


## Motivation and Context
- Legion macros are a more concise way of writing systems
- Using legion macros internally sets an example of how they can be used
- This change could be used as an example of how to port systems to legion macros.


## How Has This Been Tested?
Compiled and ran `animation` example.


## Checklist:
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [ ] If my change required a change to the documentation I have updated the documentation accordingly.
- [x] I have updated the content of the book if this PR would make the book outdated.
- [x] I have added tests to cover my changes. (Fixed + ran animation example)
- [x] My code is used in an example. (animation)
