### PR TITLE
Port Amethyst's audio to rodio v0.14.0 and refactor its API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ homepage = "https://amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 
 readme = "README.md"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 autoexamples = false # Our examples come with their own Cargo.toml and are in the [workspace] section
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ in
       xlibs.libX11
     ];
 
-    APPEND_LIBRARY_PATH = stdenv.lib.makeLibraryPath [
+    APPEND_LIBRARY_PATH = lib.makeLibraryPath [
       vulkan-loader
       xlibs.libXcursor
       xlibs.libXi

--- a/amethyst_animation/Cargo.toml
+++ b/amethyst_animation/Cargo.toml
@@ -32,6 +32,7 @@ alga = "0.9.3"
 type-uuid = "0.1.2"
 uuid = "0.8.2"
 legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "8565883493aaf6044e210ffe2e72eec519d46369" }
+legion = "0.4"
 
 [dev-dependencies]
 amethyst = { path = "../", version = "0.16.0", features = ["renderer"] }

--- a/amethyst_animation/Cargo.toml
+++ b/amethyst_animation/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 
 readme = "README.md"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.16.0" }

--- a/amethyst_animation/src/bundle.rs
+++ b/amethyst_animation/src/bundle.rs
@@ -4,7 +4,10 @@ use amethyst_core::ecs::{DispatcherBuilder, Resources, SystemBundle, World};
 use derivative::Derivative;
 use marker::PhantomData;
 
-use crate::{bundle, resources::AnimationSampling, skinning::VertexSkinningSystem};
+use crate::{
+    bundle, resources::AnimationSampling, skinning::VertexSkinningSystem,
+    systems::sampling::sampler_interpolation_system,
+};
 
 /// Bundle for vertex skinning
 ///
@@ -56,7 +59,7 @@ where
         _resources: &mut Resources,
         builder: &mut DispatcherBuilder,
     ) -> amethyst_core::Result<()> {
-        builder.add_system(crate::systems::sampling::SamplerInterpolationSystem::<T>::default());
+        builder.add_system(|| sampler_interpolation_system::<T>(Vec::new(), Vec::new()));
 
         Ok(())
     }

--- a/amethyst_animation/src/systems/sampling.rs
+++ b/amethyst_animation/src/systems/sampling.rs
@@ -65,7 +65,7 @@ pub(crate) fn sampler_interpolation<T: AnimationSampling + std::fmt::Debug>(
                 }
 
                 Some(BlendMethod::Linear) => {
-                    if let Some(p) = linear_blend::<T>(channel, &inner) {
+                    if let Some(p) = linear_blend::<T>(channel, inner) {
                         comp.apply_sample(channel, &p, commands);
                     }
                 }

--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -11,7 +11,7 @@ description = """
 Asynchronous asset management for games.
 """
 exclude = ["examples/*"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 keywords = ["game", "asset", "resource", "management", "amethyst"]
 categories = ["filesystem"]
 

--- a/amethyst_assets/src/json.rs
+++ b/amethyst_assets/src/json.rs
@@ -19,11 +19,11 @@ where
     fn import_simple(&self, bytes: Vec<u8>) -> Result<D, Error> {
         use serde_json::de::Deserializer;
         let mut d = Deserializer::from_slice(&bytes);
-        let val = D::deserialize(&mut d)
-            .with_context(|_| format_err!("Failed deserializing Json file"))?;
         d.end()
             .with_context(|_| format_err!("Failed deserializing Json file"))?;
 
+        let val = D::deserialize(&mut d)
+            .with_context(|_| format_err!("Failed deserializing Json file"))?;
         Ok(val)
     }
 }

--- a/amethyst_assets/src/json.rs
+++ b/amethyst_assets/src/json.rs
@@ -19,10 +19,9 @@ where
     fn import_simple(&self, bytes: Vec<u8>) -> Result<D, Error> {
         use serde_json::de::Deserializer;
         let mut d = Deserializer::from_slice(&bytes);
-        d.end()
-            .with_context(|_| format_err!("Failed deserializing Json file"))?;
-
         let val = D::deserialize(&mut d)
+            .with_context(|_| format_err!("Failed deserializing Json file"))?;
+        d.end()
             .with_context(|_| format_err!("Failed deserializing Json file"))?;
         Ok(val)
     }

--- a/amethyst_assets/src/loader.rs
+++ b/amethyst_assets/src/loader.rs
@@ -253,9 +253,7 @@ impl Loader for DefaultLoader {
                     self.loader.remove_ref(handle);
                 }
                 Ok(RefOp::Increase(handle)) => {
-                    self.loader
-                        .get_load_info(handle)
-                        .map(|info| self.loader.add_ref(info.asset_id));
+                    self.loader.add_ref_handle(handle);
                 }
                 Ok(RefOp::IncreaseUuid(uuid)) => {
                     self.loader.add_ref(uuid);

--- a/amethyst_assets/src/loader.rs
+++ b/amethyst_assets/src/loader.rs
@@ -167,7 +167,7 @@ impl DefaultLoader {
             log::info!("Using RpcIO");
             let rpc_io = connect_string
                 .and_then(|cs| RpcIO::new(cs).ok())
-                .unwrap_or_else(RpcIO::default);
+                .unwrap_or_default();
             Box::new(rpc_io)
         } else {
             log::info!("Using PackfileIO");

--- a/amethyst_audio/Cargo.toml
+++ b/amethyst_audio/Cargo.toml
@@ -16,7 +16,7 @@ homepage = "https://amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 
 readme = "README.md"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.16.0" }

--- a/amethyst_audio/Cargo.toml
+++ b/amethyst_audio/Cargo.toml
@@ -22,10 +22,9 @@ license = "MIT OR Apache-2.0"
 amethyst_assets = { path = "../amethyst_assets", version = "0.16.0" }
 amethyst_core = { path = "../amethyst_core", version = "0.16.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.16.0" }
-cpal = "0.11"
 derive-new = "0.5"
 log = "0.4"
-rodio = "0.11"
+rodio = "0.14"
 serde = { version = "1", features = ["derive"] }
 smallvec = { version = "1.6", features = ["serde"] }
 thread_profiler = { version = "0.3", optional = true }

--- a/amethyst_audio/Cargo.toml
+++ b/amethyst_audio/Cargo.toml
@@ -22,10 +22,9 @@ license = "MIT/Apache-2.0"
 amethyst_assets = { path = "../amethyst_assets", version = "0.16.0" }
 amethyst_core = { path = "../amethyst_core", version = "0.16.0" }
 amethyst_error = { path = "../amethyst_error", version = "0.16.0" }
-cpal = "0.11"
 derive-new = "0.5"
 log = "0.4"
-rodio = "0.11"
+rodio = "0.14"
 serde = { version = "1", features = ["derive"] }
 smallvec = { version = "1.6", features = ["serde"] }
 thread_profiler = { version = "0.3", optional = true }

--- a/amethyst_audio/src/bundle.rs
+++ b/amethyst_audio/src/bundle.rs
@@ -1,21 +1,26 @@
 //! ECS audio bundles
 
 use log::warn;
+use rodio::OutputStream;
 
 // use amethyst_assets::AssetProcessorSystem;
 use amethyst_core::ecs::{DispatcherBuilder, Resources, SystemBundle, World};
 use amethyst_error::Error;
 
 use crate::{
-    output::{init_output, Output, OutputStream},
+    output::{init_output, Output},
     systems::{AudioSystem, SelectedListener},
 };
 
-/// Audio bundle
+/// Bundle for [`AudioSystem`]; initializes output and loads necessary resources.
 ///
-/// This will add an empty `SelectedListener`, `OutputWrapper`, add the audio system and the asset processor for `Source`.
+/// This will initialize audio output by loading an [`OutputStream`], an [`Output`], and an empty
+/// [`SelectedListener`] to the world's resources. If no audio output devices are available in the
+/// system, it will not load any of these resources.
 ///
-/// `DjSystem` must be added separately if you want to use our background music system.
+/// [`DjSystem`] must be added separately if you want to use our background music system.
+///
+/// [`DjSystem`]: struct.DjSystem.html
 #[derive(Default, Debug)]
 pub struct AudioBundle;
 
@@ -36,6 +41,7 @@ impl SystemBundle for AudioBundle {
         }
 
         builder.add_system(AudioSystem);
+
         Ok(())
     }
 }

--- a/amethyst_audio/src/bundle.rs
+++ b/amethyst_audio/src/bundle.rs
@@ -1,11 +1,13 @@
 //! ECS audio bundles
 
-//use amethyst_assets::AssetProcessorSystemBundle;
+use log::warn;
+
+// use amethyst_assets::AssetProcessorSystem;
 use amethyst_core::ecs::{DispatcherBuilder, Resources, SystemBundle, World};
 use amethyst_error::Error;
 
 use crate::{
-    output::OutputWrapper,
+    output::{init_output, Output, OutputStream},
     systems::{AudioSystem, SelectedListener},
 };
 
@@ -24,8 +26,14 @@ impl SystemBundle for AudioBundle {
         resources: &mut Resources,
         builder: &mut DispatcherBuilder,
     ) -> Result<(), Error> {
-        resources.get_or_default::<OutputWrapper>();
-        resources.get_or_default::<SelectedListener>();
+        // Try to initialize output using the system's default audio device.
+        if let Ok((stream, output)) = init_output() {
+            resources.get_or_insert::<OutputStream>(stream);
+            resources.get_or_insert::<Output>(output);
+            resources.get_or_default::<SelectedListener>();
+        } else {
+            warn!("The default audio device is not available, sound will not work!");
+        }
 
         builder.add_system(AudioSystem);
         Ok(())

--- a/amethyst_audio/src/components/audio_emitter.rs
+++ b/amethyst_audio/src/components/audio_emitter.rs
@@ -9,7 +9,7 @@ use smallvec::SmallVec;
 use crate::{components, source::Source, DecoderError};
 
 /// An audio source, add this component to anything that emits sound.
-/// TODO: This should get a proper Debug impl parsing the sinks and sound queue
+// TODO: This should get a proper Debug impl parsing the sinks and sound queue
 #[allow(missing_debug_implementations)]
 #[derive(Default)]
 pub struct AudioEmitter {

--- a/amethyst_audio/src/formats.rs
+++ b/amethyst_audio/src/formats.rs
@@ -8,7 +8,7 @@ use type_uuid::TypeUuid;
 pub struct AudioData(pub Vec<u8>);
 amethyst_assets::register_asset_type!(AudioData => crate::Source; amethyst_assets::AssetProcessorSystem<crate::Source>);
 
-/// Loads audio from wav files.
+/// Loads audio from WAV files.
 #[derive(Clone, Copy, Default, Debug, Serialize, Deserialize, TypeUuid)]
 #[uuid = "e78ea33f-d506-4d4f-8276-861660bb6145"]
 pub struct WavFormat;
@@ -24,7 +24,7 @@ impl Format<AudioData> for WavFormat {
     }
 }
 
-/// Loads audio from Ogg Vorbis files
+/// Loads audio from Ogg Vorbis files.
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, TypeUuid)]
 #[uuid = "8ce12d56-9091-4e25-b764-da162fa165aa"]
 pub struct OggFormat;

