### PR TITLE
Fix refcount underflow error in tutorial pong06

### DIFF
--- a/amethyst_assets/src/loader.rs
+++ b/amethyst_assets/src/loader.rs
@@ -253,9 +253,7 @@ impl Loader for DefaultLoader {
                     self.loader.remove_ref(handle);
                 }
                 Ok(RefOp::Increase(handle)) => {
-                    self.loader
-                        .get_load_info(handle)
-                        .map(|info| self.loader.add_ref(info.asset_id));
+                    self.loader.add_ref_handle(handle);
                 }
                 Ok(RefOp::IncreaseUuid(uuid)) => {
                     self.loader.add_ref(uuid);


### PR DESCRIPTION
Indirect `LoadHandle`s are not always immediately available from the
indirection table. A cloned indirect handle would thus have their
refcount decreased on Drop, but not increased on Clone. Remove the need
for indirection table resolution to fix this bug.

## Motivation and Context
The tutorial Pong06 is crashing due to a negative refcount.
Using the DJSystem in any other project in a similar manner causes the same crash.



## How Has This Been Tested?
Tested by running the following examples:
- pong01
- pong06
- sphere
Also spam-cloned / dropped indirect handles while logging the refcount.


## Checklist:
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [x] If my change required a change to the documentation I have updated the documentation accordingly.
- [x] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [x] My code is used in an example.
