### PR TITLE
Allow use of reexported legion crate for codegen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ thread_profiler = { version = "0.3.0", optional = true }
 lazy_static = "1.4.0"
 glsl-layout = "0.4"
 # until https://github.com/amethyst/legion/pull/186 passed
-legion = { version = "0.4", default-features = false, features = [
+legion = { git = "https://github.com/amethyst/legion", rev = "0b058dd8bd3190d5d5d1d29f62571bb8b70c3b93", default-features = false, features = [
     "serialize",
     "crossbeam-events",
     "codegen",

--- a/amethyst_animation/Cargo.toml
+++ b/amethyst_animation/Cargo.toml
@@ -31,8 +31,7 @@ thread_profiler = { version = "0.3", optional = true }
 alga = "0.9.3"
 type-uuid = "0.1.2"
 uuid = "0.8.2"
-legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "8565883493aaf6044e210ffe2e72eec519d46369" }
-legion = "0.4"
+legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
 
 [dev-dependencies]
 amethyst = { path = "../", version = "0.16.0", features = ["renderer"] }

--- a/amethyst_animation/src/systems/sampling.rs
+++ b/amethyst_animation/src/systems/sampling.rs
@@ -3,6 +3,7 @@ use std::{collections::HashSet, time::Duration};
 use amethyst_assets::AssetStorage;
 use amethyst_core::{
     ecs::{system, CommandBuffer},
+    legion,
     Time,
 };
 use log::debug;

--- a/amethyst_assets/Cargo.toml
+++ b/amethyst_assets/Cargo.toml
@@ -51,8 +51,8 @@ uuid = { version = "0.8", features = ["v4"] }
 bincode = "1.3"
 type-uuid = "0.1"
 futures-executor = { version = "0.3", default-features = false }
-legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "8565883493aaf6044e210ffe2e72eec519d46369" }
-prefab-format = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "8565883493aaf6044e210ffe2e72eec519d46369" }
+legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
 encoding_rs_io = "0.1"
 serde-diff = "0.4"
 structopt = { version = "0.3", default-features = false, optional = true }

--- a/amethyst_core/Cargo.toml
+++ b/amethyst_core/Cargo.toml
@@ -26,12 +26,12 @@ serde = { version = "1", features = ["derive"] }
 approx = "0.5"
 derive-new = "0.5"
 getset = "0.1.1"
-legion = { version = "0.4", default-features = false, features = [
+legion = { git = "https://github.com/amethyst/legion", rev = "0b058dd8bd3190d5d5d1d29f62571bb8b70c3b93", default-features = false, features = [
     "serialize",
     "crossbeam-events",
-    "codegen",
+    "reexport",
 ] }
-legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "8565883493aaf6044e210ffe2e72eec519d46369" }
+legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
 nalgebra = { version = "0.25", default-features = false, features = ["serde-serialize"] }
 rayon = "1.5"
 shrev = "1.1.1"

--- a/amethyst_core/src/lib.rs
+++ b/amethyst_core/src/lib.rs
@@ -53,6 +53,9 @@ pub mod ecs {
     pub use crate::dispatcher::{Dispatcher, DispatcherBuilder, System, SystemBundle};
 }
 
+/// Re-export under name legion for proc macros
+pub use ecs as legion;
+
 /// Dispatcher module.
 pub mod dispatcher;
 

--- a/amethyst_gltf/Cargo.toml
+++ b/amethyst_gltf/Cargo.toml
@@ -24,7 +24,7 @@ err-derive = "0.3.0"
 base64 = "0.13"
 fnv = "1"
 gltf = { version = "0.16", features = ["KHR_lights_punctual"] }
-legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "8565883493aaf6044e210ffe2e72eec519d46369" }
+legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
 hibitset = { version = "0.6.3", features = ["parallel"] }
 log = "0.4"
 mikktspace = "0.2.0"

--- a/amethyst_rendy/Cargo.toml
+++ b/amethyst_rendy/Cargo.toml
@@ -34,7 +34,7 @@ indexmap = { version = "1.7", features = ["rayon"] }
 type-uuid = "0.1"
 thread_profiler = { version = "0.3", optional = true }
 approx = "0.5"
-legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "8565883493aaf6044e210ffe2e72eec519d46369" }
+legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 rendy = { version = "0.5", git = "https://github.com/amethyst/rendy", rev = "50667887612adc9314accea77438aa7fb925bce0", default-features = false, features = ["metal"] }

--- a/amethyst_ui/Cargo.toml
+++ b/amethyst_ui/Cargo.toml
@@ -44,7 +44,7 @@ lazy_static = "1.4"
 glyph_brush = "0.6"
 thread_profiler = { version = "0.3", optional = true }
 type-uuid = "0.1"
-legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "8565883493aaf6044e210ffe2e72eec519d46369" }
+legion-prefab = { version = "0.1", git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
 
 [dev-dependencies]
 amethyst = { path = "../", version = "0.16.0", features = ["renderer"] }

--- a/examples/_unused_assets/Cargo.toml
+++ b/examples/_unused_assets/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/animation/Cargo.toml
+++ b/examples/animation/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/arc_ball_camera/Cargo.toml
+++ b/examples/arc_ball_camera/Cargo.toml
@@ -17,4 +17,4 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/asset_custom/Cargo.toml
+++ b/examples/asset_custom/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/asset_loading/Cargo.toml
+++ b/examples/asset_loading/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/auto_fov/Cargo.toml
+++ b/examples/auto_fov/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/custom_game_data/Cargo.toml
+++ b/examples/custom_game_data/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/custom_render_pass/Cargo.toml
+++ b/examples/custom_render_pass/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/custom_ui/Cargo.toml
+++ b/examples/custom_ui/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/debug_lines/Cargo.toml
+++ b/examples/debug_lines/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/debug_lines_ortho/Cargo.toml
+++ b/examples/debug_lines_ortho/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/events/Cargo.toml
+++ b/examples/events/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/events_custom_state_event/Cargo.toml
+++ b/examples/events_custom_state_event/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/fly_camera/Cargo.toml
+++ b/examples/fly_camera/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/gltf_scene/Cargo.toml
+++ b/examples/gltf_scene/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/locale/Cargo.toml
+++ b/examples/locale/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/material/Cargo.toml
+++ b/examples/material/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/mouse_raycast/Cargo.toml
+++ b/examples/mouse_raycast/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/net_client/Cargo.toml
+++ b/examples/net_client/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/net_server/Cargo.toml
+++ b/examples/net_server/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/optional_graphics/Cargo.toml
+++ b/examples/optional_graphics/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/pong_tutorial_01/Cargo.toml
+++ b/examples/pong_tutorial_01/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/pong_tutorial_02/Cargo.toml
+++ b/examples/pong_tutorial_02/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/pong_tutorial_03/Cargo.toml
+++ b/examples/pong_tutorial_03/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/pong_tutorial_04/Cargo.toml
+++ b/examples/pong_tutorial_04/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/pong_tutorial_05/Cargo.toml
+++ b/examples/pong_tutorial_05/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/pong_tutorial_06/Cargo.toml
+++ b/examples/pong_tutorial_06/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/prefab/Cargo.toml
+++ b/examples/prefab/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/prefab_adapter/Cargo.toml
+++ b/examples/prefab_adapter/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/prefab_custom/Cargo.toml
+++ b/examples/prefab_custom/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/prefab_multi/Cargo.toml
+++ b/examples/prefab_multi/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/renderable/Cargo.toml
+++ b/examples/renderable/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/renderable_custom/Cargo.toml
+++ b/examples/renderable_custom/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/rendy/Cargo.toml
+++ b/examples/rendy/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/sphere/Cargo.toml
+++ b/examples/sphere/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/spotlights/Cargo.toml
+++ b/examples/spotlights/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/sprite_animation/Cargo.toml
+++ b/examples/sprite_animation/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/sprite_camera_follow/Cargo.toml
+++ b/examples/sprite_camera_follow/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/sprites_ordered/Cargo.toml
+++ b/examples/sprites_ordered/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/state_dispatcher/Cargo.toml
+++ b/examples/state_dispatcher/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/states_ui/Cargo.toml
+++ b/examples/states_ui/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/tiles/Cargo.toml
+++ b/examples/tiles/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/ui/Cargo.toml
+++ b/examples/ui/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/ui_from_code/Cargo.toml
+++ b/examples/ui_from_code/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/examples/window/Cargo.toml
+++ b/examples/window/Cargo.toml
@@ -18,5 +18,5 @@ serde-diff = "0.4"
 type-uuid = "0.1"
 glsl-layout = "0.4"
 ron = "^0.6"
-legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
-prefab-format = { git = "https://github.com/amethyst/prefab", rev = "7c30249f106e6177549e223ca2823eec8ab6c70b" }
+legion-prefab = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }
+prefab-format = { git = "https://github.com/amethyst/prefab", rev = "49ba008a3b398033725726c641b96cd48b5a1080" }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -5,6 +5,7 @@ pub use crate::{
     app::{Application, ApplicationBuilder, CoreApplication},
     config::Config,
     ecs::*,
+    ecs as legion,
     game_data::{DataInit, GameData},
     state::{
         EmptyState, EmptyTrans, SimpleState, SimpleTrans, State, StateData, Trans, TransEvent,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
This change allows amethyst users to use legion codegen without needing to add the legion crate to their Cargo.toml.



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change reduces the friction involved in using legion codegen.
The compiler will correctly identify what to import to make it work.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
This has been tested locally by compiling a personal project and the amethyst animation example.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [x] If my change required a change to the documentation I have updated the documentation accordingly.
- [x] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [ ] My code is used in an example.
