### PR TITLE
add resources to Tile.sprite and Tile.tint params

### DIFF
--- a/amethyst_tiles/src/map.rs
+++ b/amethyst_tiles/src/map.rs
@@ -2,7 +2,7 @@
 
 use amethyst_assets::{Asset, Handle};
 use amethyst_core::{
-    ecs::world::World,
+    ecs::{Resources, World},
     math::{Matrix4, Point3, Vector3},
     transform::Transform,
 };
@@ -14,12 +14,17 @@ use crate::{CoordinateEncoder, TileOutOfBoundsError};
 /// which must implement this trait to provide the `RenderPass` with the appropriate sprite and tint values.
 pub trait Tile: 'static + Clone + Send + Sync + Default {
     /// Takes an immutable reference to world to process this sprite and return its sprite.
-    fn sprite(&self, coordinates: Point3<u32>, world: &World) -> Option<usize> {
+    fn sprite(
+        &self,
+        coordinates: Point3<u32>,
+        world: &World,
+        resources: &Resources,
+    ) -> Option<usize> {
         None
     }
 
     /// Takes an immutable reference to world to process this sprite and return its tint.
-    fn tint(&self, coordinates: Point3<u32>, world: &World) -> Srgba {
+    fn tint(&self, coordinates: Point3<u32>, world: &World, resources: &Resources) -> Srgba {
         Srgba::new(1.0, 1.0, 1.0, 1.0)
     }
 }

--- a/amethyst_tiles/src/pass.rs
+++ b/amethyst_tiles/src/pass.rs
@@ -362,11 +362,17 @@ impl<B: Backend, T: Tile, E: CoordinateEncoder, Z: DrawTiles2DBounds> RenderGrou
                         .iter()
                         .filter_map(|coord| {
                             let tile = tile_map.get(&coord).unwrap();
-                            if let Some(sprite_number) = tile.sprite(coord, aux.world) {
+                            if let Some(sprite_number) =
+                                tile.sprite(coord, aux.world, aux.resources)
+                            {
                                 let batch_data = TileArgs::from_data(
                                     &sprites,
                                     sprite_number,
-                                    Some(&TintComponent(tile.tint(coord, aux.world))),
+                                    Some(&TintComponent(tile.tint(
+                                        coord,
+                                        aux.world,
+                                        aux.resources,
+                                    ))),
                                     &coord,
                                 );
 
@@ -490,12 +496,12 @@ fn build_tiles_pipeline<B: Backend>(
             .create_pipeline_layout(layouts, None as Option<(_, _)>)
     }?;
 
-    let mut shaders = SHADERS.build(factory, Default::default()).map_err(|e| {
-        match e {
+    let mut shaders = SHADERS
+        .build(factory, Default::default())
+        .map_err(|e| match e {
             hal::device::ShaderError::OutOfMemory(oom) => oom.into(),
             _ => pso::CreationError::Other,
-        }
-    })?;
+        })?;
 
     let pipes = PipelinesBuilder::new()
         .with_pipeline(


### PR DESCRIPTION
## Description
This PR adds `Resources` in methods `sprite` and `tint` of `Tile` trait


## Motivation and Context
It may be useful to generate/modify map in separate resource and then just read it from there inside `Tile.sprite`. Specs `world` had `read_resource` method. But Legion stores resources separately from world so we should pass them in here.

## Checklist:
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] My code follows the code style of this project.
- [ ] If my change required a change to the documentation I have updated the documentation accordingly.
- [ ] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [ ] My code is used in an example.
