### PR TITLE
Fix deserialize bug for material example

### DIFF
--- a/amethyst_assets/src/json.rs
+++ b/amethyst_assets/src/json.rs
@@ -19,10 +19,9 @@ where
     fn import_simple(&self, bytes: Vec<u8>) -> Result<D, Error> {
         use serde_json::de::Deserializer;
         let mut d = Deserializer::from_slice(&bytes);
-        d.end()
-            .with_context(|_| format_err!("Failed deserializing Json file"))?;
-
         let val = D::deserialize(&mut d)
+            .with_context(|_| format_err!("Failed deserializing Json file"))?;
+        d.end()
             .with_context(|_| format_err!("Failed deserializing Json file"))?;
         Ok(val)
     }

--- a/amethyst_config/src/lib.rs
+++ b/amethyst_config/src/lib.rs
@@ -219,6 +219,7 @@ where
     fn load_bytes_format(format: ConfigFormat, bytes: &[u8]) -> Result<Self, ConfigError> {
         match format {
             ConfigFormat::Ron => {
+                #[allow(clippy::shadow_unrelated)]
                 ron::de::Deserializer::from_bytes(bytes)
                     .and_then(|mut de| {
                         let val = T::deserialize(&mut de)?;

--- a/amethyst_config/src/lib.rs
+++ b/amethyst_config/src/lib.rs
@@ -221,8 +221,8 @@ where
             ConfigFormat::Ron => {
                 ron::de::Deserializer::from_bytes(bytes)
                     .and_then(|mut de| {
-                        de.end()?;
                         let val = T::deserialize(&mut de)?;
+                        de.end()?;
                         Ok(val)
                     })
                     .map_err(ConfigError::Parser)


### PR DESCRIPTION
## Description
Material example panicked and threw this error on start:
```
Error: Error { inner: Inner { source: None, backtrace: None, error: FileParser(Error { code: TrailingCharacters, position: Position { line: 6, col: 1 } }, ".../amethyst/examples/material/config/display.ron") }
```
This is due to a recent change. This commit reverts the code back to a working state.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Examples that crash is confusing for newcomers.


## How Has This Been Tested?
Running the `material` example now works.
`cargo run -p material`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [x] If my change required a change to the documentation I have updated the documentation accordingly.
- [x] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [x] My code is used in an example.
