### PR TITLE
fix: remove documented tab-order reference

### DIFF
--- a/book/src/pong-tutorial/pong-tutorial-05.md
+++ b/book/src/pong-tutorial/pong-tutorial-05.md
@@ -314,8 +314,7 @@ our `UiText` components).
 
 Next, we create a transform for each of our two scores by giving them a unique
 id (`P1` and `P2`), a UI `Anchor` at the top middle of our window, and then
-adjust their global `x`, `y`, and `z` coordinates, `width`, `height`, and
-`tab-order`.
+adjust their global `x`, `y`, and `z` coordinates, along with `width` and `height`.
 
 After creating the `font` and `transform`s, we'll create an `Entity` in the
 world for each of our players' scores, with their `transform` and a `UiText`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
<!--- Separate Additions, Removals and Modifications -->
So far as I can tell as I follow along, the referenced configuration to `tab-order` is not actually set.

> Next, we create a transform for each of our two scores by giving them a unique id (P1 and P2), a UI Anchor at the top middle of our window, and then adjust their global x, y, and z coordinates, width, height, and tab-order.

```rust
    let p1_transform = UiTransform::new(
        "P1".to_string(), Anchor::TopMiddle, Anchor::TopMiddle,
        -50.0, -50.0, 1.0, 200.0, 50.0,
    );
```

If it is set, its not immediately clear where.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Align documentation with changes made.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Locally built with mdbook

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [x] If my change required a change to the documentation I have updated the documentation accordingly.
- [x] I have updated the content of the book if this PR would make the book outdated.
- n/a - I have added tests to cover my changes.
- n/a - My code is used in an example.