--- a/amethyst_audio/src/lib.rs
+++ b/amethyst_audio/src/lib.rs
@@ -1,4 +1,9 @@
-//! Loading and playing of audio files.
+//! An audio module that enables basic audio output in Amethyst
+//!
+//! Based on [`rodio`], this crate provides audio output that works out of the box not only
+//! on many mainstream platforms, but supports different backends (e.g. Alsa and Jack on Linux).
+//!
+//! [rodio]: https://docs.rs/rodio/0.14.0/rodio/index.html
 
 #![doc(
     html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",
@@ -23,7 +28,7 @@ pub use self::{
     bundle::AudioBundle,
     components::*,
     formats::{FlacFormat, Mp3Format, OggFormat, WavFormat},
-    sink::AudioSink,
+    sink::Sink,
     source::{Source, SourceHandle},
     systems::*,
 };

--- a/amethyst_audio/src/lib.rs
+++ b/amethyst_audio/src/lib.rs
@@ -4,6 +4,19 @@
 //! on many mainstream platforms, but supports different backends (e.g. Alsa and Jack on Linux).
 //!
 //! [rodio]: https://docs.rs/rodio/0.14.0/rodio/index.html
+//!
+//! # How to use
+//!
+//! **Make sure you have enabled Amethyst's "audio" feature in your game!**
+//!
+//! For basic audio output, you can:
+//! - Add an [`AudioBundle`] to your dispatcher.
+//! - Create audio [`SourceHandle`] by loading a file as an asset using the [`Loader`].
+//! - Access the [`Output`] resource in your system and play the sound from it directly or spawn a
+//! sink for more control.
+//!
+//! [`Output`]: output/struct.Output.html
+//! [`Loader`]: ../amethyst_assets/trait.Loader.html
 
 #![doc(
     html_logo_url = "https://amethyst.rs/brand/logo-standard.svg",

--- a/amethyst_audio/src/output.rs
+++ b/amethyst_audio/src/output.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use log::error;
-pub use rodio::OutputStream;
+use rodio::OutputStream;
 use rodio::{Device, DeviceTrait, OutputStreamHandle, PlayError, StreamError};
 
 use crate::{sink::Sink, source::Source, DecoderError};
