### PR TITLE
#2703: Include a path of the file in ron parse errors

### DIFF
--- a/amethyst_config/src/lib.rs
+++ b/amethyst_config/src/lib.rs
@@ -67,9 +67,8 @@ impl fmt::Display for ConfigError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             ConfigError::File(ref err) => write!(f, "{}", err),
-            ConfigError::Parser(ref msg) => write!(f, "{}", msg),
+            ConfigError::Parser(ref msg) | ConfigError::Serializer(ref msg) => write!(f, "{}", msg),
             ConfigError::FileParser(ref msg, ref path) => write!(f, "{}: {}", path.display(), msg),
-            ConfigError::Serializer(ref msg) => write!(f, "{}", msg),
             ConfigError::Extension(ref path) => {
                 let found = match path.extension() {
                     Some(extension) => format!("{:?}", extension),
@@ -227,7 +226,7 @@ where
                         de.end()?;
                         Ok(val)
                     })
-                    .map_err(|e| ConfigError::Parser(e))
+                    .map_err(ConfigError::Parser)
             }
             #[cfg(feature = "json")]
             ConfigFormat::Json => {

--- a/amethyst_config/src/lib.rs
+++ b/amethyst_config/src/lib.rs
@@ -212,9 +212,7 @@ where
             .map_err(|err| {
                 // Enrich parsing error with a path to the file being parsed.
                 match err {
-                    ConfigError::Parser(err) => {
-                        ConfigError::FileParser(err, path.to_owned())
-                    }
+                    ConfigError::Parser(err) => ConfigError::FileParser(err, path.to_owned()),
                     _ => err,
                 }
             })
@@ -327,12 +325,7 @@ mod test {
         let result = TestConfig::load(path);
 
         assert!(
-            matches!(
-                result,
-                Err(ConfigError::FileParser(
-                    _, ref path
-                ))
-            ),
+            matches!(result, Err(ConfigError::FileParser(_, ref path))),
             format!("{:?}", result)
         );
     }

--- a/amethyst_config/src/lib.rs
+++ b/amethyst_config/src/lib.rs
@@ -327,7 +327,7 @@ mod test {
             Err(ConfigError::FileParser(_, path)) => {
                 assert_eq!(real_path, path);
             }
-            _ => panic!("{:?}", result)
+            _ => panic!("{:?}", result),
         }
     }
 }

--- a/amethyst_config/tests/invalid-syntax.ron
+++ b/amethyst_config/tests/invalid-syntax.ron
@@ -1,0 +1,3 @@
+(
+  amethyst: invalid-value,
+)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Added additional type to `ConfigError` which holds both ron error and a path to the file being parsed. Alternative was to add a path to the existing `Parser` variant, but it would require to fill it for cases that are not really appropriate like reading directly from bytes in memory.



## Motivation and Context
https://github.com/amethyst/amethyst/issues/2703



## How Has This Been Tested?
Written an unit test for it.



## Screenshots (if appropriate):



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [x] If my change required a change to the documentation I have updated the documentation accordingly.
- [x] I have updated the content of the book if this PR would make the book outdated.
- [x] I have added tests to cover my changes.
- [ ] My code is used in an example.