@@ -40,14 +40,14 @@ impl Output {
 
     /// Plays a sound once. A volume of 1.0 is unchanged, while 0.0 is silent.
     ///
-    /// This may silently fail, in order to get error information use [`try_play_once`].
+    /// This may silently fail, in order to get error information use `try_play_once`.
     pub fn play_once(&self, source: &Source, volume: f32) {
         self.play_n_times(source, volume, 1);
     }
 
     /// Plays a sound n times. A volume of 1.0 is unchanged, while 0.0 is silent.
     ///
-    /// This may silently fail, in order to get error information use [`try_play_n_times`].
+    /// This may silently fail, in order to get error information use `try_play_n_times`.
     pub fn play_n_times(&self, source: &Source, volume: f32, n: u16) {
         if let Err(err) = self.try_play_n_times(source, volume, n) {
             error!("An error occurred while trying to play a sound: {:?}", err);
@@ -58,9 +58,6 @@ impl Output {
     ///
     /// # Errors
     /// This will return an Error if the loaded audio file in source could not be decoded.
-    ///
-    /// # Panics
-    /// Panics
     pub fn try_play_n_times(
         &self,
         source: &Source,
@@ -185,7 +182,6 @@ mod tests {
     use crate::{
         output::{init_output, OutputError},
         source::Source,
-        DecoderError,
     };
     use amethyst_utils::app_root_dir::application_root_dir;
     use rodio::cpal::{default_host, traits::HostTrait};

--- a/amethyst_audio/src/sink.rs
+++ b/amethyst_audio/src/sink.rs
@@ -5,6 +5,9 @@ use rodio::{Decoder, OutputStreamHandle, PlayError, Sink as RodioSink, Source as
 use crate::{source::Source, DecoderError};
 
 /// This structure provides a way to programmatically pick and play music.
+///
+/// Please note that unless you `detach()` the sink explicitly, the audio playback stops
+/// immediately as the sink gets dropped (goes out of scope, for example).
 // TODO: This needs a proper debug implementation. This should probably propagate up to a TODO
 // for rodio, as its missing them as well.
 #[allow(missing_debug_implementations)]

--- a/amethyst_audio/src/source.rs
+++ b/amethyst_audio/src/source.rs
@@ -5,10 +5,10 @@ use type_uuid::TypeUuid;
 
 use crate::formats::AudioData;
 
-/// A handle to a source asset.
+/// A handle to a [`Source`] asset.
 pub type SourceHandle = Handle<Source>;
 
-/// A loaded audio file
+/// A loaded audio file.
 #[derive(Clone, Debug, PartialEq, Eq, TypeUuid)]
 #[uuid = "5ba63907-3883-453e-a559-9b778288f5d2"]
 pub struct Source {

--- a/amethyst_audio/src/systems/audio.rs
+++ b/amethyst_audio/src/systems/audio.rs
@@ -26,9 +26,11 @@ use crate::{
 #[derive(Debug)]
 pub struct AudioSystem;
 
+/// The AudioListener that we are listening the audio through in a 3D space.
+///
 /// Add this structure to world as a resource with ID 0 to select an entity whose `AudioListener`
 /// component will be used.  If this resource isn't found then the system will arbitrarily select
-/// the first `AudioListener` it finds.
+/// the first [`AudioListener`] it finds.
 #[derive(Debug, Default)]
 pub struct SelectedListener(pub Option<Entity>);
 

--- a/amethyst_audio/src/systems/audio.rs
+++ b/amethyst_audio/src/systems/audio.rs
@@ -19,7 +19,7 @@ use thread_profiler::profile_scope;
 use crate::{
     components::{AudioEmitter, AudioListener},
     end_signal::EndSignalSource,
-    output::OutputWrapper,
+    output::Output,
 };
 
 /// Syncs 3D transform data with the audio engine to provide 3D audio.
@@ -36,27 +36,25 @@ impl System for AudioSystem {
     fn build(self) -> Box<dyn ParallelRunnable> {
         Box::new(
             SystemBuilder::new("AudioSystem")
-                .read_resource::<OutputWrapper>()
+                .read_resource::<Output>()
                 .read_resource::<SelectedListener>()
                 .with_query(<(Entity, Read<AudioListener>)>::query())
                 .with_query(<(Write<AudioEmitter>, Read<Transform>)>::query())
                 .build(
                     move |_commands,
                           world,
-                          (wrapper, select_listener),
+                          (output, select_listener),
                           (q_audio_listener, q_audio_emitter)| {
                         #[cfg(feature = "profiler")]
                         profile_scope!("audio_system");
                         // Process emitters and listener.
                         if let Some((entity, listener)) = select_listener.0.map_or_else(
-                            // Select the first available AudioListener by default
                             || {
                                 q_audio_listener
                                     .iter(world)
                                     .next()
                                     .map(|(entity, audio_listener)| (*entity, audio_listener))
                             },
-                            // Find entity referred by SelectedListener resource
                             |entity| {
                                 world
                                     .entry_ref(entity)
@@ -113,23 +111,21 @@ impl System for AudioSystem {
                                             }
                                         }
                                         while let Some(source) = audio_emitter.sound_queue.pop() {
-                                            if let Some(output) = &wrapper.output {
-                                                let sink = SpatialSink::new(
-                                                    &output.device,
-                                                    emitter_position,
-                                                    left_ear_position,
-                                                    right_ear_position,
-                                                );
-                                                let atomic_bool = Arc::new(AtomicBool::new(false));
-                                                let clone = atomic_bool.clone();
-                                                sink.append(EndSignalSource::new(
-                                                    source,
-                                                    move || {
-                                                        clone.store(true, Ordering::Relaxed);
-                                                    },
-                                                ));
-                                                audio_emitter.sinks.push((sink, atomic_bool));
-                                            }
+                                            let stream_handle = &output.stream_handle;
+
+                                            let sink = SpatialSink::try_new(
+                                                stream_handle,
+                                                emitter_position,
+                                                left_ear_position,
+                                                right_ear_position,
+                                            )
+                                            .unwrap();
+                                            let atomic_bool = Arc::new(AtomicBool::new(false));
+                                            let clone = atomic_bool.clone();
+                                            sink.append(EndSignalSource::new(source, move || {
+                                                clone.store(true, Ordering::Relaxed);
+                                            }));
+                                            audio_emitter.sinks.push((sink, atomic_bool));
                                         }
                                     },
                                 );

--- a/amethyst_config/Cargo.toml
+++ b/amethyst_config/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.amethyst.rs/stable/amethyst_config/"
 homepage = "https://amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 ron = "0.6.4"

--- a/amethyst_config/src/lib.rs
+++ b/amethyst_config/src/lib.rs
@@ -120,8 +120,7 @@ impl Error for ConfigError {
     fn description(&self) -> &str {
         match *self {
             ConfigError::File(_) => "Project file error",
-            ConfigError::Parser(_) => "Project parser error",
-            ConfigError::FileParser(_, _) => "Project parser error",
+            ConfigError::FileParser(_, _) | ConfigError::Parser(_) => "Project parser error",
             ConfigError::Serializer(_) => "Project serializer error",
             ConfigError::Extension(_) => "Invalid extension or directory for a file",
             #[cfg(feature = "json")]

--- a/amethyst_config/src/lib.rs
+++ b/amethyst_config/src/lib.rs
@@ -67,9 +67,8 @@ impl fmt::Display for ConfigError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             ConfigError::File(ref err) => write!(f, "{}", err),
-            ConfigError::Parser(ref msg) => write!(f, "{}", msg),
+            ConfigError::Parser(ref msg) | ConfigError::Serializer(ref msg) => write!(f, "{}", msg),
             ConfigError::FileParser(ref msg, ref path) => write!(f, "{}: {}", path.display(), msg),
-            ConfigError::Serializer(ref msg) => write!(f, "{}", msg),
             ConfigError::Extension(ref path) => {
                 let found = match path.extension() {
                     Some(extension) => format!("{:?}", extension),
@@ -227,7 +226,7 @@ where
                         de.end()?;
                         Ok(val)
                     })
-                    .map_err(|e| ConfigError::Parser(e))
+                    .map_err(ConfigError::Parser)
             }
             #[cfg(feature = "json")]
             ConfigFormat::Json => {

--- a/amethyst_config/src/lib.rs
+++ b/amethyst_config/src/lib.rs
@@ -219,6 +219,7 @@ where
     fn load_bytes_format(format: ConfigFormat, bytes: &[u8]) -> Result<Self, ConfigError> {
         match format {
             ConfigFormat::Ron => {
+                #[allow(clippy::shadow_unrelated)]
                 ron::de::Deserializer::from_bytes(bytes)
                     .and_then(|mut de| {
                         let val = T::deserialize(&mut de)?;

--- a/amethyst_config/src/lib.rs
+++ b/amethyst_config/src/lib.rs
@@ -221,8 +221,8 @@ where
             ConfigFormat::Ron => {
                 ron::de::Deserializer::from_bytes(bytes)
                     .and_then(|mut de| {
-                        let val = T::deserialize(&mut de)?;
                         de.end()?;
+                        let val = T::deserialize(&mut de)?;
                         Ok(val)
                     })
                     .map_err(ConfigError::Parser)

--- a/amethyst_config/src/lib.rs
+++ b/amethyst_config/src/lib.rs
@@ -212,9 +212,7 @@ where
             .map_err(|err| {
                 // Enrich parsing error with a path to the file being parsed.
                 match err {
-                    ConfigError::Parser(err) => {
-                        ConfigError::FileParser(err, path.to_owned())
-                    }
+                    ConfigError::Parser(err) => ConfigError::FileParser(err, path.to_owned()),
                     _ => err,
                 }
             })
@@ -327,12 +325,7 @@ mod test {
         let result = TestConfig::load(path);
 
         assert!(
-            matches!(
-                result,
-                Err(ConfigError::FileParser(
-                    _, ref path
-                ))
-            ),
+            matches!(result, Err(ConfigError::FileParser(_, ref path))),
             format!("{:?}", result)
         );
     }

--- a/amethyst_config/src/lib.rs
+++ b/amethyst_config/src/lib.rs
@@ -327,7 +327,7 @@ mod test {
             Err(ConfigError::FileParser(_, path)) => {
                 assert_eq!(real_path, path);
             }
-            _ => panic!("{:?}", result)
+            _ => panic!("{:?}", result),
         }
     }
 }

--- a/amethyst_config/src/lib.rs
+++ b/amethyst_config/src/lib.rs
@@ -221,8 +221,8 @@ where
             ConfigFormat::Ron => {
                 ron::de::Deserializer::from_bytes(bytes)
                     .and_then(|mut de| {
-                        de.end()?;
                         let val = T::deserialize(&mut de)?;
+                        de.end()?;
                         Ok(val)
                     })
                     .map_err(ConfigError::Parser)

--- a/amethyst_config/tests/invalid-syntax.ron
+++ b/amethyst_config/tests/invalid-syntax.ron
@@ -1,0 +1,3 @@
+(
+  amethyst: invalid-value,
+)

--- a/amethyst_controls/Cargo.toml
+++ b/amethyst_controls/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.amethyst.rs/stable/amethyst_controls/"
 homepage = "https://amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 amethyst_core = { path = "../amethyst_core", version = "0.16.0" }

--- a/amethyst_controls/src/systems.rs
+++ b/amethyst_controls/src/systems.rs
@@ -134,16 +134,18 @@ impl System for FreeRotationSystem {
                     let focused = focus.is_focused;
                     for event in events.read(&mut self.reader) {
                         if focused && hide.hide {
-                            if let Event::DeviceEvent { ref event, .. } = *event {
-                                if let DeviceEvent::MouseMotion { delta: (x, y) } = *event {
-                                    for transform in controls.iter_mut(world) {
-                                        transform.append_rotation_x_axis(
-                                            (-(y as f32) * self.sensitivity_y).to_radians(),
-                                        );
-                                        transform.prepend_rotation_y_axis(
-                                            (-(x as f32) * self.sensitivity_x).to_radians(),
-                                        );
-                                    }
+                            if let Event::DeviceEvent {
+                                event: DeviceEvent::MouseMotion { delta: (x, y) },
+                                ..
+                            } = *event
+                            {
+                                for transform in controls.iter_mut(world) {
+                                    transform.append_rotation_x_axis(
+                                        (-(y as f32) * self.sensitivity_y).to_radians(),
+                                    );
+                                    transform.prepend_rotation_y_axis(
+                                        (-(x as f32) * self.sensitivity_x).to_radians(),
+                                    );
                                 }
                             }
                         }
@@ -171,11 +173,13 @@ impl System for MouseFocusUpdateSystem {
                     profile_scope!("mouse_focus_update_system");
 
                     for event in events.read(&mut self.reader) {
-                        if let Event::WindowEvent { ref event, .. } = *event {
-                            if let WindowEvent::Focused(focused) = *event {
-                                log::debug!("Window was focused.");
-                                focus.is_focused = focused;
-                            }
+                        if let Event::WindowEvent {
+                            event: WindowEvent::Focused(focused),
+                            ..
+                        } = *event
+                        {
+                            log::debug!("Window was focused.");
+                            focus.is_focused = focused;
                         }
                     }
                 }),

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.amethyst.rs/stable/amethyst_core/"
 homepage = "https://amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 amethyst_error = { path = "../amethyst_error", version = "0.16.0" }

--- a/amethyst_core/src/dispatcher.rs
+++ b/amethyst_core/src/dispatcher.rs
@@ -300,6 +300,6 @@ pub mod tests {
 
         dispatcher.execute(&mut world, &mut resources);
 
-        assert_eq!(resources.get::<MyResource>().unwrap().0, true);
+        assert!(resources.get::<MyResource>().unwrap().0, true);
     }
 }

--- a/amethyst_core/src/hide_hierarchy_system.rs
+++ b/amethyst_core/src/hide_hierarchy_system.rs
@@ -70,7 +70,10 @@ impl System for HideHierarchySystem {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::transform::{MissingPreviousParentSystem, Parent, ParentUpdateSystem, Transform};
+    use crate::{
+        ecs::*,
+        transform::{MissingPreviousParentSystem, Parent, ParentUpdateSystem, Transform},
+    };
 
     #[test]
     fn should_not_add_hidden_to_child_if_not_propagated() {
@@ -98,7 +101,7 @@ mod test {
 
         schedule.execute(&mut world, &mut resources);
 
-        assert_eq!(
+        assert!(
             true,
             world
                 .entry(parent)
@@ -107,7 +110,7 @@ mod test {
                 .is_err()
         );
 
-        assert_eq!(
+        assert!(
             true,
             world
                 .entry(e1)
@@ -116,7 +119,7 @@ mod test {
                 .is_err()
         );
 
-        assert_eq!(
+        assert!(
             true,
             world
                 .entry(e2)
@@ -132,7 +135,7 @@ mod test {
 
         schedule.execute(&mut world, &mut resources);
 
-        assert_eq!(
+        assert!(
             true,
             world
                 .entry(parent)
@@ -143,7 +146,7 @@ mod test {
 
         schedule.execute(&mut world, &mut resources);
 
-        assert_eq!(
+        assert!(
             true,
             world
                 .entry(e1)
@@ -152,7 +155,7 @@ mod test {
                 .is_err()
         );
 
-        assert_eq!(
+        assert!(
             true,
             world
                 .entry(e2)
@@ -190,7 +193,7 @@ mod test {
 
         schedule.execute(&mut world, &mut resources);
 
-        assert_eq!(
+        assert!(
             true,
             world
                 .entry(parent)
@@ -199,7 +202,7 @@ mod test {
                 .is_err()
         );
 
-        assert_eq!(
+        assert!(
             true,
             world
                 .entry(e1)
@@ -214,7 +217,7 @@ mod test {
             .add_component(HiddenPropagate::new());
         schedule.execute(&mut world, &mut resources);
 
-        assert_eq!(
+        assert!(
             true,
             world
                 .entry(parent)
@@ -223,7 +226,7 @@ mod test {
                 .is_ok()
         );
 
-        assert_eq!(
+        assert!(
             true,
             world
                 .entry(e1)
@@ -238,7 +241,7 @@ mod test {
             .remove_component::<HiddenPropagate>();
         schedule.execute(&mut world, &mut resources);
 
-        assert_eq!(
+        assert!(
             true,
             world
                 .entry(parent)
@@ -247,7 +250,7 @@ mod test {
                 .is_err()
         );
 
-        assert_eq!(
+        assert!(
             true,
             world
                 .entry(e1)
@@ -283,7 +286,7 @@ mod test {
 
         schedule.execute(&mut world, &mut resources);
 
-        assert_eq!(
+        assert!(
             true,
             world
                 .entry(parent)
@@ -292,7 +295,7 @@ mod test {
                 .is_err()
         );
 
-        assert_eq!(
+        assert!(
             true,
             world
                 .entry(e1)
@@ -301,7 +304,7 @@ mod test {
                 .is_err()
         );
 
-        assert_eq!(
+        assert!(
             true,
             world
                 .entry(e2)
@@ -316,7 +319,7 @@ mod test {
 
         schedule.execute(&mut world, &mut resources);
 
-        assert_eq!(
+        assert!(
             true,
             world
                 .entry(parent)
@@ -327,7 +330,7 @@ mod test {
 
         schedule.execute(&mut world, &mut resources);
 
-        assert_eq!(
+        assert!(
             true,
             world
                 .entry(e1)
@@ -336,7 +339,7 @@ mod test {
                 .is_ok()
         );
 
-        assert_eq!(
+        assert!(
             true,
             world
                 .entry(e2)
@@ -350,7 +353,7 @@ mod test {
             .unwrap()
             .remove_component::<HiddenPropagate>();
 
-        assert_eq!(
+        assert!(
             true,
             world
                 .entry(parent)
@@ -361,7 +364,7 @@ mod test {
 
         schedule.execute(&mut world, &mut resources);
 
-        assert_eq!(
+        assert!(
             true,
             world
                 .entry(e1)
@@ -370,7 +373,7 @@ mod test {
                 .is_err()
         );
 
-        assert_eq!(
+        assert!(
             true,
             world
                 .entry(e2)

--- a/amethyst_core/src/system_ext.rs
+++ b/amethyst_core/src/system_ext.rs
@@ -181,7 +181,7 @@ mod test {
     fn should_not_pause_if_resource_match_value() {
         let mut resources = Resources::default();
         let mut world = World::default();
-        resources.insert(0u32);
+        resources.insert(0_u32);
         resources.insert(CurrentState::Enabled);
 
         let mut dispatcher = DispatcherBuilder::default()
@@ -200,7 +200,7 @@ mod test {
     fn should_pause_if_resource_does_not_match_value() {
         let mut resources = Resources::default();
         let mut world = World::default();
-        resources.insert(0u32);
+        resources.insert(0_u32);
         resources.insert(CurrentState::Enabled);
 
         let mut dispatcher = DispatcherBuilder::default()

--- a/amethyst_core/src/transform/missing_previous_parent_system.rs
+++ b/amethyst_core/src/transform/missing_previous_parent_system.rs
@@ -30,6 +30,7 @@ impl System for MissingPreviousParentSystem {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::ecs::*;
 
     #[test]
     fn previous_parent_added() {
@@ -49,7 +50,7 @@ mod test {
 
         schedule.execute(&mut world, &mut resources);
 
-        assert_eq!(
+        assert!(
             world
                 .entry(e1)
                 .unwrap()
@@ -58,7 +59,7 @@ mod test {
             false
         );
 
-        assert_eq!(
+        assert!(
             world
                 .entry(e2)
                 .unwrap()

--- a/amethyst_core/src/transform/parent_update_system.rs
+++ b/amethyst_core/src/transform/parent_update_system.rs
@@ -140,7 +140,7 @@ impl System for ParentUpdateSystem {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::transform::MissingPreviousParentSystem;
+    use crate::{ecs::*, transform::MissingPreviousParentSystem};
 
     #[test]
     fn correct_children() {

--- a/amethyst_derive/Cargo.toml
+++ b/amethyst_derive/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.amethyst.rs/stable/amethyst_derive/"
 homepage = "https://amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 # FIXME: remove after legion port
 autotests = false

--- a/amethyst_derive/src/lib.rs
+++ b/amethyst_derive/src/lib.rs
@@ -35,7 +35,7 @@ pub fn event_reader_derive(input: TokenStream) -> TokenStream {
 }
 
 /// This allows the use of an enum as an ID for the `Widgets` resource. One
-/// variant has to be marked as the default variant with `#[widget_id_default]
+/// variant has to be marked as the default variant with `#[widget_id_default]`
 /// and will be used when a `Widget` is added to the resource without an
 /// explicit ID. Note that when using `Widgets::add`, this will overwrite
 /// an existing widget with the same default id!

--- a/amethyst_error/Cargo.toml
+++ b/amethyst_error/Cargo.toml
@@ -12,7 +12,7 @@ Internal error handling for Amethyst.
 """
 keywords = ["game", "error", "amethyst"]
 categories = ["rust-patterns"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 documentation = "https://docs.amethyst.rs/stable/amethyst_error/"
 homepage = "https://amethyst.rs/"

--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.amethyst.rs/stable/amethyst_gltf/"
 homepage = "https://amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.16.0" }

--- a/amethyst_gltf/src/importer/gltf_bytes_converter.rs
+++ b/amethyst_gltf/src/importer/gltf_bytes_converter.rs
@@ -38,7 +38,7 @@ mod test {
                 assert_eq!(2, doc.textures().len());
             }
             Err(e) => {
-                panic!("Error during gltf import {:?}", e)
+                panic!("Error during gltf import {:?}", e);
             }
         }
     }

--- a/amethyst_input/Cargo.toml
+++ b/amethyst_input/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.amethyst.rs/stable/amethyst_input/"
 homepage = "https://amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 amethyst_core = { path = "../amethyst_core", version = "0.16.0" }

--- a/amethyst_input/src/bindings.rs
+++ b/amethyst_input/src/bindings.rs
@@ -772,7 +772,7 @@ mod tests {
             bindings
                 .insert_action_binding(
                     TEST_ACTION,
-                    [Button::Key(VirtualKeyCode::C),].iter().cloned(),
+                    [Button::Key(VirtualKeyCode::C),].iter().copied(),
                 )
                 .unwrap_err(),
             BindingError::ButtonBoundToAxis(

--- a/amethyst_input/src/util.rs
+++ b/amethyst_input/src/util.rs
@@ -9,8 +9,8 @@ use crate::input_handler::InputHandler;
 #[must_use]
 pub fn get_key(event: &Event<'_, ()>) -> Option<(VirtualKeyCode, ElementState)> {
     match *event {
-        Event::WindowEvent { ref event, .. } => {
-            match *event {
+        Event::WindowEvent {
+            event:
                 WindowEvent::KeyboardInput {
                     input:
                         KeyboardInput {
@@ -19,10 +19,9 @@ pub fn get_key(event: &Event<'_, ()>) -> Option<(VirtualKeyCode, ElementState)> 
                             ..
                         },
                     ..
-                } => Some((*virtual_keycode, state)),
-                _ => None,
-            }
-        }
+                },
+            ..
+        } => Some((*virtual_keycode, state)),
         _ => None,
     }
 }
@@ -52,12 +51,13 @@ pub fn is_key_up(event: &Event<'_, ()>, key_code: VirtualKeyCode) -> bool {
 /// Returns true if the event passed in is a request to close the game window.
 #[must_use]
 pub fn is_close_requested(event: &Event<'_, ()>) -> bool {
-    match *event {
-        Event::WindowEvent { ref event, .. } => {
-            matches!(*event, WindowEvent::CloseRequested)
+    matches!(
+        *event,
+        Event::WindowEvent {
+            event: WindowEvent::CloseRequested,
+            ..
         }
-        _ => false,
-    }
+    )
 }
 
 /// Gets the input axis value from the `InputHandler`.
@@ -83,12 +83,10 @@ pub fn get_action_simple(name: &Option<Cow<'static, str>>, input: &InputHandler)
 #[must_use]
 pub fn get_mouse_button(event: &Event<'_, ()>) -> Option<(MouseButton, ElementState)> {
     match *event {
-        Event::WindowEvent { ref event, .. } => {
-            match *event {
-                WindowEvent::MouseInput { button, state, .. } => Some((button, state)),
-                _ => None,
-            }
-        }
+        Event::WindowEvent {
+            event: WindowEvent::MouseInput { button, state, .. },
+            ..
+        } => Some((button, state)),
         _ => None,
     }
 }

--- a/amethyst_locale/Cargo.toml
+++ b/amethyst_locale/Cargo.toml
@@ -11,7 +11,7 @@ description = """
 Localisation bindings.
 """
 exclude = ["examples/*"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 keywords = ["game", "localisation", "resource", "management", "amethyst"]
 categories = ["localization"]
 

--- a/amethyst_network/Cargo.toml
+++ b/amethyst_network/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 documentation = "https://docs.amethyst.rs/stable/amethyst_network/index.html"
 homepage = "https://amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [features]
 profiler = ["thread_profiler/thread_profiler"]

--- a/amethyst_network/src/simulation/timing.rs
+++ b/amethyst_network/src/simulation/timing.rs
@@ -174,9 +174,9 @@ mod tests {
         for i in 1..100 {
             // every second frame (even) should return true
             if i % 2 == 0 {
-                assert_eq!(time.should_send_message(i), true);
+                assert!(time.should_send_message(i), true);
             } else {
-                assert_eq!(time.should_send_message(i), false);
+                assert!(time.should_send_message(i), false);
             }
         }
     }
@@ -188,6 +188,6 @@ mod tests {
         let elapsed_time = Duration::from_millis(500);
         time.update_elapsed(elapsed_time);
 
-        assert_eq!(time.elapsed_duration(), elapsed_time)
+        assert_eq!(time.elapsed_duration(), elapsed_time);
     }
 }

--- a/amethyst_network/src/simulation/transport.rs
+++ b/amethyst_network/src/simulation/transport.rs
@@ -197,9 +197,9 @@ mod tests {
     #[test]
     fn test_has_messages() {
         let mut resource = create_test_resource();
-        assert_eq!(resource.has_messages(), false);
+        assert!(resource.has_messages(), false);
         resource.send_immediate("127.0.0.1:3000".parse().unwrap(), test_payload());
-        assert_eq!(resource.has_messages(), true);
+        assert!(resource.has_messages(), true);
     }
 
     #[test]
@@ -270,7 +270,9 @@ mod tests {
 
     #[test]
     fn test_send_with_requirements() {
-        use DeliveryRequirement::*;
+        use DeliveryRequirement::{
+            Default, Reliable, ReliableOrdered, ReliableSequenced, Unreliable, UnreliableSequenced,
+        };
         let mut resource = create_test_resource();
         let addr = "127.0.0.1:3000".parse().unwrap();
 
@@ -283,7 +285,7 @@ mod tests {
             Default,
         ];
 
-        for req in requirements.iter().cloned() {
+        for req in requirements.iter().copied() {
             resource.send_with_requirements(addr, test_payload(), req, UrgencyRequirement::OnTick);
         }
 

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 description = "High-level rendering engine with multiple backends"
 keywords = ["game", "engine", "renderer", "3d", "amethyst"]
 categories = ["rendering", "rendering::engine"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [package.metadata.docs.rs]
 features = ["shader-compiler", "test-support", "winit", "vulkan"]

--- a/amethyst_test/Cargo.toml
+++ b/amethyst_test/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["game-engines"]
 documentation = "https://docs.amethyst.rs/stable/amethyst_test/"
 homepage = "https://amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 amethyst = { path = "..", version = "0.16.0", default-features = false }

--- a/amethyst_tiles/Cargo.toml
+++ b/amethyst_tiles/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.amethyst.rs/master/amethyst_tiles/"
 homepage = "https://amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [badges]
 appveyor = { repository = "amethyst/amethyst" }

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["game-engines"]
 documentation = "https://docs.amethyst.rs/stable/amethyst_ui/"
 homepage = "https://amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.16.0" }

--- a/amethyst_ui/src/sound.rs
+++ b/amethyst_ui/src/sound.rs
@@ -1,5 +1,5 @@
 use amethyst_assets::AssetStorage;
-use amethyst_audio::{output::OutputWrapper, Source, SourceHandle};
+use amethyst_audio::{output::Output, Source, SourceHandle};
 use amethyst_core::{
     ecs::{ParallelRunnable, System, SystemBuilder},
     shrev::{EventChannel, ReaderId},
@@ -87,21 +87,16 @@ impl System for UiSoundSystem {
             SystemBuilder::new("UiSoundSystem")
                 .write_resource::<EventChannel<UiPlaySoundAction>>()
                 .read_resource::<AssetStorage<Source>>()
-                .read_resource::<OutputWrapper>()
+                .read_resource::<Output>()
                 .build(
-                    move |_commands,
-                          _world,
-                          (sound_events, audio_storage, audio_output_wrapper),
-                          _| {
+                    move |_commands, _world, (sound_events, audio_storage, audio_output), _| {
                         #[cfg(feature = "profiler")]
                         profile_scope!("ui_sound_system");
                         let event_reader = &mut self.event_reader;
                         for event in sound_events.read(event_reader) {
                             if let Some(sound) = audio_storage.get(&event.0) {
-                                if let Some(output) = &audio_output_wrapper.output {
-                                    log::trace!("Playing sound");
-                                    output.play_once(sound, 1.0);
-                                }
+                                log::trace!("Playing sound");
+                                audio_output.play_once(sound, 1.0);
                             }
                         }
                     },

--- a/amethyst_utils/Cargo.toml
+++ b/amethyst_utils/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.amethyst.rs/stable/amethyst_utils/"
 homepage = "https://amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
 
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 amethyst_assets = { path = "../amethyst_assets", version = "0.16.0" }

--- a/amethyst_window/Cargo.toml
+++ b/amethyst_window/Cargo.toml
@@ -10,7 +10,7 @@ description = "Windowing support for Amethyst engine."
 documentation = "https://www.amethyst.rs/doc/latest/doc/amethyst_window/"
 homepage = "https://www.amethyst.rs/"
 repository = "https://github.com/amethyst/amethyst"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 amethyst_core = { path = "../amethyst_core", version = "0.16.0" }

--- a/examples/animation/main.rs
+++ b/examples/animation/main.rs
@@ -154,7 +154,9 @@ impl SimpleState for Example {
     }
 
     fn handle_event(&mut self, data: StateData<'_, GameData>, event: StateEvent) -> SimpleTrans {
-        let StateData { world, .. } = data;
+        let StateData {
+            world, resources, ..
+        } = data;
         let mut buffer = CommandBuffer::new(world);
 
         if let StateEvent::Window(event) = &event {
@@ -165,6 +167,7 @@ impl SimpleState for Example {
                 Some((VirtualKeyCode::Space, ElementState::Pressed)) => {
                     add_animation(
                         world,
+                        resources,
                         self.sphere.unwrap(),
                         self.current_animation,
                         self.rate,
@@ -176,6 +179,7 @@ impl SimpleState for Example {
                 Some((VirtualKeyCode::D, ElementState::Pressed)) => {
                     add_animation(
                         world,
+                        resources,
                         self.sphere.unwrap(),
                         AnimationId::Translate,
                         self.rate,
@@ -184,6 +188,7 @@ impl SimpleState for Example {
                     );
                     add_animation(
                         world,
+                        resources,
                         self.sphere.unwrap(),
                         AnimationId::Rotate,
                         self.rate,
@@ -192,6 +197,7 @@ impl SimpleState for Example {
                     );
                     add_animation(
                         world,
+                        resources,
                         self.sphere.unwrap(),
                         AnimationId::Scale,
                         self.rate,
@@ -207,7 +213,7 @@ impl SimpleState for Example {
                         self.sphere.unwrap(),
                     )
                     .unwrap()
-                    .step(self.current_animation, StepDirection::Backward);
+                    .step(&self.current_animation, StepDirection::Backward);
                 }
 
                 Some((VirtualKeyCode::Right, ElementState::Pressed)) => {
@@ -217,7 +223,7 @@ impl SimpleState for Example {
                         self.sphere.unwrap(),
                     )
                     .unwrap()
-                    .step(self.current_animation, StepDirection::Forward);
+                    .step(&self.current_animation, StepDirection::Forward);
                 }
 
                 Some((VirtualKeyCode::F, ElementState::Pressed)) => {
@@ -228,7 +234,7 @@ impl SimpleState for Example {
                         self.sphere.unwrap(),
                     )
                     .unwrap()
-                    .set_rate(self.current_animation, self.rate);
+                    .set_rate(&self.current_animation, self.rate);
                 }
 
                 Some((VirtualKeyCode::V, ElementState::Pressed)) => {
@@ -239,7 +245,7 @@ impl SimpleState for Example {
                         self.sphere.unwrap(),
                     )
                     .unwrap()
-                    .set_rate(self.current_animation, self.rate);
+                    .set_rate(&self.current_animation, self.rate);
                 }
 
                 Some((VirtualKeyCode::H, ElementState::Pressed)) => {
@@ -250,7 +256,7 @@ impl SimpleState for Example {
                         self.sphere.unwrap(),
                     )
                     .unwrap()
-                    .set_rate(self.current_animation, self.rate);
+                    .set_rate(&self.current_animation, self.rate);
                 }
 
                 Some((VirtualKeyCode::R, ElementState::Pressed)) => {
@@ -268,7 +274,7 @@ impl SimpleState for Example {
                 _ => {}
             };
         }
-        buffer.flush(world);
+        buffer.flush(world, resources);
 
         Trans::None
     }
@@ -301,7 +307,7 @@ impl SimpleState for Example {
                 }
             }
         }
-        buffer.flush(data.world);
+        buffer.flush(data.world, data.resources);
 
         Trans::None
     }
@@ -339,6 +345,7 @@ fn main() -> amethyst::Result<()> {
 
 fn add_animation(
     world: &mut World,
+    resources: &mut Resources,
     entity: Entity,
     id: AnimationId,
     rate: f32,
@@ -362,8 +369,8 @@ fn add_animation(
 
         match defer {
             None => {
-                if toggle_if_exists && control_set.has_animation(id) {
-                    control_set.toggle(id);
+                if toggle_if_exists && control_set.has_animation(&id) {
+                    control_set.toggle(&id);
                 } else {
                     control_set.add_animation(
                         id,
@@ -388,6 +395,6 @@ fn add_animation(
             }
         }
 
-        buffer.flush(world);
+        buffer.flush(world, resources);
     }
 }

--- a/examples/auto_fov/main.rs
+++ b/examples/auto_fov/main.rs
@@ -153,7 +153,7 @@ impl SimpleState for Example {
                 buffer.remove(*entity)
             }
         }
-        buffer.flush(data.world);
+        buffer.flush(data.world, data.resources);
 
         let loader = data.resources.get::<DefaultLoader>().unwrap();
         let mesh_storage = data.resources.get::<ProcessingQueue<MeshData>>().unwrap();

--- a/examples/custom_render_pass/main.rs
+++ b/examples/custom_render_pass/main.rs
@@ -49,7 +49,7 @@ impl SimpleState for CustomShaderState {
     fn handle_event(&mut self, data: StateData<'_, GameData>, event: StateEvent) -> SimpleTrans {
         match &event {
             StateEvent::Window(event) => {
-                if is_close_requested(&event) || is_key_down(&event, VirtualKeyCode::Escape) {
+                if is_close_requested(event) || is_key_down(event, VirtualKeyCode::Escape) {
                     Trans::Quit
                 } else {
                     Trans::None

--- a/examples/gltf_scene/main.rs
+++ b/examples/gltf_scene/main.rs
@@ -35,7 +35,9 @@ impl SimpleState for GltfExample {
     }
 
     fn update(&mut self, data: &mut StateData<'_, GameData>) -> SimpleTrans {
-        let StateData { world, .. } = data;
+        let StateData {
+            world, resources, ..
+        } = data;
 
         let mut query = <(
             Entity,
@@ -67,7 +69,7 @@ impl SimpleState for GltfExample {
                 }
             }
         }
-        buffer.flush(world);
+        buffer.flush(world, resources);
 
         Trans::None
     }

--- a/examples/pong_tutorial_06/audio.rs
+++ b/examples/pong_tutorial_06/audio.rs
@@ -69,7 +69,7 @@ pub fn initialize_audio(_: &mut World, resources: &mut Resources) {
 
 /// Plays the bounce sound when a ball hits a side or a paddle.
 pub fn play_bounce(sounds: &Sounds, storage: &AssetStorage<Source>, output: Option<&Output>) {
-    if let Some(ref output) = output.as_ref() {
+    if let Some(output) = output.as_ref() {
         if let Some(sound) = storage.get(&sounds.bounce_sfx) {
             output.play_once(sound, 1.0);
         }

--- a/examples/pong_tutorial_06/audio.rs
+++ b/examples/pong_tutorial_06/audio.rs
@@ -3,7 +3,7 @@ use std::{iter::Cycle, vec::IntoIter};
 use amethyst::{
     assets::{AssetStorage, DefaultLoader, Loader},
     audio::{
-        output::{Output, OutputWrapper},
+        output::Output,
         Source, SourceHandle,
     },
     ecs::{Resources, World},
@@ -36,15 +36,6 @@ pub fn initialize_audio(_: &mut World, resources: &mut Resources) {
     let (sound_effects, music) = {
         let loader = resources.get::<DefaultLoader>().unwrap();
 
-        // Music is a bit loud, reduce the volume.
-        resources
-            .get_mut::<OutputWrapper>()
-            .unwrap()
-            .audio_sink
-            .as_mut()
-            .unwrap()
-            .set_volume(0.25);
-
         let music = AUDIO_MUSIC
             .iter()
             .map(|file| load_audio_track(&loader, file))
@@ -68,10 +59,8 @@ pub fn initialize_audio(_: &mut World, resources: &mut Resources) {
 }
 
 /// Plays the bounce sound when a ball hits a side or a paddle.
-pub fn play_bounce(sounds: &Sounds, storage: &AssetStorage<Source>, output: Option<&Output>) {
-    if let Some(output) = output.as_ref() {
-        if let Some(sound) = storage.get(&sounds.bounce_sfx) {
-            output.play_once(sound, 1.0);
-        }
+pub fn play_bounce(sounds: &Sounds, storage: &AssetStorage<Source>, output: &Output) {
+    if let Some(sound) = storage.get(&sounds.bounce_sfx) {
+        output.play_once(sound, 1.0);
     }
 }

--- a/examples/pong_tutorial_06/systems/bounce.rs
+++ b/examples/pong_tutorial_06/systems/bounce.rs
@@ -1,6 +1,6 @@
 use amethyst::{
     assets::AssetStorage,
-    audio::{output::OutputWrapper, Source},
+    audio::{output::Output, Source},
     core::transform::Transform,
     ecs::SystemBuilder,
     prelude::*,
@@ -19,7 +19,7 @@ impl System for BounceSystem {
             SystemBuilder::new("BounceSystem")
                 .read_resource::<Sounds>()
                 .read_resource::<AssetStorage<Source>>()
-                .read_resource::<OutputWrapper>()
+                .read_resource::<Output>()
                 .with_query(<(&mut Ball, &Transform)>::query())
                 .with_query(<&Paddle>::query())
                 .read_component::<Paddle>()
@@ -28,7 +28,7 @@ impl System for BounceSystem {
                 .build(
                     move |_commands,
                           world,
-                          (sounds, storage, output_wrapper),
+                          (sounds, storage, output),
                           (query_balls, query_paddles)| {
                         let (mut ball_world, remaining) = world.split_for_query(query_balls);
 
@@ -65,7 +65,7 @@ impl System for BounceSystem {
                                     || (paddle.side == Side::Right && ball.velocity[0] > 0.0))
                                 {
                                     println!("Bounce!");
-                                    play_bounce(sounds, storage, output_wrapper.output.as_ref());
+                                    play_bounce(sounds, storage, output);
                                     ball.velocity[0] = -ball.velocity[0];
                                 }
                             }

--- a/examples/sprite_animation/main.rs
+++ b/examples/sprite_animation/main.rs
@@ -120,7 +120,7 @@ impl SimpleState for ExampleState {
                 }
             }
         }
-        buffer.flush(data.world);
+        buffer.flush(data.world, data.resources);
 
         Trans::None
     }

--- a/examples/sprites_ordered/main.rs
+++ b/examples/sprites_ordered/main.rs
@@ -97,11 +97,11 @@ impl SimpleState for Example {
         event: StateEvent,
     ) -> SimpleTrans {
         if let StateEvent::Window(event) = &event {
-            if is_close_requested(&event) || is_key_down(&event, VirtualKeyCode::Escape) {
+            if is_close_requested(event) || is_key_down(event, VirtualKeyCode::Escape) {
                 return Trans::Quit;
             };
 
-            match get_key(&event) {
+            match get_key(event) {
                 Some((VirtualKeyCode::T, ElementState::Pressed)) => {
                     self.transparent = !self.transparent;
                     info!(
@@ -140,14 +140,14 @@ impl SimpleState for Example {
                 Some((VirtualKeyCode::Up, ElementState::Pressed)) => {
                     self.camera_z += 1.0;
                     info!("Camera Z position is: {}", self.camera_z);
-                    self.adjust_camera(&mut data.world, &data.resources);
+                    self.adjust_camera(&mut data.world, data.resources);
                     self.redraw_sprites(&mut data.world);
                 }
 
                 Some((VirtualKeyCode::Down, ElementState::Pressed)) => {
                     self.camera_z -= 1.0;
                     info!("Camera Z position is: {}", self.camera_z);
-                    self.adjust_camera(&mut data.world, &data.resources);
+                    self.adjust_camera(&mut data.world, data.resources);
                     self.redraw_sprites(&mut data.world);
                 }
 
@@ -156,14 +156,14 @@ impl SimpleState for Example {
                         self.camera_depth_vision -= 1.0;
                         info!("Camera depth vision: {}", self.camera_depth_vision);
                     }
-                    self.adjust_camera(&mut data.world, &data.resources);
+                    self.adjust_camera(&mut data.world, data.resources);
                     self.redraw_sprites(&mut data.world);
                 }
 
                 Some((VirtualKeyCode::Right, ElementState::Pressed)) => {
                     self.camera_depth_vision += 1.0;
                     info!("Camera depth vision: {}", self.camera_depth_vision);
-                    self.adjust_camera(&mut data.world, &data.resources);
+                    self.adjust_camera(&mut data.world, data.resources);
                     self.redraw_sprites(&mut data.world);
                 }
 
@@ -278,7 +278,7 @@ impl Example {
             );
 
             // This combines multiple `Transform`ations.
-            sprite_transform.concat(&common_transform);
+            sprite_transform.concat(common_transform);
 
             let sprite_render = SpriteRender::new(sprite_sheet_handle.clone(), i as usize);
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -345,12 +345,12 @@ where
             #[cfg(feature = "profiler")]
             profile_scope!("fixed_update");
 
-            while {
-                self.resources
-                    .get_mut::<Time>()
-                    .unwrap()
-                    .step_fixed_update()
-            } {
+            while self
+                .resources
+                .get_mut::<Time>()
+                .unwrap()
+                .step_fixed_update()
+            {
                 self.states.fixed_update(StateData::new(
                     &mut self.world,
                     &mut self.resources,


### PR DESCRIPTION
## Description

In version 0.12.0, breaking changes were made in rodio's API. The major one is the introduction of Streams, which replaced Devices as the main way to play audio.

More precisely, there is an OutputStream, which can be constructed from a default device or a Device that the user provides. This struct is !Sync and !Send, i.e. it cannot be send across threads. There is, however, an OutputStreamHandle which provides thread-safe access to an audio device. Sinks are now created from those handles instead of Devices.

Here are the adjustments made to this crate:
- Output now contains an OutputStreamHandle and the name of the device it was created with. It also provides a method to construct a Sink from the handle.
- AudioSink has been renamed to Sink.
- AudioSystem and DjSystem have been reworked according to the above changes.
- The bundles for the systems now insert at least two resources: the OutputStream resource, which must not be accessed by the systems, and the Output that is used by those systems.
- All audio functions now return results. That should make identifying the problems with audio easier.

## Motivation and Context

These changes are required to support [Android's AAudio API, which is not completely thread-safe][aaudio].

[aaudio]: https://developer.android.com/ndk/guides/audio/aaudio/aaudio#thread-safety

## How Has This Been Tested?

This has been tested using the module's unit tests and pong_tutorial_06.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [x] If my change required a change to the documentation I have updated the documentation accordingly.
- [ ] I have updated the content of the book if this PR would make the book outdated.
- [x] I have added tests to cover my changes.
- [x] My code is used in an example.
